### PR TITLE
[HOTFIX] Restore main: QA checks + flaky E2E autocomplete test

### DIFF
--- a/db/qa/QA__security_posture.sql
+++ b/db/qa/QA__security_posture.sql
@@ -125,7 +125,8 @@ WHERE n.nspname = 'public'
     'api_get_product_profile',      -- public product lookup
     'api_get_product_profile_by_ean', -- public EAN lookup
     'api_get_ingredient_profile',   -- public ingredient lookup
-    'api_get_score_history'         -- public score history
+    'api_get_score_history',        -- public score history
+    'api_get_product_allergens'     -- public allergen batch lookup
   );
 
 -- 10. anon cannot EXECUTE internal computation functions
@@ -233,7 +234,13 @@ FROM pg_proc p
 JOIN pg_namespace n ON p.pronamespace = n.oid
 WHERE n.nspname = 'public'
   AND p.proname LIKE 'api_%'
-  AND p.proname NOT IN ('api_refresh_mvs')  -- service_role-only admin RPCs
+  AND p.proname NOT IN (
+    'api_refresh_mvs',                  -- MV refresh (service_role cron)
+    'api_health_check',                 -- monitoring (service_role only)
+    'api_get_pending_notifications',    -- push queue (service_role only)
+    'api_mark_notifications_sent',      -- push queue (service_role only)
+    'api_cleanup_push_subscriptions'    -- push cleanup (service_role only)
+  )
   AND NOT has_function_privilege('authenticated', p.oid, 'EXECUTE');
 
 -- 19. user_preferences.country allows NULL (pre-onboarding state)

--- a/db/qa/QA__view_consistency.sql
+++ b/db/qa/QA__view_consistency.sql
@@ -160,13 +160,15 @@ WHERE x.product_count <> x.actual;
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 13. v_master column count matches expected (drift detection)
---     v_master should have exactly 52 columns.  If a migration adds or
+--     v_master should have exactly 55 columns.  If a migration adds or
 --     removes columns without updating the reference, this catches it.
 --     Original 47 + 5 from localization phases 2 & 4:
 --       product_name_en, product_name_en_source, created_at, updated_at, name_translations
+--     + 3 from 2026-02-22 migrations:
+--       image_thumb_url, vegan_contradiction, vegetarian_contradiction
 -- ═══════════════════════════════════════════════════════════════════════════
-SELECT '13. v_master has expected column count (52)' AS check_name,
-       ABS(52 - COUNT(*)) AS violations
+SELECT '13. v_master has expected column count (55)' AS check_name,
+       ABS(55 - COUNT(*)) AS violations
 FROM information_schema.columns
 WHERE table_schema = 'public'
   AND table_name = 'v_master';

--- a/frontend/e2e/authenticated.spec.ts
+++ b/frontend/e2e/authenticated.spec.ts
@@ -133,6 +133,9 @@ test.describe("Search page", () => {
     await page.reload({ waitUntil: "networkidle" });
 
     const input = page.getByPlaceholder(/search products/i);
+    // autoFocus may have focused the input before React hydrates,
+    // so blur first to guarantee the subsequent focus fires the event.
+    await input.blur();
     await input.focus();
 
     // Recent searches section should appear

--- a/supabase/migrations/20260222040000_idx_notification_queue_product.sql
+++ b/supabase/migrations/20260222040000_idx_notification_queue_product.sql
@@ -1,0 +1,4 @@
+-- Add missing index on notification_queue.product_id FK column
+-- (fixes QA check: "FK columns referencing products are indexed")
+CREATE INDEX IF NOT EXISTS idx_notification_queue_product
+    ON notification_queue(product_id);


### PR DESCRIPTION
## Summary

`main` is red — 4 QA check failures + 1 Playwright E2E failure across the `QA Tests` and `CI` workflows. This PR fixes all 5 issues with the smallest safe change set.

## Failing Checks

| # | Workflow | Check | Violation |
|---|---------|-------|-----------|
| 1 | QA Tests | `View & Function Consistency` | v_master expected 52 columns, actual 55 |
| 2 | QA Tests | `Security Posture #9` | `api_get_product_allergens` not in anon allowlist |
| 3 | QA Tests | `Security Posture #18` | 4 service_role-only functions not in exclusion list |
| 4 | QA Tests | `Index & Temporal #13` | `notification_queue.product_id` FK missing index |
| 5 | CI | `Playwright E2E` | `shows recent searches in autocomplete dropdown` flaky |

## Root Causes & Fixes

### 1. v_master column count (52 → 55)
**Root cause:** Three columns added by recent migrations (`image_thumb_url`, `vegan_contradiction`, `vegetarian_contradiction`) but QA check not updated.
**Fix:** Update expected count in `QA__view_consistency.sql` from 52 to 55.

### 2. anon allowlist missing `api_get_product_allergens`
**Root cause:** `20260222001000_allergen_batch_lookup.sql` grants EXECUTE to anon, but the QA allowlist in check #9 was not updated.
**Fix:** Add `api_get_product_allergens` to `QA__security_posture.sql` check #9 allowlist.

### 3. authenticated exclusion missing 4 service_role-only functions
**Root cause:** `api_health_check`, `api_get_pending_notifications`, `api_mark_notifications_sent`, `api_cleanup_push_subscriptions` are intentionally restricted to service_role, but the exclusion list in check #18 only had `api_refresh_mvs`.
**Fix:** Add all 4 to `QA__security_posture.sql` check #18 exclusion list.

### 4. Missing FK index on `notification_queue.product_id`
**Root cause:** `20260222005000_push_notifications.sql` creates `notification_queue` with FK to `products(product_id)` but no supporting index.
**Fix:** New migration `20260222040000_idx_notification_queue_product.sql`.

### 5. Flaky Playwright E2E: autocomplete dropdown
**Root cause:** `autoFocus` on search input focuses the element before React hydrates. When the test calls `await input.focus()`, the input is already focused so the browser doesn't re-fire the `focus` event → `onFocus={() => setShowAutocomplete(true)}` never runs → dropdown never appears.
**Fix:** `await input.blur()` before `await input.focus()` to guarantee the focus event fires reliably.

## Files Changed (4 files, 21 insertions, 5 deletions)
- `db/qa/QA__view_consistency.sql` — column count 52→55
- `db/qa/QA__security_posture.sql` — anon allowlist + authenticated exclusions
- `supabase/migrations/20260222040000_idx_notification_queue_product.sql` — **new** index migration
- `frontend/e2e/authenticated.spec.ts` — blur-before-focus fix

## Local Verification
- [x] `tsc --noEmit` — clean
- [x] Vitest — 3530 passed, 0 failed
- [x] ESLint — 0 warnings or errors
- [x] No unrelated changes

## Scope Confirmation
- Only fixes what is required to restore green
- No opportunistic refactors
- Backward compatible
- Migration is deterministic (CREATE INDEX IF NOT EXISTS)

## Rollback Plan
Revert this single commit. The QA checks revert to previous thresholds, index is harmless, test reverts to pre-fix.