### PR TITLE
feat(e2e): add authenticated Playwright test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
   NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+  SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
 
 jobs:
   lint-typecheck-build:
@@ -39,7 +40,7 @@ jobs:
         run: npx next build
 
   playwright:
-    name: Playwright Smoke Tests
+    name: Playwright E2E Tests
     runs-on: ubuntu-latest
     needs: lint-typecheck-build
     defaults:

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ out/
 playwright-report/
 test-results/
 coverage/
+e2e/.auth/
 tsconfig.tsbuildinfo
 
 # ─── Python ─────────────────────────────────────────────────────────────────

--- a/frontend/e2e/auth.setup.ts
+++ b/frontend/e2e/auth.setup.ts
@@ -1,0 +1,50 @@
+// ─── Playwright auth setup project ──────────────────────────────────────────
+// Creates a test user via Supabase Admin API, logs in through the UI, completes
+// onboarding, and saves browser storageState for downstream test projects.
+//
+// Skipped automatically when SUPABASE_SERVICE_ROLE_KEY is not set.
+
+import { test as setup, expect } from "@playwright/test";
+import {
+  TEST_EMAIL,
+  TEST_PASSWORD,
+  ensureTestUser,
+} from "./helpers/test-user";
+
+const AUTH_STATE_PATH = "e2e/.auth/user.json";
+
+setup("create user and authenticate via UI", async ({ page }) => {
+  // ── 1. Provision test user ────────────────────────────────────────────────
+  await ensureTestUser();
+
+  // ── 2. Login via the UI ───────────────────────────────────────────────────
+  await page.goto("/auth/login");
+  await page.getByLabel("Email").fill(TEST_EMAIL);
+  await page.getByLabel("Password").fill(TEST_PASSWORD);
+  await page.getByRole("button", { name: "Sign In" }).click();
+
+  // After login the user has no preferences → redirected to onboarding
+  await page.waitForURL(/\/(app\/search|onboarding\/region)/, {
+    timeout: 15_000,
+  });
+
+  // ── 3. Complete onboarding (if needed) ────────────────────────────────────
+  if (page.url().includes("/onboarding/region")) {
+    // Step 1 — select Poland
+    await page.getByText("Poland", { exact: false }).click();
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    // Step 2 — preferences (skip)
+    await page.waitForURL(/\/onboarding\/preferences/, { timeout: 10_000 });
+    await page.getByRole("button", { name: /skip/i }).click();
+
+    // Should land on /app/search
+    await page.waitForURL(/\/app\/search/, { timeout: 10_000 });
+  }
+
+  // ── 4. Verify we're authenticated ─────────────────────────────────────────
+  await expect(page).toHaveURL(/\/app\/search/);
+
+  // ── 5. Persist auth cookies for dependent test projects ───────────────────
+  await page.context().storageState({ path: AUTH_STATE_PATH });
+});

