### PR TITLE
feat(data-confidence): add reporting views and QA checks

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   qa:
-    name: Pipeline + QA (333 checks)
+    name: Pipeline + QA (348 checks)
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -27,6 +27,7 @@
        21. QA__allergen_filtering.sql (6 allergen filtering checks — blocking)
        22. QA__barcode_lookup.sql (6 barcode scanner checks — blocking)
        23. QA__auth_onboarding.sql (8 auth & onboarding checks — blocking)
+       24. QA__confidence_reporting.sql (7 confidence reporting checks — blocking)
 
     Returns exit code 0 if all tests pass, 1 if any violations found.
     Test Suite 3 is informational and does not affect the exit code.
@@ -130,7 +131,8 @@ $suiteCatalog = @(
     @{ Num = 20; Name = "Diet Filtering"; Short = "Diet"; Id = "diet_filtering"; Checks = 6; Blocking = $true; Kind = "sql"; File = "QA__diet_filtering.sql" },
     @{ Num = 21; Name = "Allergen Filtering"; Short = "Allergen"; Id = "allergen_filtering"; Checks = 6; Blocking = $true; Kind = "sql"; File = "QA__allergen_filtering.sql" },
     @{ Num = 22; Name = "Barcode Lookup"; Short = "Barcode"; Id = "barcode_lookup"; Checks = 6; Blocking = $true; Kind = "sql"; File = "QA__barcode_lookup.sql" },
-    @{ Num = 23; Name = "Auth & Onboarding"; Short = "AuthOnboard"; Id = "auth_onboarding"; Checks = 8; Blocking = $true; Kind = "sql"; File = "QA__auth_onboarding.sql" }
+    @{ Num = 23; Name = "Auth & Onboarding"; Short = "AuthOnboard"; Id = "auth_onboarding"; Checks = 8; Blocking = $true; Kind = "sql"; File = "QA__auth_onboarding.sql" },
+    @{ Num = 24; Name = "Confidence Reporting"; Short = "ConfReport"; Id = "confidence_reporting"; Checks = 7; Blocking = $true; Kind = "sql"; File = "QA__confidence_reporting.sql" }
 )
 
 $suiteByNum = @{}

--- a/db/qa/QA__confidence_reporting.sql
+++ b/db/qa/QA__confidence_reporting.sql
@@ -1,0 +1,83 @@
+-- ============================================================
+-- QA: Data Confidence Reporting
+-- Validates the Phase 4 reporting views and enforces guardrails
+-- on overall data quality thresholds.
+-- All checks enforce zero violations (blocking).
+-- ============================================================
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 1. v_completeness_by_country covers every active country
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '1. completeness view covers all active countries' AS check_name,
+       COUNT(*) AS violations
+FROM country_ref cr
+WHERE cr.is_active IS TRUE
+  AND NOT EXISTS (
+    SELECT 1 FROM v_completeness_by_country vc WHERE vc.country = cr.country_code
+  );
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 2. v_completeness_by_country total matches active products per country
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '2. completeness view counts match active products' AS check_name,
+       COUNT(*) AS violations
+FROM v_completeness_by_country vc
+WHERE vc.total_products != (
+    SELECT COUNT(*) FROM products p
+    WHERE p.country = vc.country AND p.is_deprecated IS NOT TRUE
+);
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 3. v_confidence_distribution covers every active country
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '3. confidence distribution covers all active countries' AS check_name,
+       COUNT(*) AS violations
+FROM country_ref cr
+WHERE cr.is_active IS TRUE
+  AND NOT EXISTS (
+    SELECT 1 FROM v_confidence_distribution cd WHERE cd.country = cr.country_code
+  );
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 4. v_confidence_distribution percentages sum to 100 per country
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '4. confidence distribution pct sums to 100 per country' AS check_name,
+       COUNT(*) AS violations
+FROM (
+    SELECT country, SUM(pct_of_country) AS total_pct
+    FROM v_confidence_distribution
+    GROUP BY country
+    HAVING ABS(SUM(pct_of_country) - 100.0) > 0.5  -- allow rounding tolerance
+) x;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 5. v_data_gap_summary covers every active (country, category) combo
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '5. gap summary covers all active country-category combos' AS check_name,
+       COUNT(*) AS violations
+FROM (
+    SELECT DISTINCT p.country, p.category
+    FROM products p
+    WHERE p.is_deprecated IS NOT TRUE
+) expected
+WHERE NOT EXISTS (
+    SELECT 1 FROM v_data_gap_summary dgs
+    WHERE dgs.country  = expected.country
+      AND dgs.category = expected.category
+);
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 6. No country has >20% low-confidence products (assign_confidence level)
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '6. no country exceeds 20% low confidence' AS check_name,
+       COUNT(*) AS violations
+FROM v_completeness_by_country
+WHERE pct_low > 20;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 7. Average completeness >= 60% per country
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '7. avg completeness >= 60% per country' AS check_name,
+       COUNT(*) AS violations
+FROM v_completeness_by_country
+WHERE avg_completeness_pct < 60;

