### PR TITLE
feat(search): surface recent search history in autocomplete dropdown (#132)

### DIFF
--- a/frontend/e2e/authenticated.spec.ts
+++ b/frontend/e2e/authenticated.spec.ts
@@ -119,6 +119,28 @@ test.describe("Search page", () => {
     // Should stay on search page (results or empty state)
     await expect(page).toHaveURL(/\/app\/search/);
   });
+
+  test("shows recent searches in autocomplete dropdown", async ({ page }) => {
+    // Seed localStorage with recent searches before navigating
+    await page.goto("/app/search");
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "fooddb:recent-searches",
+        JSON.stringify(["mleko", "jogurt"]),
+      );
+    });
+    // Reload to pick up seeded data
+    await page.reload({ waitUntil: "networkidle" });
+
+    const input = page.getByPlaceholder(/search products/i);
+    await input.focus();
+
+    // Recent searches section should appear
+    const dropdown = page.locator("#search-autocomplete-listbox");
+    await expect(dropdown).toBeVisible({ timeout: 5000 });
+    await expect(dropdown.getByText("mleko").first()).toBeVisible();
+    await expect(dropdown.getByText("jogurt").first()).toBeVisible();
+  });
 });
 
 // ─── Authenticated: Categories ──────────────────────────────────────────────

--- a/frontend/src/lib/recent-searches.test.ts
+++ b/frontend/src/lib/recent-searches.test.ts
@@ -33,6 +33,19 @@ describe("recent-searches", () => {
       expect(getRecentSearches()).toEqual([]);
     });
 
+    it("returns empty array when stored value is not an array", () => {
+      localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(42));
+      expect(getRecentSearches()).toEqual([]);
+    });
+
+    it("filters out non-string values from stored array", () => {
+      localStorage.setItem(
+        RECENT_SEARCHES_KEY,
+        JSON.stringify(["mleko", 42, null, "ser", true]),
+      );
+      expect(getRecentSearches()).toEqual(["mleko", "ser"]);
+    });
+
     it("handles localStorage unavailable gracefully", () => {
       const origGetItem = Storage.prototype.getItem;
       Storage.prototype.getItem = () => {


### PR DESCRIPTION
## Summary
Closes #132 — **[Epic 3] Surface Recent Search History in Search Autocomplete Dropdown**

The autocomplete dropdown previously hid popular searches whenever recent searches existed. This PR fixes the logic so both sections display together, with correct keyboard navigation spanning both lists.

## Changes

### Component (`SearchAutocomplete.tsx`)
- **Show both sections**: Changed `showPopular` from `!isQueryMode && recentSearches.length === 0` to `!isQueryMode` so popular searches always appear in empty-query mode alongside recents
- **Unified keyboard navigation**: Added `popularIndexOffset` to map `activeIndex` correctly across recent + popular sections; updated `navigableCount` to sum both
- **ID-based scroll**: Replaced `listRef.current.children[activeIndex]` with `containerRef.current.querySelector(`#${id}`)` for reliable cross-section scroll-into-view
- **Visual separator**: Added `border-t` divider between recent and popular sections when both are visible

### Tests
- **17 new Vitest tests** (`SearchAutocomplete.test.tsx`): recent section rendering, both sections together, click/remove/clearAll interactions, keyboard navigation (ArrowDown/Up/Enter/Escape) across dual sections, HighlightMatch rendering, outside mousedown, loading state
- **2 new edge-case tests** (`recent-searches.test.ts`): non-array JSON parse, mixed-type filtering
- **1 Playwright E2E test** (`authenticated.spec.ts`): seeds localStorage with recent searches, verifies dropdown displays them

## Coverage
| File | Statements | Branches | Declarations |
|------|-----------|----------|-------------|
| `SearchAutocomplete.tsx` | 87.46% | 83.60% | 81.57% |
| `recent-searches.ts` | 85.96% | 71.42% | 100% |

## Pre-merge checks
- `tsc --noEmit` — clean
- `vitest run` — **3337 passed**, 0 failed