### PR TITLE
feat(push-notifications): Web Push for watchlist score changes (#143)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,11 @@ SUPABASE_STAGING_PROJECT_REF=
 
 # Staging database password
 SUPABASE_STAGING_DB_PASSWORD=
+
+# ── Web Push (VAPID) ────────────────────────────────────────────────────
+# Generate with: npx web-push generate-vapid-keys
+# Set these as Supabase Edge Function secrets:
+#   supabase secrets set VAPID_PUBLIC_KEY=... VAPID_PRIVATE_KEY=... VAPID_SUBJECT=mailto:you@example.com
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=mailto:

--- a/db/qa/QA__push_notifications.sql
+++ b/db/qa/QA__push_notifications.sql
@@ -1,0 +1,140 @@
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- QA Suite: Push Notification Infrastructure
+-- Validates push_subscriptions and notification_queue tables, RLS policies,
+-- constraints, and API function contracts.
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #1  push_subscriptions table exists
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    CASE WHEN EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'push_subscriptions'
+    ) THEN 'PASS' ELSE 'FAIL' END AS "#1  push_subscriptions table exists";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #2  push_subscriptions has RLS enabled
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    CASE WHEN (
+        SELECT relrowsecurity FROM pg_class
+        WHERE oid = 'public.push_subscriptions'::regclass
+    ) THEN 'PASS' ELSE 'FAIL' END AS "#2  push_subscriptions RLS enabled";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #3  push_subscriptions has unique constraint on (user_id, endpoint)
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    CASE WHEN EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE tablename = 'push_subscriptions'
+          AND indexdef LIKE '%user_id%endpoint%'
+    ) THEN 'PASS' ELSE 'FAIL' END AS "#3  push_subscriptions unique (user_id, endpoint)";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #4  push_subscriptions user_id cascades on delete
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    CASE WHEN EXISTS (
+        SELECT 1 FROM information_schema.referential_constraints
+        WHERE constraint_name IN (
+            SELECT constraint_name FROM information_schema.table_constraints
+            WHERE table_name = 'push_subscriptions' AND constraint_type = 'FOREIGN KEY'
+        ) AND delete_rule = 'CASCADE'
+    ) THEN 'PASS' ELSE 'FAIL' END AS "#4  push_subscriptions CASCADE on user delete";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #5  notification_queue table exists
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    CASE WHEN EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'notification_queue'
+    ) THEN 'PASS' ELSE 'FAIL' END AS "#5  notification_queue table exists";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #6  notification_queue has RLS enabled
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    CASE WHEN (
+        SELECT relrowsecurity FROM pg_class
+        WHERE oid = 'public.notification_queue'::regclass
+    ) THEN 'PASS' ELSE 'FAIL' END AS "#6  notification_queue RLS enabled";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #7  api_save_push_subscription function exists
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    CASE WHEN EXISTS (
+        SELECT 1 FROM information_schema.routines
+        WHERE routine_name = 'api_save_push_subscription'
+          AND routine_schema = 'public'
+    ) THEN 'PASS' ELSE 'FAIL' END AS "#7  api_save_push_subscription exists";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #8  api_delete_push_subscription function exists
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    CASE WHEN EXISTS (
+        SELECT 1 FROM information_schema.routines
+        WHERE routine_name = 'api_delete_push_subscription'
+          AND routine_schema = 'public'
+    ) THEN 'PASS' ELSE 'FAIL' END AS "#8  api_delete_push_subscription exists";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #9  api_get_push_subscriptions function exists
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    CASE WHEN EXISTS (
+        SELECT 1 FROM information_schema.routines
+        WHERE routine_name = 'api_get_push_subscriptions'
+          AND routine_schema = 'public'
+    ) THEN 'PASS' ELSE 'FAIL' END AS "#9  api_get_push_subscriptions exists";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #10  queue_score_change_notifications trigger function exists
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    CASE WHEN EXISTS (
+        SELECT 1 FROM information_schema.routines
+        WHERE routine_name = 'queue_score_change_notifications'
+          AND routine_schema = 'public'
+    ) THEN 'PASS' ELSE 'FAIL' END AS "#10  queue_score_change_notifications function exists";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #11  trg_queue_score_notifications trigger exists on product_score_history
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    CASE WHEN EXISTS (
+        SELECT 1 FROM information_schema.triggers
+        WHERE trigger_name = 'trg_queue_score_notifications'
+          AND event_object_table = 'product_score_history'
+    ) THEN 'PASS' ELSE 'FAIL' END AS "#11  trg_queue_score_notifications trigger exists";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #12  api_save_push_subscription returns auth error without auth
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    CASE WHEN (
+        api_save_push_subscription('https://push.example.com', 'key1', 'key2')
+    )->>'error' = 'Authentication required.'
+    THEN 'PASS' ELSE 'FAIL' END AS "#12  api_save_push_subscription auth error";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #13  api_delete_push_subscription returns auth error without auth
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    CASE WHEN (
+        api_delete_push_subscription('https://push.example.com')
+    )->>'error' = 'Authentication required.'
+    THEN 'PASS' ELSE 'FAIL' END AS "#13  api_delete_push_subscription auth error";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #14  api_get_push_subscriptions returns auth error without auth
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    CASE WHEN (
+        api_get_push_subscriptions()
+    )->>'error' = 'Authentication required.'
+    THEN 'PASS' ELSE 'FAIL' END AS "#14  api_get_push_subscriptions auth error";

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -4,3 +4,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
 
 # No secret keys belong in NEXT_PUBLIC_* variables.
 # Service-role key is NEVER exposed to the browser.
+
+# Web Push — VAPID public key (safe to expose to browser)
+# Generate with: npx web-push generate-vapid-keys
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -38,7 +38,8 @@
     "pageOf": "Page {page} of {pages}",
     "items": "{count} {count|item|items}",
     "products": "{count} {count|product|products}",
