### PR TITLE
feat(desktop): command palette, keyboard shortcuts & comparison tray

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1058,5 +1058,40 @@
       "whatYouCanDoTitle": "What you can do",
       "whatYouCanDoText": "If you notice incorrect data for a product, you can help improve our database. Look for the confidence indicator on each product profile — it tells you how reliable the current data is."
     }
+  },
+  "commandPalette": {
+    "placeholder": "Search or jump to…",
+    "navigation": "Navigation",
+    "recentProducts": "Recent Products",
+    "searchFor": "Search for '{query}'",
+    "noResults": "No results found",
+    "goToDashboard": "Go to Dashboard",
+    "goToSearch": "Search Products",
+    "goToScan": "Scan Barcode",
+    "goToLists": "My Lists",
+    "goToCategories": "Browse Categories",
+    "goToCompare": "Compare Products",
+    "goToSettings": "Settings",
+    "close": "Close"
+  },
+  "shortcuts": {
+    "title": "Keyboard Shortcuts",
+    "navigation": "Navigation",
+    "general": "General",
+    "commandPalette": "Command Palette",
+    "focusSearch": "Focus Search",
+    "goHome": "Go to Dashboard",
+    "goLists": "Go to Lists",
+    "openScanner": "Open Scanner",
+    "showShortcuts": "Show this help",
+    "closeOverlay": "Close modal / overlay"
+  },
+  "comparisonTray": {
+    "title": "Compare",
+    "products": "{count} product(s)",
+    "compareNow": "Compare Now →",
+    "empty": "Add products to compare",
+    "collapse": "Collapse comparison tray",
+    "expand": "Expand comparison tray"
   }
 }

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -1058,5 +1058,40 @@
       "whatYouCanDoTitle": "Co możesz zrobić",
       "whatYouCanDoText": "Jeśli zauważysz nieprawidłowe dane dla produktu, możesz pomóc ulepszyć naszą bazę danych. Szukaj wskaźnika pewności na profilu każdego produktu — mówi ci, jak wiarygodne są obecne dane."
     }
+  },
+  "commandPalette": {
+    "placeholder": "Szukaj lub przejdź do…",
+    "navigation": "Nawigacja",
+    "recentProducts": "Ostatnie produkty",
+    "searchFor": "Szukaj '{query}'",
+    "noResults": "Brak wyników",
+    "goToDashboard": "Przejdź do pulpitu",
+    "goToSearch": "Szukaj produktów",
+    "goToScan": "Skanuj kod kreskowy",
+    "goToLists": "Moje listy",
+    "goToCategories": "Przeglądaj kategorie",
+    "goToCompare": "Porównaj produkty",
+    "goToSettings": "Ustawienia",
+    "close": "Zamknij"
+  },
+  "shortcuts": {
+    "title": "Skróty klawiszowe",
+    "navigation": "Nawigacja",
+    "general": "Ogólne",
+    "commandPalette": "Paleta poleceń",
+    "focusSearch": "Fokus na wyszukiwarkę",
+    "goHome": "Przejdź do pulpitu",
+    "goLists": "Przejdź do list",
+    "openScanner": "Otwórz skaner",
+    "showShortcuts": "Pokaż tę pomoc",
+    "closeOverlay": "Zamknij modal / nakładkę"
+  },
+  "comparisonTray": {
+    "title": "Porównaj",
+    "products": "{count} produkt(ów)",
+    "compareNow": "Porównaj teraz →",
+    "empty": "Dodaj produkty do porównania",
+    "collapse": "Zwiń panel porównania",
+    "expand": "Rozwiń panel porównania"
   }
 }

