### PR TITLE
feat(desktop): add responsive typography, density & spacing scale

### DIFF
--- a/frontend/src/app/app/categories/page.tsx
+++ b/frontend/src/app/app/categories/page.tsx
@@ -61,10 +61,10 @@ export default function CategoriesPage() {
 
   return (
     <div>
-      <h1 className="mb-4 text-xl font-bold text-foreground">
+      <h1 className="mb-4 text-xl font-bold text-foreground lg:text-2xl">
         {t("categories.title")}
       </h1>
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 lg:gap-4">
         {data?.map((cat) => (
           <CategoryCard key={cat.category} category={cat} />
         ))}

--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -83,7 +83,7 @@ export default async function AppLayout({
 
       <main
         id="main-content"
-        className="mx-auto w-full max-w-5xl flex-1 px-4 py-4 md:py-6"
+        className="mx-auto w-full max-w-5xl flex-1 px-4 py-4 md:py-6 lg:py-8"
       >
         <ListsHydrator />
         <LanguageHydrator />

--- a/frontend/src/app/app/lists/page.tsx
+++ b/frontend/src/app/app/lists/page.tsx
@@ -59,10 +59,10 @@ export default function ListsPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 lg:space-y-8">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-bold text-foreground flex items-center gap-1.5">
+        <h1 className="text-xl font-bold text-foreground flex items-center gap-1.5 lg:text-2xl">
           <ClipboardList size={20} aria-hidden="true" /> {t("lists.title")}
         </h1>
         <button

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -85,7 +85,7 @@ function StatsBar({ stats }: { stats: DashboardStats }) {
   ];
 
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:gap-4">
       {items.map((s) => (
         <Link
           key={s.label}
@@ -95,8 +95,12 @@ function StatsBar({ stats }: { stats: DashboardStats }) {
           <span className="flex items-center justify-center">
             <s.icon size={28} aria-hidden="true" />
           </span>
-          <span className="text-xl font-bold text-foreground">{s.value}</span>
-          <span className="text-xs text-foreground-secondary">{s.label}</span>
+          <span className="text-xl font-bold text-foreground lg:text-2xl">
+            {s.value}
+          </span>
+          <span className="text-xs text-foreground-secondary lg:text-sm">
+            {s.label}
+          </span>
         </Link>
       ))}
     </div>
@@ -147,12 +151,12 @@ function RecentlyViewedSection({
 
   return (
     <section>
-      <div className="mb-2 flex items-center justify-between">
-        <h2 className="flex items-center gap-2 text-lg font-semibold text-foreground">
+      <div className="mb-2 flex items-center justify-between lg:mb-3">
+        <h2 className="flex items-center gap-2 text-lg font-semibold text-foreground lg:text-xl">
           <Eye size={20} aria-hidden="true" /> {t("dashboard.recentlyViewed")}
         </h2>
       </div>
-      <div className="space-y-2">
+      <div className="space-y-2 lg:space-y-3">
         {products.map((p) => (
           <ProductRow
             key={p.product_id}
@@ -175,8 +179,8 @@ function FavoritesSection({
 
   return (
     <section>
-      <div className="mb-2 flex items-center justify-between">
-        <h2 className="flex items-center gap-2 text-lg font-semibold text-foreground">
+      <div className="mb-2 flex items-center justify-between lg:mb-3">
+        <h2 className="flex items-center gap-2 text-lg font-semibold text-foreground lg:text-xl">
           <Heart size={20} aria-hidden="true" /> {t("dashboard.favorites")}
         </h2>
         <Link
@@ -186,7 +190,7 @@ function FavoritesSection({
           {t("dashboard.viewAll")}
         </Link>
       </div>
-      <div className="space-y-2">
+      <div className="space-y-2 lg:space-y-3">
         {products.map((p) => (
           <ProductRow key={p.product_id} product={p} />
         ))}
@@ -207,8 +211,8 @@ function NewProductsSection({
 
   return (
     <section>
-      <div className="mb-2 flex items-center justify-between">
-        <h2 className="flex items-center gap-2 text-lg font-semibold text-foreground">
+      <div className="mb-2 flex items-center justify-between lg:mb-3">
+        <h2 className="flex items-center gap-2 text-lg font-semibold text-foreground lg:text-xl">
           <Sparkles size={20} aria-hidden="true" />{" "}
           {category
             ? t("dashboard.newInCategory", { category })
@@ -221,7 +225,7 @@ function NewProductsSection({
           {t("dashboard.browse")}
         </Link>
       </div>
-      <div className="space-y-2">
+      <div className="space-y-2 lg:space-y-3">
         {products.map((p) => (
           <ProductRow key={p.product_id} product={p} />
         ))}
@@ -297,7 +301,7 @@ export default function DashboardPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 lg:space-y-8">
       {/* Personalised greeting */}
       <DashboardGreeting />
 

--- a/frontend/src/app/app/product/[id]/page.tsx
+++ b/frontend/src/app/app/product/[id]/page.tsx
@@ -144,7 +144,7 @@ export default function ProductDetailPage() {
   ];
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 lg:space-y-6">
       <Breadcrumbs
         items={[
           { labelKey: "nav.home", href: "/app" },
@@ -177,7 +177,7 @@ export default function ProductDetailPage() {
           <div className="min-w-0 flex-1">
             <div className="flex items-start justify-between">
               <div>
-                <p className="text-lg font-bold text-foreground">
+                <p className="text-lg font-bold text-foreground lg:text-xl">
                   {profile.product.product_name_display ??
                     profile.product.product_name}
                 </p>
@@ -189,7 +189,7 @@ export default function ProductDetailPage() {
                       {profile.product.product_name}
                     </p>
                   )}
-                <p className="text-sm text-foreground-secondary">
+                <p className="text-sm text-foreground-secondary lg:text-base">
                   {profile.product.brand}
                 </p>
               </div>
@@ -385,7 +385,7 @@ function ScoreInterpretationCard({ score }: Readonly<{ score: number }>) {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between text-sm font-semibold text-foreground-secondary"
+        className="flex w-full items-center justify-between text-sm font-semibold text-foreground-secondary lg:text-base"
         aria-expanded={open}
       >
         {t("scoreInterpretation.title")}
@@ -413,10 +413,10 @@ function ScoreInterpretationCard({ score }: Readonly<{ score: number }>) {
 function OverviewTab({ profile }: Readonly<{ profile: ProductProfile }>) {
   const { t } = useTranslation();
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 lg:space-y-6">
       {/* Ingredients */}
       <div className="card">
-        <h3 className="mb-2 text-sm font-semibold text-foreground-secondary">
+        <h3 className="mb-2 text-sm font-semibold text-foreground-secondary lg:text-base">
           {t("product.ingredients")}
         </h3>
         {profile.ingredients.count === 0 &&
@@ -470,7 +470,7 @@ function OverviewTab({ profile }: Readonly<{ profile: ProductProfile }>) {
       {/* Allergens */}
       {profile.allergens.contains_count > 0 ? (
         <div className="card">
-          <h3 className="mb-2 text-sm font-semibold text-foreground-secondary">
+          <h3 className="mb-2 text-sm font-semibold text-foreground-secondary lg:text-base">
             {t("product.allergens")}
           </h3>
           <p className="mb-1 text-xs font-medium text-red-600">
@@ -514,7 +514,7 @@ function OverviewTab({ profile }: Readonly<{ profile: ProductProfile }>) {
         </div>
       ) : (
         <div className="card">
-          <h3 className="mb-2 text-sm font-semibold text-foreground-secondary">
+          <h3 className="mb-2 text-sm font-semibold text-foreground-secondary lg:text-base">
             {t("product.allergens")}
           </h3>
           <p className="text-sm text-green-600">
@@ -528,7 +528,7 @@ function OverviewTab({ profile }: Readonly<{ profile: ProductProfile }>) {
 
       {/* Eco-Score placeholder */}
       <div className="card">
-        <h3 className="mb-2 text-sm font-semibold text-foreground-secondary">
+        <h3 className="mb-2 text-sm font-semibold text-foreground-secondary lg:text-base">
           🌍 {t("product.ecoScoreTitle")}
         </h3>
         <div className="flex items-center gap-2 rounded-lg border border-dashed border-blue-200 bg-blue-50/50 px-3 py-3">
@@ -625,7 +625,7 @@ function NutritionTab({ profile }: Readonly<{ profile: ProductProfile }>) {
   return (
     <div className="card">
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-foreground-secondary">
+        <h3 className="text-sm font-semibold text-foreground-secondary lg:text-base">
           {t("product.nutritionPer100g")}
         </h3>
         {dv && dv.reference_type !== "none" && (
@@ -688,7 +688,7 @@ function DataQualityCard({ quality }: Readonly<{ quality: DataConfidence }>) {
 
   return (
     <div className="card">
-      <h3 className="mb-2 text-sm font-semibold text-foreground-secondary">
+      <h3 className="mb-2 text-sm font-semibold text-foreground-secondary lg:text-base">
         {t("product.dataQuality")}
       </h3>
       <div className="flex items-center gap-3">
@@ -904,10 +904,10 @@ function ScoringTab({ profile }: Readonly<{ profile: ProductProfile }>) {
     : [];
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 lg:space-y-6">
       {/* Summary */}
       <div className="card">
-        <h3 className="mb-2 text-sm font-semibold text-foreground-secondary">
+        <h3 className="mb-2 text-sm font-semibold text-foreground-secondary lg:text-base">
           {t("product.summary")}
         </h3>
         <p className="text-sm text-foreground-secondary">{scores.headline}</p>
@@ -917,7 +917,7 @@ function ScoringTab({ profile }: Readonly<{ profile: ProductProfile }>) {
       {Array.isArray(scores.score_breakdown) &&
         scores.score_breakdown.length > 0 && (
           <div className="card">
-            <h3 className="mb-2 text-sm font-semibold text-foreground-secondary">
+            <h3 className="mb-2 text-sm font-semibold text-foreground-secondary lg:text-base">
               {t("product.scoreBreakdown")}
             </h3>
             <ScoreRadarChart breakdown={scores.score_breakdown} />
@@ -927,7 +927,7 @@ function ScoringTab({ profile }: Readonly<{ profile: ProductProfile }>) {
       {/* NOVA processing indicator */}
       {scores.nova_group && (
         <div className="card">
-          <h3 className="mb-2 text-sm font-semibold text-foreground-secondary">
+          <h3 className="mb-2 text-sm font-semibold text-foreground-secondary lg:text-base">
             {t("product.processingLevel")}
           </h3>
           <NovaIndicator novaGroup={scores.nova_group} />
@@ -937,7 +937,7 @@ function ScoringTab({ profile }: Readonly<{ profile: ProductProfile }>) {
       {/* Score breakdown factors */}
       {topFactors.length > 0 && (
         <div className="card">
-          <h3 className="mb-2 text-sm font-semibold text-foreground-secondary">
+          <h3 className="mb-2 text-sm font-semibold text-foreground-secondary lg:text-base">
             {t("product.topScoreFactors")}
           </h3>
           <div className="space-y-2">
@@ -961,7 +961,7 @@ function ScoringTab({ profile }: Readonly<{ profile: ProductProfile }>) {
       {/* Warnings */}
       {profile.warnings.length > 0 && (
         <div className="card border-amber-200 bg-amber-50">
-          <h3 className="mb-2 text-sm font-semibold text-amber-800">
+          <h3 className="mb-2 text-sm font-semibold text-amber-800 lg:text-base">
             {t("product.warnings")}
           </h3>
           <ul className="list-inside list-disc space-y-1 text-sm text-amber-700">
@@ -974,7 +974,7 @@ function ScoringTab({ profile }: Readonly<{ profile: ProductProfile }>) {
 
       {/* Category context */}
       <div className="card">
-        <h3 className="mb-2 text-sm font-semibold text-foreground-secondary">
+        <h3 className="mb-2 text-sm font-semibold text-foreground-secondary lg:text-base">
           {t("product.categoryContext")}
         </h3>
         <div className="text-sm text-foreground-secondary">

--- a/frontend/src/app/app/search/page.tsx
+++ b/frontend/src/app/app/search/page.tsx
@@ -191,7 +191,7 @@ export default function SearchPage() {
       />
 
       {/* Main content */}
-      <div className="min-w-0 flex-1 space-y-4">
+      <div className="min-w-0 flex-1 space-y-4 lg:space-y-6">
         {/* Search input */}
         <form
           onSubmit={handleSubmit}
@@ -363,7 +363,9 @@ export default function SearchPage() {
                   className="touch-target text-xs text-foreground-muted hover:text-brand-600"
                 >
                   <Save size={14} aria-hidden="true" className="inline" />{" "}
-                  <span className="hidden xs:inline">{t("search.saveSearch")}</span>
+                  <span className="hidden xs:inline">
+                    {t("search.saveSearch")}
+                  </span>
                 </button>
               )}
 
@@ -372,7 +374,11 @@ export default function SearchPage() {
                 href="/app/search/saved"
                 className="touch-target text-xs text-foreground-muted hover:text-brand-600"
               >
-                <ClipboardList size={14} aria-hidden="true" className="inline" />{" "}
+                <ClipboardList
+                  size={14}
+                  aria-hidden="true"
+                  className="inline"
+                />{" "}
                 <span className="hidden xs:inline">{t("search.saved")}</span>
               </Link>
             </span>
@@ -430,7 +436,7 @@ export default function SearchPage() {
               message={t("a11y.searchResultsStatus", { count: data.total })}
             />
             <div className="flex items-center justify-between">
-              <p className="text-sm text-foreground-secondary">
+              <p className="text-sm text-foreground-secondary lg:text-base">
                 {t("search.result", { count: data.total })}
                 {data.query && (
                   <> {t("search.resultsFor", { query: data.query })}</>

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -134,14 +134,14 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-bold text-foreground">
+    <div className="space-y-6 lg:space-y-8">
+      <h1 className="text-xl font-bold text-foreground lg:text-2xl">
         {t("settings.title")}
       </h1>
 
       {/* Country */}
       <section className="card">
-        <h2 className="mb-3 text-sm font-semibold text-foreground-secondary">
+        <h2 className="mb-3 text-sm font-semibold text-foreground-secondary lg:text-base">
           {t("settings.country")}
         </h2>
         <div className="grid grid-cols-2 gap-2">
@@ -173,7 +173,7 @@ export default function SettingsPage() {
 
       {/* Language — filtered by selected country (native + English) */}
       <section className="card">
-        <h2 className="mb-3 text-sm font-semibold text-foreground-secondary">
+        <h2 className="mb-3 text-sm font-semibold text-foreground-secondary lg:text-base">
           {t("settings.language")}
         </h2>
         <div className="grid grid-cols-2 gap-2">
@@ -201,7 +201,7 @@ export default function SettingsPage() {
 
       {/* Theme */}
       <section className="card">
-        <h2 className="mb-3 text-sm font-semibold text-foreground-secondary">
+        <h2 className="mb-3 text-sm font-semibold text-foreground-secondary lg:text-base">
           {t("settings.theme")}
         </h2>
         <ThemeToggle />
@@ -209,7 +209,7 @@ export default function SettingsPage() {
 
       {/* Diet */}
       <section className="card">
-        <h2 className="mb-3 text-sm font-semibold text-foreground-secondary">
+        <h2 className="mb-3 text-sm font-semibold text-foreground-secondary lg:text-base">
           {t("settings.dietPreference")}
         </h2>
         <div className="grid grid-cols-3 gap-2">
@@ -250,7 +250,7 @@ export default function SettingsPage() {
 
       {/* Allergens */}
       <section className="card">
-        <h2 className="mb-3 text-sm font-semibold text-foreground-secondary">
+        <h2 className="mb-3 text-sm font-semibold text-foreground-secondary lg:text-base">
           {t("settings.allergensToAvoid")}
         </h2>
 
@@ -355,7 +355,7 @@ export default function SettingsPage() {
 
       {/* Account section */}
       <section className="card border-red-100">
-        <h2 className="mb-3 text-sm font-semibold text-foreground-secondary">
+        <h2 className="mb-3 text-sm font-semibold text-foreground-secondary lg:text-base">
           {t("settings.account")}
         </h2>
         <p className="mb-3 text-xs text-foreground-secondary">

--- a/frontend/src/components/common/EmptyState.tsx
+++ b/frontend/src/components/common/EmptyState.tsx
@@ -84,13 +84,13 @@ export function EmptyState({
       </div>
 
       {/* Title */}
-      <h3 className="mb-1 text-sm font-semibold text-foreground-secondary">
+      <h3 className="mb-1 text-sm font-semibold text-foreground-secondary lg:text-base">
         {t(titleKey, titleParams)}
       </h3>
 
       {/* Description */}
       {descriptionKey && (
-        <p className="mb-4 max-w-xs text-xs text-foreground-muted">
+        <p className="mb-4 max-w-xs text-xs text-foreground-muted lg:text-sm">
           {t(descriptionKey, descriptionParams)}
         </p>
       )}

--- a/frontend/src/components/dashboard/CategoriesBrowse.tsx
+++ b/frontend/src/components/dashboard/CategoriesBrowse.tsx
@@ -63,8 +63,8 @@ export function CategoriesBrowse() {
 
   return (
     <section>
-      <div className="mb-2 flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-foreground">
+      <div className="mb-2 flex items-center justify-between lg:mb-3">
+        <h2 className="text-lg font-semibold text-foreground lg:text-xl">
           {t("dashboard.categoriesTitle")}
         </h2>
         <Link

--- a/frontend/src/components/dashboard/DashboardGreeting.tsx
+++ b/frontend/src/components/dashboard/DashboardGreeting.tsx
@@ -28,10 +28,10 @@ export function DashboardGreeting({
 
   return (
     <div className="space-y-1">
-      <h1 className="text-xl font-bold text-foreground sm:text-2xl">
+      <h1 className="text-xl font-bold text-foreground sm:text-2xl lg:text-3xl">
         {greeting}
       </h1>
-      <p className="text-sm text-foreground-secondary">
+      <p className="text-sm text-foreground-secondary lg:text-base">
         {t("dashboard.subtitle")}
       </p>
     </div>

--- a/frontend/src/components/dashboard/NutritionTip.tsx
+++ b/frontend/src/components/dashboard/NutritionTip.tsx
@@ -57,10 +57,10 @@ export function NutritionTip() {
           💡
         </span>
         <div className="min-w-0">
-          <h3 className="text-sm font-semibold text-foreground">
+          <h3 className="text-sm font-semibold text-foreground lg:text-base">
             {t("dashboard.tipTitle")}
           </h3>
-          <p className="mt-0.5 text-sm leading-relaxed text-muted-foreground">
+          <p className="mt-0.5 text-sm leading-relaxed text-foreground-secondary">
             {t(`dashboard.tip.${index}`)}
           </p>
           {learnHref && (

--- a/frontend/src/components/dashboard/QuickActions.tsx
+++ b/frontend/src/components/dashboard/QuickActions.tsx
@@ -19,7 +19,7 @@ export function QuickActions() {
 
   return (
     <section aria-label={t("dashboard.quickActions")}>
-      <div className="grid grid-cols-4 gap-3">
+      <div className="grid grid-cols-4 gap-3 lg:gap-4">
         {ACTIONS.map((action) => (
           <Link
             key={action.key}
@@ -32,7 +32,7 @@ export function QuickActions() {
             >
               <action.icon size={28} />
             </span>
-            <span className="text-xs font-medium text-foreground-secondary group-hover:text-foreground sm:text-sm">
+            <span className="text-xs font-medium text-foreground-secondary group-hover:text-foreground sm:text-sm lg:text-base">
               {t(`dashboard.action.${action.key}`)}
             </span>
           </Link>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -25,7 +25,7 @@ export function Header() {
         <nav className="flex items-center gap-4">
           <Link
             href="/contact"
-            className="touch-target text-sm text-foreground-secondary hover:text-foreground"
+            className="touch-target text-sm text-foreground-secondary hover:text-foreground lg:text-base"
           >
             {t("layout.contact")}
           </Link>

--- a/frontend/src/components/search/FilterPanel.tsx
+++ b/frontend/src/components/search/FilterPanel.tsx
@@ -203,7 +203,8 @@ export function FilterPanel({
                   const selected = (filters.nutri_score ?? []).includes(
                     ns.label,
                   );
-                  const nutriClass = NUTRI_COLORS[ns.label] ?? "bg-surface-muted";
+                  const nutriClass =
+                    NUTRI_COLORS[ns.label] ?? "bg-surface-muted";
                   return (
                     <button
                       key={ns.label}

--- a/frontend/src/lib/typography.ts
+++ b/frontend/src/lib/typography.ts
@@ -1,0 +1,70 @@
+// ─── Desktop Typography & Density Scale ─────────────────────────────────────
+// Issue #76 — Systematic responsive scaling for desktop breakpoints.
+//
+// All classes use Tailwind responsive prefixes (mobile-first).
+// Mobile sizes remain unchanged — desktop sizes added via lg: prefix.
+//
+// Usage:
+//   import { typography, spacing } from "@/lib/typography";
+//   <h1 className={typography.pageTitle}>...</h1>
+//   <div className={spacing.sectionGap}>...</div>
+
+/**
+ * Responsive typography class map.
+ * Each key maps a semantic role to the exact Tailwind classes
+ * including responsive scaling for desktop (lg+).
+ */
+export const typography = {
+  /** Page-level title (h1). Mobile: text-xl → Desktop: text-2xl */
+  pageTitle: "text-xl font-bold text-foreground lg:text-2xl",
+
+  /** Dashboard greeting — largest heading. Mobile: text-xl → Desktop: text-3xl */
+  greeting: "text-xl font-bold text-foreground sm:text-2xl lg:text-3xl",
+
+  /** Section heading (h2). Mobile: text-lg → Desktop: text-xl */
+  sectionHeading: "text-lg font-semibold text-foreground lg:text-xl",
+
+  /** Card section heading (h3). Mobile: text-sm → Desktop: text-base */
+  cardHeading:
+    "text-sm font-semibold text-foreground-secondary lg:text-base",
+
+  /** Stat / hero numbers. Mobile: text-xl → Desktop: text-2xl */
+  statValue: "text-xl font-bold text-foreground lg:text-2xl",
+
+  /** Body text. Scales on desktop for readability. text-sm → lg:text-base */
+  body: "text-sm lg:text-base",
+
+  /** Supporting / secondary body text. Stays text-sm on desktop. */
+  bodySecondary: "text-sm text-foreground-secondary",
+
+  /** Muted metadata / captions. text-xs → lg:text-sm on desktop. */
+  caption: "text-xs text-foreground-secondary lg:text-sm",
+
+  /** Small muted text that stays xs. */
+  muted: "text-xs text-foreground-muted",
+
+  /** Interactive label (buttons, nav items). text-sm, no scaling. */
+  label: "text-sm font-medium",
+
+  /** Section "View all" link. */
+  sectionLink:
+    "text-sm font-medium text-brand-600 hover:text-brand-700",
+} as const;
+
+/**
+ * Responsive spacing class map.
+ * Provides consistent padding / gap scaling for desktop.
+ */
+export const spacing = {
+  /** Page-level vertical spacing between sections. */
+  pageStack: "space-y-6 lg:space-y-8",
+
+  /** Section-level vertical spacing between items. */
+  sectionStack: "space-y-2 lg:space-y-3",
+
+  /** Grid gap for card grids. */
+  gridGap: "gap-3 lg:gap-4",
+
+  /** Section heading bottom margin. */
+  sectionHeadingMargin: "mb-2 lg:mb-3",
+} as const;

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -318,7 +318,7 @@
   }
 
   .card {
-    @apply rounded-xl border bg-surface p-3 shadow-sm sm:p-4;
+    @apply rounded-xl border bg-surface p-3 shadow-sm sm:p-4 lg:p-5;
   }
 
   /* ── Motion Utility Classes (#61) ── */


### PR DESCRIPTION
## Summary

Implements the desktop typography, density & spacing scale defined in #76. This is the foundational layer that all other desktop UX issues (#72–#79) build upon.

At the `lg` breakpoint (≥1024px), text and spacing gracefully scale up so the UI doesn't feel cramped on wide screens.

## Changes

### New file
- **`src/lib/typography.ts`** — Central constants documenting the full responsive type + spacing scale (page titles, section headings, card headings, stats, body, captions, labels, and spacing tokens).

### Typography scaling (`lg:` breakpoint)

| Element | Mobile/Tablet | Desktop (lg) |
|---------|--------------|-------------|
| Page titles | `text-xl` | `lg:text-2xl` |
| Dashboard greeting | `sm:text-2xl` | `lg:text-3xl` |
| Section headings | `text-lg` | `lg:text-xl` |
| Card headings (h3/h2) | `text-sm` | `lg:text-base` |
| Body text (selective) | `text-sm` | `lg:text-base` |
| Captions | `text-xs` | `lg:text-sm` |
| Stat values | `text-xl` | `lg:text-2xl` |
| Stat labels | `text-xs` | `lg:text-sm` |

### Spacing scaling

| Element | Mobile/Tablet | Desktop (lg) |
|---------|--------------|-------------|
| `.card` padding | `p-3 sm:p-4` | `lg:p-5` |
| Page stacks | `space-y-6` | `lg:space-y-8` |
| Section stacks | `space-y-4` | `lg:space-y-6` |
| Grid gaps | `gap-3` | `lg:gap-4` |
| Section heading margins | `mb-2` | `lg:mb-3` |
| Main content padding | `py-4 md:py-6` | `lg:py-8` |

### Bug fix
- Fixed `NutritionTip.tsx` using wrong color token `text-muted-foreground` → `text-foreground-secondary`

### Files modified (16 total)
- `globals.css` — card class desktop padding
- `layout.tsx` — main content vertical padding
- `typography.ts` — **new** constants file
- `page.tsx` (dashboard) — stats, section headings, page spacing
- `DashboardGreeting.tsx` — greeting title + subtitle
- `CategoriesBrowse.tsx` — section heading
- `QuickActions.tsx` — grid gap + label text
- `NutritionTip.tsx` — heading + color fix
- `product/[id]/page.tsx` — all section headings, tab containers, product name/brand
- `search/page.tsx` — results count text, content spacing
- `categories/page.tsx` — page title, grid gap
- `lists/page.tsx` — page title, page spacing
- `settings/page.tsx` — page title, all 6 section headings, page spacing
- `EmptyState.tsx` — title + description text
- `Header.tsx` — nav link text
- `FilterPanel.tsx` — minor formatting

## Testing
- ✅ All 2,156 unit tests pass (1 pre-existing skip in a11y gate)
- ✅ No new TypeScript or lint errors introduced
- ✅ Changes are purely additive `lg:` responsive classes — zero visual change on mobile/tablet

Closes #76