### PR TITLE
Phase 5.1 — Health Profile Hardening & Stability

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   qa:
-    name: Pipeline + QA (358 checks)
+    name: Pipeline + QA (362 checks)
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -28,7 +28,7 @@
        22. QA__barcode_lookup.sql (6 barcode scanner checks — blocking)
        23. QA__auth_onboarding.sql (8 auth & onboarding checks — blocking)
        24. QA__confidence_reporting.sql (7 confidence reporting checks — blocking)
-       25. QA__health_profiles.sql (10 health profile checks — blocking)
+       25. QA__health_profiles.sql (14 health profile checks — blocking)
 
     Returns exit code 0 if all tests pass, 1 if any violations found.
     Test Suite 3 is informational and does not affect the exit code.
@@ -134,7 +134,7 @@ $suiteCatalog = @(
     @{ Num = 22; Name = "Barcode Lookup"; Short = "Barcode"; Id = "barcode_lookup"; Checks = 6; Blocking = $true; Kind = "sql"; File = "QA__barcode_lookup.sql" },
     @{ Num = 23; Name = "Auth & Onboarding"; Short = "AuthOnboard"; Id = "auth_onboarding"; Checks = 8; Blocking = $true; Kind = "sql"; File = "QA__auth_onboarding.sql" },
     @{ Num = 24; Name = "Confidence Reporting"; Short = "ConfReport"; Id = "confidence_reporting"; Checks = 7; Blocking = $true; Kind = "sql"; File = "QA__confidence_reporting.sql" },
-    @{ Num = 25; Name = "Health Profiles"; Short = "Health"; Id = "health_profiles"; Checks = 10; Blocking = $true; Kind = "sql"; File = "QA__health_profiles.sql" }
+    @{ Num = 25; Name = "Health Profiles"; Short = "Health"; Id = "health_profiles"; Checks = 14; Blocking = $true; Kind = "sql"; File = "QA__health_profiles.sql" }
 )
 
 $suiteByNum = @{}

--- a/db/qa/QA__health_profiles.sql
+++ b/db/qa/QA__health_profiles.sql
@@ -3,6 +3,8 @@
 -- Validates the user_health_profiles table structure, RLS
 -- policies, CRUD RPCs, and compute_health_warnings function.
 -- All checks are BLOCKING.
+-- Updated 2026-02-15: Phase 5.1 hardening — unique active
+--   index, compute_health_warnings flag fix, clear flags.
 -- ============================================================
 
 -- ═══════════════════════════════════════════════════════════════════════════
@@ -171,4 +173,69 @@ WHERE EXISTS (
       AND rp.routine_name = expected.fn
       AND rp.grantee = 'anon'
       AND rp.privilege_type = 'EXECUTE'
+);
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 11. Unique partial index for one active profile per user exists
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '11. unique active profile index exists' AS check_name,
+       COUNT(*) AS violations
+FROM (
+    SELECT 1
+    WHERE NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename = 'user_health_profiles'
+          AND indexname = 'idx_one_active_profile_per_user'
+    )
+) x;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 12. api_update_health_profile has clear flag parameters
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '12. update RPC has clear flag parameters' AS check_name,
+       COUNT(*) AS violations
+FROM (VALUES
+    ('p_clear_max_sugar'),
+    ('p_clear_max_salt'),
+    ('p_clear_max_sat_fat'),
+    ('p_clear_max_calories')
+) AS expected(param)
+WHERE NOT EXISTS (
+    SELECT 1 FROM information_schema.parameters ip
+    WHERE ip.specific_schema = 'public'
+      AND ip.specific_name LIKE 'api_update_health_profile%'
+      AND ip.parameter_name = expected.param
+);
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 13. No duplicate active profiles (invariant)
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '13. no duplicate active profiles per user' AS check_name,
+       COUNT(*) AS violations
+FROM (
+    SELECT user_id, COUNT(*) AS active_count
+    FROM public.user_health_profiles
+    WHERE is_active = true
+    GROUP BY user_id
+    HAVING COUNT(*) > 1
+) x;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 14. CHECK constraints exist for threshold bounds
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '14. nutrient threshold CHECK constraints exist' AS check_name,
+       COUNT(*) AS violations
+FROM (VALUES
+    ('chk_max_sugar_positive'),
+    ('chk_max_salt_positive'),
+    ('chk_max_sat_fat_positive'),
+    ('chk_max_calories_positive')
+) AS expected(con)
+WHERE NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints tc
+    WHERE tc.table_schema = 'public'
+      AND tc.table_name = 'user_health_profiles'
+      AND tc.constraint_name = expected.con
+      AND tc.constraint_type = 'CHECK'
 );

