### PR TITLE
fix: increase Playwright browser install timeout for apt-get system deps

### DIFF
--- a/.github/workflows/main-gate.yml
+++ b/.github/workflows/main-gate.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
-        timeout-minutes: 3
+        timeout-minutes: 8
 
       - name: Playwright full E2E
         id: playwright

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -244,7 +244,7 @@ jobs:
     needs: build
     permissions:
       contents: read
-    timeout-minutes: 8
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: frontend
@@ -272,7 +272,7 @@ jobs:
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
-        timeout-minutes: 5
+        timeout-minutes: 8
 
       - name: Run smoke E2E tests
         run: npx playwright test --project=smoke 2>&1 | tee ../playwright-stdout.log


### PR DESCRIPTION
## Problem

The `Install Playwright browsers` step (`npx playwright install --with-deps chromium`) times out on PR #261 (action version bumps).

Even when the Playwright browser binary is **cached** (cache hit confirmed), the `--with-deps` flag runs `apt-get update && apt-get install` for system libraries (libasound2, libatk, libgbm, etc.) which can exceed the step timeout on slow Ubuntu mirrors.

## Changes

| File | Change | Reason |
|---|---|---|
| `pr-gate.yml` | Browser install step timeout `5 → 8 min` | apt-get system deps exceed 5 min on slow mirrors |
| `pr-gate.yml` | Playwright Smoke job timeout `8 → 15 min` | Job timeout must exceed sum of install + test steps |
| `main-gate.yml` | Browser install step timeout `3 → 8 min` | Same issue on main pushes |

## Evidence

PR #261 run `22310252339`:
- Cache Playwright browsers: **HIT** ✅
- Install Playwright browsers: **FAILURE** (timeout at 5 min)
- The step ran `apt-get install` for ~40 system packages, which took > 5 min