--- a/frontend/e2e/authenticated.spec.ts
+++ b/frontend/e2e/authenticated.spec.ts
@@ -1,0 +1,168 @@
+// ─── Authenticated E2E tests ────────────────────────────────────────────────
+// These tests run with pre-authenticated storageState produced by auth.setup.ts.
+// The test user has completed onboarding (Poland, default preferences).
+//
+// No camera dependency — all interactions are keyboard / click.
+// Deterministic — each run starts from a known auth + onboarding state.
+
+import { test, expect } from "@playwright/test";
+
+// ─── Signup form (public, no auth needed) ───────────────────────────────────
+
+test.describe("Signup form", () => {
+  test("renders with all required fields", async ({ page }) => {
+    await page.goto("/auth/signup");
+    await expect(
+      page.getByRole("heading", { name: /create your account/i }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Email")).toBeVisible();
+    await expect(page.getByLabel("Password")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /sign up/i }),
+    ).toBeVisible();
+  });
+
+  test("shows validation for short password", async ({ page }) => {
+    await page.goto("/auth/signup");
+    await page.getByLabel("Email").fill("test-short-pw@example.com");
+    await page.getByLabel("Password").fill("ab"); // too short (min 6)
+    await page.getByRole("button", { name: /sign up/i }).click();
+
+    // HTML5 minLength prevents submission — button still visible, no redirect
+    await expect(page).toHaveURL(/\/auth\/signup/);
+  });
+
+  test("submits and shows confirmation message", async ({ page }) => {
+    // Intercept the Supabase signup API to avoid creating a real account
+    await page.route("**/auth/v1/signup", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "00000000-0000-0000-0000-000000000000",
+          email: "signup-test@example.com",
+          confirmation_sent_at: new Date().toISOString(),
+          created_at: new Date().toISOString(),
+        }),
+      }),
+    );
+
+    await page.goto("/auth/signup");
+    await page.getByLabel("Email").fill("signup-test@example.com");
+    await page.getByLabel("Password").fill("StrongPassword123!");
+    await page.getByRole("button", { name: /sign up/i }).click();
+
+    // App redirects to login with msg=check-email after successful signup
+    await page.waitForURL(/\/auth\/login/, { timeout: 10_000 });
+  });
+});
+
+// ─── Authenticated: Search ──────────────────────────────────────────────────
+
+test.describe("Search page", () => {
+  test("renders with search input", async ({ page }) => {
+    await page.goto("/app/search");
+    await expect(page.locator('input[placeholder*="Search"]')).toBeVisible();
+  });
+
+  test("can type and submit a query", async ({ page }) => {
+    await page.goto("/app/search");
+
+    const input = page.locator('input[placeholder*="Search"]');
+    await input.fill("milk");
+
+    // Submit — the search button is present in submit mode
+    const submitBtn = page.getByRole("button", { name: "Search" });
+    if (await submitBtn.isVisible()) {
+      await submitBtn.click();
+    } else {
+      await input.press("Enter");
+    }
+
+    // Should stay on search page (results or empty state)
+    await expect(page).toHaveURL(/\/app\/search/);
+  });
+});
+
+// ─── Authenticated: Categories ──────────────────────────────────────────────
+
+test.describe("Categories page", () => {
+  test("renders category overview", async ({ page }) => {
+    await page.goto("/app/categories");
+
+    // Should show the categories heading or grid
+    await expect(page.locator("body")).toContainText(/categor/i);
+  });
+});
+
+// ─── Authenticated: Product detail ─────────────────────────────────────────
+
+test.describe("Product detail", () => {
+  test("handles non-existent product gracefully", async ({ page }) => {
+    await page.goto("/app/product/999999");
+
+    // Should not crash — may show error, not-found, or fallback UI
+    await expect(page.locator("body")).toBeVisible();
+    // Should NOT redirect to login (user IS authenticated)
+    expect(page.url()).not.toMatch(/\/auth\/login/);
+  });
+});
+
+// ─── Authenticated: Settings ────────────────────────────────────────────────
+
+test.describe("Settings page", () => {
+  test("renders with Settings heading", async ({ page }) => {
+    await page.goto("/app/settings");
+    await expect(
+      page.getByRole("heading", { name: /settings/i }),
+    ).toBeVisible();
+  });
+
+  test("shows country preference", async ({ page }) => {
+    await page.goto("/app/settings");
+
+    // We onboarded with Poland — it should be visible
+    await expect(
+      page.getByText("Poland").or(page.getByText("Polska")),
+    ).toBeVisible();
+  });
+
+  test("shows diet preference options", async ({ page }) => {
+    await page.goto("/app/settings");
+
+    // Diet section should be visible
+    await expect(page.getByText(/diet/i).first()).toBeVisible();
+  });
+});
+
+// ─── Authenticated: Logout ─────────────────────────────────────────────────
+
+test.describe("Logout flow", () => {
+  test("sign-out redirects to login page", async ({ page }) => {
+    await page.goto("/app/settings");
+    await expect(
+      page.getByRole("button", { name: /sign out/i }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: /sign out/i }).click();
+
+    // Should redirect to login
+    await page.waitForURL(/\/auth\/login/, { timeout: 10_000 });
+    await expect(
+      page.getByRole("heading", { name: /welcome back/i }),
+    ).toBeVisible();
+  });
+
+  test("after sign-out, protected routes redirect to login", async ({
+    page,
+  }) => {
+    // Sign out first
+    await page.goto("/app/settings");
+    await page.getByRole("button", { name: /sign out/i }).click();
+    await page.waitForURL(/\/auth\/login/, { timeout: 10_000 });
+
+    // Attempt to visit a protected route
+    await page.goto("/app/search");
+    await page.waitForURL(/\/auth\/login/, { timeout: 10_000 });
+  });
+});

--- a/frontend/e2e/global-teardown.ts
+++ b/frontend/e2e/global-teardown.ts
@@ -1,0 +1,17 @@
+// ─── Global teardown: delete the e2e test user ─────────────────────────────
+// Best-effort cleanup — does not fail the run if deletion errors out.
+
+import { deleteTestUser } from "./helpers/test-user";
+
+async function globalTeardown() {
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) return;
+
+  try {
+    await deleteTestUser();
+  } catch {
+    // Non-fatal — user may already be gone or may not have been created
+    console.warn("⚠️  Could not delete e2e test user (non-fatal)");
+  }
+}
+
+export default globalTeardown;

