### PR TITLE
fix(i18n): fix pluralization grammar across UI

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -37,7 +37,8 @@
     "offlineDescription": "Check your internet connection and try again.",
     "pageOf": "Page {page} of {pages}",
     "items": "{count} {count|item|items}",
-    "products": "{count} {count|product|products}"
+    "products": "{count} {count|product|products}",
+    "allergenWarnings": "{count} allergen {count|warning|warnings}"
   },
   "toast": {
     "genericError": "Something went wrong. Please try again.",
@@ -864,7 +865,7 @@
     "comparisonInvalid": "This comparison link is invalid or has expired.",
     "goToFoodDB": "Go to FoodDB",
     "productComparison": "Product Comparison",
-    "productsCompared": "products compared",
+    "productsCompared": "{count} {count|product|products} compared",
     "wantToCompare": "Want to compare your own products?",
     "signUpFree": "Sign up for free"
   },
@@ -900,7 +901,7 @@
     "efsaGuidance": "EFSA Guidance",
     "scoreImpact": "Score impact",
     "usage": "Usage Statistics",
-    "productsContaining": "products contain this ingredient",
+    "productsContaining": "{count|product contains|products contain} this ingredient",
     "byCategory": "By Category",
     "topProducts": "Top Products",
     "relatedIngredients": "Often Found Together",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -37,7 +37,8 @@
     "offlineDescription": "Sprawdź połączenie internetowe i spróbuj ponownie.",
     "pageOf": "Strona {page} z {pages}",
     "items": "{count} {count|element|elementy|elementów}",
-    "products": "{count} {count|produkt|produkty|produktów}"
+    "products": "{count} {count|produkt|produkty|produktów}",
+    "allergenWarnings": "{count} {count|ostrzeżenie alergenowe|ostrzeżenia alergenowe|ostrzeżeń alergenowych}"
   },
   "toast": {
     "genericError": "Coś poszło nie tak. Spróbuj ponownie.",
@@ -864,7 +865,7 @@
     "comparisonInvalid": "Ten link porównania jest nieprawidłowy lub wygasł.",
     "goToFoodDB": "Przejdź do FoodDB",
     "productComparison": "Porównanie produktów",
-    "productsCompared": "porównane produkty",
+    "productsCompared": "{count} {count|produkt porównany|produkty porównane|produktów porównanych}",
     "wantToCompare": "Chcesz porównać własne produkty?",
     "signUpFree": "Zarejestruj się za darmo"
   },
@@ -900,7 +901,7 @@
     "efsaGuidance": "Wytyczne EFSA",
     "scoreImpact": "Wpływ na wynik",
     "usage": "Statystyki użycia",
-    "productsContaining": "produktów zawiera ten składnik",
+    "productsContaining": "{count|produkt zawiera|produkty zawierają|produktów zawiera} ten składnik",
     "byCategory": "Według kategorii",
     "topProducts": "Najlepsze produkty",
     "relatedIngredients": "Często spotykane razem",

--- a/frontend/src/app/compare/shared/[token]/page.tsx
+++ b/frontend/src/app/compare/shared/[token]/page.tsx
@@ -74,7 +74,7 @@ function SharedComparisonContent() {
                   {data.title ?? t("shared.productComparison")}
                 </h1>
                 <p className="text-sm text-foreground-secondary">
-                  {data.product_count} {t("shared.productsCompared")} ·{" "}
+                  {t("shared.productsCompared", { count: data.product_count })} ·{" "}
                   {new Date(data.created_at).toLocaleDateString()}
                 </p>
               </div>

--- a/frontend/src/components/common/AllergenChips.tsx
+++ b/frontend/src/components/common/AllergenChips.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslation } from "@/lib/i18n";
 import type { AllergenWarning } from "@/lib/allergen-matching";
 
 // ─── Constants ──────────────────────────────────────────────────────────────
