### PR TITLE
feat(dashboard): favorites empty state CTA (#134)

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -73,6 +73,7 @@
     "browseCategories": "Browse Categories",
     "recentlyViewed": "Recently Viewed",
     "favorites": "Favorites",
+    "favoritesEmptyCta": "Tap \u2764\uFE0F on any product",
     "newProducts": "New Products",
     "newInCategory": "New {category}",
     "viewAll": "View all →",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -73,6 +73,7 @@
     "browseCategories": "Przeglądaj kategorie",
     "recentlyViewed": "Ostatnio przeglądane",
     "favorites": "Ulubione",
+    "favoritesEmptyCta": "Kliknij \u2764\uFE0F przy produkcie",
     "newProducts": "Nowe produkty",
     "newInCategory": "Nowe {category}",
     "viewAll": "Pokaż wszystko →",

--- a/frontend/src/app/app/page.test.tsx
+++ b/frontend/src/app/app/page.test.tsx
@@ -506,4 +506,28 @@ describe("DashboardPage", () => {
     expect(screen.getByTestId("sparkline-bar-low")).toBeInTheDocument();
     expect(screen.getByTestId("sparkline-bar-high")).toBeInTheDocument();
   });
+
+  // ─── Favorites empty state CTA (#134) ───────────────────────────────────
+
+  it("renders favorites CTA when favorites_count is 0", async () => {
+    mockGetDashboardData.mockResolvedValue({
+      ok: true,
+      data: {
+        ...mockDashboard,
+        stats: { ...mockDashboard.stats, favorites_count: 0 },
+      },
+    });
+    render(<DashboardPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText(/Tap ❤️ on any product/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders favorites count (not CTA) when favorites_count > 0", async () => {
+    render(<DashboardPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("7")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Tap ❤️ on any product/)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -91,6 +91,7 @@ function StatsBar({ stats }: Readonly<{ stats: DashboardStats }>) {
       value: stats.favorites_count,
       icon: Heart,
       href: "/app/lists",
+      cta: stats.favorites_count === 0 ? t("dashboard.favoritesEmptyCta") : undefined,
     },
   ];
 
@@ -99,15 +100,21 @@ function StatsBar({ stats }: Readonly<{ stats: DashboardStats }>) {
       {items.map((s) => (
         <Link
           key={s.label}
-          href={s.href}
+          href={s.cta ? "/app/search" : s.href}
           className="card hover-lift-press flex flex-col items-center gap-1 py-3"
         >
           <span className="flex items-center justify-center">
             <s.icon size={28} aria-hidden="true" />
           </span>
-          <span className="text-xl font-bold tabular-nums text-foreground lg:text-2xl">
-            {s.value}
-          </span>
+          {s.cta ? (
+            <span className="text-center text-sm text-foreground-secondary animate-pulse">
+              {s.cta}
+            </span>
+          ) : (
+            <span className="text-xl font-bold tabular-nums text-foreground lg:text-2xl">
+              {s.value}
+            </span>
+          )}
           <span className="text-xs text-foreground-secondary lg:text-sm">
             {s.label}
           </span>


### PR DESCRIPTION
## Summary\nCloses #134 — **[Epic 3] Favorites Empty State CTA on Dashboard**\n\nWhen a user has 0 favorites, the dashboard stats card now shows a CTA (\"Tap ❤️ on any product\") instead of a plain \"0\", linking to the search page for product discovery.\n\n## Changes\n\n### i18n files\n- **en.json**: Added `dashboard.favoritesEmptyCta` — \"Tap ❤️ on any product\"\n- **pl.json**: Added `dashboard.favoritesEmptyCta` — \"Kliknij ❤️ przy produkcie\"\n\n### Component (`page.tsx` — `StatsBar`)\n- Added `cta` property to the favorites item when `favorites_count === 0`\n- Conditional rendering: CTA text with `animate-pulse` when `cta` is set, otherwise normal numeric display\n- CTA card links to `/app/search` instead of `/app/lists` to guide users to product discovery\n\n### Tests (`page.test.tsx`)\n- Added: \"renders favorites CTA when favorites_count is 0\" — overrides mock with `favorites_count: 0`, verifies CTA text\n- Added: \"renders favorites count (not CTA) when favorites_count > 0\" — verifies normal \"7\" display and no CTA\n\n## Coverage\n| File | Coverage |\n|------|----------|\n| `page.tsx` | **90.56%** |\n\n## Pre-merge checks\n- `tsc --noEmit` — clean\n- `vitest run` — **3342 passed**, 0 failed