--- a/frontend/src/components/settings/HealthProfileSection.tsx
+++ b/frontend/src/components/settings/HealthProfileSection.tsx
@@ -75,6 +75,12 @@ function ProfileForm({
       ? await updateHealthProfile(supabase, {
           p_profile_id: initial.profile_id,
           ...params,
+          // Send clear flags when editing: if the field was set before but is
+          // now empty, explicitly clear it to NULL in the database.
+          p_clear_max_sugar: !maxSugar && initial.max_sugar_g != null,
+          p_clear_max_salt: !maxSalt && initial.max_salt_g != null,
+          p_clear_max_sat_fat: !maxSatFat && initial.max_saturated_fat_g != null,
+          p_clear_max_calories: !maxCal && initial.max_calories_kcal != null,
         })
       : await createHealthProfile(supabase, params);
 

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -87,6 +87,26 @@ describe("Health Profile API functions", () => {
     );
   });
 
+  it("updateHealthProfile passes clear flags to api_update_health_profile", async () => {
+    const params = {
+      p_profile_id: "p-2",
+      p_clear_max_sugar: true,
+      p_clear_max_salt: false,
+      p_clear_max_sat_fat: true,
+      p_clear_max_calories: false,
+    };
+    mockCallRpc.mockResolvedValue({
+      ok: true,
+      data: { profile_id: "p-2", updated: true },
+    });
+    await updateHealthProfile(fakeSupabase, params);
+    expect(mockCallRpc).toHaveBeenCalledWith(
+      fakeSupabase,
+      "api_update_health_profile",
+      params,
+    );
+  });
+
   // ─── deleteHealthProfile ──────────────────────────────────────────
 
   it("deleteHealthProfile passes profile_id to api_delete_health_profile", async () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -232,6 +232,10 @@ export function updateHealthProfile(
     p_max_saturated_fat_g?: number;
     p_max_calories_kcal?: number;
     p_notes?: string;
+    p_clear_max_sugar?: boolean;
+    p_clear_max_salt?: boolean;
+    p_clear_max_sat_fat?: boolean;
+    p_clear_max_calories?: boolean;
   },
 ): Promise<RpcResult<HealthProfileMutationResponse>> {
   return callRpc<HealthProfileMutationResponse>(

--- a/supabase/migrations/20260215000100_health_profile_hardening.sql
+++ b/supabase/migrations/20260215000100_health_profile_hardening.sql
@@ -1,0 +1,526 @@
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Phase 5.1 — Health Profile Hardening & Stability
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Fixes:
+--   1. compute_health_warnings: TEXT flag comparison (= 'YES' not = true)
+--   2. Unique partial index enforcing one active profile per user
+--   3. api_update_health_profile: explicit clear-to-NULL via p_clear_* flags
+--   4. Defensive threshold validation in create/update RPCs
+--   5. Upper-bound constraints on nutrient thresholds
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+-- ─── 1. FIX: compute_health_warnings — correct TEXT flag comparisons ────────
+--    Flags (high_sugar_flag, high_salt_flag, high_sat_fat_flag) are TEXT
+--    columns storing 'YES'/'NO', not boolean. The original code compared
+--    them with = true, which always evaluates false for TEXT columns.
+
+CREATE OR REPLACE FUNCTION public.compute_health_warnings(
+    p_product_id bigint,
+    p_profile_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_user_id      uuid := auth.uid();
+    v_profile      record;
+    v_product      record;
+    v_nutrition    record;
+    v_warnings     jsonb := '[]'::jsonb;
+    -- Normalized boolean flags (TEXT 'YES' → true, anything else → false)
+    v_high_sugar   boolean;
+    v_high_salt    boolean;
+    v_high_sat_fat boolean;
+BEGIN
+    -- Resolve profile: explicit or active
+    IF p_profile_id IS NOT NULL THEN
+        SELECT * INTO v_profile
+        FROM public.user_health_profiles
+        WHERE profile_id = p_profile_id AND user_id = v_user_id;
+    ELSE
+        SELECT * INTO v_profile
+        FROM public.user_health_profiles
+        WHERE user_id = v_user_id AND is_active = true
+        LIMIT 1;
+    END IF;
+
+    -- No profile → no warnings
+    IF v_profile IS NULL THEN
+        RETURN '[]'::jsonb;
+    END IF;
+
+    -- Get product data
+    SELECT p.product_id, p.high_salt_flag, p.high_sugar_flag,
+           p.high_sat_fat_flag, p.nova_classification
+    INTO v_product
+    FROM products p
+    WHERE p.product_id = p_product_id
+      AND p.is_deprecated IS NOT TRUE;
+
+    IF v_product IS NULL THEN
+        RETURN '[]'::jsonb;
+    END IF;
+
+    -- Normalize TEXT flags to boolean once
+    v_high_sugar   := (UPPER(COALESCE(v_product.high_sugar_flag, '')) = 'YES');
+    v_high_salt    := (UPPER(COALESCE(v_product.high_salt_flag, '')) = 'YES');
+    v_high_sat_fat := (UPPER(COALESCE(v_product.high_sat_fat_flag, '')) = 'YES');
+
+    -- Get nutrition per 100g
+    SELECT nf.calories, nf.sugars_g, nf.salt_g, nf.saturated_fat_g, nf.protein_g
+    INTO v_nutrition
+    FROM nutrition_facts nf
+    WHERE nf.product_id = p_product_id
+    LIMIT 1;
+
+    -- ── Condition-based warnings ──
+
+    -- Diabetes: high sugar, high carbs
+    IF 'diabetes' = ANY(v_profile.health_conditions) THEN
+        IF v_high_sugar THEN
+            v_warnings := v_warnings || jsonb_build_object(
+                'condition', 'diabetes',
+                'severity', 'high',
+                'message', 'High sugar content — monitor blood glucose'
+            );
+        END IF;
+        IF v_nutrition IS NOT NULL AND v_nutrition.sugars_g > 10 THEN
+            v_warnings := v_warnings || jsonb_build_object(
+                'condition', 'diabetes',
+                'severity', 'moderate',
+                'message', format('Contains %.1fg sugar per 100g', v_nutrition.sugars_g)
+            );
+        END IF;
+    END IF;
+
+    -- Hypertension: high salt
+    IF 'hypertension' = ANY(v_profile.health_conditions) THEN
+        IF v_high_salt THEN
+            v_warnings := v_warnings || jsonb_build_object(
+                'condition', 'hypertension',
+                'severity', 'high',
+                'message', 'High salt content — limit sodium intake'
+            );
+        END IF;
+        IF v_nutrition IS NOT NULL AND v_nutrition.salt_g > 1.0 THEN
+            v_warnings := v_warnings || jsonb_build_object(
+                'condition', 'hypertension',
+                'severity', 'moderate',
+                'message', format('Contains %.2fg salt per 100g', v_nutrition.salt_g)
+            );
+        END IF;
+    END IF;
+
+    -- Heart disease: high saturated fat + high salt
+    IF 'heart_disease' = ANY(v_profile.health_conditions) THEN
+        IF v_high_sat_fat THEN
+            v_warnings := v_warnings || jsonb_build_object(
+                'condition', 'heart_disease',
+                'severity', 'high',
+                'message', 'High saturated fat — may impact cardiovascular health'
+            );
+        END IF;
+        IF v_high_salt THEN
+            v_warnings := v_warnings || jsonb_build_object(
+                'condition', 'heart_disease',
+                'severity', 'moderate',
+                'message', 'High salt — may raise blood pressure'
+            );
+        END IF;
+    END IF;
+
+    -- Celiac: check gluten allergen
+    IF 'celiac_disease' = ANY(v_profile.health_conditions) THEN
+        IF EXISTS (
+            SELECT 1 FROM product_allergen_info pai
+            WHERE pai.product_id = p_product_id
+              AND pai.tag = 'en:gluten'
+              AND pai.type = 'contains'
+        ) THEN
+            v_warnings := v_warnings || jsonb_build_object(
+                'condition', 'celiac_disease',
+                'severity', 'critical',
+                'message', 'Contains gluten — unsafe for celiac disease'
+            );
+        END IF;
+    END IF;
+
+    -- Gout: high protein
+    IF 'gout' = ANY(v_profile.health_conditions) THEN
+        IF v_nutrition IS NOT NULL AND v_nutrition.protein_g > 20 THEN
+            v_warnings := v_warnings || jsonb_build_object(
+                'condition', 'gout',
+                'severity', 'moderate',
+                'message', format('High protein (%.1fg/100g) — may increase uric acid', v_nutrition.protein_g)
+            );
+        END IF;
+    END IF;
+
+    -- Kidney disease: high protein + high salt
+    IF 'kidney_disease' = ANY(v_profile.health_conditions) THEN
+        IF v_nutrition IS NOT NULL AND v_nutrition.protein_g > 15 THEN
+            v_warnings := v_warnings || jsonb_build_object(
+                'condition', 'kidney_disease',
+                'severity', 'moderate',
+                'message', format('Protein: %.1fg/100g — discuss with doctor', v_nutrition.protein_g)
+            );
+        END IF;
+        IF v_high_salt THEN
+            v_warnings := v_warnings || jsonb_build_object(
+                'condition', 'kidney_disease',
+                'severity', 'high',
+                'message', 'High salt — limit sodium for kidney health'
+            );
+        END IF;
+    END IF;
+
+    -- IBS: ultra-processed NOVA 4
+    IF 'ibs' = ANY(v_profile.health_conditions) THEN
+        IF v_product.nova_classification::int = 4 THEN
+            v_warnings := v_warnings || jsonb_build_object(
+                'condition', 'ibs',
+                'severity', 'moderate',
+                'message', 'Ultra-processed (NOVA 4) — may trigger IBS symptoms'
+            );
+        END IF;
+    END IF;
+
+    -- ── Custom threshold warnings ──
+
+    IF v_nutrition IS NOT NULL THEN
+        IF v_profile.max_sugar_g IS NOT NULL AND v_nutrition.sugars_g > v_profile.max_sugar_g THEN
+            v_warnings := v_warnings || jsonb_build_object(
+                'condition', 'custom_threshold',
+                'severity', 'high',
+                'message', format('Sugar: %.1fg exceeds your limit of %.1fg per 100g',
+                                  v_nutrition.sugars_g, v_profile.max_sugar_g)
+            );
+        END IF;
+        IF v_profile.max_salt_g IS NOT NULL AND v_nutrition.salt_g > v_profile.max_salt_g THEN
+            v_warnings := v_warnings || jsonb_build_object(
+                'condition', 'custom_threshold',
+                'severity', 'high',
+                'message', format('Salt: %.2fg exceeds your limit of %.2fg per 100g',
+                                  v_nutrition.salt_g, v_profile.max_salt_g)
+            );
+        END IF;
+        IF v_profile.max_saturated_fat_g IS NOT NULL AND v_nutrition.saturated_fat_g > v_profile.max_saturated_fat_g THEN
+            v_warnings := v_warnings || jsonb_build_object(
+                'condition', 'custom_threshold',
+                'severity', 'high',
+                'message', format('Saturated fat: %.1fg exceeds your limit of %.1fg per 100g',
+                                  v_nutrition.saturated_fat_g, v_profile.max_saturated_fat_g)
+            );
+        END IF;
+        IF v_profile.max_calories_kcal IS NOT NULL AND v_nutrition.calories > v_profile.max_calories_kcal THEN
+            v_warnings := v_warnings || jsonb_build_object(
+                'condition', 'custom_threshold',
+                'severity', 'moderate',
+                'message', format('Calories: %.0f exceeds your limit of %.0f per 100g',
+                                  v_nutrition.calories, v_profile.max_calories_kcal)
+            );
+        END IF;
+    END IF;
+
+    RETURN v_warnings;
+END;
+$$;
+
+-- ─── 2. ENFORCE: Unique partial index — one active profile per user ─────────
+--    The trigger deactivates other profiles, but is NOT concurrency-safe.
+--    This unique partial index guarantees the invariant at the database level.
+--    If duplicates already exist, this migration will fail cleanly — the DBA
+--    must resolve duplicates before re-running.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_one_active_profile_per_user
+    ON public.user_health_profiles (user_id)
+    WHERE is_active = true;
+
+-- ─── 3. FIX: api_update_health_profile — allow clearing thresholds to NULL ──
+--    Previous version used CASE WHEN p_max_X IS NOT NULL, which made it
+--    impossible to clear a threshold back to NULL.
+--    New version adds p_clear_max_* BOOLEAN DEFAULT FALSE parameters.
+--    Fully backward compatible: existing callers omit the clear flags and
+--    continue to work exactly as before.
+
+-- First drop the old function signature so we can recreate with new params
+DROP FUNCTION IF EXISTS public.api_update_health_profile(uuid, text, text[], boolean, numeric, numeric, numeric, numeric, text);
+
+CREATE OR REPLACE FUNCTION public.api_update_health_profile(
+    p_profile_id            uuid,
+    p_profile_name          text        DEFAULT NULL,
+    p_health_conditions     text[]      DEFAULT NULL,
+    p_is_active             boolean     DEFAULT NULL,
+    p_max_sugar_g           numeric     DEFAULT NULL,
+    p_max_salt_g            numeric     DEFAULT NULL,
+    p_max_saturated_fat_g   numeric     DEFAULT NULL,
+    p_max_calories_kcal     numeric     DEFAULT NULL,
+    p_notes                 text        DEFAULT NULL,
+    -- Explicit clear flags (set to TRUE to clear a threshold to NULL)
+    p_clear_max_sugar       boolean     DEFAULT FALSE,
+    p_clear_max_salt        boolean     DEFAULT FALSE,
+    p_clear_max_sat_fat     boolean     DEFAULT FALSE,
+    p_clear_max_calories    boolean     DEFAULT FALSE
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_user_id uuid := auth.uid();
+    v_exists  boolean;
+BEGIN
+    IF v_user_id IS NULL THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'Authentication required'
+        );
+    END IF;
+
+    -- Verify ownership
+    SELECT EXISTS(
+        SELECT 1 FROM public.user_health_profiles
+        WHERE profile_id = p_profile_id AND user_id = v_user_id
+    ) INTO v_exists;
+
+    IF NOT v_exists THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'Profile not found'
+        );
+    END IF;
+
+    -- Validate name if provided
+    IF p_profile_name IS NOT NULL AND trim(p_profile_name) = '' THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'Profile name cannot be empty'
+        );
+    END IF;
+
+    -- Validate conditions if provided
+    IF p_health_conditions IS NOT NULL AND NOT (p_health_conditions <@ ARRAY[
+        'diabetes', 'hypertension', 'heart_disease',
+        'celiac_disease', 'gout', 'kidney_disease', 'ibs'
+    ]::text[]) THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'Invalid health condition'
+        );
+    END IF;
+
+    -- Defensive: validate thresholds are non-negative when provided
+    IF p_max_sugar_g IS NOT NULL AND p_max_sugar_g < 0 THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'max_sugar_g must be non-negative'
+        );
+    END IF;
+    IF p_max_salt_g IS NOT NULL AND p_max_salt_g < 0 THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'max_salt_g must be non-negative'
+        );
+    END IF;
+    IF p_max_saturated_fat_g IS NOT NULL AND p_max_saturated_fat_g < 0 THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'max_saturated_fat_g must be non-negative'
+        );
+    END IF;
+    IF p_max_calories_kcal IS NOT NULL AND p_max_calories_kcal < 0 THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'max_calories_kcal must be non-negative'
+        );
+    END IF;
+
+    -- Defensive: reject absurd upper bounds (per 100g limits)
+    IF p_max_sugar_g IS NOT NULL AND p_max_sugar_g > 100 THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'max_sugar_g cannot exceed 100g per 100g'
+        );
+    END IF;
+    IF p_max_salt_g IS NOT NULL AND p_max_salt_g > 100 THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'max_salt_g cannot exceed 100g per 100g'
+        );
+    END IF;
+    IF p_max_saturated_fat_g IS NOT NULL AND p_max_saturated_fat_g > 100 THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'max_saturated_fat_g cannot exceed 100g per 100g'
+        );
+    END IF;
+    IF p_max_calories_kcal IS NOT NULL AND p_max_calories_kcal > 10000 THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'max_calories_kcal cannot exceed 10000'
+        );
+    END IF;
+
+    UPDATE public.user_health_profiles SET
+        profile_name        = COALESCE(p_profile_name, profile_name),
+        health_conditions   = COALESCE(p_health_conditions, health_conditions),
+        is_active           = COALESCE(p_is_active, is_active),
+        max_sugar_g         = CASE
+            WHEN p_clear_max_sugar THEN NULL
+            WHEN p_max_sugar_g IS NOT NULL THEN p_max_sugar_g
+            ELSE max_sugar_g
+        END,
+        max_salt_g          = CASE
+            WHEN p_clear_max_salt THEN NULL
+            WHEN p_max_salt_g IS NOT NULL THEN p_max_salt_g
+            ELSE max_salt_g
+        END,
+        max_saturated_fat_g = CASE
+            WHEN p_clear_max_sat_fat THEN NULL
+            WHEN p_max_saturated_fat_g IS NOT NULL THEN p_max_saturated_fat_g
+            ELSE max_saturated_fat_g
+        END,
+        max_calories_kcal   = CASE
+            WHEN p_clear_max_calories THEN NULL
+            WHEN p_max_calories_kcal IS NOT NULL THEN p_max_calories_kcal
+            ELSE max_calories_kcal
+        END,
+        notes               = CASE WHEN p_notes IS NOT NULL THEN p_notes ELSE notes END
+    WHERE profile_id = p_profile_id
+      AND user_id = v_user_id;
+
+    RETURN jsonb_build_object(
+        'api_version', '1.0',
+        'profile_id', p_profile_id,
+        'updated', true
+    );
+END;
+$$;
+
+-- ─── 4. Defensive validation in api_create_health_profile ───────────────────
+--    Add upper-bound checks for absurd nutrient thresholds.
+
+CREATE OR REPLACE FUNCTION public.api_create_health_profile(
+    p_profile_name        text,
+    p_health_conditions   text[]      DEFAULT '{}',
+    p_is_active           boolean     DEFAULT false,
+    p_max_sugar_g         numeric     DEFAULT NULL,
+    p_max_salt_g          numeric     DEFAULT NULL,
+    p_max_saturated_fat_g numeric     DEFAULT NULL,
+    p_max_calories_kcal   numeric     DEFAULT NULL,
+    p_notes               text        DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_user_id    uuid := auth.uid();
+    v_profile_id uuid;
+    v_count      int;
+BEGIN
+    IF v_user_id IS NULL THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'Authentication required'
+        );
+    END IF;
+
+    -- Validate name
+    IF trim(COALESCE(p_profile_name, '')) = '' THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'Profile name is required'
+        );
+    END IF;
+
+    -- Limit: max 5 profiles per user
+    SELECT COUNT(*) INTO v_count
+    FROM public.user_health_profiles
+    WHERE user_id = v_user_id;
+
+    IF v_count >= 5 THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'Maximum 5 health profiles allowed'
+        );
+    END IF;
+
+    -- Validate conditions
+    IF NOT (p_health_conditions <@ ARRAY[
+        'diabetes', 'hypertension', 'heart_disease',
+        'celiac_disease', 'gout', 'kidney_disease', 'ibs'
+    ]::text[]) THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'error', 'Invalid health condition. Allowed: diabetes, hypertension, heart_disease, celiac_disease, gout, kidney_disease, ibs'
+        );
+    END IF;
+
+    -- Defensive: validate thresholds are non-negative
+    IF p_max_sugar_g IS NOT NULL AND p_max_sugar_g < 0 THEN
+        RETURN jsonb_build_object('api_version', '1.0', 'error', 'max_sugar_g must be non-negative');
+    END IF;
+    IF p_max_salt_g IS NOT NULL AND p_max_salt_g < 0 THEN
+        RETURN jsonb_build_object('api_version', '1.0', 'error', 'max_salt_g must be non-negative');
+    END IF;
+    IF p_max_saturated_fat_g IS NOT NULL AND p_max_saturated_fat_g < 0 THEN
+        RETURN jsonb_build_object('api_version', '1.0', 'error', 'max_saturated_fat_g must be non-negative');
+    END IF;
+    IF p_max_calories_kcal IS NOT NULL AND p_max_calories_kcal < 0 THEN
+        RETURN jsonb_build_object('api_version', '1.0', 'error', 'max_calories_kcal must be non-negative');
+    END IF;
+
+    -- Defensive: reject absurd upper bounds
+    IF p_max_sugar_g IS NOT NULL AND p_max_sugar_g > 100 THEN
+        RETURN jsonb_build_object('api_version', '1.0', 'error', 'max_sugar_g cannot exceed 100g per 100g');
+    END IF;
+    IF p_max_salt_g IS NOT NULL AND p_max_salt_g > 100 THEN
+        RETURN jsonb_build_object('api_version', '1.0', 'error', 'max_salt_g cannot exceed 100g per 100g');
+    END IF;
+    IF p_max_saturated_fat_g IS NOT NULL AND p_max_saturated_fat_g > 100 THEN
+        RETURN jsonb_build_object('api_version', '1.0', 'error', 'max_saturated_fat_g cannot exceed 100g per 100g');
+    END IF;
+    IF p_max_calories_kcal IS NOT NULL AND p_max_calories_kcal > 10000 THEN
+        RETURN jsonb_build_object('api_version', '1.0', 'error', 'max_calories_kcal cannot exceed 10000');
+    END IF;
+
+    INSERT INTO public.user_health_profiles (
+        user_id, profile_name, is_active, health_conditions,
+        max_sugar_g, max_salt_g, max_saturated_fat_g, max_calories_kcal, notes
+    ) VALUES (
+        v_user_id, trim(p_profile_name), p_is_active, p_health_conditions,
+        p_max_sugar_g, p_max_salt_g, p_max_saturated_fat_g, p_max_calories_kcal, p_notes
+    )
+    RETURNING profile_id INTO v_profile_id;
+
+    RETURN jsonb_build_object(
+        'api_version', '1.0',
+        'profile_id', v_profile_id,
+        'created', true
+    );
+END;
+$$;
+
+-- ─── 5. Re-grant permissions for the new function signatures ────────────────
+
+GRANT EXECUTE ON FUNCTION public.api_update_health_profile(
+    uuid, text, text[], boolean, numeric, numeric, numeric, numeric, text,
+    boolean, boolean, boolean, boolean
+) TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.api_update_health_profile(
+    uuid, text, text[], boolean, numeric, numeric, numeric, numeric, text,
+    boolean, boolean, boolean, boolean
+) FROM PUBLIC, anon;
+
+-- Re-grant for create (signature unchanged, but function recreated)
+GRANT EXECUTE ON FUNCTION public.api_create_health_profile(text, text[], boolean, numeric, numeric, numeric, numeric, text)
+    TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.api_create_health_profile(text, text[], boolean, numeric, numeric, numeric, numeric, text)
+    FROM PUBLIC, anon;


