### PR TITLE
fix(mobile): prevent viewport expansion with overflow-x containment

### DIFF
--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -70,7 +70,7 @@ export default async function AppLayout({
   }
 
   return (
-    <div className="flex min-h-screen flex-col xl:flex-row">
+    <div className="flex min-h-screen flex-col overflow-x-hidden xl:flex-row">
       <SkipLink />
       <div className="no-print">
         <OfflineIndicator />
@@ -80,7 +80,7 @@ export default async function AppLayout({
       <DesktopSidebar />
 
       {/* Main column — offset by sidebar width on xl+ */}
-      <div className="flex min-h-screen flex-1 flex-col xl:pl-56">
+      <div className="flex min-h-screen max-w-full flex-1 flex-col overflow-x-hidden xl:pl-56">
         {/* Header — visible below xl. Hidden at xl+ where sidebar takes over. */}
         <header className="sticky top-0 z-40 border-b border-border bg-surface/80 pt-[env(safe-area-inset-top)] backdrop-blur xl:hidden">
           <div className="mx-auto flex h-12 md:h-14 max-w-5xl items-center justify-between px-4">

--- a/frontend/src/components/layout/DesktopHeaderNav.tsx
+++ b/frontend/src/components/layout/DesktopHeaderNav.tsx
@@ -52,7 +52,7 @@ export function DesktopHeaderNav() {
             key={item.href}
             href={item.href}
             aria-current={isActive ? "page" : undefined}
-            className={`rounded-md px-2.5 py-1.5 text-sm font-medium transition-colors ${
+            className={`relative rounded-md px-2.5 py-1.5 text-sm font-medium transition-colors ${
               isActive
                 ? "text-brand-700 dark:text-brand-400"
                 : "text-foreground-secondary hover:bg-surface-muted hover:text-foreground"

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -266,6 +266,8 @@
     overscroll-behavior-y: contain;
     /* Smooth momentum scrolling on iOS */
     -webkit-overflow-scrolling: touch;
+    /* Prevent any descendant from widening the mobile layout viewport */
+    overflow-x: hidden;
   }
 
   body {


### PR DESCRIPTION
## Problem

After PR #72 restructured the app layout for desktop sidebar support, the mobile app "starts fully zoomed out and acts like a desktop version" on Android phones. Affects ALL pages (dashboard, search, scan, lists, settings), both PWA and browser.

PR #90 attempted to fix this by adding `overflow-x: hidden` to `body`, but the issue persisted.

## Root Cause

On mobile browsers (especially Android Chrome), the **layout viewport width** is computed from the `html` element, not `body`. When any descendant overflows horizontally — even by 1px — the browser expands the layout viewport and effectively "zooms out" to fit all content.

The desktop layout restructuring (PR #72) added nested flex wrappers without overflow containment:
```jsx
<div className="flex min-h-screen flex-col xl:flex-row">       // outer — no overflow constraint
  <DesktopSidebar />
  <div className="flex min-h-screen flex-1 flex-col xl:pl-56"> // inner — no overflow constraint
```

While `overflow-x: hidden` on `body` prevents _scrolling_, it does NOT prevent the browser's initial viewport width computation from expanding.

## Fix (3 files)

### 1. `globals.css` — Add `overflow-x: hidden` to `html`
The CSS spec says `body` overflow propagates to the viewport only when `html` has `overflow: visible`. By explicitly setting `overflow-x: hidden` on `html`, we prevent any descendant from widening the mobile layout viewport at the source.

### 2. `app/layout.tsx` — Overflow containment on both flex wrappers
- Outer wrapper: `overflow-x-hidden` prevents any child from expanding the layout
- Inner wrapper: `overflow-x-hidden` + `max-w-full` as defense-in-depth

### 3. `DesktopHeaderNav.tsx` — Add `relative` to Link items
The active indicator `<span className="absolute bottom-0 ...">` was positioned without a `relative` parent. At the lg-xl breakpoint (tablets), this span could escape its container and contribute to overflow. Adding `relative` to the `<Link>` properly contains it.

## Testing
- `npm run build` — passes
- Verified no `w-screen`, `100vw`, or `min-width` rules forcing wider layout
- All desktop-only components (`DesktopSidebar`, `ComparisonTray`, `DesktopHeaderNav`) confirmed hidden on mobile via CSS `display: none`