### PR TITLE
fix: API Contract Guard — replace Jest --testPathPattern with vitest positional arg

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -25,12 +25,14 @@ on:
       - "supabase/migrations/**"
       - "db/**"
       - "frontend/src/lib/rpc-contract*"
+      - ".github/workflows/api-contract.yml"
   pull_request:
     branches: [main]
     paths:
       - "supabase/migrations/**"
       - "db/**"
       - "frontend/src/lib/rpc-contract*"
+      - ".github/workflows/api-contract.yml"
   schedule:
     # Nightly 03:00 UTC — detect drift from manual DB changes
     - cron: "0 3 * * *"
@@ -93,17 +95,18 @@ jobs:
           INTEGRATION: "1"
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL_STAGING || secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY_STAGING || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY_STAGING || secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           echo "## API Contract Test Results" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
           set +e
-          output=$(npx vitest run --testPathPattern=rpc-contract 2>&1)
-          exit_code=$?
+          npx vitest run rpc-contract 2>&1 | tee /tmp/contract-output.txt
+          exit_code=${PIPESTATUS[0]}
           set -e
 
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          echo "$output" >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/contract-output.txt >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$exit_code" -ne 0 ]; then
@@ -112,6 +115,11 @@ jobs:
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "One or more RPC functions returned unexpected shapes." >> "$GITHUB_STEP_SUMMARY"
             echo "This means a migration likely changed the API contract." >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "**To reproduce locally:**" >> "$GITHUB_STEP_SUMMARY"
+            echo '```bash' >> "$GITHUB_STEP_SUMMARY"
+            echo 'cd frontend && npm run test:integration' >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "**Fix options:**" >> "$GITHUB_STEP_SUMMARY"
             echo "1. Fix the migration to preserve the existing contract" >> "$GITHUB_STEP_SUMMARY"
@@ -130,4 +138,4 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY_STAGING || secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           # Also run the health route unit test which validates response shape
-          npx vitest run --testPathPattern=api/health
+          npx vitest run api/health

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:integration": "INTEGRATION=1 vitest run --testPathPattern=rpc-contract",
+    "test:integration": "INTEGRATION=1 vitest run rpc-contract",
     "test:e2e": "npx playwright test",
     "test:e2e:smoke": "npx playwright test --project=smoke",
     "test:e2e:visual": "VISUAL_REGRESSION=true npx playwright test",


### PR DESCRIPTION
## Root Cause

The API Contract Guard workflow used `--testPathPattern=rpc-contract` which is a **Jest CLI flag**, not supported by vitest. Vitest 4.x throws `CACError: Unknown option '--testPathPattern'` and exits with code 1 immediately. The contract tests **never actually ran** — all 9 recorded runs failed with this error.

The error was invisible in CI logs because the workflow captured output into a bash variable (`output=$(...)`) and only wrote it to `$GITHUB_STEP_SUMMARY`, not stdout.

## Changes

| File | Before | After |
|------|--------|-------|
| `.github/workflows/api-contract.yml` L101 | `npx vitest run --testPathPattern=rpc-contract` | `npx vitest run rpc-contract` |
| `.github/workflows/api-contract.yml` L134 | `npx vitest run --testPathPattern=api/health` | `npx vitest run api/health` |
| `frontend/package.json` L14 | `vitest run --testPathPattern=rpc-contract` | `vitest run rpc-contract` |
| `frontend/src/lib/rpc-contract.integration.test.ts` L6 | Documentation comment | Updated to `npm run test:integration` |

### Additional improvements:
- **Visible output**: Use `tee` to pipe vitest output to both stdout (CI logs) and `$GITHUB_STEP_SUMMARY` (PR page), so failures are no longer invisible
- **Local repro instructions**: Failure message now includes `cd frontend && npm run test:integration`
- **Self-triggering**: Added `.github/workflows/api-contract.yml` to path filters so future workflow edits trigger the check on PRs

## Verification
This PR changes the `.github/workflows/api-contract.yml` file, which is now in the path triggers, so the API Contract Guard workflow will run on this PR and validate itself.