### PR TITLE
feat(quality): Desktop Audit Runner — Quality Gate 5/9 (#176)

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -62,13 +62,25 @@ const qualityMobileProject = {
   },
 };
 
+const qualityDesktopProject = {
+  name: "quality-desktop",
+  testDir: "../tests/quality",
+  testMatch: /desktop\.audit\.spec\.ts/,
+  dependencies: HAS_AUTH ? ["auth-setup"] : [],
+  use: {
+    ...devices["Desktop Chrome"],
+    viewport: { width: 1280, height: 800 },
+    storageState: HAS_AUTH ? "e2e/.auth/user.json" : undefined,
+  },
+};
+
 const projects = [
   ...(HAS_AUTH ? [authSetupProject] : []),
   smokeProject,
   ...(HAS_AUTH ? [authenticatedProject] : []),
   ...(HAS_VISUAL ? [visualSmokeProject] : []),
   ...(HAS_VISUAL && HAS_AUTH ? [visualAuthenticatedProject] : []),
-  ...(HAS_QUALITY ? [qualityMobileProject] : []),
+  ...(HAS_QUALITY ? [qualityMobileProject, qualityDesktopProject] : []),
 ];
 
 /* ── Config ──────────────────────────────────────────────────────────────── */

--- a/frontend/tests/quality/desktop.audit.spec.ts
+++ b/frontend/tests/quality/desktop.audit.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Quality Gate 5/9 — Desktop Audit Runner
+ *
+ * Playwright spec that visits every route from the route manifest at
+ * a standard laptop viewport (1280 × 800) and applies the invariant
+ * engine with desktop-specific checks.  Product pages cycle through
+ * all tabs.
+ *
+ * Screenshots are saved to `qa_screenshots/latest/desktop/`.
+ *
+ * Run on CI via the `quality-desktop` Playwright project or locally:
+ *
+ *   QA_MODE_LEVEL=smoke npx playwright test --project quality-desktop
+ *
+ * @see https://github.com/ericsocrat/poland-food-db/issues/176
+ */
+
+import { test, expect } from "@playwright/test";
+import { getRoutes } from "./routes";
+import {
+  setupErrorCollectors,
+  assertNoErrors,
+  runInvariantsForRoute,
+} from "./invariants";
+import { cleanScreenshotDir, takeScreenshot } from "./helpers/screenshot";
+import { waitForStable } from "./helpers/network";
+
+/* ── Config ──────────────────────────────────────────────────────────────── */
+
+/** Audit mode: `smoke` visits ~9 routes, `full` visits all ~40. */
+const MODE = (process.env.QA_MODE_LEVEL ?? "smoke") as "smoke" | "full";
+
+/* ── Setup ───────────────────────────────────────────────────────────────── */
+
+test.beforeAll(async () => {
+  await cleanScreenshotDir("desktop");
+});
+
+/* ── Route tests ─────────────────────────────────────────────────────────── */
+
+const routes = getRoutes(MODE).filter((r) => !r.mobileOnly);
+
+for (const route of routes) {
+  test(`desktop audit — ${route.label}`, async ({ page }) => {
+    // ── Attach error collectors ───────────────────────────────────────────
+    const collectors = setupErrorCollectors(page);
+
+    // ── Navigate ──────────────────────────────────────────────────────────
+    const response = await page.goto(route.path, {
+      waitUntil: "domcontentloaded",
+    });
+    expect(response?.ok() ?? false, `Navigation to ${route.path} failed`).toBe(
+      true
+    );
+    await waitForStable(page);
+
+    // ── Run invariant checks (desktop mode) ───────────────────────────────
+    await runInvariantsForRoute(page, route.path, {
+      isMobile: false,
+      isProductPage: route.path.includes("/product/"),
+      isRecipesPage: route.path.includes("/recipes"),
+      isSettingsPage: route.path.includes("/settings"),
+      isAdminPage: route.path.includes("/admin"),
+    });
+
+    // ── Screenshot: default state ─────────────────────────────────────────
+    await takeScreenshot(page, "desktop", route.label);
+
+    // ── Tab cycling for product pages ─────────────────────────────────────
+    if (route.hasTabs?.length) {
+      for (const tabId of route.hasTabs) {
+        const tabLocator = page.getByTestId("tab-bar").getByText(tabId, {
+          exact: false,
+        });
+
+        // Some tabs may not exist yet (feature in progress) — skip gracefully.
+        if ((await tabLocator.count()) === 0) continue;
+
+        await tabLocator.click();
+        await waitForStable(page, 4_000);
+
+        // Re-run invariants for the new tab content
+        await runInvariantsForRoute(page, `${route.path}#tab-${tabId}`, {
+          isMobile: false,
+          isProductPage: true,
+          isRecipesPage: false,
+          isSettingsPage: false,
+          isAdminPage: false,
+        });
+
+        await takeScreenshot(
+          page,
+          "desktop",
+          `${route.label}_tab-${tabId}`
+        );
+      }
+    }
+
+    // ── Assert no errors accumulated ──────────────────────────────────────
+    assertNoErrors(collectors, route.path);
+  });
+}


### PR DESCRIPTION
## Summary

Implements **Quality Gate 5/9 — Desktop Audit Runner** per #176.

### New files

| File | Purpose |
|------|---------|
| `tests/quality/desktop.audit.spec.ts` | Playwright spec: 1280×800 viewport, loops route manifest (non-mobileOnly), invariant engine (isMobile: false), tab cycling, screenshots |

### Modified files

| File | Change |
|------|--------|
| `playwright.config.ts` | Added `quality-desktop` project (Desktop Chrome @ 1280×800, `QA_MODE_LEVEL` toggle, auth via storageState) |

### How it works

1. `QA_MODE_LEVEL=smoke` (default) runs ~9 smoke routes; `full` runs all ~40
2. Routes filtered by `!mobileOnly` from the route manifest (#172)
3. Each route: navigate → waitForStable → invariant engine (desktop mode) → screenshot
4. Product pages: additionally cycle through all tabs (overview, nutrition, scoring, alternatives)
5. Screenshots saved to `qa_screenshots/latest/desktop/` (gitignored in #175)
6. Error collectors (console, network, page errors) assert zero errors per route

### Architecture

Mirrors the mobile audit runner (#175) exactly, sharing:
- `helpers/screenshot.ts` — screenshot capture
- `helpers/network.ts` — networkidle + fallback wait
- `invariants.ts` — 32 checks (global + desktop-specific via `isMobile: false`)
- `routes.ts` — route manifest with `mobileOnly` filter

### Test results

- 76 total quality-gate unit tests — all pass
- tsc clean, ESLint clean

### Run locally

```bash
cd frontend
QA_MODE_LEVEL=smoke npx playwright test --project quality-desktop
```

Closes #176
Depends on: #172 ✅, #174 ✅, #175 ✅
Blocks: #178 (CI Integration)