### PR TITLE
fix(mobile): conditionally render ConfirmDialog and SaveSearchDialog

### DIFF
--- a/frontend/src/components/search/SaveSearchDialog.test.tsx
+++ b/frontend/src/components/search/SaveSearchDialog.test.tsx
@@ -68,10 +68,11 @@ describe("SaveSearchDialog", () => {
     });
   });
 
-  it("dialog is closed when show is false", () => {
+  it("dialog is not rendered when show is false", () => {
     renderDialog({ show: false });
-    const dialog = screen.getByRole("dialog", { hidden: true });
-    expect(dialog).not.toHaveAttribute("open");
+    // Dialog should not be in the DOM at all — Android Chrome resolves box
+    // dimensions of closed <dialog> elements, inflating mobile viewport (#92).
+    expect(screen.queryByRole("dialog", { hidden: true })).toBeNull();
   });
 
   it("dialog is open when show is true", () => {


### PR DESCRIPTION
## Problem

Mobile viewport regression — same symptom as PR #92 (mobile UI appears zoomed out / desktop-like).

Android Chrome resolves box dimensions of `<dialog>` elements even when closed (`display:none`), inflating the layout viewport to ~2× device width.

PR #92 fixed this for `CommandPalette` and `ShortcutsHelp` in `GlobalKeyboardShortcuts`, but **two more dialog components were missed**:

| Component | Used on |
|---|---|
| `ConfirmDialog` | `/app/lists`, `/app/lists/[id]`, `/app/search/saved` |
| `SaveSearchDialog` | `/app/search` |

## Fix

Same wrapper/inner pattern from PR #92:

```tsx
// Wrapper — returns null when closed, no <dialog> in DOM
export function ConfirmDialog(props) {
  if (!props.open) return null;
  return <ConfirmDialogInner {...props} />;
}

// Inner — mounts <dialog> + calls showModal() only when open
function ConfirmDialogInner(props) {
  // ... <dialog ref={dialogRef}> ...
}
```

Applied to both `ConfirmDialog` and `SaveSearchDialog`.

## Changes

- **`ConfirmDialog.tsx`** — split into wrapper (`ConfirmDialog`) + inner (`ConfirmDialogInner`)
- **`SaveSearchDialog.tsx`** — split into wrapper (`SaveSearchDialog`) + inner (`SaveSearchDialogInner`)
- **`SaveSearchDialog.test.tsx`** — updated "closed" assertion to expect no DOM element (previously expected a closed `<dialog>`)

## Verification

- All 2,340 tests pass (165 test files)
- `grep -r '<dialog'` across all `.tsx` files confirms every dialog now uses conditional rendering
- No unconditionally rendered `<dialog>` elements remain in the codebase