### PR TITLE
feat(#65): Iconography & Illustration System — Lucide Icons + CategoryIcon

### DIFF
--- a/frontend/src/app/app/product/[id]/page.tsx
+++ b/frontend/src/app/app/product/[id]/page.tsx
@@ -44,6 +44,7 @@ import { ErrorBoundary } from "@/components/common/ErrorBoundary";
 import { PrintButton } from "@/components/common/PrintButton";
 import { WatchButton } from "@/components/product/WatchButton";
 import { ScoreHistoryPanel } from "@/components/product/ScoreHistoryPanel";
+import { AlertTriangle, Check, Info, Globe } from "lucide-react";
 import type {
   ProductProfile,
   ProfileAlternative,
@@ -510,7 +511,7 @@ function OverviewTab({ profile }: Readonly<{ profile: ProductProfile }>) {
                   className="rounded border border-red-200 bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700"
                   data-allergen-type="contains"
                 >
-                  ⚠ {tag.trim().replaceAll("en:", "")}
+                  <AlertTriangle size={12} className="inline -mt-0.5" aria-hidden="true" /> {tag.trim().replaceAll("en:", "")}
                 </span>
               ))}
           </div>
@@ -541,8 +542,8 @@ function OverviewTab({ profile }: Readonly<{ profile: ProductProfile }>) {
           <h3 className="mb-2 text-sm font-semibold text-foreground-secondary lg:text-base">
             {t("product.allergens")}
           </h3>
-          <p className="text-sm text-green-600">
-            ✓ {t("product.noKnownAllergens")}
+          <p className="flex items-center gap-1 text-sm text-green-600">
+            <Check size={14} aria-hidden="true" /> {t("product.noKnownAllergens")}
           </p>
         </div>
       )}
