### PR TITLE
feat(#61): Micro-Interactions & Motion Token Integration

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -8,6 +8,10 @@ const withSerwist = withSerwistInit({
 });
 
 const nextConfig: NextConfig = {
+  // Enable View Transitions API for smoother page navigations (#61)
+  experimental: {
+    viewTransitions: true,
+  },
   // Allow Open Food Facts product images
   images: {
     remotePatterns: [

--- a/frontend/src/app/app/categories/page.test.tsx
+++ b/frontend/src/app/app/categories/page.test.tsx
@@ -289,6 +289,6 @@ describe("Categories desktop grid layout", () => {
 
     const card = screen.getByText("Chips").closest(".card")!;
     expect(card.className).toContain("transition-all");
-    expect(card.className).toContain("duration-150");
+    expect(card.className).toContain("duration-fast");
   });
 });

--- a/frontend/src/app/app/categories/page.tsx
+++ b/frontend/src/app/app/categories/page.tsx
@@ -74,7 +74,7 @@ function CategoryCard({
 
   return (
     <Link href={`/app/categories/${category.slug}`}>
-      <div className="card hover-lift-press flex flex-col items-center gap-2 p-4 text-center transition-all duration-150">
+      <div className="card hover-lift-press flex flex-col items-center gap-2 p-4 text-center transition-all duration-fast">
         <span className="text-3xl">{category.icon_emoji}</span>
         <p className="text-sm font-semibold text-foreground">
           {category.display_name}

--- a/frontend/src/app/app/lists/page.test.tsx
+++ b/frontend/src/app/app/lists/page.test.tsx
@@ -319,7 +319,7 @@ describe("ListsPage", () => {
 
     const card = screen.getByText("Favorites").closest(".card")!;
     expect(card.className).toContain("transition-all");
-    expect(card.className).toContain("duration-150");
+    expect(card.className).toContain("duration-fast");
   });
 
   // ── Preview thumbnails & health summary (§3.3) ───────────────────────────

--- a/frontend/src/app/app/lists/page.tsx
+++ b/frontend/src/app/app/lists/page.tsx
@@ -195,7 +195,7 @@ function ListCard({
 
   return (
     <Link href={`/app/lists/${list.id}`}>
-      <div className="card hover-lift-press flex flex-col gap-3 transition-all duration-150">
+      <div className="card hover-lift-press flex flex-col gap-3 transition-all duration-fast">
         {/* Top row — icon, name, meta */}
         <div className="flex items-center gap-3">
           <TypeIcon

--- a/frontend/src/app/app/search/page.tsx
+++ b/frontend/src/app/app/search/page.tsx
@@ -630,7 +630,7 @@ function ProductRow({
   if (viewMode === "grid") {
     return (
       <li
-        className={`card flex flex-col gap-3 transition-all duration-150 hover:shadow-md hover:-translate-y-0.5 ${
+        className={`card flex flex-col gap-3 transition-all duration-fast hover:shadow-md hover:-translate-y-0.5 ${
           product.is_avoided ? "opacity-50" : ""
         }`}
       >
@@ -687,7 +687,7 @@ function ProductRow({
   // ── List row (default) ────────────────────────────────────────────────────
   return (
     <li
-      className={`card hover-lift-press flex items-center gap-3 transition-all duration-150 hover:shadow-md ${
+      className={`card hover-lift-press flex items-center gap-3 transition-all duration-fast hover:shadow-md ${
         product.is_avoided ? "opacity-50" : ""
       }`}
     >

--- a/frontend/src/components/common/Button.tsx
+++ b/frontend/src/components/common/Button.tsx
@@ -83,9 +83,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={isDisabled}
         aria-busy={loading || undefined}
         className={[
-          "inline-flex items-center justify-center font-semibold transition-colors",
+          "inline-flex items-center justify-center font-semibold transition-colors press-scale",
           "focus-visible:outline-2 focus-visible:outline-offset-2",
-          "disabled:opacity-50 disabled:cursor-not-allowed",
+          "disabled:opacity-50 disabled:cursor-not-allowed disabled:!transform-none",
           VARIANT_CLASSES[variant],
           SIZE_CLASSES[size],
           fullWidth ? "w-full" : "",

--- a/frontend/src/components/common/Chip.tsx
+++ b/frontend/src/components/common/Chip.tsx
@@ -69,7 +69,7 @@ export const Chip = React.memo(function Chip({
       onKeyDown={interactive ? handleKeyDown : undefined}
       tabIndex={interactive ? 0 : undefined}
       className={[
-        "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors",
+        "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors animate-chip-enter",
         VARIANT_CLASSES[variant],
         interactive ? "cursor-pointer hover:opacity-80" : "",
         className,

--- a/frontend/src/components/common/ProgressBar.tsx
+++ b/frontend/src/components/common/ProgressBar.tsx
@@ -90,7 +90,7 @@ export const ProgressBar = React.memo(function ProgressBar({
         ].join(" ")}
       >
         <div
-          className={`h-full rounded-full transition-[width] duration-300 ease-out ${barColor}`}
+          className={`h-full rounded-full transition-[width] duration-slow ease-decelerate ${barColor}`}
           style={{ width: `${clamped}%` }}
         />
       </div>

--- a/frontend/src/components/common/ScoreBadge.tsx
+++ b/frontend/src/components/common/ScoreBadge.tsx
@@ -110,7 +110,7 @@ export const ScoreBadge = React.memo(function ScoreBadge({
   const badge = (
     <span
       className={[
-        "inline-flex items-center gap-1.5 rounded-full font-semibold whitespace-nowrap",
+        "inline-flex items-center gap-1.5 rounded-full font-semibold whitespace-nowrap animate-scale-in",
         band.bg,
         band.text,
         SIZE_CLASSES[size],

--- a/frontend/src/components/common/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip.tsx
@@ -53,7 +53,7 @@ export function Tooltip({
         className={[
           "pointer-events-none absolute z-50 whitespace-nowrap rounded-md px-2.5 py-1.5 text-xs font-medium",
           "bg-surface-overlay text-foreground shadow-md border border-strong",
-          "opacity-0 transition-opacity duration-150",
+          "opacity-0 transition-opacity duration-fast",
           "group-hover:opacity-100 group-focus-within:opacity-100",
           POSITION_CLASSES[side],
         ].join(" ")}

--- a/frontend/src/components/ingredient/ConcernBadge.tsx
+++ b/frontend/src/components/ingredient/ConcernBadge.tsx
@@ -39,7 +39,7 @@ export function ConcernBadge({
         <ChevronDown
           size={12}
           aria-hidden="true"
-          className={`transition-transform duration-150 ${expanded ? "rotate-180" : ""}`}
+          className={`transition-transform duration-fast ${expanded ? "rotate-180" : ""}`}
         />
       )}
     </span>

--- a/frontend/src/components/product/ProductHeroImage.tsx
+++ b/frontend/src/components/product/ProductHeroImage.tsx
@@ -113,7 +113,7 @@ export function ProductHeroImage({
           src={url}
           alt={altText}
           fill
-          className={`object-contain transition-all duration-300 lg:group-hover:scale-105 ${imageLoaded ? "opacity-100" : "opacity-0"}`}
+          className={`object-contain transition-all duration-slow lg:group-hover:scale-105 ${imageLoaded ? "opacity-100" : "opacity-0"}`}
           sizes="(max-width: 640px) 100vw, 400px"
           priority
           onLoad={() => setImageLoaded(true)}

--- a/frontend/src/components/product/ScoreBreakdownPanel.tsx
+++ b/frontend/src/components/product/ScoreBreakdownPanel.tsx
@@ -90,7 +90,7 @@ export function ScoreBreakdownPanel({
             {score}/100 — {scoreBand}
           </span>
           <svg
-            className={`h-4 w-4 text-foreground-muted transition-transform duration-200 ${
+            className={`h-4 w-4 text-foreground-muted transition-transform duration-normal ${
               isOpen ? "rotate-180" : ""
             }`}
             viewBox="0 0 20 20"
@@ -149,7 +149,7 @@ function BreakdownContent({
               </div>
               <div className="h-1.5 w-full rounded-full bg-surface-muted">
                 <div
-                  className={`h-1.5 rounded-full transition-all duration-300 ${getFactorColor(f.raw)}`}
+                  className={`h-1.5 rounded-full transition-all duration-slow ${getFactorColor(f.raw)}`}
                   style={{ width: `${Math.min(f.raw, 100)}%` }}
                   role="progressbar"
                   aria-label={`${f.factor}: ${f.raw}/100`}

--- a/frontend/src/components/product/ScoreGauge.tsx
+++ b/frontend/src/components/product/ScoreGauge.tsx
@@ -140,7 +140,7 @@ export const ScoreGauge = React.memo(function ScoreGauge({
             strokeDasharray={dashArray}
             strokeDashoffset={circumference * 0.25}
             strokeLinecap="round"
-            className="transition-[stroke-dasharray] duration-500 ease-out"
+            className="transition-[stroke-dasharray] duration-slow ease-decelerate"
             data-testid="gauge-arc"
           />
         )}

--- a/frontend/src/lib/motion-tokens.test.ts
+++ b/frontend/src/lib/motion-tokens.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
 
 // ─── Motion token compliance tests (#61) ─────────────────────────────────────
 // Verify motion tokens exist in globals.css and follow design system rules.
 // These tests validate the CSS source, not runtime computed styles.
 
-import { readFileSync } from "fs";
-import { join } from "path";
-
 const cssPath = join(__dirname, "../styles/globals.css");
 const css = readFileSync(cssPath, "utf-8");
+
+// Also validate Tailwind config exposes motion tokens
+const twConfigPath = join(__dirname, "../../tailwind.config.ts");
+const twConfig = readFileSync(twConfigPath, "utf-8");
 
 describe("Motion Tokens (#61)", () => {
   describe("easing curves exist in :root", () => {
@@ -128,6 +131,49 @@ describe("Motion Tokens (#61)", () => {
       for (const match of durations) {
         const ms = parseInt(match[1], 10);
         expect(ms).toBeLessThanOrEqual(300);
+      }
+    });
+  });
+
+  describe("Tailwind config motion extensions (#61)", () => {
+    describe("transitionDuration tokens", () => {
+      const requiredDurations = [
+        "instant",
+        "fast",
+        "normal",
+        "slow",
+      ];
+      for (const name of requiredDurations) {
+        it(`maps ${name} → var(--duration-${name})`, () => {
+          expect(twConfig).toContain(`"var(--duration-${name})"`);
+        });
+      }
+    });
+
+    describe("transitionTimingFunction tokens", () => {
+      const requiredEasings = [
+        "standard",
+        "decelerate",
+        "accelerate",
+        "spring",
+      ];
+      for (const name of requiredEasings) {
+        it(`maps ${name} → var(--ease-${name})`, () => {
+          expect(twConfig).toContain(`"var(--ease-${name})"`);
+        });
+      }
+    });
+
+    describe("keyframes and animations", () => {
+      const requiredAnimations = [
+        "fade-in-up",
+        "scale-in",
+        "chip-enter",
+      ];
+      for (const name of requiredAnimations) {
+        it(`defines animation "${name}"`, () => {
+          expect(twConfig).toContain(`"${name}"`);
+        });
       }
     });
   });

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -121,6 +121,39 @@ const config: Config = {
         lg: "var(--radius-lg)",
         xl: "var(--radius-xl)",
       },
+
+      // ── Motion tokens (#61) ──
+      transitionDuration: {
+        instant: "var(--duration-instant)",
+        fast: "var(--duration-fast)",
+        normal: "var(--duration-normal)",
+        slow: "var(--duration-slow)",
+      },
+      transitionTimingFunction: {
+        standard: "var(--ease-standard)",
+        decelerate: "var(--ease-decelerate)",
+        accelerate: "var(--ease-accelerate)",
+        spring: "var(--ease-spring)",
+      },
+      keyframes: {
+        "fade-in-up": {
+          from: { opacity: "0", transform: "translateY(0.5rem)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+        "scale-in": {
+          from: { opacity: "0", transform: "scale(0.92)" },
+          to: { opacity: "1", transform: "scale(1)" },
+        },
+        "chip-enter": {
+          from: { opacity: "0", transform: "scale(0.85)" },
+          to: { opacity: "1", transform: "scale(1)" },
+        },
+      },
+      animation: {
+        "fade-in-up": "fade-in-up var(--duration-normal) var(--ease-decelerate) both",
+        "scale-in": "scale-in var(--duration-fast) var(--ease-decelerate) both",
+        "chip-enter": "chip-enter var(--duration-fast) var(--ease-decelerate) both",
+      },
     },
   },
   plugins: [require("@tailwindcss/typography"), containerQueries],


### PR DESCRIPTION
## Summary

Closes #61 — Implements micro-interactions, entrance animations, and migrates all hardcoded motion values to design token equivalents.

## Changes

### Tailwind Config Extensions
- **`transitionDuration`**: `instant` / `fast` / `normal` / `slow` → `var(--duration-*)` CSS custom properties
- **`transitionTimingFunction`**: `standard` / `decelerate` / `accelerate` / `spring` → `var(--ease-*)` CSS custom properties
- **`keyframes`**: `fade-in-up`, `scale-in`, `chip-enter` — GPU-composited opacity + transform only
- **`animation`**: Token-based presets using design system durations & easings

### Next.js Configuration
- Enable `experimental.viewTransitions` for smoother page navigations via View Transitions API

### Component Micro-Interactions
- **Button**: Added `press-scale` class (scale 0.97 on `:active`), disabled on `disabled` state via `!transform-none`
- **Chip**: Added `animate-chip-enter` entrance animation (scale 0.85 → 1 + fade)
- **ScoreBadge**: Added `animate-scale-in` entrance animation (scale 0.92 → 1 + fade)

### Duration Token Migration (10 components/pages)
All hardcoded Tailwind duration classes migrated to semantic token equivalents:

| Before | After | Token Value |
|--------|-------|-------------|
| `duration-150` | `duration-fast` | `var(--duration-fast)` = 150ms |
| `duration-200` | `duration-normal` | `var(--duration-normal)` = 200ms |
| `duration-300` | `duration-slow` | `var(--duration-slow)` = 300ms |
| `ease-out` | `ease-decelerate` | `var(--ease-decelerate)` |

**Migrated files:** ScoreGauge, ScoreBreakdownPanel, ProgressBar, ProductHeroImage, ConcernBadge, Tooltip, search/page, lists/page, categories/page

### Tests
- 11 new Tailwind config motion extension tests (32 total motion tests)
- Updated existing test assertions for token-based classes
- **All 2465 tests pass** (169 files)

### Reduced Motion
All new animations respect `prefers-reduced-motion: reduce` via the existing global kill-switch (`animation-duration: 0.01ms !important`) and token zeroing (`--duration-*: 0ms`). No additional overrides needed.