### PR TITLE
feat(#140): Set Up Staging Environment Infrastructure

### DIFF
--- a/.github/workflows/sync-cloud-db.yml
+++ b/.github/workflows/sync-cloud-db.yml
@@ -7,8 +7,36 @@ on:
       - "supabase/migrations/**"
 
 jobs:
-  sync:
+  sync-staging:
+    name: Sync Staging DB
     runs-on: ubuntu-latest
+    # Only run if the staging project ref secret is configured
+    if: ${{ vars.STAGING_ENABLED == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link to staging project
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: |
+          supabase link --project-ref "${{ secrets.SUPABASE_STAGING_PROJECT_REF }}"
+
+      - name: Push migrations to staging
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: supabase db push --yes
+
+  sync-production:
+    name: Sync Production DB
+    runs-on: ubuntu-latest
+    needs: [sync-staging]
+    # Run even if sync-staging was skipped (staging not enabled)
+    if: ${{ !failure() }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Closes #140 — Set Up Staging Environment per STAGING_SETUP.md.

This PR delivers the **code/infrastructure** side of staging environment setup:
all scripts, workflows, and documentation are updated so that staging is fully
supported. The **manual steps** (Supabase project creation, secret storage,
Vercel env configuration) are documented in STAGING_SETUP.md for the operator.

## Changes

### `RUN_REMOTE.ps1` — Environment-aware pipeline runner
- Added mandatory `-Env` parameter (`staging` | `production`) — no default, forces conscious choice
- Added `.env` file loading (matching `RUN_SANITY.ps1` / `RUN_SEED.ps1` pattern)
- Staging routes to `SUPABASE_STAGING_PROJECT_REF` + `SUPABASE_STAGING_DB_PASSWORD`
- Production routes to `SUPABASE_DB_PASSWORD` (unchanged behavior)
- Environment-colored banners (Yellow = staging, Red = production)
- Updated synopsis, usage examples, and summary output

### `.github/workflows/sync-cloud-db.yml` — Staging-first migration sync
- Split single `sync` job into `sync-staging` → `sync-production` pipeline
- Staging job gated by `STAGING_ENABLED` repository variable (`true` to enable)
- Production job runs after staging (or if staging is skipped)
- Backup + artifact upload preserved for production

### `docs/ENVIRONMENT_STRATEGY.md` — §8.1 Deferred → Active
- §8.1: Staging status changed from **Deferred** to **Active**
- §8.1A: Updated guardrails table (4 → 6 items), renamed from "Single-Cloud Mode" to "Cloud Mode"
- §1: Environment table updated — staging shows staging project reference
- §2.2: Staging definition changed from "Deferred" to "Active"
- §2.3: Removed "Single-Cloud Mode" qualifier from production
- §6: Vercel mapping — Preview now points to staging
- §8: CI architecture table updated with sync-cloud-db.yml, target table references #141
- §9: Deployment checklists updated for two-cloud workflow

### `docs/STAGING_SETUP.md` — DEFERRED → READY
- Status banner: `DEFERRED` → `READY`
- Updated migration count (75+ → 85+), sanity check count (16 → 17)
- Step 6: Added `SUPABASE_STAGING_PROJECT_REF` secret and `STAGING_ENABLED` variable
- Step 8: Changed "Future" → "Issue #141" with cross-reference
- Maintenance: Notes that `sync-cloud-db.yml` auto-pushes when enabled

## Manual Steps (Operator Checklist)

The following steps require Supabase dashboard / GitHub settings access:

- [ ] Create `poland-food-db-staging` Supabase project (Step 1)
- [ ] Apply migrations via `supabase db push` (Step 2)
- [ ] Seed staging via `RUN_SEED.ps1 -Env staging` (Step 3)
- [ ] Validate via `RUN_SANITY.ps1 -Env staging` (Step 4)
- [ ] Configure auth redirect URLs (Step 5)
- [ ] Store GitHub secrets: `SUPABASE_STAGING_PROJECT_REF`, `SUPABASE_URL_STAGING`, `SUPABASE_ANON_KEY_STAGING`, `SUPABASE_SERVICE_ROLE_KEY_STAGING` (Step 6)
- [ ] Set GitHub variable: `STAGING_ENABLED=true` (Step 6)
- [ ] Configure Vercel Preview environment variables (Step 6)
- [ ] Add staging credentials to local `.env` (Step 6)

## Testing

- **3349/3349 vitest tests pass** (no regressions)
- No migration file — changes are infra/docs only
- `RUN_REMOTE.ps1` syntax validated via PowerShell parser
- `sync-cloud-db.yml` validated via GitHub Actions schema