@@ -552,13 +553,11 @@ function OverviewTab({ profile }: Readonly<{ profile: ProductProfile }>) {
 
       {/* Eco-Score placeholder */}
       <div className="card">
-        <h3 className="mb-2 text-sm font-semibold text-foreground-secondary lg:text-base">
-          🌍 {t("product.ecoScoreTitle")}
+        <h3 className="mb-2 flex items-center gap-1.5 text-sm font-semibold text-foreground-secondary lg:text-base">
+          <Globe size={16} aria-hidden="true" /> {t("product.ecoScoreTitle")}
         </h3>
         <div className="flex items-center gap-2 rounded-lg border border-dashed border-blue-200 bg-blue-50/50 px-3 py-3">
-          <span className="text-lg" aria-hidden="true">
-            ℹ️
-          </span>
+          <Info size={18} className="flex-shrink-0 text-blue-600" aria-hidden="true" />
           <p className="text-sm text-blue-700">
             {t("product.ecoScoreComingSoon")}
           </p>

--- a/frontend/src/app/error.test.tsx
+++ b/frontend/src/app/error.test.tsx
@@ -29,4 +29,13 @@ describe("ErrorPage", () => {
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
   });
+
+  it("renders AlertTriangle icon", () => {
+    const { container } = render(
+      <ErrorPage error={new Error("test")} reset={vi.fn()} />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute("aria-hidden")).toBe("true");
+  });
 });

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -4,6 +4,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
 import { useTranslation } from "@/lib/i18n";
 
 export default function ErrorPage({
@@ -24,6 +25,7 @@ export default function ErrorPage({
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center px-4">
+      <AlertTriangle size={48} className="mb-4 text-error" aria-hidden="true" />
       <h1 className="mb-2 text-2xl font-bold text-foreground">
         {t("error.somethingWrong")}
       </h1>

--- a/frontend/src/app/not-found.test.tsx
+++ b/frontend/src/app/not-found.test.tsx
@@ -33,4 +33,11 @@ describe("NotFound (404)", () => {
     const link = screen.getByText("Go home");
     expect(link.closest("a")).toHaveAttribute("href", "/");
   });
+
+  it("renders FileQuestion icon", () => {
+    const { container } = render(<NotFound />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute("aria-hidden")).toBe("true");
+  });
 });

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -3,12 +3,14 @@
 "use client";
 
 import Link from "next/link";
+import { FileQuestion } from "lucide-react";
 import { useTranslation } from "@/lib/i18n";
 
 export default function NotFound() {
   const { t } = useTranslation();
   return (
     <div className="flex min-h-screen flex-col items-center justify-center px-4">
+      <FileQuestion size={48} className="mb-4 text-foreground-muted" aria-hidden="true" />
       <h1 className="mb-2 text-6xl font-bold text-foreground">
         {t("error.notFoundCode")}
       </h1>

--- a/frontend/src/app/onboarding/region/RegionForm.test.tsx
+++ b/frontend/src/app/onboarding/region/RegionForm.test.tsx
@@ -59,7 +59,9 @@ describe("RegionForm", () => {
 
     await user.click(screen.getByText("Poland"));
 
-    expect(screen.getByText("✓")).toBeInTheDocument();
+    // Check icon renders as SVG (Lucide)
+    const checkSpan = document.querySelector(".text-brand svg");
+    expect(checkSpan).toBeTruthy();
   });
 
   it("calls setUserPreferences with selected country on continue", async () => {

--- a/frontend/src/app/onboarding/region/RegionForm.tsx
+++ b/frontend/src/app/onboarding/region/RegionForm.tsx
@@ -8,6 +8,7 @@ import { showToast } from "@/lib/toast";
 import { createClient } from "@/lib/supabase/client";
 import { setUserPreferences } from "@/lib/api";
 import { COUNTRIES } from "@/lib/constants";
+import { Check } from "lucide-react";
 import { useTranslation } from "@/lib/i18n";
 
 export function RegionForm() {
@@ -67,7 +68,7 @@ export function RegionForm() {
               <p className="text-sm text-foreground-secondary">{country.native}</p>
             </div>
             {selected === country.code && (
-              <span className="ml-auto text-brand">✓</span>
+              <span className="ml-auto text-brand"><Check size={20} /></span>
             )}
           </button>
         ))}

--- a/frontend/src/app/onboarding/steps/RegionStep.test.tsx
+++ b/frontend/src/app/onboarding/steps/RegionStep.test.tsx
@@ -77,7 +77,9 @@ describe("RegionStep", () => {
 
   it("shows checkmark for selected country", () => {
     renderStep({ country: "PL", language: "pl" });
-    expect(screen.getByText("✓")).toBeInTheDocument();
+    // Check icon renders as SVG (Lucide)
+    const checkSpan = document.querySelector(".text-brand svg");
+    expect(checkSpan).toBeTruthy();
   });
 
   it("shows language selector after country selection", () => {

--- a/frontend/src/app/onboarding/steps/RegionStep.tsx
+++ b/frontend/src/app/onboarding/steps/RegionStep.tsx
@@ -3,6 +3,7 @@
 // ─── Step 2: Region + Language ──────────────────────────────────────────────
 
 import { COUNTRIES, getLanguagesForCountry } from "@/lib/constants";
+import { Check } from "lucide-react";
 import { useTranslation } from "@/lib/i18n";
 import type { StepProps } from "../types";
 
@@ -46,7 +47,7 @@ export function RegionStep({ data, onChange, onNext, onBack }: StepProps) {
               <p className="text-sm text-foreground-secondary">{country.native}</p>
             </div>
             {data.country === country.code && (
-              <span className="ml-auto text-brand">✓</span>
+              <span className="ml-auto text-brand"><Check size={20} /></span>
             )}
           </button>
         ))}

--- a/frontend/src/components/common/AllergenBadge.test.tsx
+++ b/frontend/src/components/common/AllergenBadge.test.tsx
@@ -37,13 +37,19 @@ describe("AllergenBadge", () => {
   });
 
   it("shows correct icon for traces", () => {
-    render(<AllergenBadge status="traces" allergenName="Fish" />);
-    expect(screen.getByText("⚡")).toBeTruthy();
+    const { container } = render(
+      <AllergenBadge status="traces" allergenName="Fish" />,
+    );
+    // Zap icon renders as SVG
+    expect(container.querySelectorAll("svg").length).toBeGreaterThanOrEqual(1);
   });
 
   it("shows correct icon for free", () => {
-    render(<AllergenBadge status="free" allergenName="Sesame" />);
-    expect(screen.getByText("✓")).toBeTruthy();
+    const { container } = render(
+      <AllergenBadge status="free" allergenName="Sesame" />,
+    );
+    // Check icon renders as SVG
+    expect(container.querySelectorAll("svg").length).toBeGreaterThanOrEqual(1);
   });
 
   it("applies size classes", () => {

--- a/frontend/src/components/common/AllergenBadge.tsx
+++ b/frontend/src/components/common/AllergenBadge.tsx
@@ -11,7 +11,7 @@
  */
 
 import React from "react";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Check, Zap } from "lucide-react";
 import { InfoTooltip } from "./InfoTooltip";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -49,13 +49,13 @@ const STATUS_CONFIGS: Record<AllergenStatus, StatusConfig> = {
     srLabel: "Contains",
   },
   traces: {
-    icon: "⚡",
+    icon: <Zap size={12} />,
     bg: "bg-allergen-traces/10",
     text: "text-allergen-traces",
     srLabel: "May contain traces of",
   },
   free: {
-    icon: "✓",
+    icon: <Check size={12} />,
     bg: "bg-allergen-free/10",
     text: "text-allergen-free",
     srLabel: "Free from",

--- a/frontend/src/components/common/CategoryIcon.test.tsx
+++ b/frontend/src/components/common/CategoryIcon.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import {
+  CategoryIcon,
+  hasCategoryIcon,
+  getSupportedCategorySlugs,
+} from "./CategoryIcon";
+
+describe("CategoryIcon", () => {
+  // ── Rendering ─────────────────────────────────────────────────────────────
+
+  it("renders an SVG for a known category slug", () => {
+    const { container } = render(<CategoryIcon slug="dairy" />);
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
+
+  it("renders an SVG for an unknown category slug (fallback)", () => {
+    const { container } = render(<CategoryIcon slug="unknown-nonsense" />);
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
+
+  // ── Size variants ─────────────────────────────────────────────────────────
+
+  it("renders sm size (16px)", () => {
+    const { container } = render(<CategoryIcon slug="dairy" size="sm" />);
+    const svg = container.querySelector("svg")!;
+    expect(svg.getAttribute("width")).toBe("16");
+    expect(svg.getAttribute("height")).toBe("16");
+  });
+
+  it("renders md size (20px)", () => {
+    const { container } = render(<CategoryIcon slug="dairy" size="md" />);
+    const svg = container.querySelector("svg")!;
+    expect(svg.getAttribute("width")).toBe("20");
+    expect(svg.getAttribute("height")).toBe("20");
+  });
+
+  it("defaults to lg size (24px)", () => {
+    const { container } = render(<CategoryIcon slug="dairy" />);
+    const svg = container.querySelector("svg")!;
+    expect(svg.getAttribute("width")).toBe("24");
+    expect(svg.getAttribute("height")).toBe("24");
+  });
+
+  it("renders xl size (32px)", () => {
+    const { container } = render(<CategoryIcon slug="dairy" size="xl" />);
+    const svg = container.querySelector("svg")!;
+    expect(svg.getAttribute("width")).toBe("32");
+    expect(svg.getAttribute("height")).toBe("32");
+  });
+
+  // ── Accessibility ─────────────────────────────────────────────────────────
+
+  it("is decorative (aria-hidden) when no label", () => {
+    const { container } = render(<CategoryIcon slug="meat" />);
+    const svg = container.querySelector("svg")!;
+    expect(svg.getAttribute("aria-hidden")).toBe("true");
+    expect(svg.getAttribute("aria-label")).toBeNull();
+    expect(svg.getAttribute("role")).toBeNull();
+  });
+
+  it("is informational (aria-label + role=img) when label provided", () => {
+    const { container } = render(
+      <CategoryIcon slug="meat" label="Meat products" />,
+    );
+    const svg = container.querySelector("svg")!;
+    expect(svg.getAttribute("aria-label")).toBe("Meat products");
+    expect(svg.getAttribute("role")).toBe("img");
+    expect(svg.getAttribute("aria-hidden")).toBeNull();
+  });
+
+  // ── All categories render ─────────────────────────────────────────────────
+
+  const CATEGORIES = [
+    "bread",
+    "breakfast-grain-based",
+    "canned-goods",
+    "cereals",
+    "chips-pl",
+    "chips-de",
+    "chips",
+    "condiments",
+    "dairy",
+    "drinks",
+    "frozen-prepared",
+    "instant-frozen",
+    "meat",
+    "nuts-seeds-legumes",
+    "plant-based-alternatives",
+    "sauces",
+    "seafood-fish",
+    "snacks",
+    "sweets",
+    "alcohol",
+    "baby",
+    "zabka",
+  ];
+
+  it.each(CATEGORIES)("renders icon for category: %s", (slug) => {
+    const { container } = render(<CategoryIcon slug={slug} />);
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
+
+  // ── CSS className passthrough ─────────────────────────────────────────────
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <CategoryIcon slug="dairy" className="text-red-500" />,
+    );
+    const svg = container.querySelector("svg")!;
+    expect(svg.className.baseVal || svg.getAttribute("class")).toContain(
+      "text-red-500",
+    );
+  });
+
+  // ── Utility: hasCategoryIcon ──────────────────────────────────────────────
+
+  it("hasCategoryIcon returns true for known slugs", () => {
+    expect(hasCategoryIcon("dairy")).toBe(true);
+    expect(hasCategoryIcon("bread")).toBe(true);
+    expect(hasCategoryIcon("sweets")).toBe(true);
+  });
+
+  it("hasCategoryIcon returns false for unknown slugs", () => {
+    expect(hasCategoryIcon("unknown")).toBe(false);
+    expect(hasCategoryIcon("")).toBe(false);
+    expect(hasCategoryIcon("pizza")).toBe(false);
+  });
+
+  // ── Utility: getSupportedCategorySlugs ────────────────────────────────────
+
+  it("getSupportedCategorySlugs returns all category slugs", () => {
+    const slugs = getSupportedCategorySlugs();
+    expect(slugs.length).toBeGreaterThanOrEqual(20);
+    expect(slugs).toContain("dairy");
+    expect(slugs).toContain("meat");
+    expect(slugs).toContain("bread");
+    expect(slugs).toContain("zabka");
+  });
+});

--- a/frontend/src/components/common/CategoryIcon.tsx
+++ b/frontend/src/components/common/CategoryIcon.tsx
@@ -1,0 +1,128 @@
+// ─── CategoryIcon — Lucide-based food category icons ────────────────────────
+// Maps category slugs to visually appropriate Lucide icons. Falls back to a
+// generic utensils icon for unknown categories.
+//
+// Issue #65 — Iconography & Illustration System
+// All icons use currentColor for automatic dark mode support.
+
+import type { LucideIcon } from "lucide-react";
+import {
+  Wheat,
+  Soup,
+  Package,
+  Cookie,
+  Droplets,
+  Milk,
+  GlassWater,
+  Snowflake,
+  Microwave,
+  Beef,
+  Nut,
+  Leaf,
+  Fish,
+  Popcorn,
+  Candy,
+  Beer,
+  Baby,
+  Store,
+  UtensilsCrossed,
+} from "lucide-react";
+
+/* ── Category → Icon map ─────────────────────────────────────────────────── */
+
+const CATEGORY_ICON_MAP: Record<string, LucideIcon> = {
+  bread: Wheat,
+  "breakfast-grain-based": Soup,
+  "canned-goods": Package,
+  cereals: Wheat,
+  "chips-pl": Cookie,
+  "chips-de": Cookie,
+  chips: Cookie,
+  condiments: Droplets,
+  dairy: Milk,
+  drinks: GlassWater,
+  "frozen-prepared": Snowflake,
+  "instant-frozen": Microwave,
+  meat: Beef,
+  "nuts-seeds-legumes": Nut,
+  "plant-based-alternatives": Leaf,
+  sauces: Droplets,
+  "seafood-fish": Fish,
+  snacks: Popcorn,
+  sweets: Candy,
+  alcohol: Beer,
+  baby: Baby,
+  zabka: Store,
+};
+
+/** Generic fallback icon for unknown categories. */
+const FALLBACK_ICON: LucideIcon = UtensilsCrossed;
+
+/* ── Size scale (matches Icon.tsx) ───────────────────────────────────────── */
+
+const SIZE_MAP = {
+  sm: 16,
+  md: 20,
+  lg: 24,
+  xl: 32,
+} as const;
+
+export type CategoryIconSize = keyof typeof SIZE_MAP;
+
+/* ── Props ───────────────────────────────────────────────────────────────── */
+
+export interface CategoryIconProps {
+  /** Food category slug (e.g. "dairy", "bread", "meat"). */
+  readonly slug: string;
+  /** Icon size preset. @default "lg" (24px) */
+  readonly size?: CategoryIconSize;
+  /** aria-label for informational usage. Omit for decorative. */
+  readonly label?: string;
+  /** Additional CSS classes. */
+  readonly className?: string;
+}
+
+/* ── Component ───────────────────────────────────────────────────────────── */
+
+/**
+ * Renders a food category icon using Lucide icons.
+ *
+ * @example
+ * // Decorative (alongside text label)
+ * <CategoryIcon slug="dairy" size="md" />
+ *
+ * // Informational (standalone)
+ * <CategoryIcon slug="dairy" size="lg" label="Dairy products" />
+ */
+export function CategoryIcon({
+  slug,
+  size = "lg",
+  label,
+  className = "",
+}: CategoryIconProps) {
+  const IconComponent = CATEGORY_ICON_MAP[slug] ?? FALLBACK_ICON;
+  const px = SIZE_MAP[size];
+  const isDecorative = !label;
+
+  return (
+    <IconComponent
+      size={px}
+      className={className}
+      aria-hidden={isDecorative ? "true" : undefined}
+      aria-label={label}
+      role={label ? "img" : undefined}
+    />
+  );
+}
+
+/* ── Utility: check if a category has a dedicated icon ───────────────────── */
+
+/** Returns true if the category slug has a dedicated icon (not fallback). */
+export function hasCategoryIcon(slug: string): boolean {
+  return slug in CATEGORY_ICON_MAP;
+}
+
+/** Returns the list of all supported category slugs. */
+export function getSupportedCategorySlugs(): string[] {
+  return Object.keys(CATEGORY_ICON_MAP);
+}

--- a/frontend/src/components/common/Chip.tsx
+++ b/frontend/src/components/common/Chip.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { type KeyboardEvent, type ReactNode } from "react";
+import { X } from "lucide-react";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -88,9 +89,7 @@ export const Chip = React.memo(function Chip({
           aria-label={removeLabel}
           className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
         >
-          <span aria-hidden="true" className="text-[10px] leading-none">
-            ✕
-          </span>
+          <X size={10} aria-hidden="true" />
         </button>
       )}
     </Tag>

--- a/frontend/src/components/compare/CompareFloatingButton.tsx
+++ b/frontend/src/components/compare/CompareFloatingButton.tsx
@@ -6,7 +6,7 @@
 import { useRouter } from "next/navigation";
 import { useCompareStore } from "@/stores/compare-store";
 import { useTranslation } from "@/lib/i18n";
-import { Scale } from "lucide-react";
+import { Scale, X } from "lucide-react";
 
 export function CompareFloatingButton() {
   const { t } = useTranslation();
@@ -31,7 +31,7 @@ export function CompareFloatingButton() {
         className="touch-target flex h-11 w-11 items-center justify-center rounded-full bg-surface-muted text-foreground-secondary shadow-md transition-colors hover:bg-surface-subtle"
         title={t("compare.clearSelection")}
       >
-        ✕
+        <X size={18} aria-hidden="true" />
       </button>
 
       {/* Compare button */}

--- a/frontend/src/components/compare/ComparisonGrid.tsx
+++ b/frontend/src/components/compare/ComparisonGrid.tsx
@@ -9,7 +9,7 @@ import { useState, useRef, useCallback, useEffect } from "react";
 import { SCORE_BANDS, NUTRI_COLORS, scoreBandFromScore } from "@/lib/constants";
 import { AvoidBadge } from "@/components/product/AvoidBadge";
 import { useTranslation } from "@/lib/i18n";
-import { Scale, Trophy } from "lucide-react";
+import { Scale, Trophy, Check, X as XIcon } from "lucide-react";
 import type { CompareProduct, CellValue } from "@/lib/types";
 import {
   fmtUnit,
@@ -522,8 +522,8 @@ function MobileSwipeView({
                   </span>
                   <span className={`text-sm ${indicator || "text-foreground"}`}>
                     {formatted}
-                    {ranking?.bestIdx === activeIdx && " ✓"}
-                    {ranking?.worstIdx === activeIdx && " ✗"}
+                    {ranking?.bestIdx === activeIdx && <Check size={14} className="inline ml-1 text-green-600" aria-hidden="true" />}
+                    {ranking?.worstIdx === activeIdx && <XIcon size={14} className="inline ml-1 text-red-600" aria-hidden="true" />}
                   </span>
                 </div>
               );

--- a/frontend/src/components/compare/ShareComparison.test.tsx
+++ b/frontend/src/components/compare/ShareComparison.test.tsx
@@ -86,7 +86,8 @@ describe("ShareComparison", () => {
     renderComponent();
     fireEvent.click(screen.getByText("Copy URL"));
     await waitFor(() => {
-      expect(screen.getByText("✓ Copied!")).toBeTruthy();
+      // Check icon + "Copied!" text (Lucide Check replaces ✓)
+      expect(screen.getByText("Copied!")).toBeTruthy();
     });
   });
 });

--- a/frontend/src/components/compare/ShareComparison.tsx
+++ b/frontend/src/components/compare/ShareComparison.tsx
@@ -5,7 +5,7 @@
 import { useState } from "react";
 import { useSaveComparison } from "@/hooks/use-compare";
 import { useTranslation } from "@/lib/i18n";
-import { ClipboardCopy, Save, Link2 } from "lucide-react";
+import { ClipboardCopy, Save, Link2, Check } from "lucide-react";
 
 interface ShareComparisonProps {
   productIds: number[];
@@ -64,7 +64,7 @@ export function ShareComparison({
         className="btn-secondary text-sm"
       >
         {copied && !shareToken ? (
-          "✓ Copied!"
+          <span className="inline-flex items-center gap-1"><Check size={14} aria-hidden="true" /> Copied!</span>
         ) : (
           <span className="inline-flex items-center gap-1">
             <ClipboardCopy size={14} aria-hidden="true" />{" "}
@@ -100,7 +100,7 @@ export function ShareComparison({
           className="btn-primary text-sm"
         >
           {copied ? (
-            "✓ Copied!"
+            <span className="inline-flex items-center gap-1"><Check size={14} aria-hidden="true" /> Copied!</span>
           ) : (
             <>
               <Link2 size={14} aria-hidden="true" className="inline" />{" "}

--- a/frontend/src/components/product/CategoryPlaceholder.test.tsx
+++ b/frontend/src/components/product/CategoryPlaceholder.test.tsx
@@ -45,4 +45,25 @@ describe("CategoryPlaceholder", () => {
     expect(el.className).toContain("h-16");
     expect(el.className).toContain("w-16");
   });
+
+  it("renders Lucide icon when categorySlug is provided", () => {
+    const { container } = render(
+      <CategoryPlaceholder icon="🧀" productName="Cheese" categorySlug="dairy" />,
+    );
+    // Lucide icon renders as SVG instead of emoji text
+    expect(container.querySelector("svg")).toBeTruthy();
+    expect(container.textContent).not.toContain("🧀");
+  });
+
+  it("falls back to emoji when categorySlug is not recognized", () => {
+    render(
+      <CategoryPlaceholder icon="🍕" productName="Pizza" categorySlug="unknown-category" />,
+    );
+    expect(screen.getByText("🍕")).toBeTruthy();
+  });
+
+  it("falls back to emoji when categorySlug is omitted", () => {
+    render(<CategoryPlaceholder icon="🍕" productName="Pizza" />);
+    expect(screen.getByText("🍕")).toBeTruthy();
+  });
 });

--- a/frontend/src/components/product/CategoryPlaceholder.tsx
+++ b/frontend/src/components/product/CategoryPlaceholder.tsx
@@ -1,32 +1,57 @@
 // ─── CategoryPlaceholder ─────────────────────────────────────────────────────
-// Placeholder icon shown when a product has no image. Uses the
-// category_icon emoji from the product profile.
+// Placeholder shown when a product has no image. Prefers the CategoryIcon
+// (Lucide-based SVG) for the product's category slug, with the legacy emoji
+// as a fallback. Issue #65: Iconography & Illustration System.
+
+import {
+  CategoryIcon,
+  hasCategoryIcon,
+  type CategoryIconSize,
+} from "@/components/common/CategoryIcon";
 
 interface CategoryPlaceholderProps {
+  /** Legacy category emoji (e.g. "🧀") — used as fallback. */
   readonly icon: string;
+  /** Product name for accessible label. */
   readonly productName: string;
+  /** Display size preset. @default "md" */
   readonly size?: "sm" | "md" | "lg";
+  /** Category slug for Lucide icon lookup (e.g. "dairy"). */
+  readonly categorySlug?: string;
 }
 
 const sizeClasses = {
-  sm: "h-10 w-10 text-lg",
-  md: "h-16 w-16 text-2xl",
-  lg: "h-32 w-full max-w-xs text-5xl",
+  sm: "h-10 w-10",
+  md: "h-16 w-16",
+  lg: "h-32 w-full max-w-xs",
 } as const;
+
+const ICON_SIZE_MAP: Record<string, CategoryIconSize> = {
+  sm: "md",
+  md: "xl",
+  lg: "xl",
+};
 
 export function CategoryPlaceholder({
   icon,
   productName,
   size = "md",
+  categorySlug,
 }: CategoryPlaceholderProps) {
+  const useLucide = categorySlug && hasCategoryIcon(categorySlug);
+
   return (
     <div
       aria-label={`${productName} — no image available`}
       className={`flex items-center justify-center rounded-xl bg-surface-muted text-foreground-muted ${sizeClasses[size]}`}
     >
-      <span className="select-none" aria-hidden="true">
-        {icon}
-      </span>
+      {useLucide ? (
+        <CategoryIcon slug={categorySlug} size={ICON_SIZE_MAP[size]} />
+      ) : (
+        <span className="select-none text-2xl" aria-hidden="true">
+          {icon}
+        </span>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/product/HealthWarningsCard.test.tsx
+++ b/frontend/src/components/product/HealthWarningsCard.test.tsx
@@ -215,12 +215,13 @@ describe("HealthWarningBadge", () => {
     mockGetActiveHealthProfile.mockResolvedValue(ok(activeProfile));
     mockGetProductHealthWarnings.mockResolvedValue(ok(noWarnings));
 
-    render(<HealthWarningBadge productId={42} />, {
+    const { container } = render(<HealthWarningBadge productId={42} />, {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      expect(screen.getByText("✓")).toBeInTheDocument();
+      // Check icon renders as SVG (Lucide)
+      expect(container.querySelector("svg")).toBeTruthy();
     });
     expect(screen.getByTitle("No health warnings")).toBeInTheDocument();
   });

--- a/frontend/src/components/product/HealthWarningsCard.tsx
+++ b/frontend/src/components/product/HealthWarningsCard.tsx
@@ -11,7 +11,7 @@ import { getProductHealthWarnings, getActiveHealthProfile } from "@/lib/api";
 import { queryKeys, staleTimes } from "@/lib/query-keys";
 import { WARNING_SEVERITY, HEALTH_CONDITIONS } from "@/lib/constants";
 import { useTranslation } from "@/lib/i18n";
-import { Ban, AlertTriangle, Info, Shield, CheckCircle } from "lucide-react";
+import { Ban, AlertTriangle, Info, Shield, CheckCircle, Check } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { HealthWarning, WarningSeverity } from "@/lib/types";
 
@@ -260,7 +260,7 @@ export function HealthWarningBadge({
           className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-success/15 text-xs text-success"
           title={t("healthWarnings.noWarnings")}
         >
-          ✓
+          <Check size={12} />
         </span>
       );
     }

--- a/frontend/src/components/pwa/InstallPrompt.tsx
+++ b/frontend/src/components/pwa/InstallPrompt.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { X } from "lucide-react";
 import { useTranslation } from "@/lib/i18n";
 
 interface BeforeInstallPromptEvent extends Event {
@@ -110,7 +111,7 @@ export function InstallPrompt() {
           className="text-foreground-muted hover:text-foreground-secondary"
           aria-label={t("pwa.dismissInstall")}
         >
-          ✕
+          <X size={16} aria-hidden="true" />
         </button>
       </div>
 


### PR DESCRIPTION
## Summary

Implements **Issue #65 — Iconography & Illustration System** by migrating inline emoji to Lucide React icons and introducing a new `CategoryIcon` component.

### Changes

#### Inline Emoji → Lucide Migration (13 components)
| Emoji | Lucide Icon | Components |
|-------|-------------|------------|
| ✕ | `X` | Chip, InstallPrompt, CompareFloatingButton |
| ✓ | `Check` | AllergenBadge, HealthWarningsCard, RegionForm, RegionStep, ShareComparison, ComparisonGrid, product page |
| ✗ | `X` (aliased) | ComparisonGrid |
| ⚠ | `AlertTriangle` | product page (allergen tags) |
| ⚡ | `Zap` | AllergenBadge (traces) |
| 🌍 | `Globe` | product page (eco-score) |
| ℹ️ | `Info` | product page (eco-score coming soon) |

#### New: `CategoryIcon` Component
- Maps **22 food category slugs** to appropriate Lucide icons (bread→Wheat, dairy→Milk, meat→Beef, etc.)
- `UtensilsCrossed` fallback for unrecognized categories
- Exports `hasCategoryIcon()` and `getSupportedCategorySlugs()` utilities
- Supports size variants (sm/md/lg/xl), labels, className passthrough

#### Enhanced Components
- **`CategoryPlaceholder`**: New optional `categorySlug` prop — renders Lucide icon when slug is recognized, falls back to emoji
- **`error.tsx`**: Added `AlertTriangle` icon
- **`not-found.tsx`**: Added `FileQuestion` icon

#### Kept As-Is (intentional)
- Food warning emoji (🧂🍬🧈⚗️🥓🌴) — domain-specific, immediately recognizable, no good Lucide equivalent
- DataQualityCard single-char labels (✓, ~, !, ?) — text labels, not icons
- Food category emoji in constants — backward compatible via CategoryPlaceholder fallback

### Testing
- **34 new tests** for `CategoryIcon` (all 22 categories, sizes, accessibility, utilities)
- **8 test files updated** for SVG assertions instead of emoji text
- **2701 tests passing**, 0 failures
- **100% coverage** on new `CategoryIcon.tsx` (9/9 statements, 8/8 branches, 3/3 declarations)
- Lint ✅ | Typecheck ✅ | Build ✅

Closes #65