### PR TITLE
feat(dashboard): 12-column asymmetric grid layout (#74)

### DIFF
--- a/frontend/src/app/app/page.test.tsx
+++ b/frontend/src/app/app/page.test.tsx
@@ -317,4 +317,56 @@ describe("DashboardPage", () => {
       .find((a) => a?.getAttribute("href") === "/app/lists");
     expect(favoritesLink).toBeUndefined();
   });
+
+  // ─── Grid layout tests (Issue #74) ─────────────────────────────────────────
+
+  it("applies 12-column grid on desktop (lg breakpoint)", async () => {
+    render(<DashboardPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("Lay's Classic")).toBeInTheDocument();
+    });
+    // h1 → space-y-1 div → col-span-12 wrapper → grid container
+    const gridContainer = screen
+      .getByRole("heading", { level: 1 })
+      .closest("[class*='lg:grid-cols-12']");
+    expect(gridContainer).toBeTruthy();
+    expect(gridContainer?.className).toContain("lg:grid");
+    expect(gridContainer?.className).toContain("lg:gap-6");
+  });
+
+  it("assigns correct grid spans to Quick Actions and Stats", async () => {
+    render(<DashboardPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("42")).toBeInTheDocument();
+    });
+    // Quick Actions section — aria-label is lowercase "Quick actions"
+    const quickActionsSection = screen.getByLabelText("Quick actions");
+    expect(quickActionsSection.parentElement?.className).toContain(
+      "lg:col-span-8",
+    );
+    // Stats — find by stat value "42" (total_scanned)
+    const statEl = screen.getByText("42").closest("[class*='lg:col-span-4']");
+    expect(statEl).toBeTruthy();
+  });
+
+  it("keeps stacked layout on mobile (space-y-6)", async () => {
+    render(<DashboardPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("Lay's Classic")).toBeInTheDocument();
+    });
+    const gridContainer = screen
+      .getByRole("heading", { level: 1 })
+      .closest("[class*='lg:grid-cols-12']");
+    expect(gridContainer?.className).toContain("space-y-6");
+    expect(gridContainer?.className).toContain("lg:space-y-0");
+  });
+
+  it("uses tabular-nums on stat values", async () => {
+    render(<DashboardPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("42")).toBeInTheDocument();
+    });
+    const statValue = screen.getByText("42");
+    expect(statValue.className).toContain("tabular-nums");
+  });
 });

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -85,17 +85,17 @@ function StatsBar({ stats }: { stats: DashboardStats }) {
   ];
 
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:gap-4">
+    <div className="grid grid-cols-2 gap-3 lg:gap-4">
       {items.map((s) => (
         <Link
           key={s.label}
           href={s.href}
-          className="card flex flex-col items-center gap-1 py-3 transition-colors hover:bg-surface-subtle"
+          className="card flex flex-col items-center gap-1 py-3 transition-shadow hover:bg-surface-subtle hover:shadow-md"
         >
           <span className="flex items-center justify-center">
             <s.icon size={28} aria-hidden="true" />
           </span>
-          <span className="text-xl font-bold text-foreground lg:text-2xl">
+          <span className="text-xl font-bold tabular-nums text-foreground lg:text-2xl">
             {s.value}
           </span>
           <span className="text-xs text-foreground-secondary lg:text-sm">
@@ -301,40 +301,68 @@ export default function DashboardPage() {
   }
 
   return (
-    <div className="space-y-6 lg:space-y-8">
-      {/* Personalised greeting */}
-      <DashboardGreeting />
+    <div className="space-y-6 lg:grid lg:grid-cols-12 lg:gap-6 lg:space-y-0">
+      {/* Row 1 — Greeting (full width) */}
+      <div className="lg:col-span-12">
+        <DashboardGreeting />
+      </div>
 
-      {/* Primary action buttons */}
-      <QuickActions />
+      {/* Row 2 — Quick Actions (8) + Stats Summary (4) */}
+      <div className="lg:col-span-8">
+        <QuickActions />
+      </div>
+      <div className="lg:col-span-4">
+        <StatsBar stats={dashboard.stats} />
+      </div>
 
-      {/* Horizontal category chips */}
-      <ErrorBoundary level="section" context={{ section: "categories-browse" }}>
-        <CategoriesBrowse />
-      </ErrorBoundary>
+      {/* Row 3 — Categories (6) + Daily Tip (6) */}
+      <div className="lg:col-span-6">
+        <ErrorBoundary
+          level="section"
+          context={{ section: "categories-browse" }}
+        >
+          <CategoriesBrowse />
+        </ErrorBoundary>
+      </div>
+      <div className="lg:col-span-6">
+        <ErrorBoundary level="section" context={{ section: "nutrition-tip" }}>
+          <NutritionTip />
+        </ErrorBoundary>
+      </div>
 
-      {/* Stats overview */}
-      <StatsBar stats={dashboard.stats} />
+      {/* Row 4 — Recently Viewed (8) + New Products (4) */}
+      {dashboard.recently_viewed.length > 0 && (
+        <div className="lg:col-span-8">
+          <ErrorBoundary
+            level="section"
+            context={{ section: "recently-viewed" }}
+          >
+            <RecentlyViewedSection products={dashboard.recently_viewed} />
+          </ErrorBoundary>
+        </div>
+      )}
+      {dashboard.new_products.length > 0 && (
+        <div className="lg:col-span-4">
+          <ErrorBoundary
+            level="section"
+            context={{ section: "new-products" }}
+          >
+            <NewProductsSection
+              products={dashboard.new_products}
+              category={dashboard.stats.most_viewed_category}
+            />
+          </ErrorBoundary>
+        </div>
+      )}
 
-      {/* Daily nutrition tip */}
-      <ErrorBoundary level="section" context={{ section: "nutrition-tip" }}>
-        <NutritionTip />
-      </ErrorBoundary>
-
-      <ErrorBoundary level="section" context={{ section: "recently-viewed" }}>
-        <RecentlyViewedSection products={dashboard.recently_viewed} />
-      </ErrorBoundary>
-
-      <ErrorBoundary level="section" context={{ section: "favorites" }}>
-        <FavoritesSection products={dashboard.favorites_preview} />
-      </ErrorBoundary>
-
-      <ErrorBoundary level="section" context={{ section: "new-products" }}>
-        <NewProductsSection
-          products={dashboard.new_products}
-          category={dashboard.stats.most_viewed_category}
-        />
-      </ErrorBoundary>
+      {/* Row 5 — Favorites (full width) */}
+      {dashboard.favorites_preview.length > 0 && (
+        <div className="lg:col-span-12">
+          <ErrorBoundary level="section" context={{ section: "favorites" }}>
+            <FavoritesSection products={dashboard.favorites_preview} />
+          </ErrorBoundary>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/common/skeletons/DashboardSkeleton.tsx
+++ b/frontend/src/components/common/skeletons/DashboardSkeleton.tsx
@@ -8,30 +8,57 @@ import { ProductCardSkeleton } from "./ProductCardSkeleton";
 
 export function DashboardSkeleton() {
   return (
-    <SkeletonContainer label="Loading dashboard" className="space-y-6">
-      {/* Greeting */}
-      <div className="space-y-1">
-        <Skeleton variant="text" width="14rem" height={24} />
+    <SkeletonContainer
+      label="Loading dashboard"
+      className="space-y-6 lg:grid lg:grid-cols-12 lg:gap-6 lg:space-y-0"
+    >
+      {/* Row 1 — Greeting (full width) */}
+      <div className="lg:col-span-12 space-y-1">
+        <Skeleton variant="text" width="14rem" height={28} />
         <Skeleton variant="text" width="10rem" height={14} />
       </div>
 
-      {/* Quick actions — 4-col grid */}
-      <div className="grid grid-cols-4 gap-3">
-        {Array.from({ length: 4 }, (_, i) => (
-          <div key={i} className="card flex flex-col items-center gap-2 py-3">
-            <Skeleton variant="rect" width={32} height={32} />
-            <Skeleton variant="text" width="3rem" height={12} />
-          </div>
-        ))}
+      {/* Row 2 — Quick Actions (8) + Stats (4) */}
+      <div className="lg:col-span-8">
+        <div className="grid grid-cols-4 gap-3">
+          {Array.from({ length: 4 }, (_, i) => (
+            <div
+              key={i}
+              className="card flex flex-col items-center gap-2 py-3 lg:py-6"
+            >
+              <Skeleton variant="rect" width={32} height={32} />
+              <Skeleton variant="text" width="3rem" height={12} />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="lg:col-span-4">
+        <div className="grid grid-cols-2 gap-3">
+          {Array.from({ length: 4 }, (_, i) => (
+            <div
+              key={i}
+              className="card flex flex-col items-center gap-1 py-3"
+            >
+              <Skeleton
+                variant="rect"
+                width={32}
+                height={32}
+                className="!rounded-md"
+              />
+              <Skeleton variant="text" width="3rem" height={20} />
+              <Skeleton variant="text" width="4rem" height={12} />
+            </div>
+          ))}
+        </div>
       </div>
 
-      {/* Categories browse — horizontal row */}
-      <div className="space-y-2">
+      {/* Row 3 — Categories (6) + Tip (6) */}
+      <div className="lg:col-span-6 space-y-2">
         <div className="flex items-center justify-between">
           <Skeleton variant="text" width="8rem" height={20} />
           <Skeleton variant="text" width="4rem" height={14} />
         </div>
-        <div className="flex gap-3 overflow-hidden">
+        <div className="flex gap-3 overflow-hidden lg:grid lg:grid-cols-3">
           {Array.from({ length: 6 }, (_, i) => (
             <div
               key={i}
@@ -44,40 +71,22 @@ export function DashboardSkeleton() {
           ))}
         </div>
       </div>
-
-      {/* Stats bar — 2×2 on mobile, 4-col on sm+ */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        {Array.from({ length: 4 }, (_, i) => (
-          <div key={i} className="card flex flex-col items-center gap-1 py-3">
-            <Skeleton
-              variant="rect"
-              width={32}
-              height={32}
-              className="!rounded-md"
-            />
-            <Skeleton variant="text" width="3rem" height={20} />
-            <Skeleton variant="text" width="4rem" height={12} />
+      <div className="lg:col-span-6">
+        <div className="card flex items-start gap-3">
+          <Skeleton variant="rect" width={32} height={32} />
+          <div className="min-w-0 flex-1 space-y-1">
+            <Skeleton variant="text" width="6rem" height={14} />
+            <Skeleton variant="text" width="100%" height={14} />
           </div>
-        ))}
-      </div>
-
-      {/* Nutrition tip */}
-      <div className="card flex items-start gap-3">
-        <Skeleton variant="rect" width={32} height={32} />
-        <div className="min-w-0 flex-1 space-y-1">
-          <Skeleton variant="text" width="6rem" height={14} />
-          <Skeleton variant="text" width="100%" height={14} />
         </div>
       </div>
 
-      {/* Recently viewed section */}
-      <div className="space-y-2">
+      {/* Row 4 — Recently viewed (8) + Favorites (4) */}
+      <div className="lg:col-span-8 space-y-2">
         <Skeleton variant="text" width="12rem" height={20} />
         <ProductCardSkeleton count={3} />
       </div>
-
-      {/* Favorites section */}
-      <div className="space-y-2">
+      <div className="lg:col-span-4 space-y-2">
         <div className="flex items-center justify-between">
           <Skeleton variant="text" width="8rem" height={20} />
           <Skeleton variant="text" width="4rem" height={14} />

--- a/frontend/src/components/dashboard/CategoriesBrowse.tsx
+++ b/frontend/src/components/dashboard/CategoriesBrowse.tsx
@@ -79,7 +79,7 @@ export function CategoriesBrowse() {
         <CategoriesBrowseSkeleton />
       ) : data && data.length > 0 ? (
         <div
-          className="scrollbar-hide flex gap-3 overflow-x-auto pb-1"
+          className="scrollbar-hide flex gap-3 overflow-x-auto pb-1 lg:grid lg:grid-cols-3 lg:overflow-visible lg:pb-0"
           role="list"
           aria-label={t("dashboard.categoriesTitle")}
         >

--- a/frontend/src/components/dashboard/DashboardGreeting.tsx
+++ b/frontend/src/components/dashboard/DashboardGreeting.tsx
@@ -28,7 +28,7 @@ export function DashboardGreeting({
 
   return (
     <div className="space-y-1">
-      <h1 className="text-xl font-bold text-foreground sm:text-2xl lg:text-3xl">
+      <h1 className="text-xl font-bold text-foreground sm:text-2xl md:text-3xl lg:text-4xl">
         {greeting}
       </h1>
       <p className="text-sm text-foreground-secondary lg:text-base">

--- a/frontend/src/components/dashboard/NutritionTip.tsx
+++ b/frontend/src/components/dashboard/NutritionTip.tsx
@@ -49,7 +49,7 @@ export function NutritionTip() {
 
   return (
     <section
-      className="rounded-xl border bg-surface p-4 shadow-sm"
+      className="rounded-xl border bg-surface p-4 shadow-sm lg:p-6"
       aria-label={t("dashboard.tipTitle")}
     >
       <div className="flex items-start gap-3">

--- a/frontend/src/components/dashboard/QuickActions.tsx
+++ b/frontend/src/components/dashboard/QuickActions.tsx
@@ -24,7 +24,7 @@ export function QuickActions() {
           <Link
             key={action.key}
             href={action.href}
-            className="card hover-lift-press group flex flex-col items-center gap-2 py-4 text-center"
+            className="card hover-lift-press group flex flex-col items-center gap-2 py-4 text-center transition-shadow hover:shadow-md lg:py-6"
           >
             <span
               className="flex items-center justify-center"


### PR DESCRIPTION
## Summary

Implements the 12-column asymmetric CSS Grid layout for the dashboard on desktop (issue #74). On mobile, the layout remains a single stacked column. At lg+ (≥1024px), sections rearrange into a content-driven grid where each section gets appropriate width based on importance.

## Changes

### Dashboard Grid Layout ([page.tsx](frontend/src/app/app/page.tsx))
- Outer container: `space-y-6 lg:grid lg:grid-cols-12 lg:gap-6 lg:space-y-0`
- Each section wrapped in grid-span divs
- Conditionally rendered wrappers for empty sections (recently viewed, new products, favorites)

### Grid Row Assignments

| Row | Left (cols) | Right (cols) |
|-----|-------------|-------------|
| 1 | Greeting (12) | — |
| 2 | Quick Actions (8) | Stats Summary (4) |
| 3 | Categories Browse (6) | Nutrition Tip (6) |
| 4 | Recently Viewed (8) | New Products (4) |
| 5 | Favorites (12) | — |

### Component Updates
- **DashboardGreeting** — Typography stepped up: `sm:text-2xl md:text-3xl lg:text-4xl`
- **QuickActions** — Added `lg:py-6` padding, `hover:shadow-md` transition
- **StatsBar** — Changed to `grid-cols-2` (2×2 in col-4 column), added `tabular-nums`, `hover:shadow-md`
- **CategoriesBrowse** — Desktop: `lg:grid lg:grid-cols-3` replaces horizontal scroll
- **NutritionTip** — Added `lg:p-6` for more breathing room
- **DashboardSkeleton** — Mirrors new grid layout structure

## Responsive Behavior

| Viewport | Layout |
|----------|--------|
| < 1024px (mobile) | Single column, `space-y-6` vertical stack |
| ≥ 1024px (lg) | 12-column CSS Grid, asymmetric spans |

## Testing

- 4 new grid layout tests: grid classes, column spans, mobile fallback, tabular-nums
- All 2286 unit tests pass (4 pre-existing E2E timeouts unrelated)
- 7 files changed, 168 insertions, 79 deletions

Closes #74