### PR TITLE
feat: mask user ID, show email as primary identifier on Settings (#137)

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -540,6 +540,9 @@
     "theme": "Theme",
     "account": "Account",
     "userId": "User ID: {id}…",
+    "accountDetails": "Account Details",
+    "copyUserId": "Copy User ID",
+    "copiedToClipboard": "Copied!",
     "signOut": "Sign out",
     "preferencesSaved": "Preferences saved!"
   },

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -540,6 +540,9 @@
     "theme": "Motyw",
     "account": "Konto",
     "userId": "ID użytkownika: {id}…",
+    "accountDetails": "Szczegóły konta",
+    "copyUserId": "Kopiuj ID użytkownika",
+    "copiedToClipboard": "Skopiowano!",
     "signOut": "Wyloguj się",
     "preferencesSaved": "Preferencje zapisane!"
   },


### PR DESCRIPTION
## Summary

Replaces the raw UUID display on the Settings page with a user-friendly layout: email as primary identifier, masked UUID behind an expandable section, and a copy-to-clipboard button.

## Changes

- **`frontend/src/app/app/settings/page.tsx`** — Fetch user email via `supabase.auth.getUser()`, show email as primary identifier, add expandable "Account Details" section with masked UUID (first 4 + last 4 chars) and "Copy User ID" button with toast confirmation
- **`frontend/messages/en.json`** / **`pl.json`** — Added `settings.accountDetails`, `settings.copyUserId`, `settings.copiedToClipboard` keys
- **`frontend/src/app/app/settings/page.test.tsx`** — Replaced old "shows user ID snippet" test with 3 new tests:
  - Email shown as primary identifier, raw UUID not visible
  - Expanding Account Details reveals masked UUID + copy button
  - Copy button calls `navigator.clipboard.writeText` with full UUID + shows toast

## Acceptance Criteria

- [x] Raw UUID is **not visible** on the Settings page without user interaction
- [x] User email is shown as primary identifier
- [x] Full UUID is accessible via expand/copy for support purposes
- [x] Copy button copies the full UUID to clipboard and shows a confirmation toast ("Copied!")
- [x] Expanding "Account Details" reveals the masked UUID
- [x] `tsc --noEmit` passes
- [x] All existing tests pass (3349 total)

Closes #137