-    "allergenWarnings": "{count} allergen {count|warning|warnings}"
+    "allergenWarnings": "{count} allergen {count|warning|warnings}",
+    "dismiss": "Dismiss"
   },
   "toast": {
     "genericError": "Something went wrong. Please try again.",
@@ -66,6 +67,18 @@
     "installDescription": "Add to your home screen for quick access and offline support.",
     "iosInstallHint": "Tap the Share button, then \"Add to Home Screen\".",
     "dismissInstall": "Dismiss install prompt"
+  },
+  "notifications": {
+    "title": "Push Notifications",
+    "promptTitle": "Get notified about score changes",
+    "promptDescription": "Enable push notifications to know when a watched product's health score changes.",
+    "settingsDescription": "Receive push notifications when a watched product's health score changes significantly.",
+    "enable": "Enable notifications",
+    "disable": "Disable notifications",
+    "enabled": "Push notifications enabled",
+    "disabled": "Push notifications disabled",
+    "permissionDenied": "Notification permission was denied. Please enable it in your browser settings.",
+    "blockedByBrowser": "Notifications are blocked by your browser. Update your site permissions to enable them."
   },
   "dashboard": {
     "title": "Dashboard",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -38,7 +38,8 @@
     "pageOf": "Strona {page} z {pages}",
     "items": "{count} {count|element|elementy|elementów}",
     "products": "{count} {count|produkt|produkty|produktów}",
-    "allergenWarnings": "{count} {count|ostrzeżenie alergenowe|ostrzeżenia alergenowe|ostrzeżeń alergenowych}"
+    "allergenWarnings": "{count} {count|ostrzeżenie alergenowe|ostrzeżenia alergenowe|ostrzeżeń alergenowych}",
+    "dismiss": "Odrzuć"
   },
   "toast": {
     "genericError": "Coś poszło nie tak. Spróbuj ponownie.",
@@ -66,6 +67,18 @@
     "installDescription": "Dodaj do ekranu głównego, aby mieć szybki dostęp i wsparcie offline.",
     "iosInstallHint": "Stuknij przycisk Udostępnij, a potem «Dodaj do ekranu głównego».",
     "dismissInstall": "Odrzuć komunikat instalacji"
+  },
+  "notifications": {
+    "title": "Powiadomienia push",
+    "promptTitle": "Otrzymuj powiadomienia o zmianach wyniku",
+    "promptDescription": "Włącz powiadomienia push, aby wiedzieć, kiedy wynik zdrowotny obserwowanego produktu się zmieni.",
+    "settingsDescription": "Otrzymuj powiadomienia push, gdy wynik zdrowotny obserwowanego produktu zmieni się znacząco.",
+    "enable": "Włącz powiadomienia",
+    "disable": "Wyłącz powiadomienia",
+    "enabled": "Powiadomienia push włączone",
+    "disabled": "Powiadomienia push wyłączone",
+    "permissionDenied": "Uprawnienia do powiadomień zostały odrzucone. Włącz je w ustawieniach przeglądarki.",
+    "blockedByBrowser": "Powiadomienia są zablokowane przez przeglądarkę. Zaktualizuj uprawnienia witryny, aby je włączyć."
   },
   "dashboard": {
     "title": "Panel",

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -9,7 +9,7 @@ import { showToast } from "@/lib/toast";
 import { createClient } from "@/lib/supabase/client";
 import { getUserPreferences, setUserPreferences } from "@/lib/api";
 import { queryKeys, staleTimes } from "@/lib/query-keys";
-import { ChevronDown, Copy, Check, Trash2 } from "lucide-react";
+import { ChevronDown, Copy, Check, Trash2, Bell, BellOff } from "lucide-react";
 import {
   COUNTRIES,
   COUNTRY_DEFAULT_LANGUAGES,
@@ -29,6 +29,16 @@ import {
   type SupportedLanguage,
 } from "@/stores/language-store";
 import { clearAllCaches, getCachedProductCount } from "@/lib/cache-manager";
+import {
+  isPushSupported,
+  getNotificationPermission,
+  requestNotificationPermission,
+  subscribeToPush,
+  unsubscribeFromPush,
+  getCurrentPushSubscription,
+  extractSubscriptionData,
+} from "@/lib/push-manager";
+import { savePushSubscription, deletePushSubscription } from "@/lib/api";
 
 export default function SettingsPage() {
   const router = useRouter();
@@ -62,6 +72,12 @@ export default function SettingsPage() {
   const [copied, setCopied] = useState(false);
   const [cachedCount, setCachedCount] = useState(0);
   const [clearingCache, setClearingCache] = useState(false);
+  const [pushEnabled, setPushEnabled] = useState(false);
+  const [pushSupported, setPushSupported] = useState(false);
+  const [pushPermission, setPushPermission] = useState<
+    NotificationPermission | "unsupported"
+  >("unsupported");
+  const [togglingPush, setTogglingPush] = useState(false);
 
   // Fetch user email from auth session
   useEffect(() => {
@@ -77,6 +93,18 @@ export default function SettingsPage() {
       .catch(() => setCachedCount(0));
   }, []);
 
+  // Check push notification status
+  useEffect(() => {
+    const supported = isPushSupported();
+    setPushSupported(supported);
+    setPushPermission(getNotificationPermission());
+    if (supported) {
+      getCurrentPushSubscription()
+        .then((sub) => setPushEnabled(!!sub))
+        .catch(() => setPushEnabled(false));
+    }
+  }, []);
+
   const handleClearCache = useCallback(async () => {
     setClearingCache(true);
     try {
@@ -90,6 +118,67 @@ export default function SettingsPage() {
       setClearingCache(false);
     }
   }, [track]);
+
+  const handleTogglePush = useCallback(async () => {
+    setTogglingPush(true);
+    try {
+      if (pushEnabled) {
+        // Unsubscribe
+        const sub = await getCurrentPushSubscription();
+        if (sub) {
+          const subData = extractSubscriptionData(sub);
+          if (subData) {
+            await deletePushSubscription(supabase, subData.endpoint);
+          }
+          await unsubscribeFromPush();
+        }
+        setPushEnabled(false);
+        track("push_notification_disabled");
+        showToast({ type: "success", messageKey: "notifications.disabled" });
+      } else {
+        // Subscribe
+        const permission = await requestNotificationPermission();
+        setPushPermission(permission);
+        if (permission !== "granted") {
+          showToast({
+            type: "error",
+            messageKey: "notifications.permissionDenied",
+          });
+          return;
+        }
+
+        const vapidKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+        if (!vapidKey) {
+          showToast({ type: "error", messageKey: "common.error" });
+          return;
+        }
+
+        const subscription = await subscribeToPush(vapidKey);
+        if (!subscription) {
+          showToast({ type: "error", messageKey: "common.error" });
+          return;
+        }
+
+        const subData = extractSubscriptionData(subscription);
+        if (subData) {
+          await savePushSubscription(
+            supabase,
+            subData.endpoint,
+            subData.p256dh,
+            subData.auth,
+          );
+        }
+
+        setPushEnabled(true);
+        track("push_notification_enabled");
+        showToast({ type: "success", messageKey: "notifications.enabled" });
+      }
+    } catch {
+      showToast({ type: "error", messageKey: "common.error" });
+    } finally {
+      setTogglingPush(false);
+    }
+  }, [pushEnabled, supabase, track]);
 
   const handleCopyUserId = useCallback(async () => {
     if (!prefs?.user_id) return;
@@ -401,6 +490,49 @@ export default function SettingsPage() {
         </button>
       )}
 
+      {/* Push Notifications */}
+      {pushSupported && (
+        <section className="card" data-testid="push-notifications-section">
+          <h2 className="mb-3 text-sm font-semibold text-foreground-secondary lg:text-base">
+            {t("notifications.title")}
+          </h2>
+          <p className="mb-3 text-sm text-foreground-secondary">
+            {t("notifications.settingsDescription")}
+          </p>
+          {pushPermission === "denied" ? (
+            <p
+              className="text-sm text-amber-600"
+              data-testid="push-denied-message"
+            >
+              {t("notifications.blockedByBrowser")}
+            </p>
+          ) : (
+            <button
+              type="button"
+              onClick={handleTogglePush}
+              disabled={togglingPush}
+              className={`inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                pushEnabled
+                  ? "border-red-200 text-red-600 hover:bg-red-50"
+                  : "border-brand/30 text-brand hover:bg-brand-subtle"
+              }`}
+              data-testid="push-toggle-button"
+            >
+              {pushEnabled ? (
+                <BellOff size={14} aria-hidden="true" />
+              ) : (
+                <Bell size={14} aria-hidden="true" />
+              )}
+              {togglingPush
+                ? t("common.loading")
+                : pushEnabled
+                  ? t("notifications.disable")
+                  : t("notifications.enable")}
+            </button>
+          )}
+        </section>
+      )}
+
       {/* Offline Cache */}
       <section className="card">
         <h2 className="mb-3 text-sm font-semibold text-foreground-secondary lg:text-base">
@@ -416,9 +548,7 @@ export default function SettingsPage() {
           className="inline-flex items-center gap-2 rounded-lg border border-amber-200 px-4 py-2 text-sm font-medium text-amber-700 transition-colors hover:bg-amber-50 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <Trash2 size={14} aria-hidden="true" />
-          {clearingCache
-            ? t("common.loading")
-            : t("settings.clearCache")}
+          {clearingCache ? t("common.loading") : t("settings.clearCache")}
         </button>
       </section>
 

--- a/frontend/src/components/product/WatchButton.tsx
+++ b/frontend/src/components/product/WatchButton.tsx
@@ -3,6 +3,7 @@
 /**
  * WatchButton — toggle button on product profile for watch/unwatch.
  * Calls api_watch_product / api_unwatch_product.
+ * Shows a notification prompt after the first successful watch action.
  */
 
 import { useState } from "react";
@@ -13,6 +14,7 @@ import { Icon } from "@/components/common/Icon";
 import { createClient } from "@/lib/supabase/client";
 import { watchProduct, unwatchProduct, isWatchingProduct } from "@/lib/api";
 import { queryKeys, staleTimes } from "@/lib/query-keys";
+import { NotificationPrompt } from "@/components/pwa/NotificationPrompt";
 
 interface WatchButtonProps {
   productId: number;
@@ -31,6 +33,7 @@ export function WatchButton({
   const [optimisticWatching, setOptimisticWatching] = useState<boolean | null>(
     null,
   );
+  const [showNotifPrompt, setShowNotifPrompt] = useState(false);
 
   const { data: watchStatus, isLoading } = useQuery({
     queryKey: queryKeys.isWatching(productId),
@@ -52,6 +55,8 @@ export function WatchButton({
         queryKey: queryKeys.isWatching(productId),
       });
       queryClient.invalidateQueries({ queryKey: queryKeys.watchlist() });
+      // Show notification prompt after first watch
+      setShowNotifPrompt(true);
     },
     onSettled: () => setOptimisticWatching(null),
   });
@@ -97,24 +102,29 @@ export function WatchButton({
   }
 
   return (
-    <button
-      onClick={handleToggle}
-      disabled={isMutating}
-      aria-pressed={watching}
-      aria-label={label}
-      className={`touch-target inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
-        watching
-          ? "border-brand bg-brand-subtle text-brand"
-          : "border-border text-foreground-secondary hover:bg-surface-muted hover:text-foreground"
-      } ${isMutating ? "opacity-70" : ""} ${className ?? ""}`}
-      data-testid="watch-button"
-    >
-      {isMutating && (
-        <Icon icon={Loader2} size="sm" className="animate-spin" />
+    <div>
+      <button
+        onClick={handleToggle}
+        disabled={isMutating}
+        aria-pressed={watching}
+        aria-label={label}
+        className={`touch-target inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+          watching
+            ? "border-brand bg-brand-subtle text-brand"
+            : "border-border text-foreground-secondary hover:bg-surface-muted hover:text-foreground"
+        } ${isMutating ? "opacity-70" : ""} ${className ?? ""}`}
+        data-testid="watch-button"
+      >
+        {isMutating && (
+          <Icon icon={Loader2} size="sm" className="animate-spin" />
+        )}
+        {!isMutating && watching && <Icon icon={Eye} size="sm" />}
+        {!isMutating && !watching && <Icon icon={EyeOff} size="sm" />}
+        {!compact && <span>{label}</span>}
+      </button>
+      {showNotifPrompt && (
+        <NotificationPrompt onDismiss={() => setShowNotifPrompt(false)} />
       )}
-      {!isMutating && watching && <Icon icon={Eye} size="sm" />}
-      {!isMutating && !watching && <Icon icon={EyeOff} size="sm" />}
-      {!compact && <span>{label}</span>}
-    </button>
+    </div>
   );
 }

--- a/frontend/src/components/pwa/NotificationPrompt.test.tsx
+++ b/frontend/src/components/pwa/NotificationPrompt.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NotificationPrompt } from "./NotificationPrompt";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/hooks/use-analytics", () => ({
+  useAnalytics: () => ({
+    track: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  showToast: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({}),
+}));
+
+vi.mock("@/lib/api", () => ({
+  savePushSubscription: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+const mockIsPushSupported = vi.fn().mockReturnValue(true);
+const mockGetNotificationPermission = vi.fn().mockReturnValue("default");
+const mockRequestNotificationPermission = vi.fn().mockResolvedValue("granted");
+const mockSubscribeToPush = vi.fn().mockResolvedValue({
+  endpoint: "https://push.example.com/sub/123",
+  getKey: (name: string) => {
+    if (name === "p256dh") return new ArrayBuffer(65);
+    if (name === "auth") return new ArrayBuffer(16);
+    return null;
+  },
+});
+const mockExtractSubscriptionData = vi.fn().mockReturnValue({
+  endpoint: "https://push.example.com/sub/123",
+  p256dh: "test-p256dh",
+  auth: "test-auth",
+});
+
+vi.mock("@/lib/push-manager", () => ({
+  isPushSupported: () => mockIsPushSupported(),
+  getNotificationPermission: () => mockGetNotificationPermission(),
+  requestNotificationPermission: () => mockRequestNotificationPermission(),
+  subscribeToPush: (...args: unknown[]) => mockSubscribeToPush(...args),
+  extractSubscriptionData: (...args: unknown[]) => mockExtractSubscriptionData(...args),
+}));
+
+describe("NotificationPrompt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsPushSupported.mockReturnValue(true);
+    mockGetNotificationPermission.mockReturnValue("default");
+    // Set the env var
+    process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = "test-vapid-key";
+  });
+
+  it("renders the prompt when push is supported and permission is default", () => {
+    render(<NotificationPrompt />);
+    expect(screen.getByTestId("notification-prompt")).toBeInTheDocument();
+    expect(screen.getByText("notifications.promptTitle")).toBeInTheDocument();
+    expect(screen.getByText("notifications.promptDescription")).toBeInTheDocument();
+    expect(screen.getByTestId("enable-notifications-button")).toBeInTheDocument();
+  });
+
+  it("does not render when push is not supported", () => {
+    mockIsPushSupported.mockReturnValue(false);
+    const { container } = render(<NotificationPrompt />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("does not render when permission is already granted", () => {
+    mockGetNotificationPermission.mockReturnValue("granted");
+    const { container } = render(<NotificationPrompt />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("does not render when permission is denied", () => {
+    mockGetNotificationPermission.mockReturnValue("denied");
+    const { container } = render(<NotificationPrompt />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("calls onDismiss when dismiss button is clicked", () => {
+    const onDismiss = vi.fn();
+    render(<NotificationPrompt onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByTestId("dismiss-notification-prompt"));
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it("enables notifications on button click", async () => {
+    const onDismiss = vi.fn();
+    render(<NotificationPrompt onDismiss={onDismiss} />);
+
+    fireEvent.click(screen.getByTestId("enable-notifications-button"));
+
+    await waitFor(() => {
+      expect(mockRequestNotificationPermission).toHaveBeenCalled();
+      expect(mockSubscribeToPush).toHaveBeenCalledWith("test-vapid-key");
+      expect(onDismiss).toHaveBeenCalled();
+    });
+  });
+
+  it("calls onDismiss when permission is denied", async () => {
+    mockRequestNotificationPermission.mockResolvedValue("denied");
+    const onDismiss = vi.fn();
+    render(<NotificationPrompt onDismiss={onDismiss} />);
+
+    fireEvent.click(screen.getByTestId("enable-notifications-button"));
+
+    await waitFor(() => {
+      expect(onDismiss).toHaveBeenCalled();
+    });
+  });
+
+  it("has accessible alert role", () => {
+    render(<NotificationPrompt />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("dismiss button has accessible label", () => {
+    render(<NotificationPrompt />);
+    expect(screen.getByLabelText("common.dismiss")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/pwa/NotificationPrompt.tsx
+++ b/frontend/src/components/pwa/NotificationPrompt.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+/**
+ * NotificationPrompt — shown after the user's first watchlist add.
+ * Prompts them to enable push notifications for score changes.
+ * Dismissible; only shown when permission is "default" (not yet asked).
+ */
+
+import { useState, useCallback } from "react";
+import { Bell, X } from "lucide-react";
+import { Icon } from "@/components/common/Icon";
+import { useTranslation } from "@/lib/i18n";
+import { useAnalytics } from "@/hooks/use-analytics";
+import { showToast } from "@/lib/toast";
+import { createClient } from "@/lib/supabase/client";
+import { savePushSubscription } from "@/lib/api";
+import {
+  isPushSupported,
+  getNotificationPermission,
+  requestNotificationPermission,
+  subscribeToPush,
+  extractSubscriptionData,
+} from "@/lib/push-manager";
+
+interface NotificationPromptProps {
+  /** Called when prompt is dismissed (either accepted or declined) */
+  onDismiss?: () => void;
+}
+
+export function NotificationPrompt({
+  onDismiss,
+}: Readonly<NotificationPromptProps>) {
+  const { t } = useTranslation();
+  const { track } = useAnalytics();
+  const [enabling, setEnabling] = useState(false);
+
+  const handleDismiss = useCallback(() => {
+    track("push_notification_dismissed");
+    onDismiss?.();
+  }, [track, onDismiss]);
+
+  // Don't render if push isn't supported or permission already decided
+  if (!isPushSupported() || getNotificationPermission() !== "default") {
+    return null;
+  }
+
+  const handleEnable = async () => {
+    setEnabling(true);
+    try {
+      const permission = await requestNotificationPermission();
+      if (permission !== "granted") {
+        track("push_notification_denied");
+        onDismiss?.();
+        return;
+      }
+
+      const vapidKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+      if (!vapidKey) {
+        console.error("VAPID public key not configured");
+        onDismiss?.();
+        return;
+      }
+
+      const subscription = await subscribeToPush(vapidKey);
+      if (!subscription) {
+        showToast({ type: "error", messageKey: "common.error" });
+        onDismiss?.();
+        return;
+      }
+
+      // Save subscription to backend
+      const subData = extractSubscriptionData(subscription);
+      if (subData) {
+        const supabase = createClient();
+        await savePushSubscription(
+          supabase,
+          subData.endpoint,
+          subData.p256dh,
+          subData.auth,
+        );
+      }
+
+      track("push_notification_enabled");
+      showToast({ type: "success", messageKey: "notifications.enabled" });
+    } catch {
+      showToast({ type: "error", messageKey: "common.error" });
+    } finally {
+      setEnabling(false);
+      onDismiss?.();
+    }
+  };
+
+  return (
+    <div
+      role="alert"
+      className="mt-3 flex items-start gap-3 rounded-lg border border-brand/20 bg-brand-subtle p-3"
+      data-testid="notification-prompt"
+    >
+      <div className="flex-shrink-0 mt-0.5">
+        <Icon icon={Bell} size="sm" className="text-brand" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-foreground">
+          {t("notifications.promptTitle")}
+        </p>
+        <p className="mt-0.5 text-xs text-foreground-secondary">
+          {t("notifications.promptDescription")}
+        </p>
+        <button
+          onClick={handleEnable}
+          disabled={enabling}
+          className="mt-2 rounded-md bg-brand px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-brand/90 disabled:opacity-70"
+          data-testid="enable-notifications-button"
+        >
+          {enabling ? t("common.loading") : t("notifications.enable")}
+        </button>
+      </div>
+      <button
+        onClick={handleDismiss}
+        className="flex-shrink-0 text-foreground-secondary hover:text-foreground transition-colors"
+        aria-label={t("common.dismiss")}
+        data-testid="dismiss-notification-prompt"
+      >
+        <Icon icon={X} size="sm" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/lib/__tests__/push-manager.test.ts
+++ b/frontend/src/lib/__tests__/push-manager.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  isPushSupported,
+  getNotificationPermission,
+  requestNotificationPermission,
+  urlBase64ToUint8Array,
+  getCurrentPushSubscription,
+  subscribeToPush,
+  unsubscribeFromPush,
+  extractSubscriptionData,
+} from "../push-manager";
+
+// ─── Mock service worker registration ───────────────────────────────────────
+
+const mockSubscription = {
+  endpoint: "https://push.example.com/sub/123",
+  getKey: vi.fn((name: string) => {
+    if (name === "p256dh") return new ArrayBuffer(65);
+    if (name === "auth") return new ArrayBuffer(16);
+    return null;
+  }),
+  unsubscribe: vi.fn().mockResolvedValue(true),
+  toJSON: vi.fn().mockReturnValue({
+    endpoint: "https://push.example.com/sub/123",
+    keys: { p256dh: "test-p256dh", auth: "test-auth" },
+  }),
+} as unknown as PushSubscription;
+
+const mockPushManager = {
+  getSubscription: vi.fn().mockResolvedValue(null),
+  subscribe: vi.fn().mockResolvedValue(mockSubscription),
+};
+
+const mockRegistration = {
+  pushManager: mockPushManager,
+  showNotification: vi.fn(),
+} as unknown as ServiceWorkerRegistration;
+
+describe("push-manager", () => {
+  const originalNavigator = { ...navigator };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Setup default Push API support
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: {
+        ready: Promise.resolve(mockRegistration),
+        controller: {},
+      },
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(window, "PushManager", {
+      value: class PushManager {},
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(window, "Notification", {
+      value: class Notification {
+        static permission: NotificationPermission = "default";
+        static requestPermission = vi.fn().mockResolvedValue("granted");
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    // Restore
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: originalNavigator.serviceWorker,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  // ─── isPushSupported ──────────────────────────────────────────────────
+
+  describe("isPushSupported", () => {
+    it("returns true when all APIs are available", () => {
+      expect(isPushSupported()).toBe(true);
+    });
+
+    it("returns false when PushManager is missing", () => {
+      Object.defineProperty(window, "PushManager", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+      expect(isPushSupported()).toBe(false);
+    });
+
+    it("returns false when Notification is missing", () => {
+      Object.defineProperty(window, "Notification", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+      expect(isPushSupported()).toBe(false);
+    });
+  });
+
+  // ─── getNotificationPermission ────────────────────────────────────────
+
+  describe("getNotificationPermission", () => {
+    it('returns current permission state ("default")', () => {
+      expect(getNotificationPermission()).toBe("default");
+    });
+
+    it("returns 'granted' when permission is granted", () => {
+      Object.defineProperty(window, "Notification", {
+        value: { permission: "granted" },
+        writable: true,
+        configurable: true,
+      });
+      expect(getNotificationPermission()).toBe("granted");
+    });
+
+    it("returns 'denied' when permission is denied", () => {
+      Object.defineProperty(window, "Notification", {
+        value: { permission: "denied" },
+        writable: true,
+        configurable: true,
+      });
+      expect(getNotificationPermission()).toBe("denied");
+    });
+  });
+
+  // ─── requestNotificationPermission ────────────────────────────────────
+
+  describe("requestNotificationPermission", () => {
+    it("requests and returns permission", async () => {
+      const result = await requestNotificationPermission();
+      expect(Notification.requestPermission).toHaveBeenCalled();
+      expect(result).toBe("granted");
+    });
+
+    it('returns "denied" when push is not supported', async () => {
+      Object.defineProperty(window, "PushManager", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+      const result = await requestNotificationPermission();
+      expect(result).toBe("denied");
+    });
+  });
+
+  // ─── urlBase64ToUint8Array ────────────────────────────────────────────
+
+  describe("urlBase64ToUint8Array", () => {
+    it("converts a base64 string to Uint8Array", () => {
+      // "SGVsbG8" = base64url of "Hello"
+      const result = urlBase64ToUint8Array("SGVsbG8");
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.length).toBe(5); // "Hello" = 5 bytes
+      expect(String.fromCharCode(...result)).toBe("Hello");
+    });
+
+    it("handles URL-safe characters (- and _)", () => {
+      // Standard base64 uses + and /, URL-safe uses - and _
+      const input = "dGVzdC1f"; // "test-_" in base64url
+      const result = urlBase64ToUint8Array(input);
+      expect(result).toBeInstanceOf(Uint8Array);
+    });
+
+    it("handles empty string", () => {
+      const result = urlBase64ToUint8Array("");
+      expect(result.length).toBe(0);
+    });
+  });
+
+  // ─── getCurrentPushSubscription ───────────────────────────────────────
+
+  describe("getCurrentPushSubscription", () => {
+    it("returns null when no subscription exists", async () => {
+      mockPushManager.getSubscription.mockResolvedValueOnce(null);
+      const result = await getCurrentPushSubscription();
+      expect(result).toBeNull();
+    });
+
+    it("returns the existing subscription", async () => {
+      mockPushManager.getSubscription.mockResolvedValueOnce(mockSubscription);
+      const result = await getCurrentPushSubscription();
+      expect(result).toBe(mockSubscription);
+    });
+
+    it("returns null when service worker is unavailable", async () => {
+      Object.defineProperty(navigator, "serviceWorker", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+      const result = await getCurrentPushSubscription();
+      expect(result).toBeNull();
+    });
+  });
+
+  // ─── subscribeToPush ─────────────────────────────────────────────────
+
+  describe("subscribeToPush", () => {
+    it("subscribes with VAPID public key", async () => {
+      const result = await subscribeToPush("BFakeVapidPublicKey123");
+      expect(mockPushManager.subscribe).toHaveBeenCalledWith({
+        userVisibleOnly: true,
+        applicationServerKey: expect.any(ArrayBuffer),
+      });
+      expect(result).toBe(mockSubscription);
+    });
+
+    it("returns null on subscribe error", async () => {
+      mockPushManager.subscribe.mockRejectedValueOnce(new Error("fail"));
+      const result = await subscribeToPush("BFakeVapidPublicKey123");
+      expect(result).toBeNull();
+    });
+
+    it("returns null when service worker is unavailable", async () => {
+      Object.defineProperty(navigator, "serviceWorker", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+      const result = await subscribeToPush("BFakeVapidPublicKey123");
+      expect(result).toBeNull();
+    });
+  });
+
+  // ─── unsubscribeFromPush ──────────────────────────────────────────────
+
+  describe("unsubscribeFromPush", () => {
+    it("returns true when already unsubscribed (no subscription)", async () => {
+      mockPushManager.getSubscription.mockResolvedValueOnce(null);
+      const result = await unsubscribeFromPush();
+      expect(result).toBe(true);
+    });
+
+    it("unsubscribes existing subscription", async () => {
+      mockPushManager.getSubscription.mockResolvedValueOnce(mockSubscription);
+      const result = await unsubscribeFromPush();
+      expect(mockSubscription.unsubscribe).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it("returns false on unsubscribe error", async () => {
+      const failSub = {
+        ...mockSubscription,
+        unsubscribe: vi.fn().mockRejectedValue(new Error("fail")),
+      };
+      mockPushManager.getSubscription.mockResolvedValueOnce(failSub as unknown as PushSubscription);
+      const result = await unsubscribeFromPush();
+      expect(result).toBe(false);
+    });
+  });
+
+  // ─── extractSubscriptionData ──────────────────────────────────────────
+
+  describe("extractSubscriptionData", () => {
+    it("extracts endpoint and keys from subscription", () => {
+      const result = extractSubscriptionData(mockSubscription);
+      expect(result).not.toBeNull();
+      expect(result!.endpoint).toBe("https://push.example.com/sub/123");
+      expect(typeof result!.p256dh).toBe("string");
+      expect(typeof result!.auth).toBe("string");
+    });
+
+    it("returns null when keys are missing", () => {
+      const noKeySub = {
+        ...mockSubscription,
+        getKey: vi.fn().mockReturnValue(null),
+      } as unknown as PushSubscription;
+      const result = extractSubscriptionData(noKeySub);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -67,6 +67,9 @@ import type {
   LinkedProduct,
   RecipeDetail,
   RecipeSummary,
+  PushSubscriptionResponse,
+  PushSubscriptionDeleteResponse,
+  PushSubscriptionsResponse,
 } from "./types";
 import type { ProductAllergenMap } from "./allergen-matching";
 
@@ -902,4 +905,45 @@ export function getProductAllergens(
   return callRpc<ProductAllergenMap>(supabase, "api_get_product_allergens", {
     p_product_ids: productIds,
   });
+}
+
+// ─── Push Notifications (#143) ──────────────────────────────────────────────
+
+export function savePushSubscription(
+  supabase: SupabaseClient,
+  endpoint: string,
+  p256dh: string,
+  auth: string,
+): Promise<RpcResult<PushSubscriptionResponse>> {
+  return callRpc<PushSubscriptionResponse>(
+    supabase,
+    "api_save_push_subscription",
+    {
+      p_endpoint: endpoint,
+      p_key_p256dh: p256dh,
+      p_key_auth: auth,
+    },
+  );
+}
+
+export function deletePushSubscription(
+  supabase: SupabaseClient,
+  endpoint: string,
+): Promise<RpcResult<PushSubscriptionDeleteResponse>> {
+  return callRpc<PushSubscriptionDeleteResponse>(
+    supabase,
+    "api_delete_push_subscription",
+    {
+      p_endpoint: endpoint,
+    },
+  );
+}
+
+export function getPushSubscriptions(
+  supabase: SupabaseClient,
+): Promise<RpcResult<PushSubscriptionsResponse>> {
+  return callRpc<PushSubscriptionsResponse>(
+    supabase,
+    "api_get_push_subscriptions",
+  );
 }

--- a/frontend/src/lib/push-manager.ts
+++ b/frontend/src/lib/push-manager.ts
@@ -1,0 +1,152 @@
+// ─── Push notification manager ──────────────────────────────────────────────
+// Client-side utilities for Web Push API subscription management.
+// All functions are designed to be called from React components.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Check if the Push API is supported in this browser.
+ */
+export function isPushSupported(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    "serviceWorker" in navigator &&
+    typeof window.PushManager !== "undefined" &&
+    typeof window.Notification !== "undefined"
+  );
+}
+
+/**
+ * Get the current notification permission state.
+ * Returns "default" | "granted" | "denied" or "unsupported".
+ */
+export function getNotificationPermission(): NotificationPermission | "unsupported" {
+  if (typeof window === "undefined" || typeof window.Notification === "undefined") {
+    return "unsupported";
+  }
+  return Notification.permission;
+}
+
+/**
+ * Request notification permission from the user.
+ * Returns the permission result: "granted" | "denied" | "default".
+ */
+export async function requestNotificationPermission(): Promise<NotificationPermission> {
+  if (!isPushSupported()) {
+    return "denied";
+  }
+  return await Notification.requestPermission();
+}
+
+/**
+ * Convert a URL-safe base64 VAPID public key to a Uint8Array
+ * for use with PushManager.subscribe().
+ */
+export function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding)
+    .replace(/-/g, "+")
+    .replace(/_/g, "/");
+  const rawData = atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; i++) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+/**
+ * Get the active service worker registration.
+ * Returns null if no service worker is registered.
+ */
+async function getServiceWorkerRegistration(): Promise<ServiceWorkerRegistration | null> {
+  if (!("serviceWorker" in navigator)) return null;
+  try {
+    return await navigator.serviceWorker.ready;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the current push subscription, if any.
+ */
+export async function getCurrentPushSubscription(): Promise<PushSubscription | null> {
+  const registration = await getServiceWorkerRegistration();
+  if (!registration) return null;
+  try {
+    return await registration.pushManager.getSubscription();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Subscribe to push notifications.
+ * Requires notification permission to be "granted".
+ * Returns the PushSubscription or null on failure.
+ */
+export async function subscribeToPush(
+  vapidPublicKey: string,
+): Promise<PushSubscription | null> {
+  const registration = await getServiceWorkerRegistration();
+  if (!registration) return null;
+
+  try {
+    const subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(vapidPublicKey).buffer as ArrayBuffer,
+    });
+    return subscription;
+  } catch (error) {
+    console.error("Push subscription failed:", error);
+    return null;
+  }
+}
+
+/**
+ * Unsubscribe from push notifications.
+ * Returns true if successfully unsubscribed.
+ */
+export async function unsubscribeFromPush(): Promise<boolean> {
+  const subscription = await getCurrentPushSubscription();
+  if (!subscription) return true; // Already unsubscribed
+
+  try {
+    return await subscription.unsubscribe();
+  } catch (error) {
+    console.error("Push unsubscribe failed:", error);
+    return false;
+  }
+}
+
+/**
+ * Extract the subscription data needed for the backend.
+ */
+export function extractSubscriptionData(subscription: PushSubscription): {
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+} | null {
+  const key_p256dh = subscription.getKey("p256dh");
+  const key_auth = subscription.getKey("auth");
+
+  if (!key_p256dh || !key_auth) return null;
+
+  return {
+    endpoint: subscription.endpoint,
+    p256dh: arrayBufferToBase64(key_p256dh),
+    auth: arrayBufferToBase64(key_auth),
+  };
+}
+
+/**
+ * Convert an ArrayBuffer to URL-safe base64 string.
+ */
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -147,6 +147,9 @@ export const queryKeys = {
   /** Batch product allergen data (#128) */
   productAllergens: (ids: number[]) =>
     ["product-allergens", ids.toSorted((a, b) => a - b).join(",")] as const,
+
+  /** Push subscriptions (#143) */
+  pushSubscriptions: ["push-subscriptions"] as const,
 } as const;
 
 // ─── Stale time constants (ms) ──────────────────────────────────────────────
@@ -271,4 +274,7 @@ export const staleTimes = {
 
   /** Product allergens — 5 min (allergen data changes only on pipeline runs) */
   productAllergens: 5 * 60 * 1000,
+
+  /** Push subscriptions — 10 min (changes on user action) */
+  pushSubscriptions: 10 * 60 * 1000,
 } as const;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1016,7 +1016,11 @@ export type AnalyticsEventName =
   | "preferences_updated"
   | "onboarding_completed"
   | "image_search_performed"
-  | "offline_cache_cleared";
+  | "offline_cache_cleared"
+  | "push_notification_enabled"
+  | "push_notification_disabled"
+  | "push_notification_denied"
+  | "push_notification_dismissed";
 
 export type DeviceType = "mobile" | "tablet" | "desktop";
 
@@ -1211,6 +1215,32 @@ export interface WatchlistResponse {
 export interface IsWatchingResponse {
   watching: boolean;
   threshold: number | null;
+}
+
+// ─── Push Notifications (#143) ──────────────────────────────────────────────
+
+export interface PushSubscriptionResponse {
+  success: boolean;
+  error?: string;
+}
+
+export interface PushSubscriptionDeleteResponse {
+  success: boolean;
+  deleted: boolean;
+  error?: string;
+}
+
+export interface PushSubscriptionInfo {
+  id: string;
+  endpoint: string;
+  created_at: string;
+}
+
+export interface PushSubscriptionsResponse {
+  success: boolean;
+  subscriptions: PushSubscriptionInfo[];
+  count: number;
+  error?: string;
 }
 
 // ─── Achievements (#51) ─────────────────────────────────────────────────────

--- a/supabase/functions/send-push-notification/index.ts
+++ b/supabase/functions/send-push-notification/index.ts
@@ -1,0 +1,321 @@
+// ─── Supabase Edge Function: send-push-notification ─────────────────────────
+// Processes the notification_queue table and sends Web Push notifications
+// to users with active push subscriptions.
+//
+// Triggered by: cron job, database webhook, or manual invocation
+// Auth: Requires service_role key (Authorization: Bearer <service_role_key>)
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+// ─── Web Push VAPID signing ────────────────────────────────────────────────
+
+/**
+ * Convert a URL-safe base64 string to a Uint8Array.
+ */
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding)
+    .replace(/-/g, "+")
+    .replace(/_/g, "/");
+  const raw = atob(base64);
+  const arr = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) {
+    arr[i] = raw.charCodeAt(i);
+  }
+  return arr;
+}
+
+/**
+ * Convert Uint8Array to URL-safe base64.
+ */
+function uint8ArrayToUrlBase64(arr: Uint8Array): string {
+  let binary = "";
+  for (const byte of arr) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Import a raw P-256 private key for ECDSA signing.
+ */
+async function importVapidPrivateKey(base64Key: string): Promise<CryptoKey> {
+  const raw = urlBase64ToUint8Array(base64Key);
+  // VAPID private key is a raw 32-byte P-256 scalar — import as JWK
+  const jwk = {
+    kty: "EC",
+    crv: "P-256",
+    d: uint8ArrayToUrlBase64(raw),
+    // Public key x, y aren't needed for signing but we need to derive them
+    // For VAPID, we sign the JWT with the private key
+    x: "", // Will be filled from public key
+    y: "",
+  };
+
+  // Actually, for Deno Edge Functions, we use the simpler approach:
+  // Import PKCS8 format or use a pre-built JWT
+  return await crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"],
+  );
+}
+
+/**
+ * Create a signed VAPID JWT for the given audience.
+ */
+async function createVapidJwt(
+  audience: string,
+  subject: string,
+  publicKey: string,
+  privateKeyBase64: string,
+): Promise<string> {
+  const header = { typ: "JWT", alg: "ES256" };
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    aud: audience,
+    exp: now + 12 * 60 * 60, // 12 hours
+    sub: subject,
+  };
+
+  const headerB64 = uint8ArrayToUrlBase64(
+    new TextEncoder().encode(JSON.stringify(header)),
+  );
+  const payloadB64 = uint8ArrayToUrlBase64(
+    new TextEncoder().encode(JSON.stringify(payload)),
+  );
+  const unsignedToken = `${headerB64}.${payloadB64}`;
+
+  // Import the private key for signing
+  const rawKey = urlBase64ToUint8Array(privateKeyBase64);
+  const privateKey = await crypto.subtle.importKey(
+    "jwk",
+    {
+      kty: "EC",
+      crv: "P-256",
+      d: uint8ArrayToUrlBase64(rawKey),
+      // For signing only, x and y are derived internally
+      x: uint8ArrayToUrlBase64(urlBase64ToUint8Array(publicKey).slice(1, 33)),
+      y: uint8ArrayToUrlBase64(urlBase64ToUint8Array(publicKey).slice(33, 65)),
+    },
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"],
+  );
+
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    privateKey,
+    new TextEncoder().encode(unsignedToken),
+  );
+
+  // Convert DER signature to raw r||s format (64 bytes)
+  const sigArray = new Uint8Array(signature);
+  const signatureB64 = uint8ArrayToUrlBase64(sigArray);
+
+  return `${unsignedToken}.${signatureB64}`;
+}
+
+/**
+ * Send a Web Push notification to a single subscription endpoint.
+ */
+async function sendPushNotification(
+  subscription: { endpoint: string; keys: { p256dh: string; auth: string } },
+  payload: object,
+  vapidPublicKey: string,
+  vapidPrivateKey: string,
+  vapidSubject: string,
+): Promise<{ success: boolean; status: number; expired: boolean }> {
+  try {
+    const url = new URL(subscription.endpoint);
+    const audience = `${url.protocol}//${url.host}`;
+
+    const jwt = await createVapidJwt(
+      audience,
+      vapidSubject,
+      vapidPublicKey,
+      vapidPrivateKey,
+    );
+
+    const body = JSON.stringify(payload);
+
+    const response = await fetch(subscription.endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/octet-stream",
+        "Content-Encoding": "aes128gcm",
+        TTL: "86400",
+        Authorization: `vapid t=${jwt}, k=${vapidPublicKey}`,
+      },
+      body: new TextEncoder().encode(body),
+    });
+
+    const expired = response.status === 404 || response.status === 410;
+
+    return {
+      success: response.status >= 200 && response.status < 300,
+      status: response.status,
+      expired,
+    };
+  } catch (error) {
+    console.error("Push send error:", error);
+    return { success: false, status: 0, expired: false };
+  }
+}
+
+// ─── Main handler ──────────────────────────────────────────────────────────
+
+Deno.serve(async (req: Request) => {
+  // Only accept POST
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Verify service_role authorization
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+  const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const VAPID_PUBLIC_KEY = Deno.env.get("VAPID_PUBLIC_KEY");
+  const VAPID_PRIVATE_KEY = Deno.env.get("VAPID_PRIVATE_KEY");
+  const VAPID_SUBJECT = Deno.env.get("VAPID_SUBJECT");
+
+  if (!VAPID_PUBLIC_KEY || !VAPID_PRIVATE_KEY || !VAPID_SUBJECT) {
+    return new Response(
+      JSON.stringify({ error: "VAPID keys not configured" }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+
+  try {
+    // 1. Fetch pending notifications with their subscriptions
+    const { data: result, error: fetchError } = await supabase.rpc(
+      "api_get_pending_notifications",
+      { p_limit: 50 },
+    );
+
+    if (fetchError) {
+      console.error("Fetch error:", fetchError);
+      return new Response(
+        JSON.stringify({ error: "Failed to fetch notifications" }),
+        { status: 500, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const notifications = result?.notifications ?? [];
+
+    if (notifications.length === 0) {
+      return new Response(
+        JSON.stringify({ processed: 0, message: "No pending notifications" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // 2. Process each notification
+    const sentIds: number[] = [];
+    const failedIds: number[] = [];
+    const expiredEndpoints: string[] = [];
+
+    for (const notif of notifications) {
+      const subscriptions = notif.subscriptions ?? [];
+      if (subscriptions.length === 0) {
+        failedIds.push(notif.id);
+        continue;
+      }
+
+      // Build notification payload
+      const directionEmoji = notif.direction === "improved" ? "📉" : "📈";
+      const directionText = notif.direction === "improved" ? "improved" : "worsened";
+      const absDelta = Math.abs(notif.delta);
+
+      const pushPayload = {
+        title: `${directionEmoji} Score ${directionText}`,
+        body: `${notif.product_name}: ${notif.old_score} → ${notif.new_score} (${notif.direction === "improved" ? "↓" : "↑"}${absDelta})`,
+        icon: "/icons/icon-192x192.png",
+        badge: "/icons/badge-72x72.png",
+        url: `/app/product/${notif.product_id}`,
+        data: {
+          product_id: notif.product_id,
+          old_score: notif.old_score,
+          new_score: notif.new_score,
+          direction: notif.direction,
+        },
+      };
+
+      let anySent = false;
+      for (const sub of subscriptions) {
+        const result = await sendPushNotification(
+          sub,
+          pushPayload,
+          VAPID_PUBLIC_KEY,
+          VAPID_PRIVATE_KEY,
+          VAPID_SUBJECT,
+        );
+
+        if (result.success) {
+          anySent = true;
+        } else if (result.expired) {
+          expiredEndpoints.push(sub.endpoint);
+        }
+      }
+
+      if (anySent) {
+        sentIds.push(notif.id);
+      } else {
+        failedIds.push(notif.id);
+      }
+    }
+
+    // 3. Mark notifications as sent/failed
+    if (sentIds.length > 0) {
+      await supabase.rpc("api_mark_notifications_sent", {
+        p_notification_ids: sentIds,
+        p_status: "sent",
+      });
+    }
+
+    if (failedIds.length > 0) {
+      await supabase.rpc("api_mark_notifications_sent", {
+        p_notification_ids: failedIds,
+        p_status: "failed",
+      });
+    }
+
+    // 4. Cleanup expired subscriptions
+    for (const endpoint of expiredEndpoints) {
+      await supabase.rpc("api_cleanup_push_subscriptions", {
+        p_endpoint: endpoint,
+      });
+    }
+
+    return new Response(
+      JSON.stringify({
+        processed: notifications.length,
+        sent: sentIds.length,
+        failed: failedIds.length,
+        expired_cleaned: expiredEndpoints.length,
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  } catch (error) {
+    console.error("Edge function error:", error);
+    return new Response(
+      JSON.stringify({ error: "Internal server error" }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+});

--- a/supabase/migrations/20260222005000_push_notifications.sql
+++ b/supabase/migrations/20260222005000_push_notifications.sql
@@ -1,0 +1,396 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Migration: push_notifications
+-- Issue:     #143 — Push Notifications for Watchlist Score Changes
+-- Purpose:   Add push subscription storage, notification queue, and API
+--            functions for Web Push notification management.
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- ─── 1. Push Subscriptions Table ────────────────────────────────────────────
+-- Stores Web Push API subscriptions (one per user per browser/device).
+
+CREATE TABLE IF NOT EXISTS push_subscriptions (
+    id         uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id    uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    endpoint   text NOT NULL,
+    keys       jsonb NOT NULL,  -- { p256dh, auth }
+    created_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (user_id, endpoint)
+);
+
+ALTER TABLE push_subscriptions ENABLE ROW LEVEL SECURITY;
+
+-- Users can only manage their own subscriptions
+CREATE POLICY "push_sub_select" ON push_subscriptions
+    FOR SELECT TO authenticated
+    USING (user_id = auth.uid());
+
+CREATE POLICY "push_sub_insert" ON push_subscriptions
+    FOR INSERT TO authenticated
+    WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "push_sub_delete" ON push_subscriptions
+    FOR DELETE TO authenticated
+    USING (user_id = auth.uid());
+
+CREATE INDEX IF NOT EXISTS idx_push_subscriptions_user
+    ON push_subscriptions (user_id);
+
+
+-- ─── 2. Notification Queue Table ────────────────────────────────────────────
+-- Queued push notifications awaiting delivery by Edge Function.
+
+CREATE TABLE IF NOT EXISTS notification_queue (
+    id           bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id      uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    product_id   bigint NOT NULL REFERENCES products(product_id) ON DELETE CASCADE,
+    product_name text NOT NULL,
+    old_score    numeric NOT NULL,
+    new_score    numeric NOT NULL,
+    delta        numeric NOT NULL,
+    direction    text NOT NULL CHECK (direction IN ('improved', 'worsened')),
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    sent_at      timestamptz,
+    status       text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'sent', 'failed', 'no_subscription'))
+);
+
+ALTER TABLE notification_queue ENABLE ROW LEVEL SECURITY;
+
+-- Users can read their own notification history
+CREATE POLICY "notif_queue_select" ON notification_queue
+    FOR SELECT TO authenticated
+    USING (user_id = auth.uid());
+
+-- Only postgres / service_role can insert/update (from triggers / edge functions)
+CREATE POLICY "notif_queue_service_insert" ON notification_queue
+    FOR INSERT TO service_role
+    WITH CHECK (true);
+
+CREATE POLICY "notif_queue_service_update" ON notification_queue
+    FOR UPDATE TO service_role
+    USING (true);
+
+CREATE INDEX IF NOT EXISTS idx_notification_queue_pending
+    ON notification_queue (status) WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_notification_queue_user
+    ON notification_queue (user_id);
+
+
+-- ─── 3. Score Change → Notification Queue Trigger ───────────────────────────
+-- When a new row is inserted into product_score_history, check if any users
+-- are watching that product and queue notifications for significant changes.
+
+CREATE OR REPLACE FUNCTION queue_score_change_notifications()
+RETURNS TRIGGER
+SECURITY DEFINER
+SET search_path = public
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_product_name text;
+    v_watcher RECORD;
+BEGIN
+    -- Only process rows with a meaningful score change
+    IF NEW.score_delta IS NULL OR NEW.score_delta = 0 THEN
+        RETURN NEW;
+    END IF;
+
+    -- Get product name
+    SELECT product_name INTO v_product_name
+    FROM products
+    WHERE product_id = NEW.product_id;
+
+    IF v_product_name IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    -- Find all users watching this product whose alert threshold is met
+    FOR v_watcher IN
+        SELECT user_id, alert_threshold
+        FROM user_watched_products
+        WHERE product_id = NEW.product_id
+          AND 'score_change' = ANY(notify_on)
+          AND ABS(NEW.score_delta) >= alert_threshold
+    LOOP
+        INSERT INTO notification_queue (
+            user_id, product_id, product_name,
+            old_score, new_score, delta, direction
+        ) VALUES (
+            v_watcher.user_id,
+            NEW.product_id,
+            v_product_name,
+            NEW.unhealthiness_score - NEW.score_delta,
+            NEW.unhealthiness_score,
+            NEW.score_delta,
+            CASE WHEN NEW.score_delta < 0 THEN 'improved' ELSE 'worsened' END
+        );
+
+        -- Update last_alerted_at on the watch entry
+        UPDATE user_watched_products
+        SET last_alerted_at = now()
+        WHERE user_id = v_watcher.user_id
+          AND product_id = NEW.product_id;
+    END LOOP;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_queue_score_notifications ON product_score_history;
+CREATE TRIGGER trg_queue_score_notifications
+    AFTER INSERT ON product_score_history
+    FOR EACH ROW
+    EXECUTE FUNCTION queue_score_change_notifications();
+
+
+-- ─── 4. API Functions ───────────────────────────────────────────────────────
+
+-- 4a) Save a push subscription
+CREATE OR REPLACE FUNCTION api_save_push_subscription(
+    p_endpoint text,
+    p_key_p256dh text,
+    p_key_auth text
+)
+RETURNS jsonb
+SECURITY DEFINER
+SET search_path = public
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_uid uuid := auth.uid();
+BEGIN
+    IF v_uid IS NULL THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'success', false,
+            'error', 'Authentication required.'
+        );
+    END IF;
+
+    -- Validate endpoint URL
+    IF p_endpoint IS NULL OR p_endpoint = '' OR
+       NOT (p_endpoint LIKE 'https://%') THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'success', false,
+            'error', 'Invalid push endpoint.'
+        );
+    END IF;
+
+    -- Validate keys
+    IF p_key_p256dh IS NULL OR p_key_p256dh = '' OR
+       p_key_auth IS NULL OR p_key_auth = '' THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'success', false,
+            'error', 'Invalid push subscription keys.'
+        );
+    END IF;
+
+    INSERT INTO push_subscriptions (user_id, endpoint, keys)
+    VALUES (
+        v_uid,
+        p_endpoint,
+        jsonb_build_object('p256dh', p_key_p256dh, 'auth', p_key_auth)
+    )
+    ON CONFLICT (user_id, endpoint) DO UPDATE SET
+        keys = EXCLUDED.keys,
+        created_at = now();
+
+    RETURN jsonb_build_object(
+        'api_version', '1.0',
+        'success', true
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION api_save_push_subscription(text, text, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION api_save_push_subscription(text, text, text) TO authenticated;
+
+
+-- 4b) Delete a push subscription (unsubscribe)
+CREATE OR REPLACE FUNCTION api_delete_push_subscription(
+    p_endpoint text
+)
+RETURNS jsonb
+SECURITY DEFINER
+SET search_path = public
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_uid uuid := auth.uid();
+    v_deleted boolean;
+BEGIN
+    IF v_uid IS NULL THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'success', false,
+            'error', 'Authentication required.'
+        );
+    END IF;
+
+    DELETE FROM push_subscriptions
+    WHERE user_id = v_uid AND endpoint = p_endpoint;
+
+    v_deleted := FOUND;
+
+    RETURN jsonb_build_object(
+        'api_version', '1.0',
+        'success', true,
+        'deleted', v_deleted
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION api_delete_push_subscription(text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION api_delete_push_subscription(text) TO authenticated;
+
+
+-- 4c) Get push subscriptions for current user
+CREATE OR REPLACE FUNCTION api_get_push_subscriptions()
+RETURNS jsonb
+SECURITY DEFINER
+SET search_path = public
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_uid uuid := auth.uid();
+    v_subs jsonb;
+BEGIN
+    IF v_uid IS NULL THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'success', false,
+            'error', 'Authentication required.'
+        );
+    END IF;
+
+    SELECT COALESCE(jsonb_agg(
+        jsonb_build_object(
+            'id', id,
+            'endpoint', endpoint,
+            'created_at', created_at
+        )
+    ), '[]'::jsonb) INTO v_subs
+    FROM push_subscriptions
+    WHERE user_id = v_uid;
+
+    RETURN jsonb_build_object(
+        'api_version', '1.0',
+        'success', true,
+        'subscriptions', v_subs,
+        'count', jsonb_array_length(v_subs)
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION api_get_push_subscriptions() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION api_get_push_subscriptions() TO authenticated;
+
+
+-- 4d) Process notification queue — called by Edge Function (service_role only)
+CREATE OR REPLACE FUNCTION api_get_pending_notifications(
+    p_limit int DEFAULT 50
+)
+RETURNS jsonb
+SECURITY DEFINER
+SET search_path = public
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_notifications jsonb;
+BEGIN
+    -- This function should only be called by service_role
+    -- (Edge Function with service_role key)
+
+    SELECT COALESCE(jsonb_agg(row_to_json(n.*)), '[]'::jsonb)
+    INTO v_notifications
+    FROM (
+        SELECT
+            nq.id,
+            nq.user_id,
+            nq.product_id,
+            nq.product_name,
+            nq.old_score,
+            nq.new_score,
+            nq.delta,
+            nq.direction,
+            nq.created_at,
+            jsonb_agg(
+                jsonb_build_object(
+                    'endpoint', ps.endpoint,
+                    'keys', ps.keys
+                )
+            ) AS subscriptions
+        FROM notification_queue nq
+        JOIN push_subscriptions ps ON ps.user_id = nq.user_id
+        WHERE nq.status = 'pending'
+        GROUP BY nq.id
+        ORDER BY nq.created_at ASC
+        LIMIT p_limit
+    ) n;
+
+    RETURN jsonb_build_object(
+        'api_version', '1.0',
+        'success', true,
+        'notifications', v_notifications,
+        'count', jsonb_array_length(v_notifications)
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION api_get_pending_notifications(int) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION api_get_pending_notifications(int) TO service_role;
+
+
+-- 4e) Mark notifications as sent — called by Edge Function
+CREATE OR REPLACE FUNCTION api_mark_notifications_sent(
+    p_notification_ids bigint[],
+    p_status text DEFAULT 'sent'
+)
+RETURNS jsonb
+SECURITY DEFINER
+SET search_path = public
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF p_status NOT IN ('sent', 'failed', 'no_subscription') THEN
+        RETURN jsonb_build_object(
+            'api_version', '1.0',
+            'success', false,
+            'error', 'Invalid status.'
+        );
+    END IF;
+
+    UPDATE notification_queue
+    SET status  = p_status,
+        sent_at = CASE WHEN p_status = 'sent' THEN now() ELSE sent_at END
+    WHERE id = ANY(p_notification_ids);
+
+    RETURN jsonb_build_object(
+        'api_version', '1.0',
+        'success', true,
+        'updated', array_length(p_notification_ids, 1)
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION api_mark_notifications_sent(bigint[], text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION api_mark_notifications_sent(bigint[], text) TO service_role;
+
+
+-- 4f) Cleanup expired push subscriptions — service_role only
+CREATE OR REPLACE FUNCTION api_cleanup_push_subscriptions(
+    p_endpoint text
+)
+RETURNS jsonb
+SECURITY DEFINER
+SET search_path = public
+LANGUAGE plpgsql AS $$
+BEGIN
+    DELETE FROM push_subscriptions WHERE endpoint = p_endpoint;
+
+    RETURN jsonb_build_object(
+        'api_version', '1.0',
+        'success', true,
+        'cleaned', FOUND
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION api_cleanup_push_subscriptions(text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION api_cleanup_push_subscriptions(text) TO service_role;

--- a/supabase/tests/push_notification_functions.test.sql
+++ b/supabase/tests/push_notification_functions.test.sql
@@ -1,0 +1,74 @@
+-- ─── pgTAP: Push Notification functions — auth error branches ───────────────
+-- Tests the auth-error branch for push notification API functions.
+-- Since pgTAP runs without auth.uid(), these all return {error: "Authentication required"}.
+-- Run via: supabase test db
+-- ─────────────────────────────────────────────────────────────────────────────
+
+BEGIN;
+SELECT plan(9);
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 1. api_save_push_subscription — auth error
+-- ═══════════════════════════════════════════════════════════════════════════
+
+SELECT lives_ok(
+  $$SELECT public.api_save_push_subscription('https://push.example.com/sub', 'p256dh-key', 'auth-key')$$,
+  'api_save_push_subscription does not throw'
+);
+
+SELECT is(
+  (public.api_save_push_subscription('https://push.example.com/sub', 'p256dh-key', 'auth-key'))->>'error',
+  'Authentication required.',
+  'api_save_push_subscription requires auth'
+);
+
+SELECT is(
+  (public.api_save_push_subscription('https://push.example.com/sub', 'p256dh-key', 'auth-key'))->>'api_version',
+  '1.0',
+  'api_save_push_subscription returns api_version even on error'
+);
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 2. api_delete_push_subscription — auth error
+-- ═══════════════════════════════════════════════════════════════════════════
+
+SELECT lives_ok(
+  $$SELECT public.api_delete_push_subscription('https://push.example.com/sub')$$,
+  'api_delete_push_subscription does not throw'
+);
+
+SELECT is(
+  (public.api_delete_push_subscription('https://push.example.com/sub'))->>'error',
+  'Authentication required.',
+  'api_delete_push_subscription requires auth'
+);
+
+SELECT is(
+  (public.api_delete_push_subscription('https://push.example.com/sub'))->>'api_version',
+  '1.0',
+  'api_delete_push_subscription returns api_version even on error'
+);
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 3. api_get_push_subscriptions — auth error
+-- ═══════════════════════════════════════════════════════════════════════════
+
+SELECT lives_ok(
+  $$SELECT public.api_get_push_subscriptions()$$,
+  'api_get_push_subscriptions does not throw'
+);
+
+SELECT is(
+  (public.api_get_push_subscriptions())->>'error',
+  'Authentication required.',
+  'api_get_push_subscriptions requires auth'
+);
+
+SELECT is(
+  (public.api_get_push_subscriptions())->>'api_version',
+  '1.0',
+  'api_get_push_subscriptions returns api_version even on error'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary
Closes #143 — Implements Web Push notifications for watchlist score changes using the Web Push API with VAPID authentication.

## Changes

### Database Layer
- **`push_subscriptions` table** — stores user push subscription endpoints with JSONB keys, UNIQUE(user_id, endpoint), RLS policies, CASCADE on user delete
- **`notification_queue` table** — queues score change notifications with status tracking (pending/sent/failed/no_subscription)
- **Trigger** `queue_score_change_notifications` on `product_score_history` INSERT — checks `user_watched_products` for watchers meeting `alert_threshold`, inserts into queue
- **6 API functions**: `api_save_push_subscription`, `api_delete_push_subscription`, `api_get_push_subscriptions`, `api_get_pending_notifications`, `api_mark_notifications_sent`, `api_cleanup_push_subscriptions`

### Edge Function
- **`send-push-notification`** — Deno Edge Function that processes the notification queue, signs VAPID JWTs, delivers Web Push payloads, handles expired subscriptions (410/404 cleanup)

### Frontend
- **`push-manager.ts`** — client library for Push API (subscribe/unsubscribe, permission management, VAPID key encoding)
- **Service worker** — push, notificationclick, pushsubscriptionchange event handlers
- **`NotificationPrompt`** — prompt shown after first watchlist add when permission is "default"
- **WatchButton** — integrated NotificationPrompt after successful watch
- **Settings page** — push notification toggle (enable/disable/blocked-by-browser states)
- **API functions** — savePushSubscription, deletePushSubscription, getPushSubscriptions
- **Types** — PushSubscription response interfaces + 4 analytics events
- **Query keys** — pushSubscriptions with 10min stale time
- **i18n** — en/pl translations for all notification strings

### Testing
- **31 unit tests** (push-manager: 22 tests, NotificationPrompt: 9 tests) — 91.86% coverage on push-manager.ts
- **14 QA SQL checks** — table existence, RLS, constraints, triggers, function auth
- **9 pgTAP tests** — auth error branches on push subscription API functions

## Pre-merge Checks
- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 3410 passed, 0 failed
- [x] Coverage ≥ 85% on new code (91.86%)
- [x] QA SQL + pgTAP tests created