### PR TITLE
feat(score): Phase 2 — upgrade ScoreGauge & categories to 5-band color system

### DIFF
--- a/frontend/src/app/app/categories/page.tsx
+++ b/frontend/src/app/app/categories/page.tsx
@@ -7,17 +7,10 @@ import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { getCategoryOverview } from "@/lib/api";
 import { queryKeys, staleTimes } from "@/lib/query-keys";
-import { SCORE_BANDS } from "@/lib/constants";
+import { SCORE_5BAND_DISPLAY, scoreColorFromScore } from "@/lib/constants";
 import { CategoryGridSkeleton } from "@/components/common/skeletons";
 import { useTranslation } from "@/lib/i18n";
-import type { CategoryOverviewItem, ScoreBand } from "@/lib/types";
-
-function scoreToBand(score: number): ScoreBand {
-  if (score <= 25) return "low";
-  if (score <= 50) return "moderate";
-  if (score <= 75) return "high";
-  return "very_high";
-}
+import type { CategoryOverviewItem } from "@/lib/types";
 
 export default function CategoriesPage() {
   const supabase = createClient();
@@ -77,8 +70,7 @@ function CategoryCard({
   category,
 }: Readonly<{ category: CategoryOverviewItem }>) {
   const { t } = useTranslation();
-  const band = scoreToBand(category.avg_score);
-  const display = SCORE_BANDS[band];
+  const display = SCORE_5BAND_DISPLAY[scoreColorFromScore(category.avg_score)];
 
   return (
     <Link href={`/app/categories/${category.slug}`}>

--- a/frontend/src/components/product/ScoreGauge.test.tsx
+++ b/frontend/src/components/product/ScoreGauge.test.tsx
@@ -36,7 +36,7 @@ describe("ScoreGauge", () => {
     expect(screen.queryByTestId("gauge-arc")).not.toBeInTheDocument();
   });
 
-  // ── Score band colors ─────────────────────────────────────────────────────
+  // ── Score band colors (5-band: green/yellow/orange/red/darkred) ─────────
 
   it("uses green color for low score (10)", () => {
     render(<ScoreGauge score={10} />);
@@ -50,16 +50,22 @@ describe("ScoreGauge", () => {
     expect(arc.getAttribute("stroke")).toBe("var(--color-score-yellow)");
   });
 
-  it("uses orange color for high score (60)", () => {
-    render(<ScoreGauge score={60} />);
+  it("uses orange color for high score (50)", () => {
+    render(<ScoreGauge score={50} />);
     const arc = screen.getByTestId("gauge-arc");
     expect(arc.getAttribute("stroke")).toBe("var(--color-score-orange)");
   });
 
-  it("uses red color for very high score (85)", () => {
-    render(<ScoreGauge score={85} />);
+  it("uses red color for very high score (70)", () => {
+    render(<ScoreGauge score={70} />);
     const arc = screen.getByTestId("gauge-arc");
     expect(arc.getAttribute("stroke")).toBe("var(--color-score-red)");
+  });
+
+  it("uses dark red color for critical score (90)", () => {
+    render(<ScoreGauge score={90} />);
+    const arc = screen.getByTestId("gauge-arc");
+    expect(arc.getAttribute("stroke")).toBe("var(--color-score-darkred)");
   });
 
   // ── Sizes ─────────────────────────────────────────────────────────────────

--- a/frontend/src/components/product/ScoreGauge.tsx
+++ b/frontend/src/components/product/ScoreGauge.tsx
@@ -2,16 +2,16 @@
  * ScoreGauge — circular SVG gauge ring for product unhealthiness scores.
  *
  * Uses `stroke-dasharray` on an SVG `<circle>` to create a fill-arc
- * proportional to the score (0–100). Color follows the SCORE_BANDS system:
- *   1–25 → green, 26–50 → yellow, 51–75 → orange, 76–100 → red.
+ * proportional to the score (0–100). Color follows the 5-band system:
+ *   1–20 → green, 21–40 → yellow, 41–60 → orange, 61–80 → red, 81–100 → dark red.
  *
  * Falls back to a gray neutral ring when score is null/undefined.
  */
 
 import React from "react";
-import { scoreBandFromScore } from "@/lib/constants";
+import { scoreColorFromScore } from "@/lib/constants";
 import { useTranslation } from "@/lib/i18n";
-import type { ScoreBand } from "@/lib/types";
+import type { ScoreColorBand } from "@/lib/constants";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -62,14 +62,15 @@ const SIZE_CONFIG: Record<
 };
 
 /**
- * Maps score bands to their CSS custom property color values.
+ * Maps 5-band color tokens to their CSS custom property color values.
  * These match the --color-score-* tokens from globals.css.
  */
-const BAND_STROKE_COLORS: Record<ScoreBand, string> = {
-  low: "var(--color-score-green)",
-  moderate: "var(--color-score-yellow)",
-  high: "var(--color-score-orange)",
-  very_high: "var(--color-score-red)",
+const BAND_STROKE_COLORS: Record<ScoreColorBand, string> = {
+  green: "var(--color-score-green)",
+  yellow: "var(--color-score-yellow)",
+  orange: "var(--color-score-orange)",
+  red: "var(--color-score-red)",
+  darkred: "var(--color-score-darkred)",
 };
 
 const NEUTRAL_STROKE = "var(--color-foreground-muted, #9ca3af)";
@@ -96,7 +97,7 @@ export const ScoreGauge = React.memo(function ScoreGauge({
 
   // Rotate -90° so the arc starts from the top (12 o'clock)
   const strokeColor = hasScore
-    ? BAND_STROKE_COLORS[scoreBandFromScore(score)]
+    ? BAND_STROKE_COLORS[scoreColorFromScore(score)]
     : NEUTRAL_STROKE;
 
   const center = svgSize / 2;

--- a/frontend/src/lib/constants.test.ts
+++ b/frontend/src/lib/constants.test.ts
@@ -5,6 +5,8 @@ import {
   ALLERGEN_PRESETS,
   DIET_OPTIONS,
   SCORE_BANDS,
+  SCORE_5BAND_DISPLAY,
+  scoreColorFromScore,
   NUTRI_COLORS,
   HEALTH_CONDITIONS,
   WARNING_SEVERITY,
@@ -100,6 +102,43 @@ describe("SCORE_BANDS", () => {
       expect(band.label).toBeTruthy();
       expect(band.color).toMatch(/^text-/);
       expect(band.bg).toMatch(/^bg-/);
+    }
+  });
+});
+
+describe("scoreColorFromScore (5-band)", () => {
+  it.each([
+    [0, "green"],
+    [10, "green"],
+    [20, "green"],
+    [21, "yellow"],
+    [40, "yellow"],
+    [41, "orange"],
+    [60, "orange"],
+    [61, "red"],
+    [80, "red"],
+    [81, "darkred"],
+    [100, "darkred"],
+  ] as const)("maps score %i to %s", (score, expected) => {
+    expect(scoreColorFromScore(score)).toBe(expected);
+  });
+});
+
+describe("SCORE_5BAND_DISPLAY", () => {
+  it("has all five bands", () => {
+    expect(Object.keys(SCORE_5BAND_DISPLAY)).toEqual([
+      "green",
+      "yellow",
+      "orange",
+      "red",
+      "darkred",
+    ]);
+  });
+
+  it("each band has color and bg using score-* tokens", () => {
+    for (const band of Object.values(SCORE_5BAND_DISPLAY)) {
+      expect(band.color).toMatch(/^text-score-/);
+      expect(band.bg).toMatch(/^bg-score-/);
     }
   });
 });

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -124,6 +124,35 @@ export function scoreBandFromScore(score: number): ScoreBand {
   return "very_high";
 }
 
+// ─── 5-band score color system ──────────────────────────────────────────────
+
+/**
+ * 5-band color token names matching CSS custom properties:
+ *   green (1–20), yellow (21–40), orange (41–60), red (61–80), darkred (81–100).
+ */
+export type ScoreColorBand = "green" | "yellow" | "orange" | "red" | "darkred";
+
+/** Map a 0-100 unhealthiness score to a 5-band color token name. */
+export function scoreColorFromScore(score: number): ScoreColorBand {
+  if (score <= 20) return "green";
+  if (score <= 40) return "yellow";
+  if (score <= 60) return "orange";
+  if (score <= 80) return "red";
+  return "darkred";
+}
+
+/**
+ * 5-band display config for visual score indicators (gauge rings, badges).
+ * Uses the score-* CSS token classes from the design system.
+ */
+export const SCORE_5BAND_DISPLAY: Record<ScoreColorBand, { color: string; bg: string }> = {
+  green: { color: "text-score-green", bg: "bg-score-green/10" },
+  yellow: { color: "text-score-yellow", bg: "bg-score-yellow/10" },
+  orange: { color: "text-score-orange", bg: "bg-score-orange/10" },
+  red: { color: "text-score-red", bg: "bg-score-red/10" },
+  darkred: { color: "text-score-darkred", bg: "bg-score-darkred/10" },
+};
+
 // Nutri-Score display config
 export const NUTRI_COLORS: Record<string, string> = {
   A: "bg-nutri-A text-foreground-inverse",

--- a/frontend/src/lib/design-system.test.ts
+++ b/frontend/src/lib/design-system.test.ts
@@ -432,6 +432,11 @@ describe("Design System — Constants Use Semantic Tokens", () => {
     expect(constants).toContain("text-score-red");
   });
 
+  it("SCORE_5BAND_DISPLAY includes darkred token class", () => {
+    expect(constants).toContain("text-score-darkred");
+    expect(constants).toContain("bg-score-darkred/10");
+  });
+
   it("NUTRI_COLORS uses nutri token classes", () => {
     expect(constants).toContain("bg-nutri-A");
     expect(constants).toContain("bg-nutri-E");


### PR DESCRIPTION
## Summary

Implements **Issue #71 Phase 2** — P1 Core UX Improvements.

### What changed

Upgraded the score display from a **4-band** system (thresholds at 25/50/75) to a **5-band** system (thresholds at 20/40/60/80), matching the existing CSS score tokens and EFSA guidance:

| Band | Score range | Color |
|------|------------|-------|
| Green | 1–20 | `--color-score-green` |
| Yellow | 21–40 | `--color-score-yellow` |
| Orange | 41–60 | `--color-score-orange` |
| Red | 61–80 | `--color-score-red` |
| Dark Red | 81–100 | `--color-score-darkred` |

### Tasks completed

| Task | Status | Notes |
|------|--------|-------|
| **2.1** Score gauge ring | ✅ Upgraded | ScoreGauge now uses 5-band stroke colors |
| **2.2** Category avg score colors | ✅ Upgraded | CategoryCard uses 5-band display config |
| **2.3** Skeleton loaders | ✅ Already done | 8 page-specific skeletons exist |
| **2.4** Empty states + retry | ✅ Already done | EmptyState component used across all pages |
| **2.5** List detail error retry | ✅ Already done | Retry button calls `refetch()` |
| **2.6** Category breadcrumbs | ✅ Already done | 3-level Breadcrumbs component in use |

### Files changed (6)

- **`constants.ts`**: Add `ScoreColorBand` type, `scoreColorFromScore()`, `SCORE_5BAND_DISPLAY` (backward-compatible — existing `ScoreBand` type and `SCORE_BANDS` untouched)
- **`ScoreGauge.tsx`**: Use 5-band stroke colors via `scoreColorFromScore()`
- **`categories/page.tsx`**: Replace local `scoreToBand()` with 5-band display config; remove unused `ScoreBand` import
- **`ScoreGauge.test.tsx`**: Update band color tests for 5 thresholds (add darkred at score 90)
- **`constants.test.ts`**: Add `scoreColorFromScore` + `SCORE_5BAND_DISPLAY` tests
- **`design-system.test.ts`**: Assert `darkred` token class usage

### Backward compatibility

- `ScoreBand` type (4 values) — **unchanged** (DB contract preserved)
- `SCORE_BANDS` config — **unchanged** (used by components reading `score_band` from API)
- `scoreBandFromScore()` — **unchanged**
- New exports are **additive only**: `ScoreColorBand`, `scoreColorFromScore()`, `SCORE_5BAND_DISPLAY`

### Test results

All **2355 tests pass** (165 test files, 0 failures). No API contract changes.

Ref: #71