### PR TITLE
feat(polish): desktop interaction polish — hover states, cursor-pointer & transitions

### DIFF
--- a/frontend/src/app/app/page.test.tsx
+++ b/frontend/src/app/app/page.test.tsx
@@ -20,7 +20,11 @@ vi.mock("@/lib/api", () => ({
 
 vi.mock("next/link", () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  default: ({ href, children }: any) => <a href={href}>{children}</a>,
+  default: ({ href, children, className, ...rest }: any) => (
+    <a href={href} className={className} {...rest}>
+      {children}
+    </a>
+  ),
 }));
 
 // ─── Wrapper ────────────────────────────────────────────────────────────────
@@ -368,5 +372,26 @@ describe("DashboardPage", () => {
     });
     const statValue = screen.getByText("42");
     expect(statValue.className).toContain("tabular-nums");
+  });
+
+  it("stat cards have hover-lift-press interaction class", async () => {
+    render(<DashboardPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("42")).toBeInTheDocument();
+    });
+    const statCard = screen.getByText("42").closest("a")!;
+    expect(statCard.className).toContain("hover-lift-press");
+  });
+
+  it("view-all links have transition-colors class", async () => {
+    render(<DashboardPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getAllByText("View all →").length).toBeGreaterThan(0);
+    });
+    const viewAllLinks = screen.getAllByText("View all →");
+    for (const link of viewAllLinks) {
+      const anchor = link.closest("a")!;
+      expect(anchor.className).toContain("transition-colors");
+    }
   });
 });

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -90,7 +90,7 @@ function StatsBar({ stats }: { stats: DashboardStats }) {
         <Link
           key={s.label}
           href={s.href}
-          className="card flex flex-col items-center gap-1 py-3 transition-shadow hover:bg-surface-subtle hover:shadow-md"
+          className="card hover-lift-press flex flex-col items-center gap-1 py-3"
         >
           <span className="flex items-center justify-center">
             <s.icon size={28} aria-hidden="true" />
@@ -185,7 +185,7 @@ function FavoritesSection({
         </h2>
         <Link
           href="/app/lists"
-          className="text-sm font-medium text-brand-600 hover:text-brand-700"
+          className="text-sm font-medium text-brand-600 transition-colors hover:text-brand-700"
         >
           {t("dashboard.viewAll")}
         </Link>
@@ -220,7 +220,7 @@ function NewProductsSection({
         </h2>
         <Link
           href="/app/categories"
-          className="text-sm font-medium text-brand-600 hover:text-brand-700"
+          className="text-sm font-medium text-brand-600 transition-colors hover:text-brand-700"
         >
           {t("dashboard.browse")}
         </Link>

--- a/frontend/src/app/app/product/[id]/page.tsx
+++ b/frontend/src/app/app/product/[id]/page.tsx
@@ -318,7 +318,7 @@ export default function ProductDetailPage() {
             onClick={() => setActiveTab(tab.key)}
             role="tab"
             aria-selected={activeTab === tab.key}
-            className={`flex-1 rounded-md px-3 py-2.5 text-sm font-medium transition-colors ${
+            className={`flex-1 cursor-pointer rounded-md px-3 py-2.5 text-sm font-medium transition-colors ${
               activeTab === tab.key
                 ? "bg-surface text-brand-700 shadow-sm"
                 : "text-foreground-secondary hover:text-foreground"

--- a/frontend/src/app/app/scan/history/page.tsx
+++ b/frontend/src/app/app/scan/history/page.tsx
@@ -76,7 +76,7 @@ export default function ScanHistoryPage() {
               setFilter(f.value);
               setPage(1);
             }}
-            className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+            className={`flex-1 cursor-pointer rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
               filter === f.value
                 ? "bg-surface text-brand-700 shadow-sm"
                 : "text-foreground-secondary hover:text-foreground"
@@ -171,7 +171,7 @@ function ScanRow({
 
   if (scan.found && scan.product_id) {
     return (
-      <li className="card">
+      <li className="card hover-lift-press">
         <button
           onClick={() => onNavigate(scan.product_id ?? 0)}
           className="flex w-full items-center gap-3 text-left"

--- a/frontend/src/components/dashboard/CategoriesBrowse.tsx
+++ b/frontend/src/components/dashboard/CategoriesBrowse.tsx
@@ -69,7 +69,7 @@ export function CategoriesBrowse() {
         </h2>
         <Link
           href="/app/categories"
-          className="text-sm font-medium text-brand-600 hover:text-brand-700"
+          className="text-sm font-medium text-brand-600 transition-colors hover:text-brand-700"
         >
           {t("dashboard.viewAll")}
         </Link>

--- a/frontend/src/components/product/ProductImageTabs.tsx
+++ b/frontend/src/components/product/ProductImageTabs.tsx
@@ -51,9 +51,9 @@ export function ProductImageTabs({
           <button
             key={img.image_id}
             onClick={() => setActiveIdx(idx)}
-            className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+            className={`cursor-pointer rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
               idx === activeIdx
-                ? "bg-blue-100 text-blue-700"
+                ? "bg-brand-50 text-brand-700"
                 : "bg-surface-subtle text-foreground-secondary hover:bg-surface-muted"
             }`}
           >

--- a/frontend/src/components/settings/ThemeToggle.test.tsx
+++ b/frontend/src/components/settings/ThemeToggle.test.tsx
@@ -88,4 +88,12 @@ describe("ThemeToggle", () => {
     const { container } = render(<ThemeToggle />);
     expect(container.querySelectorAll("svg").length).toBeGreaterThanOrEqual(1);
   });
+
+  it("theme toggle buttons have cursor-pointer class", () => {
+    render(<ThemeToggle />);
+    const buttons = screen.getAllByRole("radio");
+    buttons.forEach((btn) => {
+      expect(btn.className).toContain("cursor-pointer");
+    });
+  });
 });

--- a/frontend/src/components/settings/ThemeToggle.tsx
+++ b/frontend/src/components/settings/ThemeToggle.tsx
@@ -35,7 +35,7 @@ export function ThemeToggle() {
           role="radio"
           aria-checked={mode === option.value}
           onClick={() => setMode(option.value)}
-          className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+          className={`flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
             mode === option.value
               ? "bg-surface text-foreground shadow-sm"
               : "text-foreground-secondary hover:text-foreground"

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -294,7 +294,7 @@
   .btn-primary {
     @apply inline-flex items-center justify-center rounded-lg bg-brand px-4 py-2.5
            text-sm font-semibold text-foreground-inverse shadow-sm transition-colors
-           hover:bg-brand-hover focus-visible:outline-2 focus-visible:outline-offset-2
+           cursor-pointer hover:bg-brand-hover focus-visible:outline-2 focus-visible:outline-offset-2
            focus-visible:outline-brand disabled:opacity-50 disabled:cursor-not-allowed
            press-scale;
     /* Prevent double-tap zoom on buttons in PWA */
@@ -304,7 +304,7 @@
   .btn-secondary {
     @apply inline-flex items-center justify-center rounded-lg border border-strong
            bg-surface px-4 py-2.5 text-sm font-semibold text-foreground-secondary shadow-sm
-           transition-colors hover:bg-surface-subtle focus-visible:outline-2
+           transition-colors cursor-pointer hover:bg-surface-subtle focus-visible:outline-2
            focus-visible:outline-offset-2 focus-visible:outline-brand
            disabled:opacity-50 disabled:cursor-not-allowed
            press-scale;
@@ -351,6 +351,7 @@
   .hover-lift-press {
     transition: transform var(--duration-fast) var(--ease-standard),
                 box-shadow var(--duration-fast) var(--ease-standard);
+    cursor: pointer;
   }
   @media (hover: hover) {
     .hover-lift-press:hover {


### PR DESCRIPTION
## Summary

Closes #77 — Adds consistent hover states, cursor-pointer, and micro-interaction polish across all interactive elements.

## Changes

### Global CSS (`globals.css`)
- Added `cursor-pointer` to `.btn-primary`, `.btn-secondary`, and `.hover-lift-press` utility classes
- All ~25 primary buttons, ~10 secondary buttons, and 10+ hover-lift-press elements now get pointer cursor automatically

### Dashboard (`page.tsx`)
- **StatsBar cards**: Replaced inline `transition-shadow hover:bg-surface-subtle hover:shadow-md` with `hover-lift-press` for consistent interaction
- **View All links**: Added `transition-colors` for smooth color transitions on hover

### CategoriesBrowse
- Added `transition-colors` to "View all" link (was missing vs other view-all links)

### Product Page (`product/[id]/page.tsx`)
- Tab buttons (Overview / Nutrition / Alternatives): Added `cursor-pointer`

### ProductImageTabs
- Added `cursor-pointer` to tab buttons
- Replaced hardcoded `bg-blue-100 text-blue-700` with brand tokens `bg-brand-50 text-brand-700`

### ThemeToggle
- Added `cursor-pointer` to Light/Dark/System radio buttons

### Scan History (`scan/history/page.tsx`)
- Added `hover-lift-press` to scan row cards for consistent hover feedback
- Added `cursor-pointer` to filter toggle buttons

## Tests
- **3 new tests**: Stat card hover-lift-press class, view-all transition-colors class, ThemeToggle cursor-pointer class
- **2306 passing** (2 pre-existing e2e timeouts unrelated to this PR)

## Files Changed (9)
- `src/styles/globals.css`
- `src/app/app/page.tsx` + `page.test.tsx`
- `src/app/app/product/[id]/page.tsx`
- `src/app/app/scan/history/page.tsx`
- `src/components/dashboard/CategoriesBrowse.tsx`
- `src/components/product/ProductImageTabs.tsx`
- `src/components/settings/ThemeToggle.tsx` + `ThemeToggle.test.tsx`