### PR TITLE
feat(a11y): Phase 4 — vitest-axe component-level a11y testing

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,7 +47,8 @@
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.16",
         "typescript": "^5.7.0",
-        "vitest": "^4.0.18"
+        "vitest": "^4.0.18",
+        "vitest-axe": "^0.1.0"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -7388,6 +7389,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -10097,6 +10105,37 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest-axe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.0.0",
+        "axe-core": "^4.4.2",
+        "chalk": "^5.0.1",
+        "dom-accessibility-api": "^0.5.14",
+        "lodash-es": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.16.0"
+      }
+    },
+    "node_modules/vitest-axe/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/vitest/node_modules/picomatch": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.16",
     "typescript": "^5.7.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "vitest-axe": "^0.1.0"
   }
 }

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -1,5 +1,11 @@
 import "@testing-library/jest-dom/vitest";
-import { vi } from "vitest";
+import { expect, vi } from "vitest";
+import * as vitestAxeMatchers from "vitest-axe/matchers";
+
+// ─── vitest-axe: register toHaveNoViolations matcher ────────────────────────
+// The vitest-axe/extend-expect auto-registration is broken in v0.1.0.
+// Manually extend expect with the exported matchers.
+expect.extend(vitestAxeMatchers);
 
 // ─── Global mock: matchMedia ────────────────────────────────────────────────
 // jsdom doesn't implement matchMedia. Provide a minimal stub so hooks like

--- a/frontend/src/lib/a11y-ci-gate.test.ts
+++ b/frontend/src/lib/a11y-ci-gate.test.ts
@@ -7,6 +7,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
 const ROOT = join(__dirname, "../..");
+const SRC = join(ROOT, "src");
 const E2E = join(ROOT, "e2e");
 const HELPERS = join(E2E, "helpers");
 
