### PR TITLE
fix(nutrition): resolve 'eu_ri' to 'EU Reference Intakes' (#125)

### DIFF
--- a/frontend/src/components/product/DVReferenceBadge.test.tsx
+++ b/frontend/src/components/product/DVReferenceBadge.test.tsx
@@ -1,10 +1,41 @@
 import { render, screen } from "@testing-library/react";
-import { DVReferenceBadge } from "./DVReferenceBadge";
+import { DVReferenceBadge, resolveRegulationLabel } from "./DVReferenceBadge";
+
+// ─── resolveRegulationLabel ─────────────────────────────────────────────────
+
+describe("resolveRegulationLabel", () => {
+  it("maps 'eu_ri' to 'EU Reference Intakes'", () => {
+    expect(resolveRegulationLabel("eu_ri")).toBe("EU Reference Intakes");
+  });
+
+  it("maps 'fda_dv' to 'FDA Daily Values'", () => {
+    expect(resolveRegulationLabel("fda_dv")).toBe("FDA Daily Values");
+  });
+
+  it("returns the raw value for unknown regulation keys", () => {
+    expect(resolveRegulationLabel("some_future_reg")).toBe("some_future_reg");
+  });
+
+  it("returns 'EU RI' fallback for undefined", () => {
+    expect(resolveRegulationLabel(undefined)).toBe("EU RI");
+  });
+
+  it("returns 'EU RI' fallback for empty string", () => {
+    expect(resolveRegulationLabel("")).toBe("EU RI");
+  });
+});
+
+// ─── DVReferenceBadge component ─────────────────────────────────────────────
 
 describe("DVReferenceBadge", () => {
-  it("renders standard badge with regulation", () => {
+  it("renders standard badge with resolved regulation label", () => {
     render(<DVReferenceBadge referenceType="standard" regulation="eu_ri" />);
-    expect(screen.getByText(/eu_ri/)).toBeInTheDocument();
+    expect(screen.getByText(/EU Reference Intakes/)).toBeInTheDocument();
+  });
+
+  it("does NOT render raw 'eu_ri' constant in the DOM", () => {
+    render(<DVReferenceBadge referenceType="standard" regulation="eu_ri" />);
+    expect(screen.queryByText(/\beu_ri\b/)).not.toBeInTheDocument();
   });
 
   it("renders personalized badge", () => {
@@ -18,7 +49,7 @@ describe("DVReferenceBadge", () => {
 
   it("renders standard badge with gray styling", () => {
     render(<DVReferenceBadge referenceType="standard" regulation="eu_ri" />);
-    const badge = screen.getByText(/eu_ri/);
+    const badge = screen.getByText(/EU Reference Intakes/);
     expect(badge.closest("span")).toHaveClass("bg-surface-muted");
   });
 
@@ -39,5 +70,11 @@ describe("DVReferenceBadge", () => {
       <DVReferenceBadge referenceType="standard" regulation="eu_ri" />,
     );
     expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("falls back gracefully when regulation prop is omitted", () => {
+    render(<DVReferenceBadge referenceType="standard" />);
+    // Falls back to "EU RI" via resolveRegulationLabel
+    expect(screen.getByText(/EU RI/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/product/DVReferenceBadge.tsx
+++ b/frontend/src/components/product/DVReferenceBadge.tsx
@@ -1,6 +1,22 @@
 import { useTranslation } from "@/lib/i18n";
 import { User, BarChart3 } from "lucide-react";
 
+/**
+ * Human-readable labels for regulation constants stored in the DB.
+ * Keys match the `daily_value_references.regulation` column values.
+ * - `eu_ri` = EU Reference Intakes, Regulation (EU) No 1169/2011
+ */
+const REGULATION_LABELS: Readonly<Record<string, string>> = {
+  eu_ri: "EU Reference Intakes",
+  fda_dv: "FDA Daily Values",
+};
+
+/** Resolve a raw regulation constant to its display label. */
+export function resolveRegulationLabel(regulation: string | undefined): string {
+  if (!regulation) return "EU RI";
+  return REGULATION_LABELS[regulation] ?? regulation;
+}
+
 interface DVReferenceBadgeProps {
   readonly referenceType: "standard" | "personalized" | "none";
   readonly regulation?: string;
@@ -17,7 +33,9 @@ export function DVReferenceBadge({
   const isPersonalized = referenceType === "personalized";
   const label = isPersonalized
     ? t("product.dvPersonalized")
-    : t("product.dvStandard", { regulation: regulation ?? "EU RI" });
+    : t("product.dvStandard", {
+        regulation: resolveRegulationLabel(regulation),
+      });
 
   return (
     <span


### PR DESCRIPTION
## Summary
Closes #125 — "Fix 'eu_ri' Display Text — Should Read 'EU Reference Intakes'"

## Root Cause
The DB stores `regulation = 'eu_ri'` as a constant in `daily_value_references`. The API returns it verbatim. `DVReferenceBadge` interpolated the raw constant directly into the i18n template, producing "Based on eu_ri reference intakes (2,000 kcal)".

## Fix
Added `resolveRegulationLabel()` function with a `REGULATION_LABELS` lookup map:
- `eu_ri` → "EU Reference Intakes" (EU Regulation 1169/2011)
- `fda_dv` → "FDA Daily Values"
- Unknown keys → passed through as-is (future-proof)
- `undefined`/empty → "EU RI" fallback

## Tests (13 passing, 100% coverage)
- 5 tests for `resolveRegulationLabel()` (known keys, unknown key, undefined, empty)
- 8 tests for `DVReferenceBadge` component (resolved label renders, raw constant does NOT render, personalized/standard/none states, styling, fallback)

## Validation
- tsc: clean
- vitest: all passing
- next build: clean