--- a/frontend/e2e/helpers/test-user.ts
+++ b/frontend/e2e/helpers/test-user.ts
@@ -1,0 +1,63 @@
+// ─── E2E test user lifecycle ─────────────────────────────────────────────────
+// Creates and tears down a Supabase Auth user for authenticated Playwright tests.
+// Requires SUPABASE_SERVICE_ROLE_KEY to access the Admin API.
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+export const TEST_EMAIL = "e2e-playwright@test.fooddb.local";
+export const TEST_PASSWORD = "PlaywrightTest123!";
+
+function getAdminClient(): SupabaseClient {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !key) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY",
+    );
+  }
+
+  return createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+/** Delete any existing test user, then create a fresh auto-confirmed one. */
+export async function ensureTestUser(): Promise<string> {
+  const supabase = getAdminClient();
+
+  // Remove stale test user if present (idempotent)
+  const {
+    data: { users },
+  } = await supabase.auth.admin.listUsers();
+  const existing = users.find((u) => u.email === TEST_EMAIL);
+  if (existing) {
+    await supabase.auth.admin.deleteUser(existing.id);
+  }
+
+  // Create fresh, pre-confirmed user
+  const { data, error } = await supabase.auth.admin.createUser({
+    email: TEST_EMAIL,
+    password: TEST_PASSWORD,
+    email_confirm: true,
+  });
+
+  if (error) {
+    throw new Error(`Failed to create test user: ${error.message}`);
+  }
+
+  return data.user.id;
+}
+
+/** Delete the test user (best-effort cleanup). */
+export async function deleteTestUser(): Promise<void> {
+  const supabase = getAdminClient();
+
+  const {
+    data: { users },
+  } = await supabase.auth.admin.listUsers();
+  const user = users.find((u) => u.email === TEST_EMAIL);
+  if (user) {
+    await supabase.auth.admin.deleteUser(user.id);
+  }
+}


### PR DESCRIPTION
## Phase 3.2 — Authenticated E2E Test Coverage

Adds full authenticated Playwright test coverage on top of the existing 22 smoke tests.

### What's new
- **auth.setup.ts** — Playwright setup project: creates a test user via Supabase Admin API, logs in through the UI, completes onboarding (region → preferences skip), saves `storageState`
- **authenticated.spec.ts** — 12 new tests:
  - Signup form (render, validation, mock submit)
  - Search page (render, type + submit query)
  - Categories page (render)
  - Product detail (handles non-existent product gracefully)
  - Settings page (render, country preference, diet options)
  - Logout flow (sign-out redirect, protected route redirect after logout)
- **global-teardown.ts** — Best-effort cleanup of the test user after each run
- **helpers/test-user.ts** — Supabase Admin API helpers (`ensureTestUser`, `deleteTestUser`)
- **playwright.config.ts** — 3 conditional projects:
  - `auth-setup` (only when `SUPABASE_SERVICE_ROLE_KEY` is set)
  - `smoke` (always runs — 22 existing tests)
  - `authenticated` (depends on `auth-setup` — 12 new tests)

### Test count
| Mode | Tests |
|------|-------|
| Without service key | 22 (smoke only, backward compatible) |
| With service key | 35 (22 smoke + 1 setup + 12 authenticated) |

### CI changes
- `ci.yml`: Added `SUPABASE_SERVICE_ROLE_KEY` env var from secrets
- `build.yml`: No changes (uses placeholder keys → auth tests auto-skip)

### Required setup
Add `SUPABASE_SERVICE_ROLE_KEY` as a repository secret in GitHub Settings → Secrets → Actions. This is the service role key from the Supabase project dashboard (Settings → API → service_role).

Without this secret, CI behavior is unchanged (only smoke tests run).

### Acceptance criteria
- [x] TypeScript type-check passes
- [x] ESLint passes
- [x] Playwright discovers all 35 tests with key set
- [x] Smoke tests still pass without key (backward compatible)
- [x] No camera dependency
- [x] No reliance on production DB data
- [x] Dynamic test user creation + cleanup
- [ ] CI passes with new tests (requires `SUPABASE_SERVICE_ROLE_KEY` secret)

### Tracking
Closes Phase 3.2 in #6