### PR TITLE
feat: Image Search v0 — OCR-Only Prototype + Privacy Guardrails

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -11,6 +11,7 @@
     "watchlist": "Watchlist",
     "achievements": "Achievements",
     "recipes": "Recipes",
+    "imageSearch": "Image Search",
     "more": "More"
   },
   "common": {
@@ -1554,6 +1555,43 @@
     "all_health": {
       "title": "Health Champion",
       "desc": "Unlock all Health achievements"
+    }
+  },
+  "imageSearch": {
+    "title": "Image Search",
+    "beta": "Beta",
+    "description": "Take a photo of a food label and we'll find matching products. All processing happens on your device — images are never uploaded.",
+    "processing": "Analysing image…",
+    "processingDetail": "Extracting text from your photo on-device",
+    "ocrFailed": "Could not read text from image",
+    "unusableTip": "Very low confidence — try a clearer photo with good lighting and hold the camera steady.",
+    "privacy": {
+      "title": "Your Privacy Matters",
+      "body": "Image Search processes photos entirely on your device. No images are ever uploaded to our servers.",
+      "bullet1": "All processing runs locally in your browser",
+      "bullet2": "Photos are deleted from memory immediately after scanning",
+      "bullet3": "No image data is stored or transmitted",
+      "bullet4": "Only the extracted text is used to search for products",
+      "accept": "I Understand — Continue"
+    },
+    "capture": {
+      "instructions": "Take a photo or upload an image of a food label",
+      "openCamera": "Open Camera",
+      "uploadPhoto": "Upload Photo",
+      "capturePhoto": "Capture Photo",
+      "closeCamera": "Close Camera",
+      "tips": "Tip: For best results, ensure good lighting and hold the camera steady.",
+      "cameraError": "Camera not available. Please upload a photo instead."
+    },
+    "results": {
+      "title": "Extracted Text",
+      "confidence": "{score}% confidence",
+      "lowConfidence": "Low confidence — review and edit the text below before searching.",
+      "noText": "No text could be extracted. Try a different image.",
+      "placeholder": "Edit extracted text…",
+      "search": "Search Products",
+      "retry": "Try Again",
+      "imageDeleted": "Image was deleted from memory — your privacy is protected."
     }
   }
 }

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -11,6 +11,7 @@
     "watchlist": "Obserwowane",
     "achievements": "Osiągnięcia",
     "recipes": "Przepisy",
+    "imageSearch": "Szukaj po zdjęciu",
     "more": "Więcej"
   },
   "common": {
@@ -1554,6 +1555,43 @@
     "all_health": {
       "title": "Mistrz zdrowia",
       "desc": "Odblokuj wszystkie osiągnięcia Zdrowia"
+    }
+  },
+  "imageSearch": {
+    "title": "Szukaj po zdjęciu",
+    "beta": "Beta",
+    "description": "Zrób zdjęcie etykiety żywności, a znajdziemy pasujące produkty. Przetwarzanie odbywa się na Twoim urządzeniu — zdjęcia nigdy nie są przesyłane.",
+    "processing": "Analizowanie zdjęcia…",
+    "processingDetail": "Odczytywanie tekstu ze zdjęcia na Twoim urządzeniu",
+    "ocrFailed": "Nie udało się odczytać tekstu ze zdjęcia",
+    "unusableTip": "Bardzo niska pewność — spróbuj zrobić wyraźniejsze zdjęcie przy dobrym oświetleniu i trzymaj aparat stabilnie.",
+    "privacy": {
+      "title": "Twoja prywatność jest ważna",
+      "body": "Wyszukiwanie po zdjęciu przetwarza zdjęcia całkowicie na Twoim urządzeniu. Żadne zdjęcia nie są przesyłane na nasze serwery.",
+      "bullet1": "Przetwarzanie odbywa się lokalnie w przeglądarce",
+      "bullet2": "Zdjęcia są usuwane z pamięci natychmiast po skanowaniu",
+      "bullet3": "Żadne dane obrazu nie są przechowywane ani przesyłane",
+      "bullet4": "Tylko odczytany tekst jest używany do wyszukiwania produktów",
+      "accept": "Rozumiem — Kontynuuj"
+    },
+    "capture": {
+      "instructions": "Zrób zdjęcie lub prześlij obraz etykiety żywności",
+      "openCamera": "Otwórz aparat",
+      "uploadPhoto": "Prześlij zdjęcie",
+      "capturePhoto": "Zrób zdjęcie",
+      "closeCamera": "Zamknij aparat",
+      "tips": "Wskazówka: Aby uzyskać najlepsze wyniki, zapewnij dobre oświetlenie i trzymaj aparat stabilnie.",
+      "cameraError": "Aparat niedostępny. Zamiast tego prześlij zdjęcie."
+    },
+    "results": {
+      "title": "Odczytany tekst",
+      "confidence": "{score}% pewności",
+      "lowConfidence": "Niska pewność — przejrzyj i edytuj tekst poniżej przed wyszukiwaniem.",
+      "noText": "Nie udało się odczytać tekstu. Spróbuj innego zdjęcia.",
+      "placeholder": "Edytuj odczytany tekst…",
+      "search": "Szukaj produktów",
+      "retry": "Spróbuj ponownie",
+      "imageDeleted": "Zdjęcie zostało usunięte z pamięci — Twoja prywatność jest chroniona."
     }
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.71.1",
         "sonner": "^1.7.4",
+        "tesseract.js": "^5.1.1",
         "zod": "^4.3.6",
         "zustand": "^5.0.11"
       },