### PR DESCRIPTION
## Phase 5.1 — Health Profile Hardening & Stability

Stability + correctness patch. No new features, no schema breakage, full backward compatibility.

### Changes

#### 1. Fix: `compute_health_warnings` FLAG comparisons
- **Before:** Compared TEXT columns (`high_sugar_flag`, `high_salt_flag`, `high_sat_fat_flag`) with `= true` — always evaluated false for TEXT values
- **After:** Normalizes flags once: `v_high_sugar := (UPPER(COALESCE(v_product.high_sugar_flag, '')) = 'YES')` then uses boolean vars
- Handles `'YES'`, `'NO'`, `NULL` correctly

#### 2. Enforce: Unique active profile per user (concurrency-safe)
- **Before:** Only trigger-based deactivation — two concurrent transactions could create two active profiles
- **After:** `CREATE UNIQUE INDEX idx_one_active_profile_per_user ON user_health_profiles (user_id) WHERE is_active = true`
- Database-level invariant enforcement, supplements the existing trigger

#### 3. Fix: Cannot clear thresholds to NULL
- **Before:** `CASE WHEN p_max_sugar IS NOT NULL THEN p_max_sugar ELSE max_sugar END` — impossible to clear a value back to NULL
- **After:** Explicit clear flags: `p_clear_max_sugar`, `p_clear_max_salt`, `p_clear_max_sat_fat`, `p_clear_max_calories` (all `BOOLEAN DEFAULT FALSE`)
- Fully backward compatible: existing callers omit clear flags
- Frontend updated to send clear flags when editing profiles