--- a/frontend/src/app/app/categories/[slug]/page.tsx
+++ b/frontend/src/app/app/categories/[slug]/page.tsx
@@ -246,7 +246,10 @@ function ProductRow({ product }: Readonly<{ product: CategoryProduct }>) {
         <AddToListMenu productId={product.product_id} compact />
 
         {/* Compare checkbox */}
-        <CompareCheckbox productId={product.product_id} />
+        <CompareCheckbox
+          productId={product.product_id}
+          productName={product.product_name}
+        />
 
         <NutriScoreBadge grade={product.nutri_score} size="sm" showTooltip />
       </li>

--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -16,6 +16,7 @@ import { CountryChip } from "@/components/common/CountryChip";
 import { ListsHydrator } from "@/components/product/ListsHydrator";
 import { LanguageHydrator } from "@/components/i18n/LanguageHydrator";
 import { CompareFloatingButton } from "@/components/compare/CompareFloatingButton";
+import { ComparisonTray } from "@/components/desktop/ComparisonTray";
 import { OfflineIndicator } from "@/components/pwa/OfflineIndicator";
 import { InstallPrompt } from "@/components/pwa/InstallPrompt";
 import { GlobalKeyboardShortcuts } from "@/components/layout/GlobalKeyboardShortcuts";
@@ -103,6 +104,7 @@ export default async function AppLayout({
 
         <div className="no-print">
           <CompareFloatingButton />
+          <ComparisonTray />
           <InstallPrompt />
           <GlobalKeyboardShortcuts />
         </div>

--- a/frontend/src/app/app/product/[id]/page.tsx
+++ b/frontend/src/app/app/product/[id]/page.tsx
@@ -161,186 +161,196 @@ export default function ProductDetailPage() {
       <div className="lg:grid lg:grid-cols-12 lg:gap-6">
         {/* Left column — sticky on desktop */}
         <div className="space-y-4 lg:col-span-5 lg:space-y-6 lg:self-start lg:sticky lg:top-20">
+          {/* Header */}
+          <div className="card">
+            {/* Product Hero Image */}
+            <div className="mb-4">
+              <ProductHeroImage
+                images={profile.images}
+                productName={
+                  profile.product.product_name_display ??
+                  profile.product.product_name
+                }
+                categoryIcon={profile.product.category_icon}
+                ean={profile.product.ean}
+              />
+            </div>
 
-      {/* Header */}
-      <div className="card">
-        {/* Product Hero Image */}
-        <div className="mb-4">
-          <ProductHeroImage
-            images={profile.images}
-            productName={
-              profile.product.product_name_display ??
-              profile.product.product_name
-            }
-            categoryIcon={profile.product.category_icon}
-            ean={profile.product.ean}
-          />
-        </div>
-
-        <div className="flex items-start gap-4">
-          <ScoreGauge score={profile.scores.unhealthiness_score} size="lg" />
-          <div className="min-w-0 flex-1">
-            <div className="flex items-start justify-between">
-              <div>
-                <p className="text-lg font-bold text-foreground lg:text-xl">
-                  {profile.product.product_name_display ??
-                    profile.product.product_name}
-                </p>
-                {profile.product.product_name_en &&
-                  profile.product.product_name_display !==
-                    profile.product.product_name && (
-                    <p className="text-xs text-foreground-muted">
-                      {t("product.originalName")}:{" "}
-                      {profile.product.product_name}
+            <div className="flex items-start gap-4">
+              <ScoreGauge
+                score={profile.scores.unhealthiness_score}
+                size="lg"
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-start justify-between">
+                  <div>
+                    <p className="text-lg font-bold text-foreground lg:text-xl">
+                      {profile.product.product_name_display ??
+                        profile.product.product_name}
                     </p>
-                  )}
-                <p className="text-sm text-foreground-secondary lg:text-base">
-                  {profile.product.brand}
+                    {profile.product.product_name_en &&
+                      profile.product.product_name_display !==
+                        profile.product.product_name && (
+                        <p className="text-xs text-foreground-muted">
+                          {t("product.originalName")}:{" "}
+                          {profile.product.product_name}
+                        </p>
+                      )}
+                    <p className="text-sm text-foreground-secondary lg:text-base">
+                      {profile.product.brand}
+                    </p>
+                  </div>
+                  <div className="no-print flex flex-wrap items-center gap-2">
+                    <ShareButton
+                      productName={
+                        profile.product.product_name_display ??
+                        profile.product.product_name
+                      }
+                      score={profile.scores.unhealthiness_score}
+                      productId={productId}
+                    />
+                    <AvoidBadge productId={productId} />
+                    <AddToListMenu productId={productId} />
+                    <CompareCheckbox
+                      productId={productId}
+                      productName={
+                        profile.product.product_name_display ??
+                        profile.product.product_name
+                      }
+                    />
+                    <PrintButton />
+                  </div>
+                </div>
+                <div className="mt-2 flex items-center gap-2">
+                  <span className="inline-flex items-center gap-1 rounded-full bg-surface-muted px-2 py-0.5 text-xs font-bold">
+                    <NutriScoreBadge
+                      grade={profile.scores.nutri_score_label}
+                      size="sm"
+                    />
+                    <span className="text-foreground-secondary">
+                      {t("product.nutriScoreLabel")}
+                    </span>
+                  </span>
+                  <span className="rounded-full bg-surface-muted px-2 py-0.5 text-xs text-foreground-secondary">
+                    {t("product.novaGroup", {
+                      group: profile.scores.nova_group,
+                    })}
+                  </span>
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-xs font-medium ${band.bg} ${band.color}`}
+                  >
+                    {band.label}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* Category & EAN */}
+            <div className="mt-3 flex flex-wrap gap-2 text-xs text-foreground-secondary">
+              <span>
+                {profile.product.category_icon}{" "}
+                {profile.product.category_display}
+              </span>
+              {profile.product.ean && <span>EAN: {profile.product.ean}</span>}
+              {profile.product.store_availability && (
+                <span>Store: {profile.product.store_availability}</span>
+              )}
+            </div>
+
+            {/* Flags — with "why" explanations */}
+            {(profile.flags.high_sugar ||
+              profile.flags.high_salt ||
+              profile.flags.high_sat_fat ||
+              profile.flags.high_additive_load ||
+              profile.flags.has_palm_oil) && (
+              <div className="mt-3 space-y-1">
+                <p className="text-xs font-medium text-foreground-muted">
+                  {t("product.healthFlags")}
                 </p>
+                <div className="flex flex-wrap gap-1">
+                  {profile.flags.high_sugar && (
+                    <FlagWithExplanation
+                      label={t("product.highSugar")}
+                      explanation={t("product.highSugarExplanation")}
+                    />
+                  )}
+                  {profile.flags.high_salt && (
+                    <FlagWithExplanation
+                      label={t("product.highSalt")}
+                      explanation={t("product.highSaltExplanation")}
+                    />
+                  )}
+                  {profile.flags.high_sat_fat && (
+                    <FlagWithExplanation
+                      label={t("product.highSatFat")}
+                      explanation={t("product.highSatFatExplanation")}
+                    />
+                  )}
+                  {profile.flags.high_additive_load && (
+                    <FlagWithExplanation
+                      label={t("product.manyAdditives")}
+                      explanation={t("product.manyAdditivesExplanation")}
+                    />
+                  )}
+                  {profile.flags.has_palm_oil && (
+                    <FlagWithExplanation
+                      label={t("product.palmOil")}
+                      explanation={t("product.palmOilExplanation")}
+                    />
+                  )}
+                </div>
               </div>
-              <div className="no-print flex flex-wrap items-center gap-2">
-                <ShareButton
-                  productName={
-                    profile.product.product_name_display ??
-                    profile.product.product_name
-                  }
-                  score={profile.scores.unhealthiness_score}
-                  productId={productId}
-                />
-                <AvoidBadge productId={productId} />
-                <AddToListMenu productId={productId} />
-                <CompareCheckbox productId={productId} />
-                <PrintButton />
-              </div>
-            </div>
-            <div className="mt-2 flex items-center gap-2">
-              <span className="inline-flex items-center gap-1 rounded-full bg-surface-muted px-2 py-0.5 text-xs font-bold">
-                <NutriScoreBadge
-                  grade={profile.scores.nutri_score_label}
-                  size="sm"
-                />
-                <span className="text-foreground-secondary">
-                  {t("product.nutriScoreLabel")}
-                </span>
-              </span>
-              <span className="rounded-full bg-surface-muted px-2 py-0.5 text-xs text-foreground-secondary">
-                {t("product.novaGroup", { group: profile.scores.nova_group })}
-              </span>
-              <span
-                className={`rounded-full px-2 py-0.5 text-xs font-medium ${band.bg} ${band.color}`}
-              >
-                {band.label}
-              </span>
-            </div>
+            )}
           </div>
-        </div>
 
-        {/* Category & EAN */}
-        <div className="mt-3 flex flex-wrap gap-2 text-xs text-foreground-secondary">
-          <span>
-            {profile.product.category_icon} {profile.product.category_display}
-          </span>
-          {profile.product.ean && <span>EAN: {profile.product.ean}</span>}
-          {profile.product.store_availability && (
-            <span>Store: {profile.product.store_availability}</span>
-          )}
-        </div>
+          {/* Score interpretation — expandable "What does this score mean?" */}
+          <ScoreInterpretationCard score={profile.scores.unhealthiness_score} />
 
-        {/* Flags — with "why" explanations */}
-        {(profile.flags.high_sugar ||
-          profile.flags.high_salt ||
-          profile.flags.high_sat_fat ||
-          profile.flags.high_additive_load ||
-          profile.flags.has_palm_oil) && (
-          <div className="mt-3 space-y-1">
-            <p className="text-xs font-medium text-foreground-muted">
-              {t("product.healthFlags")}
-            </p>
-            <div className="flex flex-wrap gap-1">
-              {profile.flags.high_sugar && (
-                <FlagWithExplanation
-                  label={t("product.highSugar")}
-                  explanation={t("product.highSugarExplanation")}
-                />
-              )}
-              {profile.flags.high_salt && (
-                <FlagWithExplanation
-                  label={t("product.highSalt")}
-                  explanation={t("product.highSaltExplanation")}
-                />
-              )}
-              {profile.flags.high_sat_fat && (
-                <FlagWithExplanation
-                  label={t("product.highSatFat")}
-                  explanation={t("product.highSatFatExplanation")}
-                />
-              )}
-              {profile.flags.high_additive_load && (
-                <FlagWithExplanation
-                  label={t("product.manyAdditives")}
-                  explanation={t("product.manyAdditivesExplanation")}
-                />
-              )}
-              {profile.flags.has_palm_oil && (
-                <FlagWithExplanation
-                  label={t("product.palmOil")}
-                  explanation={t("product.palmOilExplanation")}
-                />
-              )}
-            </div>
-          </div>
-        )}
-      </div>
-
-      {/* Score interpretation — expandable "What does this score mean?" */}
-      <ScoreInterpretationCard score={profile.scores.unhealthiness_score} />
-
-      {/* Personalized health warnings */}
-      <ErrorBoundary
-        level="section"
-        context={{ section: "health-warnings", productId }}
-      >
-        <HealthWarningsCard productId={productId} />
-      </ErrorBoundary>
+          {/* Personalized health warnings */}
+          <ErrorBoundary
+            level="section"
+            context={{ section: "health-warnings", productId }}
+          >
+            <HealthWarningsCard productId={productId} />
+          </ErrorBoundary>
         </div>
 
         {/* Right column — scrollable content */}
         <div className="mt-4 space-y-4 lg:col-span-7 lg:mt-0 lg:space-y-6">
-
-      {/* Tab bar */}
-      <div
-        className="flex gap-1 rounded-lg bg-surface-muted p-1"
-        role="tablist"
-      >
-        {tabs.map((tab) => (
-          <button
-            key={tab.key}
-            onClick={() => setActiveTab(tab.key)}
-            role="tab"
-            aria-selected={activeTab === tab.key}
-            className={`flex-1 cursor-pointer rounded-md px-3 py-2.5 text-sm font-medium transition-colors ${
-              activeTab === tab.key
-                ? "bg-surface text-brand-700 shadow-sm"
-                : "text-foreground-secondary hover:text-foreground"
-            }`}
+          {/* Tab bar */}
+          <div
+            className="flex gap-1 rounded-lg bg-surface-muted p-1"
+            role="tablist"
           >
-            {tab.label}
-          </button>
-        ))}
-      </div>
+            {tabs.map((tab) => (
+              <button
+                key={tab.key}
+                onClick={() => setActiveTab(tab.key)}
+                role="tab"
+                aria-selected={activeTab === tab.key}
+                className={`flex-1 cursor-pointer rounded-md px-3 py-2.5 text-sm font-medium transition-colors ${
+                  activeTab === tab.key
+                    ? "bg-surface text-brand-700 shadow-sm"
+                    : "text-foreground-secondary hover:text-foreground"
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
 
-      {/* Tab content */}
-      <ErrorBoundary
-        level="section"
-        context={{ section: "tab-content", productId, tab: activeTab }}
-      >
-        {activeTab === "overview" && <OverviewTab profile={profile} />}
-        {activeTab === "nutrition" && <NutritionTab profile={profile} />}
-        {activeTab === "alternatives" && (
-          <AlternativesTab alternatives={profile.alternatives} />
-        )}
-        {activeTab === "scoring" && <ScoringTab profile={profile} />}
-      </ErrorBoundary>
+          {/* Tab content */}
+          <ErrorBoundary
+            level="section"
+            context={{ section: "tab-content", productId, tab: activeTab }}
+          >
+            {activeTab === "overview" && <OverviewTab profile={profile} />}
+            {activeTab === "nutrition" && <NutritionTab profile={profile} />}
+            {activeTab === "alternatives" && (
+              <AlternativesTab alternatives={profile.alternatives} />
+            )}
+            {activeTab === "scoring" && <ScoringTab profile={profile} />}
+          </ErrorBoundary>
         </div>
       </div>
     </div>
@@ -655,9 +665,15 @@ function NutritionTab({ profile }: Readonly<{ profile: ProductProfile }>) {
       <table className="w-full text-sm">
         <thead className="hidden text-xs text-foreground-muted lg:table-header-group">
           <tr className="border-b border-border">
-            <th className="pb-2 text-left font-medium">{t("product.nutrient")}</th>
-            <th className="pb-2 text-right font-medium">{t("product.per100g")}</th>
-            <th className="pb-2 pl-4 text-left font-medium">{t("product.dailyValue")}</th>
+            <th className="pb-2 text-left font-medium">
+              {t("product.nutrient")}
+            </th>
+            <th className="pb-2 text-right font-medium">
+              {t("product.per100g")}
+            </th>
+            <th className="pb-2 pl-4 text-left font-medium">
+              {t("product.dailyValue")}
+            </th>
           </tr>
         </thead>
         <tbody>

--- a/frontend/src/app/app/search/page.tsx
+++ b/frontend/src/app/app/search/page.tsx
@@ -335,8 +335,7 @@ export default function SearchPage() {
             <button
               type="button"
               onClick={() => {
-                const next: ViewMode =
-                  viewMode === "grid" ? "list" : "grid";
+                const next: ViewMode = viewMode === "grid" ? "list" : "grid";
                 setViewMode(next);
                 setViewModeStorage(next);
               }}
@@ -668,7 +667,10 @@ function ProductRow({
           <AvoidBadge productId={product.product_id} />
           <AddToListMenu productId={product.product_id} compact />
           <span className="hidden sm:inline-flex">
-            <CompareCheckbox productId={product.product_id} />
+            <CompareCheckbox
+              productId={product.product_id}
+              productName={product.product_name_display ?? product.product_name}
+            />
           </span>
         </div>
       </li>
@@ -732,7 +734,10 @@ function ProductRow({
 
         {/* Compare checkbox — hidden on small screens */}
         <span className="hidden sm:inline-flex">
-          <CompareCheckbox productId={product.product_id} />
+          <CompareCheckbox
+            productId={product.product_id}
+            productName={product.product_name_display ?? product.product_name}
+          />
         </span>
 
         {/* NOVA processing badge — hidden on xs screens */}

--- a/frontend/src/components/compare/CompareCheckbox.test.tsx
+++ b/frontend/src/components/compare/CompareCheckbox.test.tsx
@@ -40,7 +40,7 @@ describe("CompareCheckbox", () => {
   it("calls toggle on click when not disabled", () => {
     render(<CompareCheckbox productId={42} />);
     fireEvent.click(screen.getByRole("button"));
-    expect(mockToggle).toHaveBeenCalledWith(42);
+    expect(mockToggle).toHaveBeenCalledWith(42, undefined);
   });
 
   it("does not call toggle when disabled (full + not selected)", () => {

--- a/frontend/src/components/compare/CompareCheckbox.tsx
+++ b/frontend/src/components/compare/CompareCheckbox.tsx
@@ -10,9 +10,13 @@ import { Scale } from "lucide-react";
 
 interface CompareCheckboxProps {
   productId: number;
+  productName?: string;
 }
 
-export function CompareCheckbox({ productId }: Readonly<CompareCheckboxProps>) {
+export function CompareCheckbox({
+  productId,
+  productName,
+}: Readonly<CompareCheckboxProps>) {
   const { t } = useTranslation();
   const isSelected = useCompareStore((s) => s.isSelected(productId));
   const isFull = useCompareStore((s) => s.isFull());
@@ -39,7 +43,7 @@ export function CompareCheckbox({ productId }: Readonly<CompareCheckboxProps>) {
       onClick={(e) => {
         e.preventDefault();
         e.stopPropagation();
-        if (!disabled) toggle(productId);
+        if (!disabled) toggle(productId, productName);
       }}
       disabled={disabled}
       title={getTitle()}

--- a/frontend/src/components/compare/CompareFloatingButton.tsx
+++ b/frontend/src/components/compare/CompareFloatingButton.tsx
@@ -23,7 +23,7 @@ export function CompareFloatingButton() {
   }
 
   return (
-    <div className="fixed bottom-20 right-4 z-50 flex items-center gap-2">
+    <div className="fixed bottom-20 right-4 z-50 flex items-center gap-2 lg:hidden">
       {/* Clear button */}
       <button
         type="button"

--- a/frontend/src/components/desktop/CommandPalette.test.tsx
+++ b/frontend/src/components/desktop/CommandPalette.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { CommandPalette } from "./CommandPalette";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({}),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getRecentlyViewed: () =>
+    Promise.resolve({ ok: true, data: { products: [] } }),
+}));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function renderPalette(open = true) {
+  const onClose = vi.fn();
+  const result = render(<CommandPalette open={open} onClose={onClose} />, {
+    wrapper: createWrapper(),
+  });
+  return { onClose, ...result };
+}
+
+// ─── Stubs ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn();
+  HTMLDialogElement.prototype.close = vi.fn();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("CommandPalette", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls showModal when open is true", () => {
+    renderPalette(true);
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled();
+  });
+
+  it("does not call showModal when open is false", () => {
+    renderPalette(false);
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled();
+  });
+
+  it("renders navigation items", () => {
+    renderPalette();
+    expect(screen.getByText("Go to Dashboard")).toBeTruthy();
+    expect(screen.getByText("Search Products")).toBeTruthy();
+    expect(screen.getByText("Scan Barcode")).toBeTruthy();
+    expect(screen.getByText("My Lists")).toBeTruthy();
+    expect(screen.getByText("Browse Categories")).toBeTruthy();
+    expect(screen.getByText("Compare Products")).toBeTruthy();
+    expect(screen.getByText("Settings")).toBeTruthy();
+  });
+
+  it("renders search input with placeholder", () => {
+    renderPalette();
+    expect(screen.getByPlaceholderText("Search or jump to…")).toBeTruthy();
+  });
+
+  it("renders navigation section label", () => {
+    renderPalette();
+    expect(screen.getByText("Navigation")).toBeTruthy();
+  });
+
+  it("filters items by query", () => {
+    renderPalette();
+    const input = screen.getByPlaceholderText("Search or jump to…");
+    fireEvent.change(input, { target: { value: "dashboard" } });
+    expect(screen.getByText("Go to Dashboard")).toBeTruthy();
+    // Other items should be filtered out
+    expect(screen.queryByText("Search Products")).toBeNull();
+    expect(screen.queryByText("Settings")).toBeNull();
+  });
+
+  it("shows search fallback for unmatched query", () => {
+    renderPalette();
+    const input = screen.getByPlaceholderText("Search or jump to…");
+    fireEvent.change(input, { target: { value: "zzzzzzz" } });
+    // When no nav items match, a "Search for …" fallback is added
+    expect(screen.getByText("Search for 'zzzzzzz'")).toBeTruthy();
+  });
+
+  it("navigates on item click", () => {
+    renderPalette();
+    fireEvent.click(screen.getByText("Go to Dashboard"));
+    expect(mockPush).toHaveBeenCalledWith("/app");
+  });
+
+  it("calls onClose on item click", () => {
+    const { onClose } = renderPalette();
+    fireEvent.click(screen.getByText("Go to Dashboard"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("navigates to correct path for each nav item", () => {
+    renderPalette();
+
+    const items: [string, string][] = [
+      ["Go to Dashboard", "/app"],
+      ["Search Products", "/app/search"],
+      ["Scan Barcode", "/app/scan"],
+      ["My Lists", "/app/lists"],
+      ["Browse Categories", "/app/categories"],
+      ["Compare Products", "/app/compare"],
+      ["Settings", "/app/settings"],
+    ];
+
+    for (const [label, path] of items) {
+      mockPush.mockClear();
+      fireEvent.click(screen.getByText(label));
+      expect(mockPush).toHaveBeenCalledWith(path);
+    }
+  });
+
+  it("supports ArrowDown keyboard navigation", () => {
+    renderPalette();
+    const input = screen.getByPlaceholderText("Search or jump to…");
+
+    // First item is active by default
+    const firstButton = screen.getByText("Go to Dashboard").closest("button");
+    expect(firstButton!.getAttribute("data-active")).toBe("true");
+
+    // Arrow down moves to next item
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    const secondButton = screen.getByText("Search Products").closest("button");
+    expect(secondButton!.getAttribute("data-active")).toBe("true");
+  });
+
+  it("supports ArrowUp keyboard navigation", () => {
+    renderPalette();
+    const input = screen.getByPlaceholderText("Search or jump to…");
+
+    // Move down first, then up
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    const firstButton = screen.getByText("Go to Dashboard").closest("button");
+    expect(firstButton!.getAttribute("data-active")).toBe("true");
+  });
+
+  it("selects item on Enter", () => {
+    renderPalette();
+    const input = screen.getByPlaceholderText("Search or jump to…");
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mockPush).toHaveBeenCalledWith("/app");
+  });
+
+  it("calls onClose on backdrop click", () => {
+    const { onClose } = renderPalette();
+    const dialog = document.querySelector("dialog");
+    fireEvent.click(dialog!);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose when clicking inside the dialog content", () => {
+    const { onClose } = renderPalette();
+    fireEvent.click(screen.getByText("Navigation"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("renders ESC kbd indicator", () => {
+    renderPalette();
+    expect(screen.getByText("ESC")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/desktop/CommandPalette.tsx
+++ b/frontend/src/components/desktop/CommandPalette.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+// ─── CommandPalette — Ctrl+K quick navigation & search ──────────────────────
+// VS Code / Spotlight-style command palette for power users.
+// Desktop only (lg+). Uses native <dialog> following the SaveSearchDialog pattern.
+
+import {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  useMemo,
+  type KeyboardEvent,
+} from "react";
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Search,
+  Home,
+  Camera,
+  ClipboardList,
+  Scale,
+  FolderOpen,
+  Settings,
+  ArrowRight,
+} from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+import { getRecentlyViewed } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
+import { useTranslation } from "@/lib/i18n";
+import type { LucideIcon } from "lucide-react";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+interface NavItem {
+  id: string;
+  label: string;
+  href: string;
+  icon: LucideIcon;
+  section: "navigation";
+}
+
+interface ProductItem {
+  id: string;
+  label: string;
+  sublabel: string;
+  href: string;
+  section: "recent";
+}
+
+interface SearchItem {
+  id: string;
+  label: string;
+  href: string;
+  section: "search";
+}
+
+type PaletteItem = NavItem | ProductItem | SearchItem;
+
+// ─── Props ──────────────────────────────────────────────────────────────────
+
+interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+export function CommandPalette({
+  open,
+  onClose,
+}: Readonly<CommandPaletteProps>) {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Fetch recent products (lightweight — reuses cache if dashboard was visited)
+  const supabase = createClient();
+  const { data: recentData } = useQuery({
+    queryKey: queryKeys.recentlyViewed(5),
+    queryFn: () => getRecentlyViewed(supabase, 5),
+    staleTime: 60_000,
+    enabled: open,
+  });
+
+  // Navigation items
+  const navItems: NavItem[] = useMemo(
+    () => [
+      {
+        id: "nav-dashboard",
+        label: t("commandPalette.goToDashboard"),
+        href: "/app",
+        icon: Home,
+        section: "navigation",
+      },
+      {
+        id: "nav-search",
+        label: t("commandPalette.goToSearch"),
+        href: "/app/search",
+        icon: Search,
+        section: "navigation",
+      },
+      {
+        id: "nav-scan",
+        label: t("commandPalette.goToScan"),
+        href: "/app/scan",
+        icon: Camera,
+        section: "navigation",
+      },
+      {
+        id: "nav-lists",
+        label: t("commandPalette.goToLists"),
+        href: "/app/lists",
+        icon: ClipboardList,
+        section: "navigation",
+      },
+      {
+        id: "nav-categories",
+        label: t("commandPalette.goToCategories"),
+        href: "/app/categories",
+        icon: FolderOpen,
+        section: "navigation",
+      },
+      {
+        id: "nav-compare",
+        label: t("commandPalette.goToCompare"),
+        href: "/app/compare",
+        icon: Scale,
+        section: "navigation",
+      },
+      {
+        id: "nav-settings",
+        label: t("commandPalette.goToSettings"),
+        href: "/app/settings",
+        icon: Settings,
+        section: "navigation",
+      },
+    ],
+    [t],
+  );
+
+  // Recent product items
+  const recentItems: ProductItem[] = useMemo(() => {
+    if (!recentData?.ok || !recentData.data?.products) return [];
+    return recentData.data.products.slice(0, 5).map((p) => ({
+      id: `recent-${p.product_id}`,
+      label: p.product_name,
+      sublabel: p.brand ?? p.category,
+      href: `/app/product/${p.product_id}`,
+      section: "recent" as const,
+    }));
+  }, [recentData]);
+
+  // Filter items by query
+  const filteredItems: PaletteItem[] = useMemo(() => {
+    const q = query.toLowerCase().trim();
+    const items: PaletteItem[] = [];
+
+    // Filter nav items
+    const matchedNav = q
+      ? navItems.filter((item) => item.label.toLowerCase().includes(q))
+      : navItems;
+    items.push(...matchedNav);
+
+    // Filter recent products
+    const matchedRecent = q
+      ? recentItems.filter(
+          (item) =>
+            item.label.toLowerCase().includes(q) ||
+            item.sublabel.toLowerCase().includes(q),
+        )
+      : recentItems;
+    items.push(...matchedRecent);
+
+    // If query doesn't match much, offer a search option
+    if (q && matchedNav.length === 0) {
+      items.push({
+        id: "search-query",
+        label: t("commandPalette.searchFor", { query }),
+        href: `/app/search?q=${encodeURIComponent(query)}`,
+        section: "search",
+      });
+    }
+
+    return items;
+  }, [query, navItems, recentItems, t]);
+
+  // Reset state when opening/closing
+  useEffect(() => {
+    const el = dialogRef.current;
+    if (!el) return;
+    if (open && !el.open) {
+      setQuery("");
+      setActiveIndex(0);
+      el.showModal();
+      // Focus input after dialog opens
+      requestAnimationFrame(() => inputRef.current?.focus());
+    } else if (!open && el.open) {
+      el.close();
+    }
+  }, [open]);
+
+  // Keep active index in bounds
+  useEffect(() => {
+    if (activeIndex >= filteredItems.length) {
+      setActiveIndex(Math.max(0, filteredItems.length - 1));
+    }
+  }, [filteredItems.length, activeIndex]);
+
+  // Scroll active item into view
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const activeEl = list.querySelector("[data-active='true']");
+    activeEl?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
+  // Handle native dialog cancel (Escape)
+  const handleCancel = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  useEffect(() => {
+    const el = dialogRef.current;
+    if (!el) return;
+    el.addEventListener("cancel", handleCancel);
+    return () => el.removeEventListener("cancel", handleCancel);
+  }, [handleCancel]);
+
+  // Navigate to selected item
+  const selectItem = useCallback(
+    (item: PaletteItem) => {
+      onClose();
+      router.push(item.href);
+    },
+    [onClose, router],
+  );
+
+  // Keyboard navigation within the palette
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setActiveIndex((i) => Math.min(i + 1, filteredItems.length - 1));
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setActiveIndex((i) => Math.max(i - 1, 0));
+          break;
+        case "Enter":
+          e.preventDefault();
+          if (filteredItems[activeIndex]) {
+            selectItem(filteredItems[activeIndex]);
+          }
+          break;
+      }
+    },
+    [filteredItems, activeIndex, selectItem],
+  );
+
+  // Click on backdrop closes
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDialogElement>) => {
+      if (e.target === dialogRef.current) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  // Section separators
+  const getSectionLabel = useCallback(
+    (item: PaletteItem, index: number): string | null => {
+      const LABELS: Record<string, string> = {
+        navigation: t("commandPalette.navigation"),
+        recent: t("commandPalette.recentProducts"),
+      };
+
+      if (index === 0) {
+        return LABELS[item.section] ?? null;
+      }
+      const prevItem = filteredItems[index - 1];
+      if (prevItem.section !== item.section) {
+        return LABELS[item.section] ?? null;
+      }
+      return null;
+    },
+    [filteredItems, t],
+  );
+
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
+    <dialog
+      ref={dialogRef}
+      aria-label={t("commandPalette.placeholder")}
+      onClick={handleBackdropClick}
+      className="fixed inset-0 z-50 m-auto mt-[15vh] mb-auto w-full max-w-lg rounded-2xl bg-surface p-0 shadow-2xl backdrop:bg-black/40"
+    >
+      {/* Search input */}
+      <div className="flex items-center gap-3 border-b border-border px-4 py-3">
+        <Search
+          size={18}
+          aria-hidden="true"
+          className="shrink-0 text-foreground-secondary"
+        />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setActiveIndex(0);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={t("commandPalette.placeholder")}
+          className="flex-1 bg-transparent text-base text-foreground outline-none placeholder:text-foreground-secondary/60"
+          aria-label={t("commandPalette.placeholder")}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <kbd className="hidden rounded border border-border bg-surface-muted px-1.5 py-0.5 text-xs text-foreground-secondary sm:inline-block">
+          ESC
+        </kbd>
+      </div>
+
+      {/* Results list */}
+      <div ref={listRef} className="max-h-[50vh] overflow-y-auto py-2">
+        {filteredItems.length === 0 && (
+          <p className="px-4 py-6 text-center text-sm text-foreground-secondary">
+            {t("commandPalette.noResults")}
+          </p>
+        )}
+
+        {filteredItems.map((item, index) => {
+          const sectionLabel = getSectionLabel(item, index);
+          const isActive = index === activeIndex;
+
+          return (
+            <div key={item.id}>
+              {sectionLabel && (
+                <div className="px-4 pb-1 pt-3 text-xs font-semibold uppercase tracking-wider text-foreground-secondary/70">
+                  {sectionLabel}
+                </div>
+              )}
+              <button
+                type="button"
+                aria-current={isActive || undefined}
+                data-active={isActive}
+                onClick={() => selectItem(item)}
+                onMouseEnter={() => setActiveIndex(index)}
+                className={`flex w-full cursor-pointer items-center gap-3 px-4 py-2.5 text-left text-sm transition-colors ${
+                  isActive
+                    ? "bg-brand-50 text-brand-700"
+                    : "text-foreground hover:bg-surface-subtle"
+                }`}
+              >
+                {item.section === "navigation" && (
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-surface-muted">
+                    <item.icon size={16} aria-hidden="true" />
+                  </span>
+                )}
+                {item.section === "search" && (
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-brand-50 text-brand-600">
+                    <ArrowRight size={16} aria-hidden="true" />
+                  </span>
+                )}
+                <div className="min-w-0 flex-1">
+                  <span className="block truncate font-medium">
+                    {item.label}
+                  </span>
+                  {item.section === "recent" && "sublabel" in item && (
+                    <span className="block truncate text-xs text-foreground-secondary">
+                      {item.sublabel}
+                    </span>
+                  )}
+                </div>
+                {isActive && (
+                  <kbd className="hidden shrink-0 rounded border border-border bg-surface-muted px-1.5 py-0.5 text-xs text-foreground-secondary sm:inline-block">
+                    ↵
+                  </kbd>
+                )}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </dialog>
+  );
+}

--- a/frontend/src/components/desktop/ComparisonTray.test.tsx
+++ b/frontend/src/components/desktop/ComparisonTray.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ComparisonTray } from "./ComparisonTray";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockCount = vi.fn();
+const mockGetIds = vi.fn();
+const mockGetName = vi.fn();
+const mockRemove = vi.fn();
+const mockClear = vi.fn();
+const mockPush = vi.fn();
+
+vi.mock("@/stores/compare-store", () => ({
+  useCompareStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      count: mockCount,
+      getIds: mockGetIds,
+      getName: mockGetName,
+      remove: mockRemove,
+      clear: mockClear,
+    }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("ComparisonTray", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetIds.mockReturnValue([1, 2]);
+    mockGetName.mockImplementation((id: number) => `Product #${id}`);
+  });
+
+  it("renders nothing when count is 0", () => {
+    mockCount.mockReturnValue(0);
+    const { container } = render(<ComparisonTray />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders tray when products are selected", () => {
+    mockCount.mockReturnValue(2);
+    render(<ComparisonTray />);
+    expect(screen.getByText("Compare")).toBeTruthy();
+  });
+
+  it("shows product count badge", () => {
+    mockCount.mockReturnValue(2);
+    render(<ComparisonTray />);
+    expect(screen.getByText("2")).toBeTruthy();
+  });
+
+  it("lists product names", () => {
+    mockCount.mockReturnValue(2);
+    render(<ComparisonTray />);
+    expect(screen.getByText("Product #1")).toBeTruthy();
+    expect(screen.getByText("Product #2")).toBeTruthy();
+  });
+
+  it("calls remove when remove button clicked", () => {
+    mockCount.mockReturnValue(2);
+    render(<ComparisonTray />);
+    // Two remove buttons for two products
+    const removeBtns = screen.getAllByLabelText("Remove from comparison");
+    fireEvent.click(removeBtns[0]);
+    expect(mockRemove).toHaveBeenCalledWith(1);
+  });
+
+  it("calls clear on clear button click", () => {
+    mockCount.mockReturnValue(2);
+    render(<ComparisonTray />);
+    fireEvent.click(screen.getByLabelText("Clear selection"));
+    expect(mockClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("navigates to compare page on Compare Now click", () => {
+    mockCount.mockReturnValue(2);
+    mockGetIds.mockReturnValue([1, 2]);
+    render(<ComparisonTray />);
+    fireEvent.click(screen.getByText("Compare Now →"));
+    expect(mockPush).toHaveBeenCalledWith("/app/compare?ids=1,2");
+  });
+
+  it("shows 'select at least 2' when only 1 selected", () => {
+    mockCount.mockReturnValue(1);
+    mockGetIds.mockReturnValue([1]);
+    render(<ComparisonTray />);
+    expect(screen.getByText(/Select at least 2/)).toBeTruthy();
+  });
+
+  it("collapses and expands on toggle", () => {
+    mockCount.mockReturnValue(2);
+    render(<ComparisonTray />);
+    // Products are visible
+    expect(screen.getByText("Product #1")).toBeTruthy();
+
+    // Click collapse
+    fireEvent.click(screen.getByLabelText("Collapse comparison tray"));
+
+    // Products should be hidden
+    expect(screen.queryByText("Product #1")).toBeNull();
+
+    // Click expand
+    fireEvent.click(screen.getByLabelText("Expand comparison tray"));
+
+    // Products visible again
+    expect(screen.getByText("Product #1")).toBeTruthy();
+  });
+
+  it("has proper aria-label on the aside element", () => {
+    mockCount.mockReturnValue(2);
+    render(<ComparisonTray />);
+    expect(screen.getByLabelText("Compare")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/desktop/ComparisonTray.tsx
+++ b/frontend/src/components/desktop/ComparisonTray.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+// ─── ComparisonTray — floating tray for product comparison ──────────────────
+// Shows selected products with names. Collapse/expand. Navigate to compare page.
+// Desktop only (hidden below lg via CSS). Replaces CompareFloatingButton on lg+.
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { Scale, ChevronDown, ChevronUp, X } from "lucide-react";
+import { useCompareStore } from "@/stores/compare-store";
+import { useTranslation } from "@/lib/i18n";
+
+export function ComparisonTray() {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const [collapsed, setCollapsed] = useState(false);
+
+  const count = useCompareStore((s) => s.count());
+  const getIds = useCompareStore((s) => s.getIds);
+  const getName = useCompareStore((s) => s.getName);
+  const remove = useCompareStore((s) => s.remove);
+  const clear = useCompareStore((s) => s.clear);
+
+  const handleCompare = useCallback(() => {
+    const ids = getIds();
+    router.push(`/app/compare?ids=${ids.join(",")}`);
+  }, [getIds, router]);
+
+  // Don't render if no products selected
+  if (count === 0) return null;
+
+  const ids = getIds();
+
+  return (
+    <aside
+      className="fixed bottom-6 right-6 z-50 hidden w-72 overflow-hidden rounded-2xl border border-border bg-surface shadow-xl lg:block"
+      aria-label={t("comparisonTray.title")}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border bg-surface-muted/50 px-4 py-2.5">
+        <div className="flex items-center gap-2">
+          <Scale size={16} aria-hidden="true" className="text-brand-600" />
+          <span className="text-sm font-semibold text-foreground">
+            {t("comparisonTray.title")}
+          </span>
+          <span className="flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-brand-600 px-1.5 text-xs font-bold text-white">
+            {count}
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setCollapsed((c) => !c)}
+            className="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-foreground-secondary transition-colors hover:bg-surface-subtle hover:text-foreground"
+            aria-label={
+              collapsed
+                ? t("comparisonTray.expand")
+                : t("comparisonTray.collapse")
+            }
+          >
+            {collapsed ? (
+              <ChevronUp size={14} aria-hidden="true" />
+            ) : (
+              <ChevronDown size={14} aria-hidden="true" />
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={clear}
+            className="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-foreground-secondary transition-colors hover:bg-red-50 hover:text-red-600"
+            aria-label={t("compare.clearSelection")}
+          >
+            <X size={14} aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      {/* Product list (shown when expanded) */}
+      {!collapsed && (
+        <>
+          <ul className="max-h-48 divide-y divide-border/50 overflow-y-auto">
+            {ids.map((id) => (
+              <li
+                key={id}
+                className="flex items-center gap-2 px-4 py-2 text-sm"
+              >
+                <span className="min-w-0 flex-1 truncate text-foreground">
+                  {getName(id)}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => remove(id)}
+                  className="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-foreground-secondary/60 transition-colors hover:bg-red-50 hover:text-red-600"
+                  aria-label={t("compare.removeFromComparison")}
+                >
+                  <X size={12} aria-hidden="true" />
+                </button>
+              </li>
+            ))}
+          </ul>
+
+          {/* Compare button */}
+          <div className="border-t border-border px-4 py-3">
+            {count >= 2 ? (
+              <button
+                type="button"
+                onClick={handleCompare}
+                className="btn-primary w-full text-sm"
+              >
+                {t("comparisonTray.compareNow")}
+              </button>
+            ) : (
+              <p className="text-center text-xs text-foreground-secondary">
+                {t("compare.selectAtLeast2")}
+              </p>
+            )}
+          </div>
+        </>
+      )}
+    </aside>
+  );
+}

--- a/frontend/src/components/desktop/ShortcutsHelp.test.tsx
+++ b/frontend/src/components/desktop/ShortcutsHelp.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ShortcutsHelp } from "./ShortcutsHelp";
+
+// ─── Stub native dialog methods (jsdom doesn't support them) ────────────────
+
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn();
+  HTMLDialogElement.prototype.close = vi.fn();
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("ShortcutsHelp", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls showModal when open is true", () => {
+    render(<ShortcutsHelp open={true} onClose={onClose} />);
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled();
+  });
+
+  it("does not call showModal when open is false", () => {
+    render(<ShortcutsHelp open={false} onClose={onClose} />);
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled();
+  });
+
+  it("renders the title", () => {
+    render(<ShortcutsHelp open={true} onClose={onClose} />);
+    expect(screen.getByText("Keyboard Shortcuts")).toBeTruthy();
+  });
+
+  it("renders navigation shortcut keys", () => {
+    render(<ShortcutsHelp open={true} onClose={onClose} />);
+    expect(screen.getByText("Command Palette")).toBeTruthy();
+    expect(screen.getByText("Focus Search")).toBeTruthy();
+    expect(screen.getByText("Go to Dashboard")).toBeTruthy();
+    expect(screen.getByText("Go to Lists")).toBeTruthy();
+    expect(screen.getByText("Open Scanner")).toBeTruthy();
+  });
+
+  it("renders general shortcut labels", () => {
+    render(<ShortcutsHelp open={true} onClose={onClose} />);
+    expect(screen.getByText("Show this help")).toBeTruthy();
+    expect(screen.getByText("Close modal / overlay")).toBeTruthy();
+  });
+
+  it("renders kbd elements for shortcut keys", () => {
+    render(<ShortcutsHelp open={true} onClose={onClose} />);
+    // Ctrl+K for command palette
+    expect(screen.getByText("Ctrl")).toBeTruthy();
+    expect(screen.getByText("K")).toBeTruthy();
+    // Single key shortcuts
+    expect(screen.getByText("/")).toBeTruthy();
+    expect(screen.getByText("H")).toBeTruthy();
+    expect(screen.getByText("L")).toBeTruthy();
+    expect(screen.getByText("S")).toBeTruthy();
+    expect(screen.getByText("?")).toBeTruthy();
+    expect(screen.getByText("Esc")).toBeTruthy();
+  });
+
+  it("renders section headings", () => {
+    render(<ShortcutsHelp open={true} onClose={onClose} />);
+    expect(screen.getByText("Navigation")).toBeTruthy();
+    expect(screen.getByText("General")).toBeTruthy();
+  });
+
+  it("calls onClose when close button is clicked", () => {
+    render(<ShortcutsHelp open={true} onClose={onClose} />);
+    const closeBtn = screen.getByLabelText("Close");
+    fireEvent.click(closeBtn);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose on backdrop click", () => {
+    render(<ShortcutsHelp open={true} onClose={onClose} />);
+    const dialog = document.querySelector("dialog");
+    // Simulate clicking the dialog element itself (backdrop)
+    fireEvent.click(dialog!);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose when clicking inside the dialog content", () => {
+    render(<ShortcutsHelp open={true} onClose={onClose} />);
+    fireEvent.click(screen.getByText("Keyboard Shortcuts"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/desktop/ShortcutsHelp.tsx
+++ b/frontend/src/components/desktop/ShortcutsHelp.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+// ─── ShortcutsHelp — keyboard shortcuts help overlay ────────────────────────
+// Triggered by "?" key. Shows all available keyboard shortcuts.
+// Desktop only (lg+). Uses native <dialog>.
+
+import { useRef, useEffect, useCallback } from "react";
+import { X } from "lucide-react";
+import { useTranslation } from "@/lib/i18n";
+
+// ─── Shortcut definitions ───────────────────────────────────────────────────
+
+interface Shortcut {
+  keys: string[];
+  labelKey: string;
+}
+
+const NAVIGATION_SHORTCUTS: Shortcut[] = [
+  { keys: ["Ctrl", "K"], labelKey: "shortcuts.commandPalette" },
+  { keys: ["/"], labelKey: "shortcuts.focusSearch" },
+  { keys: ["H"], labelKey: "shortcuts.goHome" },
+  { keys: ["L"], labelKey: "shortcuts.goLists" },
+  { keys: ["S"], labelKey: "shortcuts.openScanner" },
+];
+
+const GENERAL_SHORTCUTS: Shortcut[] = [
+  { keys: ["?"], labelKey: "shortcuts.showShortcuts" },
+  { keys: ["Esc"], labelKey: "shortcuts.closeOverlay" },
+];
+
+// ─── Props ──────────────────────────────────────────────────────────────────
+
+interface ShortcutsHelpProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+export function ShortcutsHelp({ open, onClose }: Readonly<ShortcutsHelpProps>) {
+  const { t } = useTranslation();
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const el = dialogRef.current;
+    if (!el) return;
+    if (open && !el.open) {
+      el.showModal();
+    } else if (!open && el.open) {
+      el.close();
+    }
+  }, [open]);
+
+  const handleCancel = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  useEffect(() => {
+    const el = dialogRef.current;
+    if (!el) return;
+    el.addEventListener("cancel", handleCancel);
+    return () => el.removeEventListener("cancel", handleCancel);
+  }, [handleCancel]);
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDialogElement>) => {
+      if (e.target === dialogRef.current) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
+    <dialog
+      ref={dialogRef}
+      aria-labelledby="shortcuts-help-title"
+      onClick={handleBackdropClick}
+      className="fixed inset-0 z-50 m-auto w-full max-w-sm rounded-2xl bg-surface p-6 shadow-xl backdrop:bg-black/30"
+    >
+      {/* Header */}
+      <div className="mb-5 flex items-center justify-between">
+        <h2
+          id="shortcuts-help-title"
+          className="text-base font-semibold text-foreground"
+        >
+          {t("shortcuts.title")}
+        </h2>
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-foreground-secondary transition-colors hover:bg-surface-subtle hover:text-foreground"
+          aria-label={t("common.close")}
+        >
+          <X size={18} aria-hidden="true" />
+        </button>
+      </div>
+
+      {/* Navigation section */}
+      <div className="mb-4">
+        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-foreground-secondary/70">
+          {t("shortcuts.navigation")}
+        </h3>
+        <div className="space-y-2">
+          {NAVIGATION_SHORTCUTS.map((shortcut) => (
+            <ShortcutRow
+              key={shortcut.labelKey}
+              keys={shortcut.keys}
+              label={t(shortcut.labelKey)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* General section */}
+      <div>
+        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-foreground-secondary/70">
+          {t("shortcuts.general")}
+        </h3>
+        <div className="space-y-2">
+          {GENERAL_SHORTCUTS.map((shortcut) => (
+            <ShortcutRow
+              key={shortcut.labelKey}
+              keys={shortcut.keys}
+              label={t(shortcut.labelKey)}
+            />
+          ))}
+        </div>
+      </div>
+    </dialog>
+  );
+}
+
+// ─── ShortcutRow ────────────────────────────────────────────────────────────
+
+function ShortcutRow({
+  keys,
+  label,
+}: Readonly<{ keys: string[]; label: string }>) {
+  return (
+    <div className="flex items-center justify-between py-1">
+      <span className="text-sm text-foreground">{label}</span>
+      <span className="flex items-center gap-1">
+        {keys.map((key, i) => (
+          <span key={`${key}-${i}`}>
+            <kbd className="inline-block min-w-[1.5rem] rounded border border-border bg-surface-muted px-1.5 py-0.5 text-center text-xs font-medium text-foreground-secondary">
+              {key}
+            </kbd>
+            {i < keys.length - 1 && (
+              <span className="mx-0.5 text-xs text-foreground-secondary/50">
+                +
+              </span>
+            )}
+          </span>
+        ))}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/GlobalKeyboardShortcuts.test.tsx
+++ b/frontend/src/components/layout/GlobalKeyboardShortcuts.test.tsx
@@ -1,23 +1,60 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { GlobalKeyboardShortcuts } from "./GlobalKeyboardShortcuts";
 
-// Mock next/navigation
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
 const mockPush = vi.fn();
 let mockPathname = "/app";
+
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
   usePathname: () => mockPathname,
 }));
 
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({}),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getRecentlyViewed: () =>
+    Promise.resolve({ ok: true, data: { products: [] } }),
+}));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function renderShortcuts() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <GlobalKeyboardShortcuts />
+    </QueryClientProvider>,
+  );
+}
+
+// ─── Stubs ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn();
+  HTMLDialogElement.prototype.close = vi.fn();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
 describe("GlobalKeyboardShortcuts", () => {
   beforeEach(() => {
-    mockPush.mockClear();
+    vi.clearAllMocks();
     mockPathname = "/app";
   });
 
+  // ─── / key (search) ──────────────────────────────────────────────
+
   it("navigates to /app/search when / is pressed", () => {
-    render(<GlobalKeyboardShortcuts />);
+    renderShortcuts();
     fireEvent.keyDown(document, { key: "/" });
     expect(mockPush).toHaveBeenCalledWith("/app/search");
   });
@@ -29,7 +66,7 @@ describe("GlobalKeyboardShortcuts", () => {
     input.setAttribute("aria-label", "Search");
     document.body.appendChild(input);
 
-    render(<GlobalKeyboardShortcuts />);
+    renderShortcuts();
     fireEvent.keyDown(document, { key: "/" });
 
     expect(mockPush).not.toHaveBeenCalled();
@@ -39,7 +76,7 @@ describe("GlobalKeyboardShortcuts", () => {
   });
 
   it("does not trigger when typing in an input", () => {
-    render(<GlobalKeyboardShortcuts />);
+    renderShortcuts();
     const input = document.createElement("input");
     document.body.appendChild(input);
 
@@ -50,7 +87,7 @@ describe("GlobalKeyboardShortcuts", () => {
   });
 
   it("does not trigger when typing in a textarea", () => {
-    render(<GlobalKeyboardShortcuts />);
+    renderShortcuts();
     const textarea = document.createElement("textarea");
     document.body.appendChild(textarea);
 
@@ -60,10 +97,91 @@ describe("GlobalKeyboardShortcuts", () => {
     document.body.removeChild(textarea);
   });
 
-  it("does not trigger for other keys", () => {
-    render(<GlobalKeyboardShortcuts />);
-    fireEvent.keyDown(document, { key: "a" });
-    fireEvent.keyDown(document, { key: "Escape" });
+  // ─── H key (dashboard) ───────────────────────────────────────────
+
+  it("navigates to /app when H is pressed", () => {
+    renderShortcuts();
+    fireEvent.keyDown(document, { key: "H" });
+    expect(mockPush).toHaveBeenCalledWith("/app");
+  });
+
+  it("navigates to /app when h is pressed (lowercase)", () => {
+    renderShortcuts();
+    fireEvent.keyDown(document, { key: "h" });
+    expect(mockPush).toHaveBeenCalledWith("/app");
+  });
+
+  // ─── L key (lists) ───────────────────────────────────────────────
+
+  it("navigates to /app/lists when L is pressed", () => {
+    renderShortcuts();
+    fireEvent.keyDown(document, { key: "L" });
+    expect(mockPush).toHaveBeenCalledWith("/app/lists");
+  });
+
+  // ─── S key (scanner) ─────────────────────────────────────────────
+
+  it("navigates to /app/scan when S is pressed", () => {
+    renderShortcuts();
+    fireEvent.keyDown(document, { key: "S" });
+    expect(mockPush).toHaveBeenCalledWith("/app/scan");
+  });
+
+  // ─── Ctrl+K (command palette) ─────────────────────────────────────
+
+  it("opens command palette on Ctrl+K", () => {
+    renderShortcuts();
+    fireEvent.keyDown(document, { key: "k", ctrlKey: true });
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled();
+  });
+
+  it("opens command palette on Meta+K (Mac)", () => {
+    renderShortcuts();
+    fireEvent.keyDown(document, { key: "k", metaKey: true });
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled();
+  });
+
+  it("Ctrl+K works even when typing in an input", () => {
+    renderShortcuts();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    fireEvent.keyDown(input, { key: "k", ctrlKey: true });
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+
+  // ─── ? key (shortcuts help) ──────────────────────────────────────
+
+  it("opens shortcuts help on ? key", () => {
+    renderShortcuts();
+    fireEvent.keyDown(document, { key: "?" });
+    // When shortcuts open, showModal is called for the shortcuts dialog
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled();
+  });
+
+  // ─── input guard ─────────────────────────────────────────────────
+
+  it("does not trigger single-key shortcuts when typing in an input", () => {
+    renderShortcuts();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    fireEvent.keyDown(input, { key: "H" });
+    fireEvent.keyDown(input, { key: "L" });
+    fireEvent.keyDown(input, { key: "S" });
+    expect(mockPush).not.toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+
+  // ─── modifier guard ──────────────────────────────────────────────
+
+  it("does not trigger navigation when modifier keys are held (except Ctrl+K)", () => {
+    renderShortcuts();
+    fireEvent.keyDown(document, { key: "H", ctrlKey: true });
+    fireEvent.keyDown(document, { key: "L", altKey: true });
     expect(mockPush).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/layout/GlobalKeyboardShortcuts.tsx
+++ b/frontend/src/components/layout/GlobalKeyboardShortcuts.tsx
@@ -1,50 +1,107 @@
 "use client";
 
 // ─── Global keyboard shortcuts for the app shell ────────────────────────────
-// Phase 3 of #62: "/" to focus search
+// Handles all keyboard shortcuts and renders desktop-only overlays
+// (CommandPalette, ShortcutsHelp). Desktop features hidden on mobile via CSS.
 
-import { useEffect } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useRouter, usePathname } from "next/navigation";
+import { CommandPalette } from "@/components/desktop/CommandPalette";
+import { ShortcutsHelp } from "@/components/desktop/ShortcutsHelp";
 
 /**
  * Global keyboard shortcuts:
- * - `/` — Focus the search input (or navigate to /app/search)
+ * - Ctrl+K / Cmd+K — Open command palette
+ * - `/` — Focus search input (or navigate to /app/search)
+ * - `H` — Navigate to Dashboard
+ * - `L` — Navigate to Lists
+ * - `S` — Open scanner
+ * - `?` — Show keyboard shortcuts help
+ * - `Escape` — Close any open overlay
  */
 export function GlobalKeyboardShortcuts() {
   const router = useRouter();
   const pathname = usePathname();
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+
+  const closePalette = useCallback(() => setPaletteOpen(false), []);
+  const closeShortcuts = useCallback(() => setShortcutsOpen(false), []);
 
   useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      // Ignore when typing in an input, textarea or contenteditable
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (
-        tag === "INPUT" ||
-        tag === "TEXTAREA" ||
-        (e.target as HTMLElement)?.isContentEditable
-      ) {
-        return;
-      }
-
-      if (e.key === "/") {
+    function handleCtrlK(e: KeyboardEvent): boolean {
+      if ((e.ctrlKey || e.metaKey) && e.key === "k") {
         e.preventDefault();
-
-        if (pathname === "/app/search") {
-          // Already on search page — focus the input
-          const input = document.querySelector<HTMLInputElement>(
-            'input[type="text"][aria-label]',
-          );
-          input?.focus();
-        } else {
-          // Navigate to search (will auto-focus via autoFocus prop)
-          router.push("/app/search");
-        }
+        setPaletteOpen((prev) => !prev);
+        setShortcutsOpen(false);
+        return true;
       }
+      return false;
+    }
+
+    function handleSlash() {
+      if (pathname === "/app/search") {
+        const input = document.querySelector<HTMLInputElement>(
+          'input[type="text"][aria-label]',
+        );
+        input?.focus();
+      } else {
+        router.push("/app/search");
+      }
+    }
+
+    function handleSingleKey(e: KeyboardEvent) {
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+      switch (e.key) {
+        case "/":
+          e.preventDefault();
+          handleSlash();
+          break;
+        case "H":
+        case "h":
+          router.push("/app");
+          break;
+        case "L":
+        case "l":
+          router.push("/app/lists");
+          break;
+        case "S":
+        case "s":
+          router.push("/app/scan");
+          break;
+        case "?":
+          setShortcutsOpen((prev) => !prev);
+          setPaletteOpen(false);
+          break;
+        case "Escape":
+          setPaletteOpen(false);
+          setShortcutsOpen(false);
+          break;
+      }
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (handleCtrlK(e)) return;
+
+      const target = e.target as HTMLElement;
+      const isTyping =
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.tagName === "SELECT" ||
+        target.isContentEditable;
+
+      if (!isTyping) handleSingleKey(e);
     }
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [router, pathname]);
 
-  return null;
+  return (
+    <>
+      <CommandPalette open={paletteOpen} onClose={closePalette} />
+      <ShortcutsHelp open={shortcutsOpen} onClose={closeShortcuts} />
+    </>
+  );
 }

--- a/frontend/src/stores/compare-store.test.ts
+++ b/frontend/src/stores/compare-store.test.ts
@@ -10,7 +10,10 @@ const store = () => useCompareStore.getState();
 describe("useCompareStore", () => {
   beforeEach(() => {
     // Reset to initial state before each test
-    useCompareStore.setState({ selectedIds: new Set() });
+    useCompareStore.setState({
+      selectedIds: new Set(),
+      productNames: new Map(),
+    });
   });
 
   // ─── maxItems ───────────────────────────────────────────────────────
@@ -152,5 +155,57 @@ describe("useCompareStore", () => {
 
   it("getIds returns empty array when none selected", () => {
     expect(store().getIds()).toEqual([]);
+  });
+
+  // ─── productNames ──────────────────────────────────────────────────
+
+  it("stores product name when adding with name", () => {
+    store().add(1, "Lays Classic");
+    expect(store().getName(1)).toBe("Lays Classic");
+  });
+
+  it("stores product name when toggling on with name", () => {
+    store().toggle(7, "Doritos Cool Ranch");
+    expect(store().getName(7)).toBe("Doritos Cool Ranch");
+  });
+
+  it("add without name does not overwrite existing name", () => {
+    store().add(1, "Lays Classic");
+    // add again without name (no-op since duplicate, but confirm name persists)
+    store().add(1);
+    expect(store().getName(1)).toBe("Lays Classic");
+  });
+
+  // ─── getName ────────────────────────────────────────────────────────
+
+  it("getName returns fallback for unknown product", () => {
+    expect(store().getName(999)).toBe("Product #999");
+  });
+
+  it("getName returns stored name for known product", () => {
+    store().add(42, "Pringles Original");
+    expect(store().getName(42)).toBe("Pringles Original");
+  });
+
+  // ─── name cleanup on remove ────────────────────────────────────────
+
+  it("remove cleans up product name", () => {
+    store().add(1, "Lays Classic");
+    store().remove(1);
+    expect(store().getName(1)).toBe("Product #1");
+  });
+
+  it("toggle off cleans up product name", () => {
+    store().toggle(7, "Doritos");
+    store().toggle(7);
+    expect(store().getName(7)).toBe("Product #7");
+  });
+
+  it("clear cleans up all product names", () => {
+    store().add(1, "Lays");
+    store().add(2, "Doritos");
+    store().clear();
+    expect(store().getName(1)).toBe("Product #1");
+    expect(store().getName(2)).toBe("Product #2");
   });
 });

--- a/frontend/src/stores/compare-store.ts
+++ b/frontend/src/stores/compare-store.ts
@@ -1,12 +1,15 @@
 // ─── Zustand store for product comparison selection ─────────────────────────
 // Holds the set of product IDs selected for comparison (max 4).
-// Used by CompareCheckbox and CompareFloatingButton components.
+// Used by CompareCheckbox, CompareFloatingButton, and ComparisonTray components.
 
 import { create } from "zustand";
 
 interface CompareStore {
   /** Set of product IDs selected for comparison */
   selectedIds: Set<number>;
+
+  /** Map of product ID → display name (for ComparisonTray) */
+  productNames: Map<number, string>;
 
   /** Maximum number of products that can be compared */
   maxItems: 4;
@@ -21,10 +24,10 @@ interface CompareStore {
   count: () => number;
 
   /** Toggle a product in/out of the selection */
-  toggle: (productId: number) => void;
+  toggle: (productId: number, productName?: string) => void;
 
   /** Add a product to the selection (no-op if full or already selected) */
-  add: (productId: number) => void;
+  add: (productId: number, productName?: string) => void;
 
   /** Remove a product from the selection */
   remove: (productId: number) => void;
@@ -34,10 +37,14 @@ interface CompareStore {
 
   /** Get sorted array of selected IDs */
   getIds: () => number[];
+
+  /** Get display name for a product (or "Product #ID" fallback) */
+  getName: (productId: number) => string;
 }
 
 export const useCompareStore = create<CompareStore>((set, get) => ({
   selectedIds: new Set(),
+  productNames: new Map(),
   maxItems: 4,
 
   isSelected: (productId: number) => get().selectedIds.has(productId),
@@ -46,38 +53,49 @@ export const useCompareStore = create<CompareStore>((set, get) => ({
 
   count: () => get().selectedIds.size,
 
-  toggle: (productId: number) => {
+  toggle: (productId: number, productName?: string) => {
     const state = get();
     if (state.selectedIds.has(productId)) {
-      const next = new Set(state.selectedIds);
-      next.delete(productId);
-      set({ selectedIds: next });
+      const nextIds = new Set(state.selectedIds);
+      nextIds.delete(productId);
+      const nextNames = new Map(state.productNames);
+      nextNames.delete(productId);
+      set({ selectedIds: nextIds, productNames: nextNames });
     } else if (state.selectedIds.size < 4) {
-      const next = new Set(state.selectedIds);
-      next.add(productId);
-      set({ selectedIds: next });
+      const nextIds = new Set(state.selectedIds);
+      nextIds.add(productId);
+      const nextNames = new Map(state.productNames);
+      if (productName) nextNames.set(productId, productName);
+      set({ selectedIds: nextIds, productNames: nextNames });
     }
   },
 
-  add: (productId: number) =>
+  add: (productId: number, productName?: string) =>
     set((state) => {
       if (state.selectedIds.has(productId) || state.selectedIds.size >= 4) {
         return state;
       }
-      const next = new Set(state.selectedIds);
-      next.add(productId);
-      return { selectedIds: next };
+      const nextIds = new Set(state.selectedIds);
+      nextIds.add(productId);
+      const nextNames = new Map(state.productNames);
+      if (productName) nextNames.set(productId, productName);
+      return { selectedIds: nextIds, productNames: nextNames };
     }),
 
   remove: (productId: number) =>
     set((state) => {
       if (!state.selectedIds.has(productId)) return state;
-      const next = new Set(state.selectedIds);
-      next.delete(productId);
-      return { selectedIds: next };
+      const nextIds = new Set(state.selectedIds);
+      nextIds.delete(productId);
+      const nextNames = new Map(state.productNames);
+      nextNames.delete(productId);
+      return { selectedIds: nextIds, productNames: nextNames };
     }),
 
-  clear: () => set({ selectedIds: new Set() }),
+  clear: () => set({ selectedIds: new Set(), productNames: new Map() }),
 
   getIds: () => [...get().selectedIds].sort((a, b) => a - b),
+
+  getName: (productId: number) =>
+    get().productNames.get(productId) ?? `Product #${productId}`,
 }));


### PR DESCRIPTION
## Summary

Implements the final desktop sprint issue — **Command Palette, Keyboard Shortcuts & Comparison Tray** (#78).

This completes the desktop sprint roadmap: #76 ✅ → #72 ✅ → #74 ✅ → #73 ✅ → #75 ✅ → #79 ✅ → #77 ✅ → **#78 ✅**

## What's New

### 🔍 Command Palette (`Ctrl+K` / `⌘K`)
- VS Code / Spotlight-style overlay with fuzzy search
- 7 navigation items (Dashboard, Search, Scan, Lists, Categories, Compare, Settings)
- Recent products section (reuses TanStack Query cache)
- Keyboard navigation (↑↓ arrows + Enter to select)
- "Search for '…'" fallback when no items match
- Native `<dialog>` with backdrop click to close

### ⌨️ Keyboard Shortcuts
- `/` — Focus search (or navigate to search page)
- `H` — Dashboard, `L` — Lists, `S` — Scanner
- `?` — Show keyboard shortcuts help overlay
- `Ctrl+K` / `⌘K` — Toggle command palette (works even in inputs)
- `Escape` — Close any open overlay
- All single-key shortcuts disabled when typing in inputs/textareas

### 📊 Comparison Tray (Desktop)
- Floating `<aside>` tray at bottom-right on `lg+` screens
- Shows product names via extended `useCompareStore` (with `productNames` map)
- Individual remove buttons per product
- Collapse/expand toggle
- "Compare Now →" button (enabled at ≥2 products)
- Replaces `CompareFloatingButton` on desktop (FAB gets `lg:hidden`)

## Files Changed (19)

| Category | Files |
|----------|-------|
| **New components** | `CommandPalette.tsx`, `ShortcutsHelp.tsx`, `ComparisonTray.tsx` |
| **New tests** | `CommandPalette.test.tsx`, `ShortcutsHelp.test.tsx`, `ComparisonTray.test.tsx` |
| **Extended** | `GlobalKeyboardShortcuts.tsx` (full shortcut hub + overlay renderer) |
| **Store** | `compare-store.ts` (added `productNames` map, `getName()`) |
| **Updated** | `CompareCheckbox.tsx` (optional `productName` prop), `CompareFloatingButton.tsx` (`lg:hidden`) |
| **Call sites** | `search/page.tsx`, `product/[id]/page.tsx`, `categories/[slug]/page.tsx` |
| **Layout** | `layout.tsx` (mounts `ComparisonTray`) |
| **i18n** | `en.json`, `pl.json` (3 new namespaces: `commandPalette`, `shortcuts`, `comparisonTray`) |
| **Updated tests** | `compare-store.test.ts`, `CompareCheckbox.test.tsx`, `GlobalKeyboardShortcuts.test.tsx` |

## Testing

- **76 new/updated tests** across 5 test files
- **All 2361 tests pass** (full suite)
- Zero lint errors

Closes #78