@@ -4669,6 +4670,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -6587,6 +6594,12 @@
       "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
       "license": "ISC"
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6826,6 +6839,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -7062,6 +7081,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
@@ -7735,6 +7760,48 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -7903,6 +7970,15 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
       }
     },
     "node_modules/optionator": {
@@ -8540,6 +8616,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -9497,6 +9579,31 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tesseract.js": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-5.1.1.tgz",
+      "integrity": "sha512-lzVl/Ar3P3zhpUT31NjqeCo1f+D5+YfpZ5J62eo2S14QNVOmHBTtbchHm/YAbOOOzCegFnKf4B3Qih9LuldcYQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-electron": "^2.2.2",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^5.1.1",
+        "wasm-feature-detect": "^1.2.11",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-5.1.1.tgz",
+      "integrity": "sha512-KX3bYSU5iGcO1XJa+QGPbi+Zjo2qq6eBhNjSGR5E5q0JtzkoipJKOUQD7ph8kFyteCEfEQ0maWLu8MCXtvX5uQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -10190,6 +10297,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -10513,6 +10626,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/zod": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.71.1",
     "sonner": "^1.7.4",
+    "tesseract.js": "^5.1.1",
     "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },

--- a/frontend/src/app/app/image-search/page.test.tsx
+++ b/frontend/src/app/app/image-search/page.test.tsx
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// Privacy mocks
+const mockHasConsent = vi.fn().mockReturnValue(true);
+const mockAcceptConsent = vi.fn();
+const mockRevokeConsent = vi.fn();
+const mockReleaseImageData = vi.fn();
+const mockInitOCR = vi.fn().mockResolvedValue(undefined);
+const mockTerminateOCR = vi.fn().mockResolvedValue(undefined);
+const mockExtractText = vi.fn();
+const mockBuildSearchQuery = vi.fn();
+
+vi.mock("@/lib/ocr", () => ({
+  hasPrivacyConsent: () => mockHasConsent(),
+  acceptPrivacyConsent: () => mockAcceptConsent(),
+  revokePrivacyConsent: () => mockRevokeConsent(),
+  releaseImageData: (...args: unknown[]) => mockReleaseImageData(...args),
+  initOCR: () => mockInitOCR(),
+  terminateOCR: () => mockTerminateOCR(),
+  extractText: (...args: unknown[]) => mockExtractText(...args),
+  buildSearchQuery: (...args: unknown[]) => mockBuildSearchQuery(...args),
+  isOCRReady: () => true,
+  CONFIDENCE: { HIGH: 80, LOW: 50, UNUSABLE: 30 },
+  OCR_TIMEOUT_MS: 15000,
+}));
+
+vi.mock("@/components/layout/Breadcrumbs", () => ({
+  Breadcrumbs: () => <nav data-testid="breadcrumbs" />,
+}));
+
+vi.mock("@/components/common/LoadingSpinner", () => ({
+  LoadingSpinner: () => <div data-testid="loading-spinner" />,
+}));
+
+// Mock components with functional implementations
+vi.mock("@/components/ocr", () => ({
+  PrivacyNotice: ({
+    open,
+    onAccept,
+  }: {
+    open: boolean;
+    onAccept: () => void;
+  }) =>
+    open ? (
+      <div data-testid="privacy-notice">
+        <button data-testid="accept-privacy" onClick={onAccept}>
+          Accept
+        </button>
+      </div>
+    ) : null,
+  ImageCapture: ({
+    onCapture,
+    processing,
+  }: {
+    onCapture: (blob: Blob) => void;
+    processing: boolean;
+  }) => (
+    <div data-testid="image-capture">
+      <button
+        data-testid="mock-capture"
+        disabled={processing}
+        onClick={() => onCapture(new Blob(["fake"], { type: "image/jpeg" }))}
+      >
+        Capture
+      </button>
+    </div>
+  ),
+  OCRResults: ({
+    result,
+    onSearch,
+    onRetry,
+  }: {
+    result: { text: string; confidence: number };
+    onSearch: (text: string) => void;
+    onRetry: () => void;
+  }) => (
+    <div data-testid="ocr-results">
+      <span data-testid="result-text">{result.text}</span>
+      <span data-testid="result-confidence">{result.confidence}</span>
+      <button data-testid="mock-search" onClick={() => onSearch(result.text)}>
+        Search
+      </button>
+      <button data-testid="mock-retry" onClick={onRetry}>
+        Retry
+      </button>
+    </div>
+  ),
+}));
+
+import ImageSearchPage from "./page";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeOCRResult(text = "Cukier mąka", confidence = 85) {
+  return {
+    text,
+    confidence,
+    words: [
+      {
+        text: "Cukier",
+        confidence: 90,
+        bbox: { x0: 0, y0: 0, x1: 50, y1: 20 },
+      },
+    ],
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("ImageSearchPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHasConsent.mockReturnValue(true);
+    mockExtractText.mockResolvedValue(makeOCRResult());
+    mockBuildSearchQuery.mockReturnValue({
+      cleaned: "cukier mąka",
+      tokens: ["cukier", "mąka"],
+      query: "cukier mąka",
+    });
+  });
+
+  it("renders page title", () => {
+    render(<ImageSearchPage />);
+    expect(screen.getByText("imageSearch.title")).toBeInTheDocument();
+  });
+
+  it("renders beta badge", () => {
+    render(<ImageSearchPage />);
+    expect(screen.getByTestId("beta-badge")).toBeInTheDocument();
+    expect(screen.getByTestId("beta-badge")).toHaveTextContent("imageSearch.beta");
+  });
+
+  it("renders description", () => {
+    render(<ImageSearchPage />);
+    expect(screen.getByText("imageSearch.description")).toBeInTheDocument();
+  });
+
+  it("renders breadcrumbs", () => {
+    render(<ImageSearchPage />);
+    expect(screen.getByTestId("breadcrumbs")).toBeInTheDocument();
+  });
+
+  // ── Privacy consent flow ──────────────────────────────────────────────
+
+  it("shows privacy notice when no consent", async () => {
+    mockHasConsent.mockReturnValue(false);
+    render(<ImageSearchPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("privacy-notice")).toBeInTheDocument();
+    });
+  });
+
+  it("hides privacy notice and shows capture after accepting", async () => {
+    mockHasConsent.mockReturnValue(false);
+    render(<ImageSearchPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("privacy-notice")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("accept-privacy"));
+    expect(mockAcceptConsent).toHaveBeenCalledOnce();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("privacy-notice")).not.toBeInTheDocument();
+      expect(screen.getByTestId("image-capture")).toBeInTheDocument();
+    });
+  });
+
+  it("skips privacy notice when consent exists", () => {
+    mockHasConsent.mockReturnValue(true);
+    render(<ImageSearchPage />);
+    expect(screen.queryByTestId("privacy-notice")).not.toBeInTheDocument();
+    expect(screen.getByTestId("image-capture")).toBeInTheDocument();
+  });
+
+  // ── Capture → OCR flow ────────────────────────────────────────────────
+
+  it("shows processing state during OCR", async () => {
+    // Make extractText hang
+    mockExtractText.mockReturnValue(new Promise(() => {}));
+    render(<ImageSearchPage />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("mock-capture"));
+    });
+
+    expect(screen.getByTestId("ocr-processing")).toBeInTheDocument();
+    expect(screen.getByText("imageSearch.processing")).toBeInTheDocument();
+  });
+
+  it("shows OCR results after successful extraction", async () => {
+    render(<ImageSearchPage />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("mock-capture"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ocr-results")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("result-text")).toHaveTextContent("Cukier mąka");
+  });
+
+  it("releases image data after OCR", async () => {
+    render(<ImageSearchPage />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("mock-capture"));
+    });
+
+    await waitFor(() => {
+      expect(mockReleaseImageData).toHaveBeenCalled();
+    });
+  });
+
+  it("shows error and returns to capture on OCR failure", async () => {
+    mockExtractText.mockRejectedValue(new Error("OCR failed"));
+    render(<ImageSearchPage />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("mock-capture"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ocr-error")).toBeInTheDocument();
+      expect(screen.getByTestId("image-capture")).toBeInTheDocument();
+    });
+  });
+
+  // ── Search navigation ─────────────────────────────────────────────────
+
+  it("navigates to search page with query on search", async () => {
+    render(<ImageSearchPage />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("mock-capture"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ocr-results")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("mock-search"));
+    expect(mockBuildSearchQuery).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith(
+      "/app/search?q=cukier%20m%C4%85ka",
+    );
+  });
+
+  it("does not navigate when query is empty", async () => {
+    mockBuildSearchQuery.mockReturnValue({
+      cleaned: "",
+      tokens: [],
+      query: "",
+    });
+    render(<ImageSearchPage />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("mock-capture"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ocr-results")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("mock-search"));
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  // ── Retry flow ────────────────────────────────────────────────────────
+
+  it("returns to capture step on retry", async () => {
+    render(<ImageSearchPage />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("mock-capture"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ocr-results")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("mock-retry"));
+    expect(screen.getByTestId("image-capture")).toBeInTheDocument();
+  });
+
+  // ── OCR worker lifecycle ──────────────────────────────────────────────
+
+  it("pre-warms OCR worker after privacy consent", async () => {
+    mockHasConsent.mockReturnValue(true);
+    render(<ImageSearchPage />);
+
+    await waitFor(() => {
+      expect(mockInitOCR).toHaveBeenCalled();
+    });
+  });
+
+  it("terminates OCR worker on unmount", () => {
+    const { unmount } = render(<ImageSearchPage />);
+    unmount();
+    expect(mockTerminateOCR).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/app/image-search/page.tsx
+++ b/frontend/src/app/app/image-search/page.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+// ─── Image Search page — OCR-only prototype with privacy guardrails ──────────
+// Issue #55 — Image Search v0
+//
+// Flow:
+// 1. Privacy consent → 2. Capture/Upload → 3. OCR → 4. Review text → 5. Search
+//
+// All image processing is client-side. No images are ever uploaded.
+
+import { useState, useCallback, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslation } from "@/lib/i18n";
+import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
+import { PrivacyNotice, ImageCapture, OCRResults } from "@/components/ocr";
+import {
+  extractText,
+  buildSearchQuery,
+  initOCR,
+  terminateOCR,
+  hasPrivacyConsent,
+  acceptPrivacyConsent,
+  releaseImageData,
+  CONFIDENCE,
+} from "@/lib/ocr";
+import type { OCRResult } from "@/lib/ocr";
+
+/* ── Step union ───────────────────────────────────────────────────────────── */
+
+type Step = "capture" | "processing" | "results";
+
+/* ── Component ────────────────────────────────────────────────────────────── */
+
+export default function ImageSearchPage() {
+  const { t } = useTranslation();
+  const router = useRouter();
+
+  const [showPrivacy, setShowPrivacy] = useState(false);
+  const [step, setStep] = useState<Step>("capture");
+  const [ocrResult, setOcrResult] = useState<OCRResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Track object URLs for cleanup
+  const objectUrlRef = useRef<string | null>(null);
+
+  // Check privacy consent on mount (SSR-safe: hasPrivacyConsent returns true server-side)
+  useEffect(() => {
+    if (!hasPrivacyConsent()) {
+      setShowPrivacy(true);
+    }
+  }, []);
+
+  // Pre-warm OCR worker after consent
+  useEffect(() => {
+    if (!showPrivacy && hasPrivacyConsent()) {
+      // Pre-warm in background — don't block UI
+      initOCR().catch(() => {
+        // Non-critical — worker will init on first capture
+      });
+    }
+  }, [showPrivacy]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      terminateOCR().catch(() => {});
+      if (objectUrlRef.current) {
+        releaseImageData({ objectUrl: objectUrlRef.current });
+        objectUrlRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleAcceptPrivacy = useCallback(() => {
+    acceptPrivacyConsent();
+    setShowPrivacy(false);
+  }, []);
+
+  const handleCapture = useCallback(async (blob: Blob) => {
+    setStep("processing");
+    setError(null);
+
+    try {
+      const result = await extractText(blob);
+      setOcrResult(result);
+      setStep("results");
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "OCR processing failed",
+      );
+      setStep("capture");
+    } finally {
+      // Release image data immediately after OCR
+      releaseImageData({ blob });
+    }
+  }, []);
+
+  const handleSearch = useCallback(
+    (text: string) => {
+      const { query } = buildSearchQuery(text);
+      if (query.length > 0) {
+        router.push(`/app/search?q=${encodeURIComponent(query)}`);
+      }
+    },
+    [router],
+  );
+
+  const handleRetry = useCallback(() => {
+    setOcrResult(null);
+    setError(null);
+    setStep("capture");
+  }, []);
+
+  return (
+    <div>
+      <Breadcrumbs
+        items={[
+          { labelKey: "nav.home", href: "/app" },
+          { labelKey: "nav.imageSearch" },
+        ]}
+      />
+
+      {/* Header */}
+      <div className="mb-6 flex items-center gap-3">
+        <h1 className="text-xl font-bold text-foreground lg:text-2xl">
+          {t("imageSearch.title")}
+        </h1>
+        <span className="rounded-full bg-brand/10 px-2.5 py-0.5 text-xs font-semibold text-brand" data-testid="beta-badge">
+          {t("imageSearch.beta")}
+        </span>
+      </div>
+
+      <p className="mb-6 text-sm text-foreground-secondary">
+        {t("imageSearch.description")}
+      </p>
+
+      {/* Privacy consent dialog */}
+      <PrivacyNotice open={showPrivacy} onAccept={handleAcceptPrivacy} />
+
+      {/* Error banner */}
+      {error && (
+        <div
+          className="mb-4 rounded-lg border border-error/20 bg-error/5 px-4 py-3 text-sm text-error"
+          role="alert"
+          data-testid="ocr-error"
+        >
+          <p className="font-medium">{t("imageSearch.ocrFailed")}</p>
+          <p className="mt-1 text-xs">{error}</p>
+        </div>
+      )}
+
+      {/* Step: Capture */}
+      {step === "capture" && !showPrivacy && (
+        <ImageCapture
+          onCapture={handleCapture}
+          processing={false}
+        />
+      )}
+
+      {/* Step: Processing */}
+      {step === "processing" && (
+        <div
+          className="flex flex-col items-center gap-4 py-12"
+          data-testid="ocr-processing"
+        >
+          <LoadingSpinner size="lg" />
+          <p className="text-sm text-foreground-secondary">
+            {t("imageSearch.processing")}
+          </p>
+          <p className="text-xs text-foreground-muted">
+            {t("imageSearch.processingDetail")}
+          </p>
+        </div>
+      )}
+
+      {/* Step: Results */}
+      {step === "results" && ocrResult && (
+        <OCRResults
+          result={ocrResult}
+          onSearch={handleSearch}
+          onRetry={handleRetry}
+        />
+      )}
+
+      {/* Unusable result tip */}
+      {step === "results" &&
+        ocrResult &&
+        ocrResult.confidence < CONFIDENCE.UNUSABLE && (
+          <div className="mt-4 rounded-lg border border-warning/20 bg-warning/5 px-4 py-3 text-sm text-warning">
+            {t("imageSearch.unusableTip")}
+          </div>
+        )}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/DesktopSidebar.tsx
+++ b/frontend/src/components/layout/DesktopSidebar.tsx
@@ -20,6 +20,7 @@ import {
   FolderOpen,
   Trophy,
   UtensilsCrossed,
+  ScanText,
   Settings,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -79,6 +80,12 @@ const PRIMARY_ITEMS: readonly SidebarNavItem[] = [
     labelKey: "nav.recipes",
     icon: UtensilsCrossed,
     routeKey: "recipes",
+  },
+  {
+    href: "/app/image-search",
+    labelKey: "nav.imageSearch",
+    icon: ScanText,
+    routeKey: "image-search",
   },
 ] as const;
 

--- a/frontend/src/components/layout/MoreDrawer.tsx
+++ b/frontend/src/components/layout/MoreDrawer.tsx
@@ -19,6 +19,7 @@ import {
   ShieldCheck,
   Trophy,
   UtensilsCrossed,
+  ScanText,
   X,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -70,6 +71,12 @@ const DRAWER_ITEMS: readonly DrawerNavItem[] = [
     labelKey: "nav.recipes",
     icon: UtensilsCrossed,
     routeKey: "recipes",
+  },
+  {
+    href: "/app/image-search",
+    labelKey: "nav.imageSearch",
+    icon: ScanText,
+    routeKey: "image-search",
   },
   {
     href: "/app/admin/submissions",

--- a/frontend/src/components/ocr/ImageCapture.test.tsx
+++ b/frontend/src/components/ocr/ImageCapture.test.tsx
@@ -1,0 +1,375 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+import { ImageCapture } from "./ImageCapture";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeFile(name = "label.jpg", type = "image/jpeg"): File {
+  return new File(["fake image data"], name, { type });
+}
+
+// ── Camera mock helpers ──────────────────────────────────────────────────────
+
+const mockStop = vi.fn();
+const mockTrack = { stop: mockStop, kind: "video", id: "t1" };
+const mockStream = {
+  getTracks: () => [mockTrack],
+  getVideoTracks: () => [mockTrack],
+  getAudioTracks: () => [],
+  active: true,
+} as unknown as MediaStream;
+
+const mockGetUserMedia = vi.fn<[], Promise<MediaStream>>();
+const mockDrawImage = vi.fn();
+const mockClearRect = vi.fn();
+const mockCtx = {
+  drawImage: mockDrawImage,
+  clearRect: mockClearRect,
+} as unknown as CanvasRenderingContext2D;
+
+function setupCameraSupport(): void {
+  Object.defineProperty(navigator, "mediaDevices", {
+    value: { getUserMedia: mockGetUserMedia },
+    writable: true,
+    configurable: true,
+  });
+}
+
+/** Start the camera in a rendered component and wait for the UI to show */
+async function openCamera(): Promise<void> {
+  await waitFor(() => {
+    expect(screen.getByTestId("open-camera-btn")).toBeInTheDocument();
+  });
+  fireEvent.click(screen.getByTestId("open-camera-btn"));
+  await waitFor(() => {
+    expect(screen.getByTestId("capture-btn")).toBeInTheDocument();
+  });
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("ImageCapture", () => {
+  let origGetContext: typeof HTMLCanvasElement.prototype.getContext;
+  let origToBlob: typeof HTMLCanvasElement.prototype.toBlob;
+  let origPlay: typeof HTMLVideoElement.prototype.play;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserMedia.mockResolvedValue(mockStream);
+
+    // Save originals
+    origGetContext = HTMLCanvasElement.prototype.getContext;
+    origToBlob = HTMLCanvasElement.prototype.toBlob;
+    origPlay = HTMLVideoElement.prototype.play;
+
+    // Mock video.play
+    HTMLVideoElement.prototype.play = vi
+      .fn()
+      .mockResolvedValue(undefined) as typeof HTMLVideoElement.prototype.play;
+
+    // Mock canvas.getContext to return our stub
+    HTMLCanvasElement.prototype.getContext = vi
+      .fn()
+      .mockReturnValue(mockCtx) as typeof HTMLCanvasElement.prototype.getContext;
+
+    // Mock canvas.toBlob — calls callback synchronously with a Blob
+    HTMLCanvasElement.prototype.toBlob = vi
+      .fn()
+      .mockImplementation(function (this: HTMLCanvasElement, cb: BlobCallback) {
+        cb(new Blob(["frame"], { type: "image/jpeg" }));
+      }) as typeof HTMLCanvasElement.prototype.toBlob;
+  });
+
+  afterEach(() => {
+    // Restore original prototypes
+    HTMLCanvasElement.prototype.getContext = origGetContext;
+    HTMLCanvasElement.prototype.toBlob = origToBlob;
+    HTMLVideoElement.prototype.play = origPlay;
+  });
+
+  // ── Basic rendering ──────────────────────────────────────────────────────
+
+  it("renders upload button", () => {
+    render(<ImageCapture onCapture={vi.fn()} processing={false} />);
+    expect(screen.getByTestId("upload-btn")).toBeInTheDocument();
+  });
+
+  it("renders instructions text", () => {
+    render(<ImageCapture onCapture={vi.fn()} processing={false} />);
+    expect(
+      screen.getByText("imageSearch.instructions"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders tips text", () => {
+    render(<ImageCapture onCapture={vi.fn()} processing={false} />);
+    expect(screen.getByText("imageSearch.tips")).toBeInTheDocument();
+  });
+
+  it("has a hidden file input with correct attributes", () => {
+    render(<ImageCapture onCapture={vi.fn()} processing={false} />);
+    const input = screen.getByTestId("file-input");
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute("type", "file");
+    expect(input).toHaveAttribute("accept", "image/*");
+  });
+
+  it("clicking upload button triggers file input", () => {
+    render(<ImageCapture onCapture={vi.fn()} processing={false} />);
+    const input = screen.getByTestId("file-input");
+    const clickSpy = vi.spyOn(input, "click");
+
+    fireEvent.click(screen.getByTestId("upload-btn"));
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  // ── File upload ──────────────────────────────────────────────────────────
+
+  it("calls onCapture when file is selected", async () => {
+    const onCapture = vi.fn();
+    render(<ImageCapture onCapture={onCapture} processing={false} />);
+
+    const input = screen.getByTestId("file-input");
+    const file = makeFile();
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(onCapture).toHaveBeenCalledWith(file);
+    });
+  });
+
+  it("does not call onCapture when file selection is cancelled", () => {
+    const onCapture = vi.fn();
+    render(<ImageCapture onCapture={onCapture} processing={false} />);
+
+    const input = screen.getByTestId("file-input");
+    fireEvent.change(input, { target: { files: [] } });
+
+    expect(onCapture).not.toHaveBeenCalled();
+  });
+
+  it("resets file input after selection so same file can be re-selected", async () => {
+    const onCapture = vi.fn();
+    render(<ImageCapture onCapture={onCapture} processing={false} />);
+
+    const input = screen.getByTestId("file-input") as HTMLInputElement;
+    const file = makeFile();
+
+    // Simulate first selection
+    fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() => expect(onCapture).toHaveBeenCalledTimes(1));
+
+    // After reset, the input value should be empty
+    expect(input.value).toBe("");
+  });
+
+  // ── Processing state ─────────────────────────────────────────────────────
+
+  it("disables upload button when processing", () => {
+    render(<ImageCapture onCapture={vi.fn()} processing={true} />);
+    expect(screen.getByTestId("upload-btn")).toBeDisabled();
+  });
+
+  // ── Camera support detection ─────────────────────────────────────────────
+
+  it("hides camera button when getUserMedia is not available", () => {
+    // Default jsdom has no mediaDevices, so camera should be hidden
+    render(<ImageCapture onCapture={vi.fn()} processing={false} />);
+    expect(screen.queryByTestId("open-camera-btn")).not.toBeInTheDocument();
+  });
+
+  it("shows camera button when getUserMedia is available", async () => {
+    setupCameraSupport();
+    render(<ImageCapture onCapture={vi.fn()} processing={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("open-camera-btn")).toBeInTheDocument();
+    });
+  });
+
+  // ── Camera workflow ──────────────────────────────────────────────────────
+
+  describe("camera workflow", () => {
+    beforeEach(() => {
+      setupCameraSupport();
+    });
+
+    it("opens camera and shows preview + capture controls", async () => {
+      render(<ImageCapture onCapture={vi.fn()} processing={false} />);
+      await openCamera();
+
+      expect(mockGetUserMedia).toHaveBeenCalledWith({
+        video: { facingMode: "environment" },
+      });
+      expect(screen.getByTestId("camera-preview")).toBeInTheDocument();
+      expect(screen.getByTestId("capture-btn")).toBeInTheDocument();
+      expect(screen.getByLabelText("common.cancel")).toBeInTheDocument();
+
+      // Action buttons (upload/open-camera) should be hidden while camera active
+      expect(screen.queryByTestId("open-camera-btn")).not.toBeInTheDocument();
+    });
+
+    it("shows camera error when getUserMedia rejects", async () => {
+      mockGetUserMedia.mockRejectedValueOnce(new Error("Permission denied"));
+      render(<ImageCapture onCapture={vi.fn()} processing={false} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("open-camera-btn")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId("open-camera-btn"));
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(
+          "imageSearch.cameraError",
+        );
+      });
+
+      // Camera preview should NOT be shown
+      expect(screen.queryByTestId("camera-preview")).not.toBeInTheDocument();
+    });
+
+    it("captures frame, calls onCapture with blob, and stops camera", async () => {
+      const onCapture = vi.fn();
+      render(<ImageCapture onCapture={onCapture} processing={false} />);
+      await openCamera();
+
+      // Mock video dimensions
+      const video = screen.getByTestId("camera-preview");
+      Object.defineProperty(video, "videoWidth", {
+        value: 640,
+        configurable: true,
+      });
+      Object.defineProperty(video, "videoHeight", {
+        value: 480,
+        configurable: true,
+      });
+
+      fireEvent.click(screen.getByTestId("capture-btn"));
+
+      await waitFor(() => {
+        expect(onCapture).toHaveBeenCalledTimes(1);
+      });
+
+      const blob = onCapture.mock.calls[0][0];
+      expect(blob).toBeInstanceOf(Blob);
+      expect(mockDrawImage).toHaveBeenCalled();
+      expect(mockClearRect).toHaveBeenCalled();
+
+      // Camera should have been stopped
+      expect(mockStop).toHaveBeenCalled();
+      expect(screen.queryByTestId("camera-preview")).not.toBeInTheDocument();
+    });
+
+    it("does not call onCapture when toBlob returns null", async () => {
+      const onCapture = vi.fn();
+
+      // Override toBlob to return null
+      HTMLCanvasElement.prototype.toBlob = vi
+        .fn()
+        .mockImplementation(function (
+          this: HTMLCanvasElement,
+          cb: BlobCallback,
+        ) {
+          cb(null);
+        }) as typeof HTMLCanvasElement.prototype.toBlob;
+
+      render(<ImageCapture onCapture={onCapture} processing={false} />);
+      await openCamera();
+
+      const video = screen.getByTestId("camera-preview");
+      Object.defineProperty(video, "videoWidth", {
+        value: 640,
+        configurable: true,
+      });
+      Object.defineProperty(video, "videoHeight", {
+        value: 480,
+        configurable: true,
+      });
+
+      fireEvent.click(screen.getByTestId("capture-btn"));
+
+      // onCapture should NOT be called when blob is null
+      expect(onCapture).not.toHaveBeenCalled();
+      // Canvas cleanup still runs
+      expect(mockClearRect).toHaveBeenCalled();
+    });
+
+    it("handles captureFrame when getContext returns null", async () => {
+      const onCapture = vi.fn();
+
+      // Override getContext to return null
+      HTMLCanvasElement.prototype.getContext = vi
+        .fn()
+        .mockReturnValue(null) as typeof HTMLCanvasElement.prototype.getContext;
+
+      render(<ImageCapture onCapture={onCapture} processing={false} />);
+      await openCamera();
+
+      const video = screen.getByTestId("camera-preview");
+      Object.defineProperty(video, "videoWidth", {
+        value: 640,
+        configurable: true,
+      });
+      Object.defineProperty(video, "videoHeight", {
+        value: 480,
+        configurable: true,
+      });
+
+      fireEvent.click(screen.getByTestId("capture-btn"));
+
+      // Should bail out — no drawImage, no onCapture
+      expect(mockDrawImage).not.toHaveBeenCalled();
+      expect(onCapture).not.toHaveBeenCalled();
+    });
+
+    it("stops camera and removes preview when cancel is clicked", async () => {
+      render(<ImageCapture onCapture={vi.fn()} processing={false} />);
+      await openCamera();
+
+      fireEvent.click(screen.getByLabelText("common.cancel"));
+
+      await waitFor(() => {
+        expect(mockStop).toHaveBeenCalled();
+        expect(
+          screen.queryByTestId("camera-preview"),
+        ).not.toBeInTheDocument();
+      });
+
+      // Action buttons should reappear
+      expect(screen.getByTestId("open-camera-btn")).toBeInTheDocument();
+      expect(screen.getByTestId("upload-btn")).toBeInTheDocument();
+    });
+
+    it("cleans up camera stream on component unmount", async () => {
+      const { unmount } = render(
+        <ImageCapture onCapture={vi.fn()} processing={false} />,
+      );
+      await openCamera();
+
+      unmount();
+      expect(mockStop).toHaveBeenCalled();
+    });
+
+    it("disables camera and capture buttons when processing", async () => {
+      setupCameraSupport();
+      render(<ImageCapture onCapture={vi.fn()} processing={true} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("open-camera-btn")).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId("open-camera-btn")).toBeDisabled();
+      expect(screen.getByTestId("upload-btn")).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/components/ocr/ImageCapture.tsx
+++ b/frontend/src/components/ocr/ImageCapture.tsx
@@ -1,0 +1,219 @@
+/**
+ * ImageCapture — File upload (+ optional camera capture) for OCR input.
+ * Issue #55 — Image Search v0
+ *
+ * Two input modes:
+ * 1. File upload — always available (`` with accept="image/*")
+ * 2. Live camera — via getUserMedia (shows if browser supports it)
+ *
+ * After an image is selected/captured, it fires `onCapture` with a Blob.
+ * The blob is ephemeral — the parent handles OCR processing and cleanup.
+ */
+
+"use client";
+
+import { useRef, useState, useCallback, useEffect } from "react";
+import { Camera, Upload, X, SwitchCamera } from "lucide-react";
+import { useTranslation } from "@/lib/i18n";
+import { Icon } from "@/components/common/Icon";
+
+interface ImageCaptureProps {
+  /** Called when user has selected/captured an image. */
+  readonly onCapture: (blob: Blob) => void;
+  /** Whether OCR is currently processing (disables controls). */
+  readonly processing: boolean;
+}
+
+export function ImageCapture({ onCapture, processing }: ImageCaptureProps) {
+  const { t } = useTranslation();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const [cameraActive, setCameraActive] = useState(false);
+  const [cameraSupported, setCameraSupported] = useState(false);
+  const [cameraError, setCameraError] = useState<string | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  // Check camera support on mount
+  useEffect(() => {
+    const supported =
+      typeof navigator !== "undefined" &&
+      !!navigator.mediaDevices?.getUserMedia;
+    setCameraSupported(supported);
+  }, []);
+
+  // Cleanup camera stream on unmount
+  useEffect(() => {
+    return () => {
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach((t) => t.stop());
+        streamRef.current = null;
+      }
+    };
+  }, []);
+
+  const startCamera = useCallback(async () => {
+    setCameraError(null);
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: "environment" },
+      });
+      streamRef.current = stream;
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        await videoRef.current.play();
+      }
+      setCameraActive(true);
+    } catch {
+      setCameraError(t("imageSearch.cameraError"));
+      setCameraActive(false);
+    }
+  }, [t]);
+
+  const stopCamera = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    }
+    if (videoRef.current) {
+      videoRef.current.srcObject = null;
+    }
+    setCameraActive(false);
+  }, []);
+
+  const captureFrame = useCallback(() => {
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+    if (!video || !canvas) return;
+
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    ctx.drawImage(video, 0, 0);
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          stopCamera();
+          onCapture(blob);
+        }
+      },
+      "image/jpeg",
+      0.9,
+    );
+    // Canvas is cleared after capture (privacy)
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    canvas.width = 0;
+    canvas.height = 0;
+  }, [onCapture, stopCamera]);
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) onCapture(file);
+      // Reset input so re-selecting the same file works
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    },
+    [onCapture],
+  );
+
+  return (
+    <div className="space-y-4">
+      {/* Camera view (when active) */}
+      {cameraActive && (
+        <div className="relative overflow-hidden rounded-xl border border-border">
+          <video
+            ref={videoRef}
+            autoPlay
+            playsInline
+            muted
+            className="w-full"
+            data-testid="camera-preview"
+          />
+          {/* Alignment guide */}
+          <div className="pointer-events-none absolute inset-4 rounded-lg border-2 border-dashed border-white/50" />
+          <div className="absolute bottom-4 left-0 right-0 flex justify-center gap-3">
+            <button
+              type="button"
+              onClick={captureFrame}
+              disabled={processing}
+              className="btn-primary rounded-full px-6 py-2.5 text-sm font-medium shadow-lg"
+              data-testid="capture-btn"
+            >
+              <Icon icon={Camera} size="sm" className="mr-1.5" />
+              {t("imageSearch.capture")}
+            </button>
+            <button
+              type="button"
+              onClick={stopCamera}
+              className="rounded-full bg-surface/80 p-2.5 shadow-lg backdrop-blur-sm"
+              aria-label={t("common.cancel")}
+            >
+              <Icon icon={X} size="sm" />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Action buttons (when camera not active) */}
+      {!cameraActive && (
+        <div className="flex flex-col items-center gap-3 rounded-xl border-2 border-dashed border-border p-8">
+          <p className="text-center text-sm text-foreground-secondary">
+            {t("imageSearch.instructions")}
+          </p>
+
+          <div className="flex gap-3">
+            {cameraSupported && (
+              <button
+                type="button"
+                onClick={startCamera}
+                disabled={processing}
+                className="btn-primary flex items-center gap-2 px-4 py-2.5 text-sm"
+                data-testid="open-camera-btn"
+              >
+                <Icon icon={SwitchCamera} size="sm" />
+                {t("imageSearch.openCamera")}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={processing}
+              className="btn-secondary flex items-center gap-2 px-4 py-2.5 text-sm"
+              data-testid="upload-btn"
+            >
+              <Icon icon={Upload} size="sm" />
+              {t("imageSearch.uploadPhoto")}
+            </button>
+          </div>
+
+          {cameraError && (
+            <p className="text-xs text-error" role="alert">
+              {cameraError}
+            </p>
+          )}
+
+          <p className="mt-2 text-center text-xs text-foreground-secondary">
+            {t("imageSearch.tips")}
+          </p>
+        </div>
+      )}
+
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        onChange={handleFileChange}
+        className="hidden"
+        data-testid="file-input"
+      />
+
+      {/* Hidden canvas for frame capture */}
+      <canvas ref={canvasRef} className="hidden" />
+    </div>
+  );
+}

--- a/frontend/src/components/ocr/OCRResults.test.tsx
+++ b/frontend/src/components/ocr/OCRResults.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (params) {
+        return Object.entries(params).reduce(
+          (acc, [k, v]) => acc.replace(`{${k}}`, String(v)),
+          key,
+        );
+      }
+      return key;
+    },
+  }),
+}));
+
+import { OCRResults } from "./OCRResults";
+import type { OCRResult } from "@/lib/ocr";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeResult(overrides?: Partial<OCRResult>): OCRResult {
+  return {
+    text: "Cukier mąka masło",
+    confidence: 85,
+    words: [
+      { text: "Cukier", confidence: 90, bbox: { x0: 0, y0: 0, x1: 50, y1: 20 } },
+      { text: "mąka", confidence: 80, bbox: { x0: 55, y0: 0, x1: 100, y1: 20 } },
+      { text: "masło", confidence: 85, bbox: { x0: 105, y0: 0, x1: 150, y1: 20 } },
+    ],
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("OCRResults", () => {
+  it("renders extracted text title", () => {
+    render(
+      <OCRResults result={makeResult()} onSearch={vi.fn()} onRetry={vi.fn()} />,
+    );
+    expect(screen.getByText("imageSearch.results.title")).toBeInTheDocument();
+  });
+
+  it("renders confidence badge", () => {
+    render(
+      <OCRResults result={makeResult()} onSearch={vi.fn()} onRetry={vi.fn()} />,
+    );
+    const badge = screen.getByTestId("confidence-badge");
+    expect(badge).toBeInTheDocument();
+    // Mock t returns key with params interpolated
+    expect(badge).toHaveTextContent("confidence");
+  });
+
+  it("renders extracted text in textarea", () => {
+    render(
+      <OCRResults result={makeResult()} onSearch={vi.fn()} onRetry={vi.fn()} />,
+    );
+    const textarea = screen.getByTestId("ocr-text");
+    expect(textarea).toHaveValue("Cukier mąka masło");
+  });
+
+  it("allows editing extracted text", () => {
+    render(
+      <OCRResults result={makeResult()} onSearch={vi.fn()} onRetry={vi.fn()} />,
+    );
+    const textarea = screen.getByTestId("ocr-text");
+    fireEvent.change(textarea, { target: { value: "mleko cukier" } });
+    expect(textarea).toHaveValue("mleko cukier");
+  });
+
+  it("calls onSearch with edited text when search button clicked", () => {
+    const onSearch = vi.fn();
+    render(
+      <OCRResults result={makeResult()} onSearch={onSearch} onRetry={vi.fn()} />,
+    );
+
+    const textarea = screen.getByTestId("ocr-text");
+    fireEvent.change(textarea, { target: { value: "mleko" } });
+    fireEvent.click(screen.getByTestId("search-btn"));
+
+    expect(onSearch).toHaveBeenCalledWith("mleko");
+  });
+
+  it("calls onRetry when retry button clicked", () => {
+    const onRetry = vi.fn();
+    render(
+      <OCRResults result={makeResult()} onSearch={vi.fn()} onRetry={onRetry} />,
+    );
+    fireEvent.click(screen.getByTestId("retry-btn"));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("disables search button when text is empty", () => {
+    render(
+      <OCRResults
+        result={makeResult({ text: "" })}
+        onSearch={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("search-btn")).toBeDisabled();
+  });
+
+  it("shows low confidence warning when below threshold", () => {
+    render(
+      <OCRResults
+        result={makeResult({ confidence: 40 })}
+        onSearch={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("low-confidence-warning")).toBeInTheDocument();
+  });
+
+  it("does not show low confidence warning when above threshold", () => {
+    render(
+      <OCRResults
+        result={makeResult({ confidence: 85 })}
+        onSearch={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("low-confidence-warning")).not.toBeInTheDocument();
+  });
+
+  it("shows empty text warning when no text extracted", () => {
+    render(
+      <OCRResults
+        result={makeResult({ text: "   " })}
+        onSearch={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("empty-text-warning")).toBeInTheDocument();
+  });
+
+  it("renders privacy confirmation message", () => {
+    render(
+      <OCRResults result={makeResult()} onSearch={vi.fn()} onRetry={vi.fn()} />,
+    );
+    expect(
+      screen.getByText("imageSearch.results.imageDeleted"),
+    ).toBeInTheDocument();
+  });
+
+  it("applies green class for high confidence", () => {
+    render(
+      <OCRResults
+        result={makeResult({ confidence: 90 })}
+        onSearch={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    );
+    const badge = screen.getByTestId("confidence-badge");
+    expect(badge.className).toContain("text-success");
+  });
+
+  it("applies yellow class for medium confidence", () => {
+    render(
+      <OCRResults
+        result={makeResult({ confidence: 65 })}
+        onSearch={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    );
+    const badge = screen.getByTestId("confidence-badge");
+    expect(badge.className).toContain("text-warning");
+  });
+
+  it("applies red class for low confidence", () => {
+    render(
+      <OCRResults
+        result={makeResult({ confidence: 30 })}
+        onSearch={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    );
+    const badge = screen.getByTestId("confidence-badge");
+    expect(badge.className).toContain("text-error");
+  });
+});

--- a/frontend/src/components/ocr/OCRResults.tsx
+++ b/frontend/src/components/ocr/OCRResults.tsx
@@ -1,0 +1,119 @@
+/**
+ * OCRResults — Display extracted text with confidence indicator and actions.
+ * Issue #55 — Image Search v0
+ *
+ * Shows:
+ * - Extracted text in an editable textarea
+ * - Confidence badge (green/yellow/red)
+ * - Search, Edit, Retry actions
+ * - Privacy confirmation ("Image deleted from memory")
+ */
+
+"use client";
+
+import { useState } from "react";
+import { Search, RefreshCw, Lock } from "lucide-react";
+import { useTranslation } from "@/lib/i18n";
+import { Icon } from "@/components/common/Icon";
+import { CONFIDENCE } from "@/lib/ocr";
+import type { OCRResult } from "@/lib/ocr";
+
+interface OCRResultsProps {
+  /** The OCR extraction result. */
+  readonly result: OCRResult;
+  /** Called when user wants to search with (possibly edited) text. */
+  readonly onSearch: (text: string) => void;
+  /** Called when user wants to retry capture. */
+  readonly onRetry: () => void;
+}
+
+function confidenceBand(score: number): {
+  label: string;
+  className: string;
+} {
+  if (score >= CONFIDENCE.HIGH)
+    return { label: "high", className: "bg-success/10 text-success" };
+  if (score >= CONFIDENCE.LOW)
+    return { label: "medium", className: "bg-warning/10 text-warning" };
+  return { label: "low", className: "bg-error/10 text-error" };
+}
+
+export function OCRResults({ result, onSearch, onRetry }: OCRResultsProps) {
+  const { t } = useTranslation();
+  const [editedText, setEditedText] = useState(result.text);
+  const band = confidenceBand(result.confidence);
+
+  const isEmpty = result.text.trim().length === 0;
+
+  return (
+    <div className="space-y-4">
+      {/* Header with confidence */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-foreground">
+          {t("imageSearch.results.title")}
+        </h3>
+        <span
+          className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${band.className}`}
+          data-testid="confidence-badge"
+        >
+          {t("imageSearch.results.confidence", {
+            score: Math.round(result.confidence),
+          })}
+        </span>
+      </div>
+
+      {/* Low confidence warning */}
+      {result.confidence < CONFIDENCE.LOW && (
+        <p className="text-xs text-warning" role="alert" data-testid="low-confidence-warning">
+          {t("imageSearch.results.lowConfidence")}
+        </p>
+      )}
+
+      {/* Empty text warning */}
+      {isEmpty && (
+        <p className="text-xs text-error" role="alert" data-testid="empty-text-warning">
+          {t("imageSearch.results.noText")}
+        </p>
+      )}
+
+      {/* Editable extracted text */}
+      <textarea
+        value={editedText}
+        onChange={(e) => setEditedText(e.target.value)}
+        rows={5}
+        className="w-full rounded-lg border border-border bg-surface-muted p-3 text-sm text-foreground focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand"
+        placeholder={t("imageSearch.results.placeholder")}
+        data-testid="ocr-text"
+      />
+
+      {/* Actions */}
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => onSearch(editedText)}
+          disabled={editedText.trim().length === 0}
+          className="btn-primary flex items-center gap-2 px-4 py-2 text-sm"
+          data-testid="search-btn"
+        >
+          <Icon icon={Search} size="sm" />
+          {t("imageSearch.results.search")}
+        </button>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="btn-secondary flex items-center gap-2 px-4 py-2 text-sm"
+          data-testid="retry-btn"
+        >
+          <Icon icon={RefreshCw} size="sm" />
+          {t("imageSearch.results.retry")}
+        </button>
+      </div>
+
+      {/* Privacy confirmation */}
+      <p className="flex items-center gap-1.5 text-xs text-foreground-secondary">
+        <Icon icon={Lock} size="sm" className="text-brand" />
+        {t("imageSearch.results.imageDeleted")}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/ocr/PrivacyNotice.test.tsx
+++ b/frontend/src/components/ocr/PrivacyNotice.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// Mock HTMLDialogElement.showModal (not available in jsdom)
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal =
+    HTMLDialogElement.prototype.showModal || vi.fn();
+  HTMLDialogElement.prototype.close =
+    HTMLDialogElement.prototype.close || vi.fn();
+});
+
+import { PrivacyNotice } from "./PrivacyNotice";
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("PrivacyNotice", () => {
+  it("renders nothing when open is false", () => {
+    const { container } = render(
+      <PrivacyNotice open={false} onAccept={vi.fn()} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders dialog with title when open", () => {
+    render(<PrivacyNotice open={true} onAccept={vi.fn()} />);
+    expect(
+      screen.getByText("imageSearch.privacy.title"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders body text", () => {
+    render(<PrivacyNotice open={true} onAccept={vi.fn()} />);
+    expect(
+      screen.getByText("imageSearch.privacy.body"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all 4 privacy bullets", () => {
+    render(<PrivacyNotice open={true} onAccept={vi.fn()} />);
+    expect(screen.getByText("imageSearch.privacy.bullet1")).toBeInTheDocument();
+    expect(screen.getByText("imageSearch.privacy.bullet2")).toBeInTheDocument();
+    expect(screen.getByText("imageSearch.privacy.bullet3")).toBeInTheDocument();
+    expect(screen.getByText("imageSearch.privacy.bullet4")).toBeInTheDocument();
+  });
+
+  it("renders accept button", () => {
+    render(<PrivacyNotice open={true} onAccept={vi.fn()} />);
+    const btn = screen.getByTestId("privacy-accept-btn");
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveTextContent("imageSearch.privacy.accept");
+  });
+
+  it("calls onAccept when accept button is clicked", () => {
+    const onAccept = vi.fn();
+    render(<PrivacyNotice open={true} onAccept={onAccept} />);
+    fireEvent.click(screen.getByTestId("privacy-accept-btn"));
+    expect(onAccept).toHaveBeenCalledOnce();
+  });
+
+  it("has correct aria-labelledby on dialog", () => {
+    const { container } = render(<PrivacyNotice open={true} onAccept={vi.fn()} />);
+    const dialog = container.querySelector("dialog");
+    expect(dialog).toHaveAttribute(
+      "aria-labelledby",
+      "privacy-notice-title",
+    );
+  });
+});

--- a/frontend/src/components/ocr/PrivacyNotice.tsx
+++ b/frontend/src/components/ocr/PrivacyNotice.tsx
@@ -1,0 +1,102 @@
+/**
+ * PrivacyNotice — First-use dialog informing users that image processing is
+ * entirely client-side and no images are uploaded.
+ * Issue #55 — Image Search v0
+ */
+
+"use client";
+
+import { useRef, useEffect, useCallback } from "react";
+import { useTranslation } from "@/lib/i18n";
+import { Shield, Smartphone, EyeOff, Lock, CheckCircle } from "lucide-react";
+import { Icon } from "@/components/common/Icon";
+import type { LucideIcon } from "lucide-react";
+
+interface PrivacyNoticeProps {
+  readonly open: boolean;
+  readonly onAccept: () => void;
+}
+
+const BULLETS: ReadonlyArray<{ icon: LucideIcon; key: string }> = [
+  { icon: Smartphone, key: "imageSearch.privacy.bullet1" },
+  { icon: EyeOff, key: "imageSearch.privacy.bullet2" },
+  { icon: Lock, key: "imageSearch.privacy.bullet3" },
+  { icon: CheckCircle, key: "imageSearch.privacy.bullet4" },
+];
+
+export function PrivacyNotice({ open, onAccept }: PrivacyNoticeProps) {
+  if (!open) return null;
+  return <PrivacyNoticeInner onAccept={onAccept} />;
+}
+
+function PrivacyNoticeInner({
+  onAccept,
+}: Readonly<{ onAccept: () => void }>) {
+  const { t } = useTranslation();
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const el = dialogRef.current;
+    if (el && !el.open) el.showModal();
+  }, []);
+
+  const handleCancel = useCallback(
+    (e: Event) => {
+      e.preventDefault(); // don't let Escape dismiss without accepting
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const el = dialogRef.current;
+    if (!el) return;
+    el.addEventListener("cancel", handleCancel);
+    return () => el.removeEventListener("cancel", handleCancel);
+  }, [handleCancel]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      aria-labelledby="privacy-notice-title"
+      className="mx-auto w-full max-w-md rounded-xl border border-border bg-surface p-0 shadow-lg backdrop:bg-black/40"
+    >
+      <div className="p-6">
+        <div className="mb-4 flex items-center gap-2">
+          <Icon icon={Shield} size="lg" className="text-brand" />
+          <h2
+            id="privacy-notice-title"
+            className="text-lg font-semibold text-foreground"
+          >
+            {t("imageSearch.privacy.title")}
+          </h2>
+        </div>
+
+        <p className="mb-4 text-sm text-foreground-secondary">
+          {t("imageSearch.privacy.body")}
+        </p>
+
+        <ul className="mb-6 space-y-3">
+          {BULLETS.map((b) => (
+            <li key={b.key} className="flex items-start gap-2 text-sm">
+              <Icon
+                icon={b.icon}
+                size="sm"
+                className="mt-0.5 shrink-0 text-brand"
+              />
+              <span className="text-foreground">{t(b.key)}</span>
+            </li>
+          ))}
+        </ul>
+
+        <button
+          type="button"
+          onClick={onAccept}
+          className="btn-primary w-full py-2.5 text-sm font-medium"
+          data-testid="privacy-accept-btn"
+        >
+          {t("imageSearch.privacy.accept")}
+        </button>
+      </div>
+    </dialog>
+  );
+}

--- a/frontend/src/components/ocr/index.ts
+++ b/frontend/src/components/ocr/index.ts
@@ -1,0 +1,3 @@
+export { PrivacyNotice } from "./PrivacyNotice";
+export { ImageCapture } from "./ImageCapture";
+export { OCRResults } from "./OCRResults";

--- a/frontend/src/hooks/use-active-route.test.ts
+++ b/frontend/src/hooks/use-active-route.test.ts
@@ -91,4 +91,10 @@ describe("useActiveRoute", () => {
     const { result } = renderHook(() => useActiveRoute());
     expect(result.current).toBeNull();
   });
+
+  it("returns 'image-search' for /app/image-search", () => {
+    mockPathname.mockReturnValue("/app/image-search");
+    const { result } = renderHook(() => useActiveRoute());
+    expect(result.current).toBe("image-search");
+  });
 });

--- a/frontend/src/hooks/use-active-route.ts
+++ b/frontend/src/hooks/use-active-route.ts
@@ -23,6 +23,7 @@ const PRIMARY_ROUTES = [
   { key: "categories", prefix: "/app/categories" },
   { key: "achievements", prefix: "/app/achievements" },
   { key: "recipes", prefix: "/app/recipes" },
+  { key: "image-search", prefix: "/app/image-search" },
 ] as const;
 
 export type PrimaryRouteKey =

--- a/frontend/src/lib/ocr/engine.test.ts
+++ b/frontend/src/lib/ocr/engine.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockRecognize = vi.fn();
+const mockTerminate = vi.fn();
+const mockCreateWorker = vi.fn();
+
+vi.mock("tesseract.js", () => ({
+  createWorker: (...args: unknown[]) => mockCreateWorker(...args),
+}));
+
+import {
+  initOCR,
+  extractText,
+  terminateOCR,
+  isOCRReady,
+  CONFIDENCE,
+  OCR_TIMEOUT_MS,
+} from "./engine";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeFakeWorker() {
+  return {
+    recognize: mockRecognize,
+    terminate: mockTerminate,
+  };
+}
+
+function makeRecognizeResult(text = "Mleko 3.2%", confidence = 85, words: Array<{ text: string; confidence: number }> = []) {
+  const wordResults = words.length > 0
+    ? words.map((w) => ({
+        text: w.text,
+        confidence: w.confidence,
+        bbox: { x0: 0, y0: 0, x1: 100, y1: 20 },
+      }))
+    : [
+        { text: "Mleko", confidence: 90, bbox: { x0: 0, y0: 0, x1: 50, y1: 20 } },
+        { text: "3.2%", confidence: 80, bbox: { x0: 55, y0: 0, x1: 100, y1: 20 } },
+      ];
+
+  return {
+    data: {
+      text: `  ${text}  `,
+      confidence,
+      words: wordResults,
+    },
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("engine", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateWorker.mockResolvedValue(makeFakeWorker());
+    mockRecognize.mockResolvedValue(makeRecognizeResult());
+    mockTerminate.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    // Ensure worker is terminated between tests to reset module state
+    await terminateOCR();
+  });
+
+  // ── Constants ────────────────────────────────────────────────────────────
+
+  describe("constants", () => {
+    it("exports confidence thresholds", () => {
+      expect(CONFIDENCE.HIGH).toBe(80);
+      expect(CONFIDENCE.LOW).toBe(50);
+      expect(CONFIDENCE.UNUSABLE).toBe(30);
+    });
+
+    it("exports OCR timeout", () => {
+      expect(OCR_TIMEOUT_MS).toBe(15_000);
+    });
+  });
+
+  // ── initOCR ──────────────────────────────────────────────────────────────
+
+  describe("initOCR", () => {
+    it("creates a worker on first call", async () => {
+      await initOCR();
+      expect(mockCreateWorker).toHaveBeenCalledOnce();
+      expect(mockCreateWorker).toHaveBeenCalledWith(
+        "pol+eng",
+        undefined,
+        expect.objectContaining({
+          workerPath: expect.stringContaining("tesseract.js"),
+          langPath: expect.stringContaining("tessdata"),
+          corePath: expect.stringContaining("tesseract-core"),
+        }),
+      );
+    });
+
+    it("does not create a second worker on repeated calls", async () => {
+      await initOCR();
+      await initOCR();
+      expect(mockCreateWorker).toHaveBeenCalledOnce();
+    });
+
+    it("marks OCR as ready after init", async () => {
+      expect(isOCRReady()).toBe(false);
+      await initOCR();
+      expect(isOCRReady()).toBe(true);
+    });
+  });
+
+  // ── extractText ──────────────────────────────────────────────────────────
+
+  describe("extractText", () => {
+    it("auto-initialises worker if not already ready", async () => {
+      const blob = new Blob(["fake image"], { type: "image/png" });
+      const result = await extractText(blob);
+
+      expect(mockCreateWorker).toHaveBeenCalledOnce();
+      expect(result.text).toBe("Mleko 3.2%");
+    });
+
+    it("uses existing worker without re-initialising", async () => {
+      await initOCR();
+      const blob = new Blob(["fake"], { type: "image/png" });
+      await extractText(blob);
+      // createWorker only from initOCR, not again from extractText
+      expect(mockCreateWorker).toHaveBeenCalledOnce();
+    });
+
+    it("returns trimmed text", async () => {
+      const blob = new Blob(["fake"], { type: "image/png" });
+      const result = await extractText(blob);
+      expect(result.text).toBe("Mleko 3.2%");
+    });
+
+    it("returns overall confidence", async () => {
+      const blob = new Blob(["fake"], { type: "image/png" });
+      const result = await extractText(blob);
+      expect(result.confidence).toBe(85);
+    });
+
+    it("maps individual word results", async () => {
+      mockRecognize.mockResolvedValue(
+        makeRecognizeResult("cukier mąka", 78, [
+          { text: "cukier", confidence: 88 },
+          { text: "mąka", confidence: 68 },
+        ]),
+      );
+      const blob = new Blob(["fake"], { type: "image/png" });
+      const result = await extractText(blob);
+
+      expect(result.words).toHaveLength(2);
+      expect(result.words[0].text).toBe("cukier");
+      expect(result.words[0].confidence).toBe(88);
+      expect(result.words[1].text).toBe("mąka");
+      expect(result.words[1].bbox).toEqual(
+        expect.objectContaining({ x0: 0, y0: 0 }),
+      );
+    });
+
+    it("throws if recognition fails", async () => {
+      mockRecognize.mockRejectedValue(new Error("recognition error"));
+      const blob = new Blob(["fake"], { type: "image/png" });
+      await expect(extractText(blob)).rejects.toThrow("recognition error");
+    });
+  });
+
+  // ── terminateOCR ─────────────────────────────────────────────────────────
+
+  describe("terminateOCR", () => {
+    it("terminates an active worker", async () => {
+      await initOCR();
+      await terminateOCR();
+      expect(mockTerminate).toHaveBeenCalledOnce();
+      expect(isOCRReady()).toBe(false);
+    });
+
+    it("is a no-op if no worker exists", async () => {
+      await terminateOCR();
+      expect(mockTerminate).not.toHaveBeenCalled();
+    });
+
+    it("allows re-initialisation after termination", async () => {
+      await initOCR();
+      await terminateOCR();
+      await initOCR();
+      expect(mockCreateWorker).toHaveBeenCalledTimes(2);
+      expect(isOCRReady()).toBe(true);
+    });
+  });
+
+  // ── isOCRReady ───────────────────────────────────────────────────────────
+
+  describe("isOCRReady", () => {
+    it("returns false before init", () => {
+      expect(isOCRReady()).toBe(false);
+    });
+
+    it("returns true after init", async () => {
+      await initOCR();
+      expect(isOCRReady()).toBe(true);
+    });
+
+    it("returns false after terminate", async () => {
+      await initOCR();
+      await terminateOCR();
+      expect(isOCRReady()).toBe(false);
+    });
+  });
+});

--- a/frontend/src/lib/ocr/engine.ts
+++ b/frontend/src/lib/ocr/engine.ts
@@ -1,0 +1,107 @@
+/**
+ * OCR Engine — Client-side text extraction via Tesseract.js (WASM).
+ * Issue #55 — Image Search v0
+ *
+ * Images are NEVER uploaded to any server. All processing is ephemeral.
+ * Tesseract.js is lazily loaded only when the user initiates OCR.
+ *
+ * Supports Polish (pol) and English (eng) for accurate diacritics
+ * (ą, ć, ę, ł, ń, ó, ś, ź, ż).
+ */
+
+import type { Worker } from "tesseract.js";
+
+/* ── Types ────────────────────────────────────────────────────────────────── */
+
+export interface OCRWord {
+  text: string;
+  confidence: number;
+  bbox: { x0: number; y0: number; x1: number; y1: number };
+}
+
+export interface OCRResult {
+  /** Full extracted text, trimmed */
+  text: string;
+  /** Overall confidence 0–100 */
+  confidence: number;
+  /** Individual word results with bounding boxes */
+  words: OCRWord[];
+}
+
+/* ── Constants ────────────────────────────────────────────────────────────── */
+
+/** Languages to load — Polish + English */
+const OCR_LANGUAGES = "pol+eng";
+
+/** Maximum time (ms) before OCR times out */
+export const OCR_TIMEOUT_MS = 15_000;
+
+/** Confidence thresholds for UI indicators */
+export const CONFIDENCE = {
+  HIGH: 80,
+  LOW: 50,
+  UNUSABLE: 30,
+} as const;
+
+/* ── Worker lifecycle ─────────────────────────────────────────────────────── */
+
+let worker: Worker | null = null;
+
+/**
+ * Lazily initialise the Tesseract OCR worker.
+ * Downloads WASM + trained data from CDN on first call.
+ */
+export async function initOCR(): Promise<void> {
+  if (worker) return;
+  const { createWorker } = await import("tesseract.js");
+  worker = await createWorker(OCR_LANGUAGES, undefined, {
+    workerPath:
+      "https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js",
+    langPath: "https://tessdata.projectnaptha.com/4.0.0",
+    corePath:
+      "https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core-simd-lstm.wasm.js",
+  });
+}
+
+/**
+ * Run OCR on the given image source.
+ * Initialises the worker lazily if not already running.
+ *
+ * @throws Error if worker cannot be created or recognition fails
+ */
+export async function extractText(
+  imageData: Blob | File | HTMLCanvasElement,
+): Promise<OCRResult> {
+  if (!worker) await initOCR();
+
+  const result = await worker!.recognize(imageData);
+
+  return {
+    text: result.data.text.trim(),
+    confidence: result.data.confidence,
+    words: result.data.words.map((w) => ({
+      text: w.text,
+      confidence: w.confidence,
+      bbox: w.bbox,
+    })),
+  };
+}
+
+/**
+ * Terminate the OCR worker and release WASM memory.
+ * Safe to call multiple times (no-op if already terminated).
+ */
+export async function terminateOCR(): Promise<void> {
+  if (worker) {
+    await worker.terminate();
+    worker = null;
+  }
+}
+
+/**
+ * Check if the OCR worker is currently initialised.
+ * Useful for showing loading indicators.
+ */
+export function isOCRReady(): boolean {
+  return worker !== null;
+}

--- a/frontend/src/lib/ocr/index.ts
+++ b/frontend/src/lib/ocr/index.ts
@@ -1,0 +1,13 @@
+export { initOCR, extractText, terminateOCR, isOCRReady } from "./engine";
+export { CONFIDENCE, OCR_TIMEOUT_MS } from "./engine";
+export type { OCRResult, OCRWord } from "./engine";
+
+export {
+  releaseImageData,
+  hasPrivacyConsent,
+  acceptPrivacyConsent,
+  revokePrivacyConsent,
+} from "./privacy";
+
+export { cleanOCRText, tokenise, buildSearchQuery } from "./matching";
+export type { TokenisedText } from "./matching";

--- a/frontend/src/lib/ocr/matching.test.ts
+++ b/frontend/src/lib/ocr/matching.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import { cleanOCRText, tokenise, buildSearchQuery } from "./matching";
+
+// ─── cleanOCRText ───────────────────────────────────────────────────────────
+
+describe("cleanOCRText", () => {
+  it("trims and collapses whitespace", () => {
+    expect(cleanOCRText("  hello   world  ")).toBe("hello world");
+  });
+
+  it("replaces newlines with spaces", () => {
+    expect(cleanOCRText("line1\nline2\r\nline3")).toBe("line1 line2 line3");
+  });
+
+  it("corrects pipe-before-ó to ł", () => {
+    // |ód → łód
+    expect(cleanOCRText("K|ódź")).toContain("ł");
+  });
+
+  it("corrects Czech č to Polish ć", () => {
+    expect(cleanOCRText("čwikła")).toBe("ćwikła");
+  });
+
+  it("corrects Czech š to Polish ś", () => {
+    expect(cleanOCRText("šniadanie")).toBe("śniadanie");
+  });
+
+  it("corrects Czech ž to Polish ź", () => {
+    expect(cleanOCRText("žródło")).toBe("źródło");
+  });
+
+  it("corrects Czech ř to Polish ż (approximate)", () => {
+    expect(cleanOCRText("řołądek")).toBe("żołądek");
+  });
+
+  it("corrects ĺ to ł", () => {
+    expect(cleanOCRText("maĺy")).toBe("mały");
+  });
+
+  it("removes weight/volume patterns with decimals like 2.5ml", () => {
+    expect(cleanOCRText("cukier 2.5ml mąka 100.0g")).toBe("cukier mąka");
+  });
+
+  it("removes integer percentage values", () => {
+    expect(cleanOCRText("tłuszczu 45% białko 12%")).toBe(
+      "tłuszczu białko",
+    );
+  });
+
+  it("removes inequality symbols", () => {
+    expect(cleanOCRText("< 5 > 10")).toBe("5 10");
+  });
+
+  it("replaces parenthetical notes with space", () => {
+    expect(cleanOCRText("cukier (brązowy) mąka")).toBe("cukier mąka");
+  });
+
+  it("handles empty input", () => {
+    expect(cleanOCRText("")).toBe("");
+  });
+
+  it("handles input that is only noise", () => {
+    // "100g" without decimal stays (regex requires decimal for weight pattern)
+    // but percentages and parentheticals are removed
+    expect(cleanOCRText("2.5ml 45% (note)")).toBe("");
+  });
+});
+
+// ─── tokenise ───────────────────────────────────────────────────────────────
+
+describe("tokenise", () => {
+  it("splits on spaces", () => {
+    expect(tokenise("cukier mąka masło")).toEqual(["cukier", "mąka", "masło"]);
+  });
+
+  it("splits on commas and semicolons", () => {
+    expect(tokenise("cukier, mąka; masło")).toEqual(["cukier", "mąka", "masło"]);
+  });
+
+  it("filters tokens shorter than 3 characters", () => {
+    expect(tokenise("a to cukier")).toEqual(["cukier"]);
+  });
+
+  it("removes Polish stop words", () => {
+    expect(tokenise("składniki cukier wartość mąka")).toEqual([
+      "cukier",
+      "mąka",
+    ]);
+  });
+
+  it("removes English stop words", () => {
+    expect(tokenise("ingredients sugar nutrition flour")).toEqual([
+      "sugar",
+      "flour",
+    ]);
+  });
+
+  it("lowercases tokens", () => {
+    expect(tokenise("CUKIER Mąka")).toEqual(["cukier", "mąka"]);
+  });
+
+  it("deduplicates tokens", () => {
+    expect(tokenise("cukier cukier mąka cukier")).toEqual(["cukier", "mąka"]);
+  });
+
+  it("strips non-alpha edges from tokens", () => {
+    expect(tokenise("(cukier) -mąka.")).toEqual(["cukier", "mąka"]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(tokenise("")).toEqual([]);
+  });
+
+  it("returns empty array when all words are stop words", () => {
+    expect(tokenise("składniki wartość odżywcze")).toEqual([]);
+  });
+});
+
+// ─── buildSearchQuery ───────────────────────────────────────────────────────
+
+describe("buildSearchQuery", () => {
+  it("returns cleaned text, tokens, and query", () => {
+    const result = buildSearchQuery("Cukier  mąka  masło");
+    expect(result.cleaned).toBe("Cukier mąka masło");
+    expect(result.tokens).toEqual(["cukier", "mąka", "masło"]);
+    expect(result.query).toBe("cukier mąka masło");
+  });
+
+  it("caps query at 8 tokens", () => {
+    const input = "alpha bravo charlie delta echo foxtrot golf hotel india juliet";
+    const result = buildSearchQuery(input);
+    const queryTokens = result.query.split(" ");
+    expect(queryTokens).toHaveLength(8);
+    expect(queryTokens).not.toContain("india");
+    expect(queryTokens).not.toContain("juliet");
+  });
+
+  it("applies OCR corrections before tokenising", () => {
+    // č → ć
+    const result = buildSearchQuery("čwikła buraczana");
+    expect(result.tokens).toContain("ćwikła");
+    expect(result.tokens).toContain("buraczana");
+  });
+
+  it("returns empty query for noise-only input", () => {
+    const result = buildSearchQuery("100g 45%");
+    expect(result.query).toBe("");
+    expect(result.tokens).toEqual([]);
+  });
+
+  it("handles real-world Polish ingredient list", () => {
+    const raw =
+      "Składniki: mąka pszenna, cukier, olej palmowy, jaja, mleko w proszku, sól";
+    const result = buildSearchQuery(raw);
+    expect(result.tokens).toContain("mąka");
+    expect(result.tokens).toContain("pszenna");
+    expect(result.tokens).toContain("cukier");
+    expect(result.tokens).toContain("palmowy");
+    expect(result.tokens).not.toContain("składniki");
+    expect(result.tokens).toContain("sól"); // 3 chars, Polish diacritics preserved
+  });
+
+  it("returns TokenisedText type shape", () => {
+    const result = buildSearchQuery("test");
+    expect(result).toHaveProperty("cleaned");
+    expect(result).toHaveProperty("tokens");
+    expect(result).toHaveProperty("query");
+  });
+});

--- a/frontend/src/lib/ocr/matching.ts
+++ b/frontend/src/lib/ocr/matching.ts
@@ -1,0 +1,135 @@
+/**
+ * OCR Text Matching — Clean, tokenise, and match extracted text against products.
+ * Issue #55 — Image Search v0
+ *
+ * Strategies:
+ * 1. Clean OCR output (remove noise, fix common Polish OCR errors)
+ * 2. Tokenise into significant words
+ * 3. Use existing searchProducts API with extracted tokens as query
+ */
+
+/* ── Types ────────────────────────────────────────────────────────────────── */
+
+export interface TokenisedText {
+  /** Original cleaned text */
+  cleaned: string;
+  /** Significant tokens suitable for search queries */
+  tokens: string[];
+  /** Full query string built from tokens */
+  query: string;
+}
+
+/* ── Constants ────────────────────────────────────────────────────────────── */
+
+/**
+ * Polish ingredient-list filler words to exclude from search queries.
+ * These appear on virtually every label and add noise to product matching.
+ */
+const POLISH_STOP_WORDS = new Set([
+  "składniki",
+  "skład",
+  "wartość",
+  "wartości",
+  "odżywcze",
+  "odżywcza",
+  "zawiera",
+  "może",
+  "zawierać",
+  "śladowe",
+  "ilości",
+  "masa",
+  "netto",
+  "przechowywać",
+  "najlepiej",
+  "spożyć",
+  "przed",
+  "wyprodukowano",
+  "ingredients",
+  "nutrition",
+  "facts",
+  "contains",
+  "may",
+  "contain",
+  "traces",
+  "best",
+  "before",
+  "net",
+  "weight",
+  "store",
+  "produced",
+]);
+
+/** Minimum token length to be considered significant */
+const MIN_TOKEN_LENGTH = 3;
+
+/** Max tokens to include in a search query */
+const MAX_QUERY_TOKENS = 8;
+
+/* ── Common OCR error corrections for Polish text ─────────────────────────── */
+
+const OCR_CORRECTIONS: ReadonlyArray<[RegExp, string]> = [
+  // Common glyph confusions in Polish
+  [/[|l](?=ó)/g, "ł"], // |ó → łó  (pipe/l before ó → ł)
+  [/[0O](?=ś)/g, "ó"], // 0ś → óś  (zero/O → ó when before ś)
+  [/ĺ/g, "ł"], // ĺ → ł  (accented l → barred l)
+  [/č/g, "ć"], // Czech č → Polish ć
+  [/š/g, "ś"], // Czech š → Polish ś
+  [/ž/g, "ź"], // Czech ž → Polish ź
+  [/ř/g, "ż"], // Czech ř → sometimes Polish ż
+  // Numeric/symbol noise
+  [/\d+[.,]\d+\s*[gGmMlLkK]{1,2}\b/g, ""], // "100g", "2.5ml"
+  [/\d+\s*%/g, ""], // "45%"
+  [/[<>≤≥]/g, ""], // inequality symbols
+  [/\(.*?\)/g, " "], // parenthetical notes → space
+];
+
+/* ── Functions ────────────────────────────────────────────────────────────── */
+
+/**
+ * Clean raw OCR output: apply error corrections, normalise whitespace,
+ * remove non-text noise.
+ */
+export function cleanOCRText(raw: string): string {
+  let text = raw;
+
+  // Apply correction patterns
+  for (const [pattern, replacement] of OCR_CORRECTIONS) {
+    text = text.replace(pattern, replacement);
+  }
+
+  // Normalise whitespace and trim
+  text = text
+    .replace(/[\r\n]+/g, " ") // newlines → space
+    .replace(/\s{2,}/g, " ") // collapse multiple spaces
+    .trim();
+
+  return text;
+}
+
+/**
+ * Tokenise cleaned text into significant words suitable for product search.
+ * Removes stop words, short tokens, and duplicate words.
+ */
+export function tokenise(cleaned: string): string[] {
+  const raw = cleaned
+    .toLowerCase()
+    .split(/[\s,;:]+/)
+    .map((t) => t.replace(/^[^a-ząćęłńóśźż]+|[^a-ząćęłńóśźż]+$/gi, ""))
+    .filter(
+      (t) => t.length >= MIN_TOKEN_LENGTH && !POLISH_STOP_WORDS.has(t),
+    );
+
+  // Deduplicate while preserving order
+  return [...new Set(raw)];
+}
+
+/**
+ * Process raw OCR text into a cleaned, tokenised search query.
+ */
+export function buildSearchQuery(rawText: string): TokenisedText {
+  const cleaned = cleanOCRText(rawText);
+  const tokens = tokenise(cleaned);
+  const query = tokens.slice(0, MAX_QUERY_TOKENS).join(" ");
+
+  return { cleaned, tokens, query };
+}

--- a/frontend/src/lib/ocr/privacy.test.ts
+++ b/frontend/src/lib/ocr/privacy.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  hasPrivacyConsent,
+  acceptPrivacyConsent,
+  revokePrivacyConsent,
+} from "./privacy";
+
+// ─── localStorage mock ──────────────────────────────────────────────────────
+
+const store: Record<string, string> = {};
+
+const localStorageMock = {
+  getItem: vi.fn((key: string) => store[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    store[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete store[key];
+  }),
+};
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("privacy", () => {
+  const CONSENT_KEY = "fooddb:image-search-privacy-accepted";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear store
+    Object.keys(store).forEach((key) => delete store[key]);
+  });
+
+  // ── hasPrivacyConsent ──────────────────────────────────────────────────
+
+  describe("hasPrivacyConsent", () => {
+    it("returns false when no consent stored", () => {
+      expect(hasPrivacyConsent()).toBe(false);
+      expect(localStorageMock.getItem).toHaveBeenCalledWith(CONSENT_KEY);
+    });
+
+    it("returns true when consent is '1'", () => {
+      store[CONSENT_KEY] = "1";
+      expect(hasPrivacyConsent()).toBe(true);
+    });
+
+    it("returns false when consent value is not '1'", () => {
+      store[CONSENT_KEY] = "yes";
+      expect(hasPrivacyConsent()).toBe(false);
+    });
+  });
+
+  // ── acceptPrivacyConsent ───────────────────────────────────────────────
+
+  describe("acceptPrivacyConsent", () => {
+    it("stores '1' in localStorage", () => {
+      acceptPrivacyConsent();
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(CONSENT_KEY, "1");
+      expect(store[CONSENT_KEY]).toBe("1");
+    });
+
+    it("makes hasPrivacyConsent return true", () => {
+      acceptPrivacyConsent();
+      expect(hasPrivacyConsent()).toBe(true);
+    });
+  });
+
+  // ── revokePrivacyConsent ───────────────────────────────────────────────
+
+  describe("revokePrivacyConsent", () => {
+    it("removes consent from localStorage", () => {
+      store[CONSENT_KEY] = "1";
+      revokePrivacyConsent();
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith(CONSENT_KEY);
+      expect(store[CONSENT_KEY]).toBeUndefined();
+    });
+
+    it("makes hasPrivacyConsent return false", () => {
+      acceptPrivacyConsent();
+      revokePrivacyConsent();
+      expect(hasPrivacyConsent()).toBe(false);
+    });
+  });
+
+  // ── releaseImageData re-export ─────────────────────────────────────────
+
+  describe("releaseImageData re-export", () => {
+    it("re-exports releaseImageData from enforcement", async () => {
+      const { releaseImageData } = await import("./privacy");
+      expect(typeof releaseImageData).toBe("function");
+    });
+  });
+
+  // ── SSR guards (typeof window === "undefined") ─────────────────────────
+
+  describe("SSR guards", () => {
+    let origWindow: typeof globalThis.window;
+
+    beforeEach(() => {
+      origWindow = globalThis.window;
+      // Make typeof window === "undefined"
+      Object.defineProperty(globalThis, "window", {
+        value: undefined,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, "window", {
+        value: origWindow,
+        configurable: true,
+      });
+    });
+
+    it("hasPrivacyConsent returns true on server (SSR)", () => {
+      expect(hasPrivacyConsent()).toBe(true);
+    });
+
+    it("acceptPrivacyConsent is a no-op on server", () => {
+      acceptPrivacyConsent();
+      // Should not throw and should not touch localStorage
+      expect(localStorageMock.setItem).not.toHaveBeenCalled();
+    });
+
+    it("revokePrivacyConsent is a no-op on server", () => {
+      revokePrivacyConsent();
+      expect(localStorageMock.removeItem).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/lib/ocr/privacy.ts
+++ b/frontend/src/lib/ocr/privacy.ts
@@ -1,0 +1,35 @@
+/**
+ * OCR Privacy — Image data cleanup and privacy utilities.
+ * Issue #55 — Image Search v0
+ *
+ * Re-exports releaseImageData from image-policy/enforcement.ts (single source
+ * of truth) and adds OCR-specific privacy helpers like the consent flag.
+ */
+
+export { releaseImageData } from "@/lib/image-policy/enforcement";
+
+/* ── Consent persistence ──────────────────────────────────────────────────── */
+
+const CONSENT_KEY = "fooddb:image-search-privacy-accepted";
+
+/**
+ * Check if the user has previously accepted the image search privacy notice.
+ * Returns `true` on the server (SSR) to avoid hydration mismatch — actual
+ * gating happens in an effect.
+ */
+export function hasPrivacyConsent(): boolean {
+  if (typeof window === "undefined") return true;
+  return localStorage.getItem(CONSENT_KEY) === "1";
+}
+
+/** Record that the user accepted the privacy notice. */
+export function acceptPrivacyConsent(): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(CONSENT_KEY, "1");
+}
+
+/** Clear consent (for testing or settings reset). */
+export function revokePrivacyConsent(): void {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(CONSENT_KEY);
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1003,7 +1003,8 @@ export type AnalyticsEventName =
   | "share_link_opened"
   | "category_viewed"
   | "preferences_updated"
-  | "onboarding_completed";
+  | "onboarding_completed"
+  | "image_search_performed";
 
 export type DeviceType = "mobile" | "tablet" | "desktop";
 


### PR DESCRIPTION
Closes #55

## Summary

Client-side OCR-based image search prototype. Users can photograph a food label or upload an image, extract text via Tesseract.js (WASM, `pol+eng`), edit/review the OCR output, and search for matching products — all without uploading any image to the server.

## Changes

### Core Library (`src/lib/ocr/`)
- **engine.ts** — Tesseract.js worker lifecycle (lazy init, CDN-hosted WASM), `extractText()`, confidence scoring, timeout constants
- **privacy.ts** — Consent persistence (`localStorage`), SSR-safe guards, re-exports `releaseImageData` from image-policy
- **matching.ts** — Polish/Czech OCR corrections (8 regex patterns), stop-word removal, tokenisation → `buildSearchQuery()`

### Components (`src/components/ocr/`)
- **PrivacyNotice.tsx** — First-use privacy dialog (native `<dialog>`, 4 bullet points: on-device, no upload, auto-delete, no storage)
- **ImageCapture.tsx** — Camera (`getUserMedia`) + file upload, frame capture to JPEG, canvas cleanup on capture
- **OCRResults.tsx** — Confidence badge (green/yellow/red), editable textarea, search + retry actions, privacy confirmation

### Page + Navigation
- **`/app/image-search`** page — Full capture → processing → results flow, beta badge, breadcrumbs, pre-warms OCR worker, releases image data after processing
- **DesktopSidebar + MoreDrawer** — `ScanText` icon nav entry
- **use-active-route** — Added `image-search` route key

### i18n
- ~35 keys each in `en.json` and `pl.json` under `imageSearch.*` namespace + `nav.imageSearch`

### Analytics
- Added `image_search_performed` to `AnalyticsEventName` type

## Testing

**114 tests** across 7 test files, all passing:

| File | Tests | Coverage (stmts) |
|---|---|---|
| engine.test.ts | 17 | 100% |
| privacy.test.ts | 11 | 100% |
| matching.test.ts | 30 | 100% |
| PrivacyNotice.test.tsx | 7 | 100%* |
| ImageCapture.test.tsx | 19 | 95.16% |
| OCRResults.test.tsx | 14 | 100% |
| page.test.tsx | 16 | 95.12% |

Overall new code coverage: **lib/ocr 100%**, **components/ocr 94.73%**, **page 95.12%**

*Coverage includes camera workflow mocks (getUserMedia, canvas, video), toBlob null path, getContext null path, SSR guards, unmount cleanup.

## Privacy Guardrails
- ✅ Images processed entirely client-side (Tesseract WASM)
- ✅ No image upload to any server
- ✅ Canvas and blob data released immediately after OCR
- ✅ First-use privacy dialog with consent persistence
- ✅ Compliant with existing image-policy/enforcement.ts (CSP, releaseImageData)