### PR TITLE
feat: hide eco-score placeholder behind FEATURES.ECO_SCORE flag (#136)

### DIFF
--- a/frontend/src/app/app/product/[id]/page.tsx
+++ b/frontend/src/app/app/product/[id]/page.tsx
@@ -14,6 +14,7 @@ import { getProductProfile, recordProductView } from "@/lib/api";
 import { queryKeys, staleTimes } from "@/lib/query-keys";
 import {
   SCORE_BANDS,
+  FEATURES,
   scoreBandFromScore,
   getScoreInterpretation,
 } from "@/lib/constants";
@@ -465,22 +466,24 @@ function OverviewTab({ profile }: Readonly<{ profile: ProductProfile }>) {
       {/* Data quality */}
       <DataQualityCard quality={profile.quality} />
 
-      {/* Eco-Score placeholder */}
-      <div className="card">
-        <h3 className="mb-2 flex items-center gap-1.5 text-sm font-semibold text-foreground-secondary lg:text-base">
-          <Globe size={16} aria-hidden="true" /> {t("product.ecoScoreTitle")}
-        </h3>
-        <div className="flex items-center gap-2 rounded-lg border border-dashed border-blue-200 bg-blue-50/50 px-3 py-3">
-          <Info
-            size={18}
-            className="flex-shrink-0 text-blue-600"
-            aria-hidden="true"
-          />
-          <p className="text-sm text-blue-700">
-            {t("product.ecoScoreComingSoon")}
-          </p>
+      {/* Eco-Score placeholder – hidden until FEATURES.ECO_SCORE is enabled */}
+      {FEATURES.ECO_SCORE && (
+        <div className="card">
+          <h3 className="mb-2 flex items-center gap-1.5 text-sm font-semibold text-foreground-secondary lg:text-base">
+            <Globe size={16} aria-hidden="true" /> {t("product.ecoScoreTitle")}
+          </h3>
+          <div className="flex items-center gap-2 rounded-lg border border-dashed border-blue-200 bg-blue-50/50 px-3 py-3">
+            <Info
+              size={18}
+              className="flex-shrink-0 text-blue-600"
+              aria-hidden="true"
+            />
+            <p className="text-sm text-blue-700">
+              {t("product.ecoScoreComingSoon")}
+            </p>
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Product image gallery */}
       <ProductImageTabs

--- a/frontend/src/lib/constants.test.ts
+++ b/frontend/src/lib/constants.test.ts
@@ -12,6 +12,7 @@ import {
   WARNING_SEVERITY,
   SCORE_INTERPRETATION_BANDS,
   TRAFFIC_LIGHT_NUTRIENTS,
+  FEATURES,
   getScoreInterpretation,
 } from "@/lib/constants";
 
@@ -231,5 +232,11 @@ describe("TRAFFIC_LIGHT_NUTRIENTS", () => {
       expect(n.nutrient).toBeTruthy();
       expect(n.labelKey).toMatch(/^product\./);
     }
+  });
+});
+
+describe("FEATURES", () => {
+  it("has ECO_SCORE set to false by default", () => {
+    expect(FEATURES.ECO_SCORE).toBe(false);
   });
 });

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -244,3 +244,10 @@ export const TRAFFIC_LIGHT_NUTRIENTS = [
   { nutrient: "sugars", labelKey: "product.sugars" },
   { nutrient: "salt", labelKey: "product.salt" },
 ] as const;
+
+// ─── Feature flags ──────────────────────────────────────────────────────────
+// Flip to `true` when the corresponding feature is production-ready.
+export const FEATURES = {
+  /** Show the Environmental Impact / Eco-Score section on product pages. */
+  ECO_SCORE: false,
+} as const;


### PR DESCRIPTION
## Summary

Hides the "Environmental Impact" / Eco-Score placeholder section on the product detail page behind a feature flag (`FEATURES.ECO_SCORE`). The flag defaults to `false`, so the section is hidden until Eco-Score data is production-ready.

## Changes

- **`frontend/src/lib/constants.ts`** — Added `FEATURES` constant with `ECO_SCORE: false`
- **`frontend/src/app/app/product/[id]/page.tsx`** — Imported `FEATURES` and wrapped eco-score placeholder with `{FEATURES.ECO_SCORE && (...)}`
- **`frontend/src/app/app/product/[id]/page.test.tsx`** — Updated existing test to verify placeholder is hidden by default; added new test to verify it renders when flag is on; used `vi.hoisted()` + mock for feature flag control
- **`frontend/src/lib/constants.test.ts`** — Added test for `FEATURES.ECO_SCORE` default value

## Test Coverage

- 3 new tests added (2 product page, 1 constants)
- All 3347 tests pass, 0 failures
- tsc clean

Closes #136