@@ -57,6 +58,8 @@ interface AllergenChipsProps {
  * - Returns null when no warnings
  */
 export function AllergenChips({ warnings }: AllergenChipsProps) {
+  const { t } = useTranslation();
+
   if (warnings.length === 0) return null;
 
   const visible = warnings.slice(0, MAX_VISIBLE);
@@ -67,7 +70,7 @@ export function AllergenChips({ warnings }: AllergenChipsProps) {
       className="flex flex-wrap items-center gap-1"
       data-testid="allergen-chips"
       role="status"
-      aria-label={`${warnings.length} allergen warning${warnings.length !== 1 ? "s" : ""}`}
+      aria-label={t("common.allergenWarnings", { count: warnings.length })}
     >
       {visible.map((w) => (
         <AllergenChip key={`${w.tag}-${w.type}`} warning={w} />

--- a/frontend/src/components/ingredient/IngredientUsageStats.tsx
+++ b/frontend/src/components/ingredient/IngredientUsageStats.tsx
@@ -23,7 +23,7 @@ export function IngredientUsageStats({ usage }: IngredientUsageStatsProps) {
       <p className="mb-3 text-2xl font-bold text-foreground">
         {usage.product_count.toLocaleString()}{" "}
         <span className="text-sm font-normal text-foreground-secondary">
-          {t("ingredient.productsContaining")}
+          {t("ingredient.productsContaining", { count: usage.product_count })}
         </span>
       </p>
 

--- a/frontend/src/lib/i18n.test.ts
+++ b/frontend/src/lib/i18n.test.ts
@@ -220,6 +220,71 @@ describe("translate", () => {
         "22 elementy",
       );
     });
+
+    // ── New pluralized keys (Issue #126 audit) ──────────────────────────────
+
+    it("pluralizes common.allergenWarnings (en)", () => {
+      expect(translate("en", "common.allergenWarnings", { count: 1 })).toBe(
+        "1 allergen warning",
+      );
+      expect(translate("en", "common.allergenWarnings", { count: 3 })).toBe(
+        "3 allergen warnings",
+      );
+    });
+
+    it("pluralizes common.allergenWarnings (pl)", () => {
+      expect(translate("pl", "common.allergenWarnings", { count: 1 })).toBe(
+        "1 ostrzeżenie alergenowe",
+      );
+      expect(translate("pl", "common.allergenWarnings", { count: 3 })).toBe(
+        "3 ostrzeżenia alergenowe",
+      );
+      expect(translate("pl", "common.allergenWarnings", { count: 5 })).toBe(
+        "5 ostrzeżeń alergenowych",
+      );
+    });
+
+    it("pluralizes shared.productsCompared (en)", () => {
+      expect(translate("en", "shared.productsCompared", { count: 1 })).toBe(
+        "1 product compared",
+      );
+      expect(translate("en", "shared.productsCompared", { count: 3 })).toBe(
+        "3 products compared",
+      );
+    });
+
+    it("pluralizes shared.productsCompared (pl)", () => {
+      expect(translate("pl", "shared.productsCompared", { count: 1 })).toBe(
+        "1 produkt porównany",
+      );
+      expect(translate("pl", "shared.productsCompared", { count: 3 })).toBe(
+        "3 produkty porównane",
+      );
+      expect(translate("pl", "shared.productsCompared", { count: 5 })).toBe(
+        "5 produktów porównanych",
+      );
+    });
+
+    it("pluralizes ingredient.productsContaining (en)", () => {
+      expect(
+        translate("en", "ingredient.productsContaining", { count: 1 }),
+      ).toBe("product contains this ingredient");
+      expect(
+        translate("en", "ingredient.productsContaining", { count: 5 }),
+      ).toBe("products contain this ingredient");
+    });
+
+    it("pluralizes ingredient.productsContaining (pl)", () => {
+      expect(
+        translate("pl", "ingredient.productsContaining", { count: 1 }),
+      ).toBe("produkt zawiera ten składnik");
+      expect(
+        translate("pl", "ingredient.productsContaining", { count: 3 }),
+      ).toBe("produkty zawierają ten składnik");
+      expect(
+        translate("pl", "ingredient.productsContaining", { count: 5 }),
+      ).toBe("produktów zawiera ten składnik");
+    });
   });
 
   // ── useTranslation hook ─────────────────────────────────────────────────


### PR DESCRIPTION
## Closes #126

## Problem
Several UI components bypassed the i18n pluralization system, using hardcoded English ternary expressions or separate count + static noun patterns. This caused:
- **AllergenChips**: Hardcoded `allergen warning${count !== 1 ? "s" : ""}` — broken in Polish
- **Shared comparison page**: `{data.product_count} {t("productsCompared")}` — count displayed separately from a static noun, no pluralization
- **IngredientUsageStats**: Static "products contain this ingredient" label regardless of count

## Frontend-Wide Audit Results

| # | File | Issue | Severity | Fixed |
|---|---|---|---|---|
| A | `AllergenChips.tsx` | Hardcoded ternary plural in `aria-label` | **High** | ✅ |
| B | `shared/[token]/page.tsx` | Count + static noun, no plural pipe syntax | **Medium** | ✅ |
| C | `IngredientUsageStats.tsx` | Static "products contain" not adapting to count | **Medium** | ✅ |

The original `product.ingredientCount` key (`{count} {count|ingredient|ingredients}`) was already properly pluralized via the pipe syntax system — the "1 ingredients" bug reported in #126 was resolved previously.

## Changes

### Translation keys (en.json + pl.json)
- **Added** `common.allergenWarnings`: `"{count} allergen {count|warning|warnings}"` (en) / Polish 3-form
- **Updated** `shared.productsCompared`: `"{count} {count|product|products} compared"` (en) / Polish 3-form
- **Updated** `ingredient.productsContaining`: `"{count|product contains|products contain} this ingredient"` (en) / Polish 3-form

### Component fixes
- `AllergenChips.tsx`: Import `useTranslation`, replace hardcoded aria-label with `t("common.allergenWarnings", { count })`
- `shared/[token]/page.tsx`: Replace `{count} {t("shared.productsCompared")}` with `{t("shared.productsCompared", { count })}`
- `IngredientUsageStats.tsx`: Pass `{ count }` to `t("ingredient.productsContaining")`

### Tests
- 6 new integration tests in `i18n.test.ts` verifying all 3 new/updated keys for both English and Polish
- All 3318 vitest tests pass
- All 22 existing AllergenChips + shared comparison tests pass unchanged
- 100% coverage on AllergenChips.tsx

## Pre-merge checklist
- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 3318 pass, 0 fail
- [x] i18n dictionary integrity — 15/15 pass
- [x] AllergenChips coverage — 100%
- [x] No raw i18n keys in rendered output