### PR TITLE
fix(nutrition): centralize banding logic, fix 0g/null edge cases (#153)

### DIFF
--- a/frontend/src/components/product/TrafficLightChip.test.tsx
+++ b/frontend/src/components/product/TrafficLightChip.test.tsx
@@ -21,15 +21,19 @@ describe("getTrafficLight", () => {
     expect(getTrafficLight("total_fat", 3)).toBe("green");
   });
 
-  it("total_fat: amber when 3.1–17.5g", () => {
+  it("total_fat: amber when 3.1–17.4g", () => {
     expect(getTrafficLight("total_fat", 3.1)).toBe("amber");
     expect(getTrafficLight("total_fat", 10)).toBe("amber");
-    expect(getTrafficLight("total_fat", 17.5)).toBe("amber");
   });
 
-  it("total_fat: red when > 17.5g", () => {
+  it("total_fat: red when ≥ 17.5g (exact high threshold)", () => {
+    expect(getTrafficLight("total_fat", 17.5)).toBe("red");
     expect(getTrafficLight("total_fat", 17.6)).toBe("red");
     expect(getTrafficLight("total_fat", 30)).toBe("red");
+  });
+
+  it("total_fat: null for 0g (no band)", () => {
+    expect(getTrafficLight("total_fat", 0)).toBeNull();
   });
 
   // ── Saturated fat thresholds ──────────────────────────────────────────
@@ -38,13 +42,18 @@ describe("getTrafficLight", () => {
     expect(getTrafficLight("saturated_fat", 1.5)).toBe("green");
   });
 
-  it("saturated_fat: amber when 1.6–5g", () => {
+  it("saturated_fat: amber when 1.6–4.9g", () => {
     expect(getTrafficLight("saturated_fat", 2)).toBe("amber");
-    expect(getTrafficLight("saturated_fat", 5)).toBe("amber");
+    expect(getTrafficLight("saturated_fat", 4.9)).toBe("amber");
   });
 
-  it("saturated_fat: red when > 5g", () => {
+  it("saturated_fat: red when ≥ 5g (exact high threshold)", () => {
+    expect(getTrafficLight("saturated_fat", 5)).toBe("red");
     expect(getTrafficLight("saturated_fat", 5.1)).toBe("red");
+  });
+
+  it("saturated_fat: null for 0g (no band)", () => {
+    expect(getTrafficLight("saturated_fat", 0)).toBeNull();
   });
 
   // ── Sugars thresholds ─────────────────────────────────────────────────
@@ -77,16 +86,21 @@ describe("getTrafficLight", () => {
   it("fibre: green when high (≥ 6g) — beneficial inversion", () => {
     expect(getTrafficLight("fibre", 8)).toBe("green");
     expect(getTrafficLight("fibre", 6.1)).toBe("green");
+    expect(getTrafficLight("fibre", 6)).toBe("green"); // exact high threshold
   });
 
-  it("fibre: amber when moderate (3–6g)", () => {
+  it("fibre: amber when moderate (3.1–5.9g)", () => {
     expect(getTrafficLight("fibre", 4)).toBe("amber");
-    expect(getTrafficLight("fibre", 6)).toBe("amber");
+    expect(getTrafficLight("fibre", 5.9)).toBe("amber");
   });
 
-  it("fibre: red when low (< 3g) — beneficial inversion", () => {
+  it("fibre: red when low (≤ 3g) — beneficial inversion", () => {
     expect(getTrafficLight("fibre", 1)).toBe("red");
     expect(getTrafficLight("fibre", 3)).toBe("red");
+  });
+
+  it("fibre: null for 0g — the original bug (was showing 'High')", () => {
+    expect(getTrafficLight("fibre", 0)).toBeNull();
   });
 
   it("fiber (US spelling) follows same inversion as fibre", () => {
@@ -116,6 +130,14 @@ describe("getTrafficLight", () => {
   it("sugar low → green (harmful), fibre low → red (beneficial)", () => {
     expect(getTrafficLight("sugars", 2)).toBe("green");
     expect(getTrafficLight("fibre", 1)).toBe("red");
+  });
+
+  // ── Zero-value edge cases (core bug fix for #153) ─────────────────────
+  it("returns null for 0g of any nutrient (never shows a band label)", () => {
+    expect(getTrafficLight("sugars", 0)).toBeNull();
+    expect(getTrafficLight("salt", 0)).toBeNull();
+    expect(getTrafficLight("fibre", 0)).toBeNull();
+    expect(getTrafficLight("protein", 0)).toBeNull();
   });
 });
 

--- a/frontend/src/components/product/TrafficLightChip.tsx
+++ b/frontend/src/components/product/TrafficLightChip.tsx
@@ -2,47 +2,21 @@
 // Displays a green / amber / red chip next to a nutrient value based on
 // UK FSA / EFSA traffic-light thresholds (per 100 g for food).
 //
-// Thresholds: https://www.food.gov.uk/business-guidance/signposting-and-traffic-light-labelling
-//
-// | Nutrient      | Green (Low) | Amber (Medium) | Red (High) |
-// | ------------- | ----------- | -------------- | ---------- |
-// | Total fat     | ≤ 3.0 g     | 3.1–17.5 g     | > 17.5 g   |
-// | Saturated fat | ≤ 1.5 g     | 1.6–5.0 g      | > 5.0 g    |
-// | Sugars        | ≤ 5.0 g     | 5.1–22.5 g     | > 22.5 g   |
-// | Salt          | ≤ 0.3 g     | 0.31–1.5 g     | > 1.5 g    |
+// Thresholds are defined in the centralized utility:
+//   frontend/src/lib/nutrition-banding.ts
 //
 // Beneficial nutrients (fibre, protein) use INVERTED colours:
 // high = green (good), low = red (less ideal).
-//
-// Fibre thresholds (EU Regulation 1924/2006):
-// | Level  | Threshold   | Colour (inverted) |
-// | ------ | ----------- | ----------------- |
-// | Low    | < 3.0 g     | Red (bad)         |
-// | Source | 3.0–5.9 g   | Amber             |
-// | High   | ≥ 6.0 g     | Green (good)      |
+
+import {
+  getNutritionBand,
+  BENEFICIAL_NUTRIENTS,
+  type NutritionBand,
+} from "@/lib/nutrition-banding";
+
+export { BENEFICIAL_NUTRIENTS } from "@/lib/nutrition-banding";
 
 export type TrafficLight = "green" | "amber" | "red";
-
-interface Threshold {
-  greenMax: number;
-  amberMax: number;
-}
-
-const THRESHOLDS: Record<string, Threshold> = {
-  total_fat: { greenMax: 3, amberMax: 17.5 },
-  saturated_fat: { greenMax: 1.5, amberMax: 5 },
-  sugars: { greenMax: 5, amberMax: 22.5 },
-  salt: { greenMax: 0.3, amberMax: 1.5 },
-  fibre: { greenMax: 3, amberMax: 6 },
-  fiber: { greenMax: 3, amberMax: 6 },
-  protein: { greenMax: 8, amberMax: 16 },
-};
-
-/**
- * Beneficial nutrients where high values are positive (green).
- * For these, the traffic light colours are inverted: high → green, low → red.
- */
-export const BENEFICIAL_NUTRIENTS = new Set(["fibre", "fiber", "protein"]);
 
 /** Invert green ↔ red while keeping amber unchanged. */
 function invertLight(level: TrafficLight): TrafficLight {
@@ -51,22 +25,23 @@ function invertLight(level: TrafficLight): TrafficLight {
   return "amber";
 }
 
-/** Resolve the traffic-light level for a nutrient. */
+/** Map NutritionBand → base TrafficLight colour (before beneficial inversion). */
+const BAND_TO_LIGHT: Record<Exclude<NutritionBand, "none">, TrafficLight> = {
+  low: "green",
+  medium: "amber",
+  high: "red",
+};
+
+/** Resolve the traffic-light level for a nutrient using centralized thresholds. */
 export function getTrafficLight(
   nutrient: string,
   valuePer100g: number | null,
 ): TrafficLight | null {
-  if (valuePer100g === null || valuePer100g === undefined) return null;
-  const t = THRESHOLDS[nutrient];
-  if (!t) return null;
+  const band = getNutritionBand(nutrient, valuePer100g);
+  if (band === "none") return null;
 
-  let level: TrafficLight;
-  if (valuePer100g <= t.greenMax) level = "green";
-  else if (valuePer100g <= t.amberMax) level = "amber";
-  else level = "red";
-
-  // Beneficial nutrients: high is good (green), low is bad (red)
-  return BENEFICIAL_NUTRIENTS.has(nutrient) ? invertLight(level) : level;
+  const light = BAND_TO_LIGHT[band];
+  return BENEFICIAL_NUTRIENTS.has(nutrient) ? invertLight(light) : light;
 }
 
 const TL_STYLES: Record<TrafficLight, string> = {

--- a/frontend/src/components/product/TrafficLightStrip.test.tsx
+++ b/frontend/src/components/product/TrafficLightStrip.test.tsx
@@ -43,10 +43,9 @@ describe("TrafficLightStrip", () => {
     expect(dots.length).toBe(4);
   });
 
-  it("returns null when no traffic light data available", () => {
-    // getTrafficLight returns null when nutrient is not in thresholds
-    // but all 4 are in thresholds, so we test with 0 values (still yields green)
-    render(
+  it("returns null when all nutrient values are 0 (no misleading bands)", () => {
+    // After #153 fix: getTrafficLight returns null for 0g → strip renders nothing
+    const { container } = render(
       <TrafficLightStrip
         nutrition={{
           total_fat_g: 0,
@@ -57,7 +56,7 @@ describe("TrafficLightStrip", () => {
       />,
     );
 
-    // Should still render (all green) — <fieldset> has implicit group role
-    expect(screen.getByRole("group")).toBeInTheDocument();
+    // Component returns null — nothing in the DOM
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/frontend/src/lib/nutrition-banding.test.ts
+++ b/frontend/src/lib/nutrition-banding.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from "vitest";
+import {
+  getNutritionBand,
+  NUTRITION_THRESHOLDS,
+  BENEFICIAL_NUTRIENTS,
+  type NutritionBand,
+} from "./nutrition-banding";
+
+// ─── Threshold constant assertions ──────────────────────────────────────────
+
+describe("NUTRITION_THRESHOLDS", () => {
+  it("defines thresholds for all expected nutrients", () => {
+    const expected = [
+      "total_fat",
+      "saturated_fat",
+      "sugars",
+      "salt",
+      "fibre",
+      "fiber",
+      "protein",
+    ];
+    for (const nutrient of expected) {
+      expect(NUTRITION_THRESHOLDS[nutrient]).toBeDefined();
+      expect(NUTRITION_THRESHOLDS[nutrient].low).toBeGreaterThan(0);
+      expect(NUTRITION_THRESHOLDS[nutrient].high).toBeGreaterThan(
+        NUTRITION_THRESHOLDS[nutrient].low,
+      );
+    }
+  });
+
+  it("fibre and fiber have identical thresholds", () => {
+    expect(NUTRITION_THRESHOLDS.fibre).toEqual(NUTRITION_THRESHOLDS.fiber);
+  });
+
+  // EU Regulation 1924/2006 reference thresholds
+  it("fibre high threshold is 6g (EU Reg 1924/2006 'high fibre')", () => {
+    expect(NUTRITION_THRESHOLDS.fibre.high).toBe(6);
+  });
+
+  it("total_fat thresholds match FSA guidance (low ≤3g, high ≥17.5g)", () => {
+    expect(NUTRITION_THRESHOLDS.total_fat).toEqual({ low: 3, high: 17.5 });
+  });
+});
+
+describe("BENEFICIAL_NUTRIENTS", () => {
+  it("includes fibre, fiber, and protein", () => {
+    expect(BENEFICIAL_NUTRIENTS.has("fibre")).toBe(true);
+    expect(BENEFICIAL_NUTRIENTS.has("fiber")).toBe(true);
+    expect(BENEFICIAL_NUTRIENTS.has("protein")).toBe(true);
+  });
+
+  it("does not include harmful nutrients", () => {
+    expect(BENEFICIAL_NUTRIENTS.has("sugars")).toBe(false);
+    expect(BENEFICIAL_NUTRIENTS.has("salt")).toBe(false);
+    expect(BENEFICIAL_NUTRIENTS.has("total_fat")).toBe(false);
+    expect(BENEFICIAL_NUTRIENTS.has("saturated_fat")).toBe(false);
+  });
+});
+
+// ─── getNutritionBand: edge cases ───────────────────────────────────────────
+
+describe("getNutritionBand", () => {
+  // ── Null / undefined / zero / negative → "none" ─────────────────────
+  it("returns 'none' for null value", () => {
+    expect(getNutritionBand("sugars", null)).toBe("none");
+  });
+
+  it("returns 'none' for undefined value", () => {
+    expect(getNutritionBand("sugars", undefined)).toBe("none");
+  });
+
+  it("returns 'none' for 0g (core bug: was returning 'low' or 'high')", () => {
+    expect(getNutritionBand("sugars", 0)).toBe("none");
+    expect(getNutritionBand("fibre", 0)).toBe("none");
+    expect(getNutritionBand("total_fat", 0)).toBe("none");
+    expect(getNutritionBand("salt", 0)).toBe("none");
+    expect(getNutritionBand("saturated_fat", 0)).toBe("none");
+    expect(getNutritionBand("protein", 0)).toBe("none");
+  });
+
+  it("returns 'none' for negative values", () => {
+    expect(getNutritionBand("sugars", -1)).toBe("none");
+    expect(getNutritionBand("fibre", -0.5)).toBe("none");
+  });
+
+  it("returns 'none' for unknown nutrient key", () => {
+    expect(getNutritionBand("unknown_nutrient", 50)).toBe("none");
+    expect(getNutritionBand("", 10)).toBe("none");
+  });
+
+  // ── Total fat: low ≤3, medium 3–17.5, high ≥17.5 ───────────────────
+
+  describe("total_fat", () => {
+    it("below low threshold → 'low'", () => {
+      expect(getNutritionBand("total_fat", 1)).toBe("low");
+      expect(getNutritionBand("total_fat", 2.5)).toBe("low");
+    });
+
+    it("exact low threshold (3g) → 'low'", () => {
+      expect(getNutritionBand("total_fat", 3)).toBe("low");
+    });
+
+    it("between thresholds → 'medium'", () => {
+      expect(getNutritionBand("total_fat", 3.1)).toBe("medium");
+      expect(getNutritionBand("total_fat", 10)).toBe("medium");
+      expect(getNutritionBand("total_fat", 17.4)).toBe("medium");
+    });
+
+    it("exact high threshold (17.5g) → 'high'", () => {
+      expect(getNutritionBand("total_fat", 17.5)).toBe("high");
+    });
+
+    it("above high threshold → 'high'", () => {
+      expect(getNutritionBand("total_fat", 18)).toBe("high");
+      expect(getNutritionBand("total_fat", 50)).toBe("high");
+    });
+  });
+
+  // ── Saturated fat: low ≤1.5, medium 1.5–5, high ≥5 ─────────────────
+
+  describe("saturated_fat", () => {
+    it("below low threshold → 'low'", () => {
+      expect(getNutritionBand("saturated_fat", 0.5)).toBe("low");
+    });
+
+    it("exact low threshold (1.5g) → 'low'", () => {
+      expect(getNutritionBand("saturated_fat", 1.5)).toBe("low");
+    });
+
+    it("between thresholds → 'medium'", () => {
+      expect(getNutritionBand("saturated_fat", 2)).toBe("medium");
+      expect(getNutritionBand("saturated_fat", 4.9)).toBe("medium");
+    });
+
+    it("exact high threshold (5g) → 'high'", () => {
+      expect(getNutritionBand("saturated_fat", 5)).toBe("high");
+    });
+
+    it("above high threshold → 'high'", () => {
+      expect(getNutritionBand("saturated_fat", 7)).toBe("high");
+    });
+  });
+
+  // ── Sugars: low ≤5, medium 5–22.5, high ≥22.5 ──────────────────────
+
+  describe("sugars", () => {
+    it("below low threshold → 'low'", () => {
+      expect(getNutritionBand("sugars", 2)).toBe("low");
+    });
+
+    it("exact low threshold (5g) → 'low'", () => {
+      expect(getNutritionBand("sugars", 5)).toBe("low");
+    });
+
+    it("between thresholds → 'medium'", () => {
+      expect(getNutritionBand("sugars", 10)).toBe("medium");
+      expect(getNutritionBand("sugars", 22.4)).toBe("medium");
+    });
+
+    it("exact high threshold (22.5g) → 'high'", () => {
+      expect(getNutritionBand("sugars", 22.5)).toBe("high");
+    });
+
+    it("above high threshold → 'high'", () => {
+      expect(getNutritionBand("sugars", 30)).toBe("high");
+    });
+  });
+
+  // ── Salt: low ≤0.3, medium 0.3–1.5, high ≥1.5 ─────────────────────
+
+  describe("salt", () => {
+    it("below low threshold → 'low'", () => {
+      expect(getNutritionBand("salt", 0.1)).toBe("low");
+    });
+
+    it("exact low threshold (0.3g) → 'low'", () => {
+      expect(getNutritionBand("salt", 0.3)).toBe("low");
+    });
+
+    it("between thresholds → 'medium'", () => {
+      expect(getNutritionBand("salt", 0.5)).toBe("medium");
+      expect(getNutritionBand("salt", 1.4)).toBe("medium");
+    });
+
+    it("exact high threshold (1.5g) → 'high'", () => {
+      expect(getNutritionBand("salt", 1.5)).toBe("high");
+    });
+
+    it("above high threshold → 'high'", () => {
+      expect(getNutritionBand("salt", 2.5)).toBe("high");
+    });
+  });
+
+  // ── Fibre: low ≤3, medium 3–6, high ≥6 (EU Reg 1924/2006) ─────────
+
+  describe("fibre", () => {
+    it("below low threshold → 'low'", () => {
+      expect(getNutritionBand("fibre", 1)).toBe("low");
+    });
+
+    it("exact low threshold (3g) → 'low'", () => {
+      expect(getNutritionBand("fibre", 3)).toBe("low");
+    });
+
+    it("between thresholds → 'medium'", () => {
+      expect(getNutritionBand("fibre", 4)).toBe("medium");
+      expect(getNutritionBand("fibre", 5.9)).toBe("medium");
+    });
+
+    it("exact high threshold (6g) → 'high' (EU 'high fibre' claim)", () => {
+      expect(getNutritionBand("fibre", 6)).toBe("high");
+    });
+
+    it("above high threshold → 'high'", () => {
+      expect(getNutritionBand("fibre", 10)).toBe("high");
+    });
+  });
+
+  // ── Fiber (US spelling alias) ───────────────────────────────────────
+
+  describe("fiber (US spelling)", () => {
+    it("matches fibre thresholds exactly", () => {
+      expect(getNutritionBand("fiber", 1)).toBe("low");
+      expect(getNutritionBand("fiber", 4)).toBe("medium");
+      expect(getNutritionBand("fiber", 8)).toBe("high");
+      expect(getNutritionBand("fiber", 0)).toBe("none");
+      expect(getNutritionBand("fiber", null)).toBe("none");
+    });
+  });
+
+  // ── Protein: low ≤8, medium 8–16, high ≥16 ─────────────────────────
+
+  describe("protein", () => {
+    it("below low threshold → 'low'", () => {
+      expect(getNutritionBand("protein", 3)).toBe("low");
+    });
+
+    it("exact low threshold (8g) → 'low'", () => {
+      expect(getNutritionBand("protein", 8)).toBe("low");
+    });
+
+    it("between thresholds → 'medium'", () => {
+      expect(getNutritionBand("protein", 12)).toBe("medium");
+      expect(getNutritionBand("protein", 15.9)).toBe("medium");
+    });
+
+    it("exact high threshold (16g) → 'high'", () => {
+      expect(getNutritionBand("protein", 16)).toBe("high");
+    });
+
+    it("above high threshold → 'high'", () => {
+      expect(getNutritionBand("protein", 25)).toBe("high");
+    });
+  });
+
+  // ── Very large values ───────────────────────────────────────────────
+
+  it("handles very large values as 'high'", () => {
+    expect(getNutritionBand("sugars", 999)).toBe("high");
+    expect(getNutritionBand("total_fat", 100)).toBe("high");
+  });
+
+  // ── Tiny positive values ────────────────────────────────────────────
+
+  it("tiny positive values (0.01g) are classified, not 'none'", () => {
+    const band = getNutritionBand("salt", 0.01);
+    expect(band).not.toBe("none");
+    expect(band).toBe("low"); // 0.01 ≤ 0.3
+  });
+
+  // ── Type safety: band return type ───────────────────────────────────
+
+  it("always returns a valid NutritionBand value", () => {
+    const validBands: NutritionBand[] = ["none", "low", "medium", "high"];
+    const testCases = [
+      getNutritionBand("sugars", null),
+      getNutritionBand("sugars", 0),
+      getNutritionBand("sugars", 2),
+      getNutritionBand("sugars", 10),
+      getNutritionBand("sugars", 30),
+      getNutritionBand("unknown", 50),
+    ];
+    for (const result of testCases) {
+      expect(validBands).toContain(result);
+    }
+  });
+});

--- a/frontend/src/lib/nutrition-banding.ts
+++ b/frontend/src/lib/nutrition-banding.ts
@@ -1,0 +1,81 @@
+// ─── Centralized Nutrition Banding ────────────────────────────────────────────
+//
+// Single source of truth for nutrition-band thresholds and classification.
+// Used by TrafficLightChip, NutritionDVBar, and any other component that needs
+// to classify a nutrient value as low / medium / high.
+//
+// Thresholds: UK FSA traffic-light guidance (per 100 g for food)
+// Reference : https://www.food.gov.uk/business-guidance/signposting-and-traffic-light-labelling
+//
+// Fibre / protein thresholds follow EU Regulation 1924/2006:
+//   - "Source of fibre" ≥ 3 g / 100 g
+//   - "High fibre"     ≥ 6 g / 100 g
+//
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** Qualitative band for a nutrient value. `"none"` means no band applies (0, null, or unknown nutrient). */
+export type NutritionBand = "none" | "low" | "medium" | "high";
+
+export interface NutrientThresholds {
+  /** Values ≤ this are classified as "low". */
+  readonly low: number;
+  /** Values ≥ this are classified as "high". Values between low and high are "medium". */
+  readonly high: number;
+}
+
+/**
+ * FSA / EFSA per-100 g thresholds.
+ *
+ * | Nutrient      | Low (≤)  | High (≥)  | Source                    |
+ * | ------------- | -------- | --------- | ------------------------- |
+ * | Total fat     | 3.0 g    | 17.5 g    | UK FSA traffic-light      |
+ * | Saturated fat | 1.5 g    | 5.0 g     | UK FSA traffic-light      |
+ * | Sugars        | 5.0 g    | 22.5 g    | UK FSA traffic-light      |
+ * | Salt          | 0.3 g    | 1.5 g     | UK FSA traffic-light      |
+ * | Fibre         | 3.0 g    | 6.0 g     | EU Reg 1924/2006          |
+ * | Protein       | 8.0 g    | 16.0 g    | UK FSA traffic-light      |
+ */
+export const NUTRITION_THRESHOLDS: Readonly<Record<string, NutrientThresholds>> = {
+  total_fat: { low: 3, high: 17.5 },
+  saturated_fat: { low: 1.5, high: 5 },
+  sugars: { low: 5, high: 22.5 },
+  salt: { low: 0.3, high: 1.5 },
+  fibre: { low: 3, high: 6 },
+  fiber: { low: 3, high: 6 }, // US spelling alias
+  protein: { low: 8, high: 16 },
+};
+
+/**
+ * Nutrients where higher values are positive (green / good).
+ * For these nutrients the traffic-light colours are inverted at the display
+ * level: high → green (good), low → red (concerning).
+ */
+export const BENEFICIAL_NUTRIENTS: ReadonlySet<string> = new Set([
+  "fibre",
+  "fiber",
+  "protein",
+]);
+
+/**
+ * Classify a nutrient value into a qualitative band.
+ *
+ * - `null`, `undefined`, `0`, and negative values → `"none"` (no band displayed)
+ * - Unknown nutrient keys → `"none"`
+ * - Otherwise → `"low"` / `"medium"` / `"high"` based on FSA thresholds
+ *
+ * **Note:** the returned band always describes the *amount* of the nutrient,
+ * regardless of whether the nutrient is beneficial or harmful. Colour
+ * inversion for beneficial nutrients happens at the display layer.
+ */
+export function getNutritionBand(
+  nutrient: string,
+  valuePer100g: number | null | undefined,
+): NutritionBand {
+  if (valuePer100g == null) return "none";
+  if (valuePer100g <= 0) return "none"; // 0 g or negative → no meaningful band
+  const t = NUTRITION_THRESHOLDS[nutrient];
+  if (!t) return "none";
+  if (valuePer100g <= t.low) return "low";
+  if (valuePer100g >= t.high) return "high";
+  return "medium";
+}


### PR DESCRIPTION
## Summary
Closes #153 — "Fix Nutrition Banding Logic — Fibre 0g Showing 'High', Zero/Null Edge Cases"

## Root Cause
`getTrafficLight()` in `TrafficLightChip.tsx` had no guard for zero values. For `fibre = 0g`:
- `0 ≤ greenMax(3)` → classified as "green" (low amount)
- Beneficial inversion: green → red
- Red label = "High"
- **Result: "High Fibre" displayed for a product with 0g fibre**

Same pattern affected all nutrients: `sugar = 0g` showed "Low" instead of nothing.

## Solution

### 1. Centralized `nutrition-banding.ts` (new file)
- Single source of truth for all FSA/EU thresholds
- `getNutritionBand(nutrient, value)` returns `"none"` | `"low"` | `"medium"` | `"high"`
- **Zero, null, undefined, negative → always `"none"`** (no band displayed)
- Thresholds documented with EU Regulation 1924/2006 references
- Exported constants: `NUTRITION_THRESHOLDS`, `BENEFICIAL_NUTRIENTS`

### 2. Refactored `TrafficLightChip.tsx`
- Removed inline `THRESHOLDS` and `BENEFICIAL_NUTRIENTS` constants
- `getTrafficLight()` now delegates to `getNutritionBand()` + maps to traffic light colours
- Re-exports `BENEFICIAL_NUTRIENTS` from centralized utility for existing consumers

### 3. Updated `TrafficLightStrip.test.tsx`
- Test for 0g values now correctly expects empty render (no misleading "Low" labels)

## Test Coverage
| File | Tests | Coverage |
|---|---|---|
| `nutrition-banding.ts` | 45 | **100%** |
| `TrafficLightChip.tsx` | 32 | **100%** |
| `TrafficLightStrip.tsx` | 3 | passing |
| Product detail page | 66 | passing |

### Test matrix (nutrition-banding.test.ts)
- 6 nutrients × 7 value types (0, null, below-low, exact-low, between, exact-high, above-high) = 42+ assertions
- Edge cases: negative values, very large values, undefined, unknown nutrients, US spelling alias
- Threshold constant validation with EU regulation references

## Acceptance Criteria Verification
- [x] 0g of any nutrient → no band displayed (never "High" or "Low")
- [x] NULL nutrition values → no band (returns "none")
- [x] Fibre = 0g → does NOT show "High" (the original bug)
- [x] Sugar = 0g → does NOT show "Low"
- [x] Banding thresholds match EU Regulation 1924/2006 (documented)
- [x] Exact-low returns "Low", exact-high returns "High"
- [x] Banding logic in exactly ONE place (centralized utility)
- [x] `tsc --noEmit` passes
- [x] All Vitest tests pass
- [x] `next build` passes