### PR TITLE
fix(ci): bump Playwright system-deps timeout 5→8 min in main-gate + nightly

### DIFF
--- a/.github/workflows/main-gate.yml
+++ b/.github/workflows/main-gate.yml
@@ -263,7 +263,7 @@ jobs:
       - name: Install Playwright system deps
         if: steps.pw-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
-        timeout-minutes: 5
+        timeout-minutes: 8
 
       - name: Playwright full E2E
         run: npx playwright test 2>&1 | tee ../playwright-stdout.log

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install Playwright system deps
         if: steps.pw-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
-        timeout-minutes: 5
+        timeout-minutes: 8
 
       - name: Full Playwright (all projects including visual)
         run: npx playwright test 2>&1 | tee ../playwright-stdout.log


### PR DESCRIPTION
## Problem

Main Gate CI on `main` is failing because the `Install Playwright system deps` step times out at 5 minutes. When browsers are cached, the separate `install-deps` step runs `apt-get` for system libraries (libasound2, libatk, etc.) and on slow Azure mirrors this exceeds 5 minutes.

PR Gate already uses 8 minutes for this step — Main Gate and Nightly were missed.

## Fix

Bump `timeout-minutes: 5` → `timeout-minutes: 8` for the `Install Playwright system deps` step in:
- `.github/workflows/main-gate.yml` (line 266)
- `.github/workflows/nightly.yml` (line 95)

This aligns all workflows with the same 8-minute timeout already used in `pr-gate.yml`.

## Files Changed

| File | Change |
|------|--------|
| `.github/workflows/main-gate.yml` | `timeout-minutes: 5` → `8` for system deps install |
| `.github/workflows/nightly.yml` | `timeout-minutes: 5` → `8` for system deps install |