@@ -23,6 +24,18 @@ describe("A11y CI Gate — file existence", () => {
     {
       name: "authenticated a11y spec",
       path: join(E2E, "authenticated-a11y.spec.ts"),
+    },
+    {
+      name: "component a11y helper",
+      path: join(SRC, "utils", "test", "a11y.ts"),
+    },
+    {
+      name: "component a11y helper tests",
+      path: join(SRC, "utils", "test", "a11y.test.tsx"),
+    },
+    {
+      name: "component a11y test suite",
+      path: join(SRC, "lib", "component-a11y.test.tsx"),
     },
   ];
 
@@ -97,6 +110,88 @@ describe("A11y helper — e2e/helpers/a11y.ts", () => {
   it("includes WCAG references in violation output", () => {
     expect(src).toContain("wcag");
     expect(src).toContain("helpUrl");
+  });
+});
+
+/* ── Component a11y helper patterns ──────────────────────────────────────── */
+
+describe("Component a11y helper — src/utils/test/a11y.ts", () => {
+  const src = readFile(join(SRC, "utils", "test", "a11y.ts"));
+
+  it("imports from vitest-axe", () => {
+    expect(src).toContain("vitest-axe");
+  });
+
+  it("imports from @testing-library/react", () => {
+    expect(src).toContain("@testing-library/react");
+  });
+
+  it("exports assertComponentA11y", () => {
+    expect(src).toContain("export async function assertComponentA11y");
+  });
+
+  it("exports auditComponentA11y", () => {
+    expect(src).toContain("export async function auditComponentA11y");
+  });
+
+  it("extends expect with toHaveNoViolations via setup file", () => {
+    const setup = readFile(join(SRC, "__tests__", "setup.ts"));
+    expect(setup).toContain("vitest-axe/extend-expect");
+    expect(src).toContain("toHaveNoViolations");
+  });
+
+  it("uses render from testing-library", () => {
+    expect(src).toContain("render");
+  });
+
+  it("accepts axe-core run options", () => {
+    expect(src).toContain("axeOptions");
+    expect(src).toContain("RunOptions");
+  });
+});
+
+/* ── Component a11y test suite patterns ──────────────────────────────────── */
+
+describe("Component a11y test suite — src/lib/component-a11y.test.tsx", () => {
+  const src = readFile(join(SRC, "lib", "component-a11y.test.tsx"));
+
+  it("imports assertComponentA11y from helper", () => {
+    expect(src).toContain("assertComponentA11y");
+    expect(src).toContain("@/utils/test/a11y");
+  });
+
+  it("tests Button component", () => {
+    expect(src).toContain("Button");
+    expect(src).toContain("primary button passes axe");
+  });
+
+  it("tests ScoreBadge component", () => {
+    expect(src).toContain("ScoreBadge");
+    expect(src).toContain("score badge");
+  });
+
+  it("tests FormField component", () => {
+    expect(src).toContain("FormField");
+    expect(src).toContain("form field");
+  });
+
+  it("tests all Button variants", () => {
+    expect(src).toContain("secondary");
+    expect(src).toContain("ghost");
+    expect(src).toContain("danger");
+  });
+
+  it("tests label-input association", () => {
+    expect(src).toContain("htmlFor");
+    expect(src).toContain("aria-describedby");
+  });
+
+  it("tests aria-invalid on error state", () => {
+    expect(src).toContain("aria-invalid");
+  });
+
+  it("tests aria-required on required state", () => {
+    expect(src).toContain("aria-required");
   });
 });
 
@@ -260,6 +355,15 @@ describe("Package.json — a11y dependencies", () => {
     const deps = pkg.dependencies ?? {};
     expect(deps).not.toHaveProperty("@axe-core/playwright");
     expect(deps).not.toHaveProperty("axe-core");
+  });
+
+  it("has vitest-axe as devDependency (Phase 4 — component-level testing)", () => {
+    expect(pkg.devDependencies).toHaveProperty("vitest-axe");
+  });
+
+  it("vitest-axe is devDependency only (not in dependencies)", () => {
+    const deps = pkg.dependencies ?? {};
+    expect(deps).not.toHaveProperty("vitest-axe");
   });
 });
 

