### PR TITLE
fix(ci): let withSentryConfig handle sourcemap upload during build

### DIFF
--- a/.github/workflows/main-gate.yml
+++ b/.github/workflows/main-gate.yml
@@ -68,9 +68,13 @@ jobs:
             next-cache-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}-
             next-cache-${{ runner.os }}-
 
-      - name: Build
+      - name: Build (+ Sentry sourcemap upload)
         run: npx next build
         timeout-minutes: 5
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
       # ── Unit tests with coverage ───────────────────────────────────────
       - name: Unit tests with coverage
@@ -128,36 +132,11 @@ jobs:
         # NO continue-on-error — quality gate BLOCKS the build
 
       # ── Sentry sourcemap upload ────────────────────────────────────────
-      # STRICT on push-to-main: warns if secrets are missing (sourcemaps
-      # won't be uploaded), but does NOT fail the build so CI stays green
-      # until the secrets are first configured.
-      - name: Verify Sentry secrets
-        id: sentry_check
-        working-directory: .
-        run: |
-          missing=""
-          [ -z "$SENTRY_AUTH_TOKEN" ] && missing="$missing SENTRY_AUTH_TOKEN"
-          [ -z "$SENTRY_ORG" ]        && missing="$missing SENTRY_ORG"
-          [ -z "$SENTRY_PROJECT" ]     && missing="$missing SENTRY_PROJECT"
-          if [ -n "$missing" ]; then
-            echo "::warning::Sentry secrets not configured:$missing — sourcemap upload skipped"
-            echo "sentry_ready=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "sentry_ready=true" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-
-      - name: Upload Sentry sourcemaps
-        if: steps.sentry_check.outputs.sentry_ready == 'true'
-        run: npx @sentry/cli sourcemaps upload --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" .next
-        timeout-minutes: 3
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      # Sourcemaps are uploaded automatically by @sentry/nextjs during
+      # `next build` via withSentryConfig() when SENTRY_AUTH_TOKEN,
+      # SENTRY_ORG, and SENTRY_PROJECT env vars are present (passed to
+      # the Build step above). If secrets are missing, the plugin silently
+      # skips upload. No separate sentry-cli step required.
 
       # ── CI runtime observability ───────────────────────────────────────
       - name: CI runtime summary


### PR DESCRIPTION
## What

Passes `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` to the Build step in `main-gate.yml` so `@sentry/nextjs` (`withSentryConfig()`) handles sourcemap upload natively during `next build`.

Removes the redundant manual `sentry-cli` upload step that was:
- A separate download/install of `@sentry/cli`
- Uploading from `.next` after build
- Not leveraging `deleteSourcemapsAfterUpload` (which only works when `withSentryConfig` has auth)

## Why

`next.config.ts` already wraps the config with `withSentryConfig()` which:
- Uploads sourcemaps during build when Sentry env vars are present
- Deletes sourcemaps from build output after upload (keeps bundle clean)
- Handles release creation automatically

The old approach skipped the native integration and ran a redundant `sentry-cli` step.

## Checklist

- [x] Sentry env vars passed to Build step
- [x] Redundant `sentry-cli` step removed
- [x] Comment explains the approach for future maintainers
- [x] `deleteSourcemapsAfterUpload` now works correctly