--- a/supabase/migrations/20260214000100_data_confidence_reporting.sql
+++ b/supabase/migrations/20260214000100_data_confidence_reporting.sql
@@ -1,0 +1,76 @@
+-- ─── Data Confidence Reporting Views ─────────────────────────────────────────
+-- Adds two reporting views for monitoring data completeness and confidence
+-- distribution across countries and categories.
+--
+-- These views support Phase 4 — Data Confidence Upgrade by making gaps
+-- visible and trackable over time.
+
+-- ─── 1. Completeness summary by country ─────────────────────────────────────
+
+CREATE OR REPLACE VIEW v_completeness_by_country AS
+SELECT
+    p.country,
+    COUNT(*)                                                      AS total_products,
+    ROUND(AVG(p.data_completeness_pct), 1)                        AS avg_completeness_pct,
+    COUNT(*) FILTER (WHERE p.confidence = 'verified')             AS verified_count,
+    COUNT(*) FILTER (WHERE p.confidence = 'estimated')            AS estimated_count,
+    COUNT(*) FILTER (WHERE p.confidence = 'low')                  AS low_count,
+    ROUND(100.0 * COUNT(*) FILTER (WHERE p.confidence = 'verified')
+          / NULLIF(COUNT(*), 0), 1)                               AS pct_verified,
+    ROUND(100.0 * COUNT(*) FILTER (WHERE p.confidence = 'low')
+          / NULLIF(COUNT(*), 0), 1)                               AS pct_low,
+    COUNT(*) FILTER (WHERE NOT EXISTS (
+        SELECT 1 FROM product_ingredient pi WHERE pi.product_id = p.product_id
+    ))                                                            AS missing_ingredients,
+    COUNT(*) FILTER (WHERE NOT EXISTS (
+        SELECT 1 FROM product_allergen_info pai WHERE pai.product_id = p.product_id
+    ))                                                            AS missing_allergens
+FROM products p
+WHERE p.is_deprecated IS NOT TRUE
+GROUP BY p.country
+ORDER BY p.country;
+
+-- ─── 2. Confidence distribution by country ──────────────────────────────────
+
+CREATE OR REPLACE VIEW v_confidence_distribution AS
+SELECT
+    p.country,
+    p.confidence                                                  AS confidence_level,
+    COUNT(*)                                                      AS product_count,
+    ROUND(100.0 * COUNT(*) / NULLIF(SUM(COUNT(*)) OVER (PARTITION BY p.country), 0), 1)
+                                                                  AS pct_of_country,
+    ROUND(AVG(p.data_completeness_pct), 1)                        AS avg_completeness_pct,
+    MIN(p.data_completeness_pct)                                  AS min_completeness_pct,
+    MAX(p.data_completeness_pct)                                  AS max_completeness_pct
+FROM products p
+WHERE p.is_deprecated IS NOT TRUE
+GROUP BY p.country, p.confidence
+ORDER BY p.country, CASE p.confidence
+    WHEN 'verified'  THEN 1
+    WHEN 'estimated' THEN 2
+    WHEN 'low'       THEN 3
+    ELSE 4
+END;
+
+-- ─── 3. Data gap summary by category ────────────────────────────────────────
+
+CREATE OR REPLACE VIEW v_data_gap_summary AS
+SELECT
+    p.country,
+    p.category,
+    COUNT(*)                                                      AS total_products,
+    ROUND(AVG(p.data_completeness_pct), 1)                        AS avg_completeness_pct,
+    COUNT(*) FILTER (WHERE NOT EXISTS (
+        SELECT 1 FROM product_ingredient pi WHERE pi.product_id = p.product_id
+    ))                                                            AS missing_ingredients,
+    COUNT(*) FILTER (WHERE NOT EXISTS (
+        SELECT 1 FROM product_allergen_info pai WHERE pai.product_id = p.product_id
+    ))                                                            AS missing_allergens,
+    COUNT(*) FILTER (WHERE p.confidence = 'low')                  AS low_confidence_count,
+    COUNT(*) FILTER (WHERE p.nutri_score_label IN ('UNKNOWN', 'NOT-APPLICABLE')
+                     OR p.nutri_score_label IS NULL)               AS missing_nutri_score,
+    COUNT(*) FILTER (WHERE p.nova_classification IS NULL)          AS missing_nova
+FROM products p
+WHERE p.is_deprecated IS NOT TRUE
+GROUP BY p.country, p.category
+ORDER BY p.country, p.category;


### PR DESCRIPTION
## Phase 4 — Data Confidence Upgrade

### What this PR does

Adds **3 reporting views** and **7 QA checks** to make data quality gaps visible and enforceable.

### Reporting Views (migration `20260214000100`)

| View | Purpose |
|------|---------|
| `v_completeness_by_country` | Per-country summary: product counts, avg completeness %, confidence breakdown (verified/estimated/low), missing ingredients & allergens |
| `v_confidence_distribution` | Confidence level distribution per country with min/max/avg completeness per band |
| `v_data_gap_summary` | Missing data breakdown by country × category (ingredients, allergens, Nutri-Score, NOVA) |

### QA Suite #24 — Confidence Reporting (7 checks)

1. Completeness view covers all active countries
2. Completeness view counts match active products
3. Confidence distribution covers all active countries
4. Confidence distribution percentages sum to 100% per country
5. Gap summary covers all active (country, category) combos
6. No country exceeds 20% low-confidence products
7. Average completeness ≥ 60% per country

### Pre-existing guardrails (no changes needed)

- **QA checks 19 & 20** in `QA__data_consistency.sql` — verify stored `data_completeness_pct` and `confidence` match dynamic computation
- **`ci_post_pipeline.sql` step 4a** — recomputes completeness/confidence after allergen enrichment
- **Confidence coverage threshold** in `qa.yml` — fails CI if >5% products are low-confidence

### Checklist

- [x] Migration creates views with `CREATE OR REPLACE VIEW`
- [x] QA suite registered in `RUN_QA.ps1` catalog (#24, 7 checks, blocking)
- [x] QA job label updated in `qa.yml`
- [x] No cross-country data leakage (views group by country)
- [x] All checks are zero-violation (blocking)