--- a/frontend/src/lib/component-a11y.test.tsx
+++ b/frontend/src/lib/component-a11y.test.tsx
@@ -1,0 +1,195 @@
+// ─── Component-level a11y tests ─────────────────────────────────────────────
+// Validates that core UI components produce accessible HTML via axe-core
+// running in jsdom (Vitest). Complements the E2E Playwright a11y audits.
+//
+// Issue #50 — A11y CI Gate, Phase 4/
+//
+// Components tested:
+//   - Button (all variants)
+//   - ScoreBadge (score display with aria-label)
+//   - FormField (label-input association, error/hint binding)
+
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { render } from "@testing-library/react";
+import { assertComponentA11y } from "@/utils/test/a11y";
+
+/* ── Button ──────────────────────────────────────────────────────────────── */
+
+describe("Button — a11y", () => {
+  // Dynamic import to avoid module-level React errors with client components
+  let Button: typeof import("@/components/common/Button").Button;
+
+  beforeAll(async () => {
+    const mod = await import("@/components/common/Button");
+    Button = mod.Button;
+  });
+
+  it("primary button passes axe", async () => {
+    await assertComponentA11y(<Button>Save</Button>);
+  });
+
+  it("secondary button passes axe", async () => {
+    await assertComponentA11y(<Button variant="secondary">Cancel</Button>);
+  });
+
+  it("ghost button passes axe", async () => {
+    await assertComponentA11y(<Button variant="ghost">More</Button>);
+  });
+
+  it("danger button passes axe", async () => {
+    await assertComponentA11y(<Button variant="danger">Delete</Button>);
+  });
+
+  it("disabled button passes axe", async () => {
+    await assertComponentA11y(<Button disabled>Disabled</Button>);
+  });
+
+  it("loading button passes axe", async () => {
+    await assertComponentA11y(<Button loading>Saving</Button>);
+  });
+
+  it("button with icon passes axe", async () => {
+    await assertComponentA11y(
+      <Button icon={<span aria-hidden="true">✓</span>}>Confirm</Button>,
+    );
+  });
+});
+
+/* ── ScoreBadge ──────────────────────────────────────────────────────────── */
+
+describe("ScoreBadge — a11y", () => {
+  let ScoreBadge: typeof import("@/components/common/ScoreBadge").ScoreBadge;
+
+  beforeAll(async () => {
+    const mod = await import("@/components/common/ScoreBadge");
+    ScoreBadge = mod.ScoreBadge;
+  });
+
+  it("score badge with valid score passes axe", async () => {
+    await assertComponentA11y(<ScoreBadge score={42} />);
+  });
+
+  it("score badge with null score (N/A) passes axe", async () => {
+    await assertComponentA11y(<ScoreBadge score={null} />);
+  });
+
+  it("score badge with label passes axe", async () => {
+    await assertComponentA11y(<ScoreBadge score={75} showLabel />);
+  });
+
+  it("score badge has aria-label", async () => {
+    const { container } = render(<ScoreBadge score={42} />);
+    const badge = container.querySelector("[aria-label]");
+    expect(badge).toBeTruthy();
+    expect(badge?.getAttribute("aria-label")).toContain("42");
+  });
+
+  it("N/A badge has aria-label", async () => {
+    const { container } = render(<ScoreBadge score={null} />);
+    const badge = container.querySelector("[aria-label]");
+    expect(badge).toBeTruthy();
+    expect(badge?.getAttribute("aria-label")).toContain("N/A");
+  });
+
+  it("all size variants pass axe", async () => {
+    for (const size of ["sm", "md", "lg"] as const) {
+      await assertComponentA11y(<ScoreBadge score={50} size={size} />);
+    }
+  });
+});
+
+/* ── FormField ───────────────────────────────────────────────────────────── */
+
+describe("FormField — a11y", () => {
+  let FormField: typeof import("@/components/common/FormField").FormField;
+
+  beforeAll(async () => {
+    const mod = await import("@/components/common/FormField");
+    FormField = mod.FormField;
+  });
+
+  it("form field with text input passes axe", async () => {
+    await assertComponentA11y(
+      <FormField label="Email" name="email">
+        <input type="email" />
+      </FormField>,
+    );
+  });
+
+  it("required form field passes axe", async () => {
+    await assertComponentA11y(
+      <FormField label="Name" name="name" required>
+        <input type="text" />
+      </FormField>,
+    );
+  });
+
+  it("form field with error passes axe", async () => {
+    await assertComponentA11y(
+      <FormField label="Password" name="password" error="Too short">
+        <input type="password" />
+      </FormField>,
+    );
+  });
+
+  it("form field with hint passes axe", async () => {
+    await assertComponentA11y(
+      <FormField label="Username" name="username" hint="3-20 characters">
+        <input type="text" />
+      </FormField>,
+    );
+  });
+
+  it("label is associated with input via htmlFor/id", async () => {
+    const { container } = render(
+      <FormField label="Email" name="email">
+        <input type="email" />
+      </FormField>,
+    );
+
+    const label = container.querySelector("label");
+    const input = container.querySelector("input");
+    expect(label).toBeTruthy();
+    expect(input).toBeTruthy();
+    expect(label?.getAttribute("for")).toBe(input?.getAttribute("id"));
+  });
+
+  it("error message is linked via aria-describedby", async () => {
+    const { container } = render(
+      <FormField label="Name" name="name" error="Required">
+        <input type="text" />
+      </FormField>,
+    );
+
+    const input = container.querySelector("input");
+    const errorEl = container.querySelector('[role="alert"]');
+    expect(input).toBeTruthy();
+    expect(errorEl).toBeTruthy();
+    expect(input?.getAttribute("aria-describedby")).toBe(
+      errorEl?.getAttribute("id"),
+    );
+  });
+
+  it("error state sets aria-invalid", async () => {
+    const { container } = render(
+      <FormField label="Email" name="email" error="Invalid email">
+        <input type="email" />
+      </FormField>,
+    );
+
+    const input = container.querySelector("input");
+    expect(input?.getAttribute("aria-invalid")).toBe("true");
+  });
+
+  it("required state sets aria-required", async () => {
+    const { container } = render(
+      <FormField label="Email" name="email" required>
+        <input type="email" />
+      </FormField>,
+    );
+
+    const input = container.querySelector("input");
+    expect(input?.getAttribute("aria-required")).toBe("true");
+  });
+});