#### 4. Defensive threshold validation
- RPCs reject negative values (belt-and-suspenders with CHECK constraints)
- RPCs reject absurd upper bounds: sugar/salt/fat > 100g per 100g, calories > 10,000
- Applied to both `api_create_health_profile` and `api_update_health_profile`

#### 5. E2E test user cleanup — paginated
- **Before:** `listUsers()` loaded all users, scanned sequentially
- **After:** Paginated with `{ page, perPage: 50 }`, stops early on match

#### 6. QA checks: 358 → 362
- `#11`: unique active profile index exists
- `#12`: update RPC has clear flag parameters
- `#13`: no duplicate active profiles per user
- `#14`: nutrient threshold CHECK constraints exist

#### 7. Unit tests: 119 → 121
- `api.test.ts`: updateHealthProfile passes clear flags
- `HealthProfileSection.test.tsx`: clearing thresholds sends clear flags on update

### Files Modified
| File | Change |
|------|--------|
| `supabase/migrations/20260215000100_health_profile_hardening.sql` | New migration |
| `frontend/src/lib/api.ts` | Add clear flag params to `updateHealthProfile` |
| `frontend/src/lib/api.test.ts` | New test for clear flags |
| `frontend/src/components/settings/HealthProfileSection.tsx` | Send clear flags on edit |
| `frontend/src/components/settings/HealthProfileSection.test.tsx` | New test for clear threshold |
| `frontend/e2e/helpers/test-user.ts` | Paginated user lookup |
| `db/qa/QA__health_profiles.sql` | 4 new QA checks (#11–#14) |
| `RUN_QA.ps1` | Update check count 10 → 14 |
| `.github/workflows/qa.yml` | Update label 358 → 362 |

### Migration Safety
- No data loss
- No schema breakage
- Backward compatible (new params have defaults)
- `CREATE UNIQUE INDEX IF NOT EXISTS` — safe on empty or single-active tables
