### PR TITLE
feat(search): desktop power mode with multi-column grid and view toggle

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -118,6 +118,8 @@
     "toggleViewMode": "Toggle view mode",
     "compactView": "Compact",
     "detailedView": "Detailed",
+    "gridView": "Grid",
+    "listView": "List",
     "recentSearches": "Recent searches",
     "emptyState": "Search by name, brand, or browse with filters",
     "searchFailed": "Search failed. Please try again.",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -118,6 +118,8 @@
     "toggleViewMode": "Przełącz widok",
     "compactView": "Kompaktowy",
     "detailedView": "Szczegółowy",
+    "gridView": "Siatka",
+    "listView": "Lista",
     "recentSearches": "Ostatnie wyszukiwania",
     "emptyState": "Szukaj po nazwie, marce lub przeglądaj z filtrami",
     "searchFailed": "Wyszukiwanie nie powiodło się. Spróbuj ponownie.",

--- a/frontend/src/components/search/FilterPanel.tsx
+++ b/frontend/src/components/search/FilterPanel.tsx
@@ -317,7 +317,7 @@ export function FilterPanel({
     <>
       {/* Desktop sidebar */}
       <div className="hidden lg:block">
-        <div className="sticky top-20 w-64 rounded-xl border border bg-surface p-4">
+        <div className="sticky top-20 w-64 rounded-xl border border bg-surface p-4 xl:w-72">
           <div className="mb-3 flex items-center justify-between">
             <h2 className="text-sm font-semibold text-foreground">
               {t("search.filters")}


### PR DESCRIPTION
## Summary
Closes #75 — Search Page Desktop Power Mode: Wide Sidebar, Multi-Column Grid & Filter Summary

Transforms the search results page from a single-column list into a responsive multi-column grid layout with a grid/list view toggle, wider filter sidebar, and hover states.

## Changes

### Grid/List View Mode
- Replaced `"detailed" | "compact"` view mode with `"grid" | "list"`
- Grid is the new default — shows responsive card layout (`2 cols lg`, `3 cols xl`)
- List mode preserves the familiar row layout with hover states
- localStorage migration: legacy `"compact"` → `"list"`, `"detailed"` → `"grid"`
- Updated toggle with `LayoutGrid` / `LayoutList` icons and translated labels

### Grid Card Design
- Vertical card layout with score + nutri-score row at top
- Product name, brand/category, calories display
- Action buttons (health warning, avoid) in separated footer section
- Hover elevation: `shadow-md` + slight translate-y lift

### Filter Sidebar
- Widened from `w-64` to `w-64 xl:w-72` on extra-large screens

### i18n
- Added `gridView` / `listView` keys for English and Polish
- Kept legacy `compactView` / `detailedView` for backward compatibility

## Files Changed
- `src/app/app/search/page.tsx` — ViewMode type, grid layout, ProductRow grid card variant
- `src/app/app/search/page.test.tsx` — Updated all tests for grid/list, added 3 new tests (41 total)
- `src/components/search/FilterPanel.tsx` — Sidebar width responsive widening
- `messages/en.json` / `messages/pl.json` — New i18n keys

## Testing
- 41/41 search page tests pass
- 2299/2300 full suite pass (1 pre-existing a11y-ci-gate failure unrelated to this PR)