--- a/frontend/src/utils/test/a11y.test.tsx
+++ b/frontend/src/utils/test/a11y.test.tsx
@@ -1,0 +1,57 @@
+// ─── Tests for assertComponentA11y helper ───────────────────────────────────
+// Validates that the vitest-axe wrapper works correctly.
+//
+// Issue #50 — A11y CI Gate, Phase 4
+
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { render } from "@testing-library/react";
+import { axe } from "vitest-axe";
+import { assertComponentA11y, auditComponentA11y } from "./a11y";
+
+describe("assertComponentA11y", () => {
+  it("passes for an accessible button", async () => {
+    const results = await assertComponentA11y(
+      <button type="button">Click me</button>,
+    );
+    expect(results.violations).toHaveLength(0);
+  });
+
+  it("fails for an image without alt text", async () => {
+    // eslint-disable-next-line @next/next/no-img-element
+    const { container } = render(<img src="/test.png" />);
+    const results = await axe(container);
+
+    // There should be at least one violation (missing alt)
+    expect(results.violations.length).toBeGreaterThan(0);
+    expect(results.violations.some((v) => v.id === "image-alt")).toBe(true);
+  });
+
+  it("returns AxeResults with passes array", async () => {
+    const results = await assertComponentA11y(
+      <button type="button">OK</button>,
+    );
+    expect(results.passes).toBeDefined();
+    expect(results.passes.length).toBeGreaterThan(0);
+  });
+});
+
+describe("auditComponentA11y", () => {
+  it("returns results without asserting", async () => {
+    // eslint-disable-next-line @next/next/no-img-element
+    const { container } = render(<img src="/test.png" />);
+    const results = await auditComponentA11y(container);
+
+    // Should return violations but not throw
+    expect(results.violations.length).toBeGreaterThan(0);
+  });
+
+  it("accepts custom axe options", async () => {
+    const { container } = render(<button type="button">OK</button>);
+    const results = await auditComponentA11y(container, {
+      axeOptions: { rules: { "color-contrast": { enabled: false } } },
+    });
+    expect(results).toBeDefined();
+    expect(results.violations).toBeDefined();
+  });
+});

