### PR TITLE
fix(mobile): use fixed positioning for bottom navigation

### DIFF
--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -80,9 +80,7 @@ export default async function AppLayout({
       <DesktopSidebar />
 
       {/* Main column — offset by sidebar width on xl+ */}
-      {/* overflow-x-hidden creates a scroll container (overflow-y becomes auto)
-          which the sticky bottom Navigation depends on. Do NOT remove. */}
-      <div className="flex min-h-screen max-w-full flex-1 flex-col overflow-x-hidden xl:pl-56">
+      <div className="flex min-h-screen max-w-full flex-1 flex-col overflow-x-hidden pb-16 lg:pb-0 xl:pl-56">
         {/* Header — visible below xl. Hidden at xl+ where sidebar takes over. */}
         <header className="sticky top-0 z-40 border-b border-border bg-surface/80 pt-[env(safe-area-inset-top)] backdrop-blur xl:hidden">
           <div className="mx-auto flex h-12 md:h-14 max-w-5xl items-center justify-between px-4">

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -53,7 +53,7 @@ export function Navigation() {
 
   return (
     <nav
-      className="sticky bottom-0 z-40 border-t border-border bg-surface pb-[env(safe-area-inset-bottom)] lg:hidden"
+      className="fixed bottom-0 left-0 right-0 z-40 border-t border-border bg-surface pb-[env(safe-area-inset-bottom)] lg:hidden"
       aria-label="Main navigation"
     >
       <div className="mx-auto flex max-w-5xl">


### PR DESCRIPTION
## Problem

Bottom navigation (Home, Search, Scan, Lists, Settings) is not pinned to the viewport bottom — users have to scroll all the way down to find it.

## Root Cause

`sticky bottom-0` depends on the nearest scroll container. The Navigation's ancestor div has `overflow-x-hidden`, which creates a scroll container per CSS spec. But this div uses `min-h-screen flex-1` — it **expands to fit all content** and never actually scrolls. Scrolling happens at the body/html level. Since the div doesn't scroll, `sticky` has nothing to stick within and the nav just sits at the end of the document flow.

This has been broken since `overflow-x-hidden` was added to the layout divs (PR #91).

## Fix

Change the Navigation from `sticky` to `fixed` positioning — the industry standard for mobile bottom navs:

```diff
- className="sticky bottom-0 z-40 ..."
+ className="fixed bottom-0 left-0 right-0 z-40 ..."
```

`fixed` positions relative to the viewport, unaffected by scroll containers or overflow settings.

Added `pb-16 lg:pb-0` to the inner layout column to prevent content from being hidden behind the fixed nav (64px padding on mobile, 0 on desktop where nav is `lg:hidden`).

## Verification

- All 2,340 tests pass (165 test files)
- 2 files changed, +2/-4 lines