--- a/frontend/src/utils/test/a11y.ts
+++ b/frontend/src/utils/test/a11y.ts
@@ -1,0 +1,58 @@
+// ─── Component-level a11y test helper ────────────────────────────────────────
+// Wraps vitest-axe to provide a one-liner for asserting zero a11y violations
+// on rendered React components in Vitest + jsdom.
+//
+// Issue #50 — A11y CI Gate, Phase 4
+
+import type { RenderResult } from "@testing-library/react";
+import { render } from "@testing-library/react";
+import type { AxeResults, RunOptions } from "axe-core";
+import type { ReactElement } from "react";
+import { axe } from "vitest-axe";
+
+/* ── Types ───────────────────────────────────────────────────────────────── */
+
+export interface ComponentA11yOptions {
+  /** axe-core run options (rules to enable/disable, tags, etc.) */
+  axeOptions?: RunOptions;
+}
+
+/* ── Core helper ─────────────────────────────────────────────────────────── */
+
+/**
+ * Render a React element and run axe-core against its container.
+ * Asserts zero violations via vitest-axe's `toHaveNoViolations` matcher.
+ *
+ * @example
+ * ```tsx
+ * await assertComponentA11y(<Button>Click me</Button>);
+ * await assertComponentA11y(<FormField label="Name" name="name"><input /></FormField>);
+ * ```
+ *
+ * @returns The axe results for further inspection if needed.
+ */
+export async function assertComponentA11y(
+  ui: ReactElement,
+  options: ComponentA11yOptions = {},
+): Promise<AxeResults> {
+  const { container } = render(ui);
+  const results = await axe(container, options.axeOptions);
+
+  expect(results).toHaveNoViolations();
+
+  return results;
+}
+
+/**
+ * Run axe-core against an already-rendered container without asserting.
+ * Useful when you need to inspect specific violations or do custom assertions.
+ *
+ * @param container The DOM element to audit (e.g., from `render().container`).
+ * @returns The full axe results.
+ */
+export async function auditComponentA11y(
+  container: RenderResult["container"],
+  options: ComponentA11yOptions = {},
+): Promise<AxeResults> {
+  return axe(container, options.axeOptions);
+}


### PR DESCRIPTION
# A11y CI Gate — Phase 4: Component-Level axe Testing

Closes #50

## Summary
Completes the final phase of Issue #50 by adding Vitest component-level axe-core auditing. This enables rapid a11y feedback during unit tests without requiring full E2E Playwright runs.

**7 files changed, +463/−3 lines, 46 new tests (2454 total pass)**

## What was already done (Phases 1-3, 5)
- `@axe-core/playwright` installed with shared `e2e/helpers/a11y.ts` helper
- `smoke-a11y.spec.ts` — 14 public pages + dark mode + mobile audit
- `authenticated-a11y.spec.ts` — 5 auth pages + mobile + dark mode + baseline
- CI integration — JSON reporter, artifact upload, zero-tolerance enforcement
- `a11y-ci-gate.test.ts` — structural validation of the E2E scaffold

## What this PR adds (Phase 4)

### New: `vitest-axe` Integration
- **Installed** `vitest-axe` (v0.1.0) devDependency
- **Registered** `toHaveNoViolations` matcher in `src/__tests__/setup.ts` (workaround for vitest-axe v0.1.0 empty `extend-expect.js` — uses manual `expect.extend()`)

### New: Component A11y Helper (`src/utils/test/a11y.ts`)
- `assertComponentA11y(ui, options?)` — renders a React element and asserts zero axe violations
- `auditComponentA11y(container, options?)` — runs axe without asserting, for custom checks
- Accepts `axeOptions` (RunOptions) for rule customization

### New: Helper Tests (`src/utils/test/a11y.test.tsx` — 5 tests)
- Accessible button passes
- Image without alt fails (detects `image-alt` violation)
- Returns AxeResults with passes array
- `auditComponentA11y` returns without asserting
- Custom axe options accepted

### New: Component A11y Test Suite (`src/lib/component-a11y.test.tsx` — 21 tests)
- **Button** (7 tests): primary, secondary, ghost, danger, disabled, loading, with icon
- **ScoreBadge** (6 tests): valid score, null/N/A, with label, aria-label check, all sizes
- **FormField** (8 tests): text input, required, error, hint, label-input association, aria-describedby, aria-invalid, aria-required

### Updated: Gate Tests (`src/lib/a11y-ci-gate.test.ts` — +22 tests → 70 total)
- Validates Phase 4 file existence (helper, helper tests, component test suite)
- Validates helper patterns (vitest-axe import, render, assertComponentA11y export, axeOptions)
- Validates component test patterns (Button/ScoreBadge/FormField coverage, ARIA checks)
- Validates vitest-axe in package.json devDependencies

## Test Results
**2454 tests pass** (169 files, 0 failures) — up from 2408