### PR TITLE
docs(governance): add documentation index, audit, and project layout restructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ Adheres to [Semantic Versioning](https://semver.org/).
   lifecycle, database object cleanup procedure, tech debt classification (4 tiers),
   feature flag expiration policy, quarterly hygiene review checklist template, and
   initial candidate audit
+- Add canonical documentation index (`docs/INDEX.md`) with domain-classified map of
+  all 44 markdown files across 10 domains, redundancy assessment (7 pairs investigated,
+  no actual redundancy found), obsolete reference audit, removed documents tracking,
+  and documentation standards (frontmatter, update triggers, add/archive procedures)
+- Restructure `copilot-instructions.md` project layout: alphabetically sort docs
+  listing, expand from 25 to 41 entries with 14 previously-unlisted documents
 
 ### CI/CD & Infrastructure
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -168,30 +168,45 @@ poland-food-db/
 ├── docs/
 │   ├── SCORING_METHODOLOGY.md       # v3.2 algorithm (9 factors, ceilings, bands)
 │   ├── API_CONTRACTS.md             # API surface contracts (6 endpoints) — response shapes, hidden columns
-│   ├── PERFORMANCE_REPORT.md        # Performance audit, scale projections, query patterns
-│   ├── DATA_SOURCES.md              # Source hierarchy & validation workflow
-│   ├── RESEARCH_WORKFLOW.md         # Data collection lifecycle (manual + automated OFF pipeline)
-│   ├── VIEWING_AND_TESTING.md       # Queries, Studio UI, test runner
-│   ├── COUNTRY_EXPANSION_GUIDE.md   # Multi-country protocol (PL active, DE micro-pilot)
-│   ├── UX_UI_DESIGN.md              # UI/UX guidelines
-│   ├── UX_IMPACT_METRICS.md         # UX measurement standard, metric catalog, SQL templates
-│   ├── FRONTEND_API_MAP.md          # Frontend ↔ API mapping reference
-│   ├── ENVIRONMENT_STRATEGY.md      # Local/staging/production environment strategy
-│   ├── STAGING_SETUP.md             # Staging environment setup
-│   ├── PRODUCTION_DATA.md           # Production data management
-│   ├── DATA_INTEGRITY_AUDITS.md     # Ongoing data integrity audit framework
-│   ├── EAN_VALIDATION_STATUS.md     # 997/1,025 coverage (97.3%)
-│   ├── CI_ARCHITECTURE_PROPOSAL.md  # CI pipeline design
-│   ├── LABELS.md                    # Labeling conventions
-│   ├── MONITORING.md                # Runtime monitoring
-│   ├── OBSERVABILITY.md             # Observability strategy
-│   ├── INCIDENT_RESPONSE.md         # Incident response playbook (severity, escalation, runbooks)
-│   ├── DOMAIN_BOUNDARIES.md         # Domain boundary enforcement & ownership mapping
 │   ├── API_VERSIONING.md            # API deprecation & versioning policy
 │   ├── ACCESS_AUDIT.md              # Data access pattern audit & quarterly review
-│   ├── PRIVACY_CHECKLIST.md         # GDPR/RODO compliance checklist & data lifecycle
+│   ├── BACKFILL_STANDARD.md         # Backfill orchestration standard & migration templates
+│   ├── CI_ARCHITECTURE_PROPOSAL.md  # CI pipeline design
+│   ├── CONTRACT_TESTING.md          # API contract testing strategy & pgTAP patterns
+│   ├── COUNTRY_EXPANSION_GUIDE.md   # Multi-country protocol (PL active, DE micro-pilot)
+│   ├── DATA_INTEGRITY_AUDITS.md     # Ongoing data integrity audit framework
+│   ├── DATA_PROVENANCE.md           # Data provenance & freshness governance
+│   ├── DATA_SOURCES.md              # Source hierarchy & validation workflow
+│   ├── DISASTER_DRILL_REPORT.md     # Disaster recovery drill report & findings
+│   ├── DOMAIN_BOUNDARIES.md         # Domain boundary enforcement & ownership mapping
+│   ├── EAN_VALIDATION_STATUS.md     # 997/1,025 coverage (97.3%)
+│   ├── ENVIRONMENT_STRATEGY.md      # Local/staging/production environment strategy
+│   ├── FEATURE_FLAGS.md             # Feature flag architecture & toggle registry
 │   ├── FEATURE_SUNSETTING.md        # Feature retirement criteria & cleanup policy
-│   └── SONAR.md                     # SonarCloud configuration & quality gates
+│   ├── FRONTEND_API_MAP.md          # Frontend ↔ API mapping reference
+│   ├── GOVERNANCE_BLUEPRINT.md      # Execution governance blueprint (master GOV plan)
+│   ├── INCIDENT_RESPONSE.md         # Incident response playbook (severity, escalation, runbooks)
+│   ├── INDEX.md                     # Canonical documentation map (40 docs, domain-classified)
+│   ├── LABELS.md                    # Labeling conventions
+│   ├── METRICS.md                   # Application, infrastructure & business metrics catalog
+│   ├── MONITORING.md                # Runtime monitoring
+│   ├── OBSERVABILITY.md             # Observability strategy
+│   ├── PERFORMANCE_GUARDRAILS.md    # Performance guardrails, query budgets & scale projections
+│   ├── PERFORMANCE_REPORT.md        # Performance audit, scale projections, query patterns
+│   ├── PRIVACY_CHECKLIST.md         # GDPR/RODO compliance checklist & data lifecycle
+│   ├── PRODUCTION_DATA.md           # Production data management
+│   ├── RATE_LIMITING.md             # Rate limiting strategy & API abuse prevention
+│   ├── RESEARCH_WORKFLOW.md         # Data collection lifecycle (manual + automated OFF pipeline)
+│   ├── SCORING_ENGINE.md            # Scoring engine architecture & version management
+│   ├── SCORING_METHODOLOGY.md       # v3.2 algorithm (9 factors, ceilings, bands)
+│   ├── SEARCH_ARCHITECTURE.md       # Search architecture (pg_trgm, tsvector, ranking)
+│   ├── SECURITY_AUDIT.md            # Full security audit report
+│   ├── SLO.md                       # Service Level Objectives (availability, latency, error rate)
+│   ├── SONAR.md                     # SonarCloud configuration & quality gates
+│   ├── STAGING_SETUP.md             # Staging environment setup
+│   ├── UX_IMPACT_METRICS.md         # UX measurement standard, metric catalog, SQL templates
+│   ├── UX_UI_DESIGN.md              # UI/UX guidelines
+│   └── VIEWING_AND_TESTING.md       # Queries, Studio UI, test runner
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
 ├── RUN_QA.ps1                       # QA test runner (429 checks across 30 suites)
 ├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (23 injection tests)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,223 @@
+# Documentation Index
+
+> **Last updated:** 2026-02-28
+> **Status:** Active — update when adding, renaming, or archiving docs
+> **Total documents:** 39 in `docs/` + 5 elsewhere in repo
+> **Reference:** Issue [#200](https://github.com/ericsocrat/poland-food-db/issues/200)
+
+---
+
+## Quick Navigation
+
+| Domain | Count | Documents |
+|---|---|---|
+| [Architecture & Design](#architecture--design) | 6 | Governance blueprint, domain boundaries, feature flags, scoring engine, search architecture, CI proposal |
+| [API](#api) | 4 | Contracts, versioning, frontend mapping, contract testing |
+| [Scoring](#scoring) | 2 | Methodology (formula), engine (architecture) |
+| [Data & Provenance](#data--provenance) | 5 | Sources, provenance, integrity audits, EAN validation, production data |
+| [Security & Compliance](#security--compliance) | 5 | Root policy, audit report, access audit, privacy checklist, rate limiting |
+| [Observability & Operations](#observability--operations) | 6 | Monitoring, observability, SLOs, metrics, incident response, disaster drill |
+| [DevOps & Environment](#devops--environment) | 3 | Environment strategy, staging setup, Sonar config |
+| [Frontend & UX](#frontend--ux) | 4 | UX/UI design, UX impact metrics, design system, frontend README |
+| [Process & Workflow](#process--workflow) | 5 | Research workflow, viewing & testing, backfill standard, labels, country expansion |
+| [Governance & Policy](#governance--policy) | 4 | Feature sunsetting, performance guardrails, this index, governance blueprint |
+
+---
+
+## Architecture & Design
+
+| Document | Purpose | Owner Issue | Last Updated |
+|---|---|---|---|
+| [GOVERNANCE_BLUEPRINT.md](GOVERNANCE_BLUEPRINT.md) | Execution governance blueprint — master plan for all GOV-* issues | [#195](https://github.com/ericsocrat/poland-food-db/issues/195) | 2026-02-24 |
+| [DOMAIN_BOUNDARIES.md](DOMAIN_BOUNDARIES.md) | Domain boundary enforcement, 13 domains, ownership mapping, interface contracts | [#196](https://github.com/ericsocrat/poland-food-db/issues/196) | 2026-02-24 |
+| [FEATURE_FLAGS.md](FEATURE_FLAGS.md) | Feature flag architecture — toggle registry, rollout strategy | [#191](https://github.com/ericsocrat/poland-food-db/issues/191) | 2026-02-24 |
+| [SCORING_ENGINE.md](SCORING_ENGINE.md) | Scoring engine architecture — versioned function design, regression anchor products | [#189](https://github.com/ericsocrat/poland-food-db/issues/189) | 2026-02-24 |
+| [SEARCH_ARCHITECTURE.md](SEARCH_ARCHITECTURE.md) | Search architecture — pg_trgm, tsvector, ranking, synonym management | [#192](https://github.com/ericsocrat/poland-food-db/issues/192) | 2026-02-24 |
+| [CI_ARCHITECTURE_PROPOSAL.md](CI_ARCHITECTURE_PROPOSAL.md) | CI pipeline design proposal | — | 2026-02-23 |
+
+## API
+
+| Document | Purpose | Owner Issue | Last Updated |
+|---|---|---|---|
+| [API_CONTRACTS.md](API_CONTRACTS.md) | API surface contracts — response shapes, hidden columns, 20+ RPC functions | — | 2026-02-24 |
+| [API_VERSIONING.md](API_VERSIONING.md) | API deprecation & versioning policy — function-name versioning, sunset timelines | [#234](https://github.com/ericsocrat/poland-food-db/issues/234) | 2026-02-24 |
+| [FRONTEND_API_MAP.md](FRONTEND_API_MAP.md) | Frontend-to-API mapping reference — which pages call which RPCs | — | 2026-02-13 |
+| [CONTRACT_TESTING.md](CONTRACT_TESTING.md) | API contract testing strategy — pgTAP patterns, response shape validation | — | 2026-02-24 |
+
+## Scoring
+
+| Document | Purpose | Owner Issue | Last Updated |
+|---|---|---|---|
+| [SCORING_METHODOLOGY.md](SCORING_METHODOLOGY.md) | v3.2 scoring formula — 9 factors, weights, ceilings, bands | — | 2026-02-12 |
+| [SCORING_ENGINE.md](SCORING_ENGINE.md) | Scoring engine architecture — function versioning, regression testing | [#189](https://github.com/ericsocrat/poland-food-db/issues/189) | 2026-02-24 |
+
+> **Relationship:** SCORING_METHODOLOGY.md defines the **formula** (what is computed). SCORING_ENGINE.md defines the **architecture** (how it is maintained, versioned, and tested). No redundancy — they serve different audiences.
+
+## Data & Provenance
+
+| Document | Purpose | Owner Issue | Last Updated |
+|---|---|---|---|
+| [DATA_SOURCES.md](DATA_SOURCES.md) | Source hierarchy & validation workflow — OFF API, manual entry | — | 2026-02-12 |
+| [DATA_PROVENANCE.md](DATA_PROVENANCE.md) | Data provenance & freshness governance — lineage tracking, staleness detection | [#193](https://github.com/ericsocrat/poland-food-db/issues/193) | 2026-02-24 |
+| [DATA_INTEGRITY_AUDITS.md](DATA_INTEGRITY_AUDITS.md) | Ongoing data integrity audit framework — nightly checks, contradiction detection | [#184](https://github.com/ericsocrat/poland-food-db/issues/184) | 2026-02-22 |
+| [EAN_VALIDATION_STATUS.md](EAN_VALIDATION_STATUS.md) | EAN coverage tracking — 997/1,025 (97.3%) | — | 2026-02-24 |
+| [PRODUCTION_DATA.md](PRODUCTION_DATA.md) | Production data management — sync, backup, restore procedures | — | 2026-02-24 |
+
+> **Relationship:** DATA_SOURCES.md catalogs **where** data comes from. DATA_PROVENANCE.md governs **how freshness and lineage are tracked**. No redundancy.
+
+## Security & Compliance
+
+| Document | Purpose | Owner Issue | Last Updated |
+|---|---|---|---|
+| [../SECURITY.md](../SECURITY.md) | Root security policy — vulnerability table, reporting process | — | 2026-02-24 |
+| [SECURITY_AUDIT.md](SECURITY_AUDIT.md) | Full security audit report — RLS, function security, headers, dependencies | — | 2026-02-23 |
+| [ACCESS_AUDIT.md](ACCESS_AUDIT.md) | Data access pattern audit — table-by-role matrix, quarterly review process | [#235](https://github.com/ericsocrat/poland-food-db/issues/235) | 2026-02-24 |
+| [PRIVACY_CHECKLIST.md](PRIVACY_CHECKLIST.md) | GDPR/RODO compliance checklist — data inventory, retention, subject rights | [#236](https://github.com/ericsocrat/poland-food-db/issues/236) | 2026-02-24 |
+| [RATE_LIMITING.md](RATE_LIMITING.md) | Rate limiting strategy — API abuse prevention, throttle tiers | — | 2026-02-23 |
+
+> **Relationship:** SECURITY.md (root) is a **policy overview** (required by GitHub security features). SECURITY_AUDIT.md is a **detailed audit report**. ACCESS_AUDIT.md focuses on **access patterns**. No redundancy — each has distinct scope.
+
+## Observability & Operations
+
+| Document | Purpose | Owner Issue | Last Updated |
+|---|---|---|---|
+| [MONITORING.md](MONITORING.md) | Runtime monitoring — alerts, dashboards, health checks | — | 2026-02-24 |
+| [OBSERVABILITY.md](OBSERVABILITY.md) | Observability strategy — structured logging, tracing, metrics pipeline | — | 2026-02-23 |
+| [SLO.md](SLO.md) | Service Level Objectives — availability, latency, error rate targets | — | 2026-02-24 |
+| [METRICS.md](METRICS.md) | Metrics catalog — application metrics, infrastructure metrics, business metrics | — | 2026-02-24 |
+| [INCIDENT_RESPONSE.md](INCIDENT_RESPONSE.md) | Incident response playbook — severity, escalation, runbooks, post-mortem | [#231](https://github.com/ericsocrat/poland-food-db/issues/231) | 2026-02-24 |
+| [DISASTER_DRILL_REPORT.md](DISASTER_DRILL_REPORT.md) | Disaster recovery drill report — test results, findings, remediation | — | 2026-02-23 |
+
+## DevOps & Environment
+
+| Document | Purpose | Owner Issue | Last Updated |
+|---|---|---|---|
+| [ENVIRONMENT_STRATEGY.md](ENVIRONMENT_STRATEGY.md) | Local/staging/production environment strategy | — | 2026-02-22 |
+| [STAGING_SETUP.md](STAGING_SETUP.md) | Staging environment setup guide — scripts, sync workflow, configuration | — | 2026-02-24 |
+| [SONAR.md](SONAR.md) | SonarCloud configuration & quality gates | — | 2026-02-23 |
+
+> **Relationship:** ENVIRONMENT_STRATEGY.md defines the **overall strategy** (3 environments). STAGING_SETUP.md provides **operational setup steps** for staging specifically. Complementary, not redundant.
+
+## Frontend & UX
+
+| Document | Purpose | Owner Issue | Last Updated |
+|---|---|---|---|
+| [UX_UI_DESIGN.md](UX_UI_DESIGN.md) | UI/UX design guidelines — color system, components, layouts | — | 2026-02-24 |
+| [UX_IMPACT_METRICS.md](UX_IMPACT_METRICS.md) | UX measurement standard — event catalog, metric templates, performance budget | — | 2026-02-24 |
+| [../frontend/docs/DESIGN_SYSTEM.md](../frontend/docs/DESIGN_SYSTEM.md) | Frontend design system — Tailwind tokens, component patterns | — | 2026-02-17 |
+| [../frontend/README.md](../frontend/README.md) | Frontend project overview — setup, scripts, architecture | — | 2026-02-24 |
+
+## Process & Workflow
+
+| Document | Purpose | Owner Issue | Last Updated |
+|---|---|---|---|
+| [RESEARCH_WORKFLOW.md](RESEARCH_WORKFLOW.md) | Data collection lifecycle — manual + automated OFF pipeline | — | 2026-02-24 |
+| [VIEWING_AND_TESTING.md](VIEWING_AND_TESTING.md) | Queries, Studio UI, test runner guide | — | 2026-02-24 |
+| [BACKFILL_STANDARD.md](BACKFILL_STANDARD.md) | Backfill orchestration standard — migration templates, validation patterns | — | 2026-02-24 |
+| [LABELS.md](LABELS.md) | GitHub labeling conventions — issue/PR label taxonomy | — | 2026-02-23 |
+| [COUNTRY_EXPANSION_GUIDE.md](COUNTRY_EXPANSION_GUIDE.md) | Multi-country expansion protocol — PL active, DE micro-pilot | — | 2026-02-24 |
+
+## Governance & Policy
+
+| Document | Purpose | Owner Issue | Last Updated |
+|---|---|---|---|
+| [FEATURE_SUNSETTING.md](FEATURE_SUNSETTING.md) | Feature retirement criteria, cleanup policy, quarterly hygiene review | [#237](https://github.com/ericsocrat/poland-food-db/issues/237) | 2026-02-24 |
+| [PERFORMANCE_GUARDRAILS.md](PERFORMANCE_GUARDRAILS.md) | Performance guardrails — query budgets, index policy, scale projections | — | 2026-02-23 |
+| INDEX.md | This file — canonical documentation map | [#200](https://github.com/ericsocrat/poland-food-db/issues/200) | 2026-02-28 |
+
+## Other Repository Documents
+
+| Document | Purpose | Last Updated |
+|---|---|---|
+| [../README.md](../README.md) | Project overview | 2026-02-24 |
+| [../SECURITY.md](../SECURITY.md) | Security policy (root — GitHub-required location) | 2026-02-24 |
+| [../DEPLOYMENT.md](../DEPLOYMENT.md) | Deployment procedures, rollback playbook | 2026-02-24 |
+| [../CHANGELOG.md](../CHANGELOG.md) | Structured changelog (Keep a Changelog + Conventional Commits) | 2026-02-24 |
+| [../copilot-instructions.md](../copilot-instructions.md) | AI agent instructions — schema, conventions, testing rules (~1,510 lines) | 2026-02-24 |
+| [../supabase/seed/README.md](../supabase/seed/README.md) | Seed data documentation | 2026-02-15 |
+
+---
+
+## Redundancy Assessment
+
+Pairs investigated for overlap during the 2026-02-28 audit:
+
+| Pair | Assessment | Verdict |
+|---|---|---|
+| SECURITY.md (root) ↔ SECURITY_AUDIT.md | Root = policy overview; Audit = detailed report | **No redundancy** — distinct scope |
+| DATA_SOURCES.md ↔ DATA_PROVENANCE.md | Sources = where data comes from; Provenance = freshness governance | **No redundancy** — complements |
+| SCORING_METHODOLOGY.md ↔ SCORING_ENGINE.md | Methodology = formula; Engine = architecture | **No redundancy** — what vs how |
+| ENVIRONMENT_STRATEGY.md ↔ STAGING_SETUP.md | Strategy = overall design; Setup = operational steps | **No redundancy** — complements |
+| MONITORING.md ↔ OBSERVABILITY.md | Monitoring = alerts/dashboards; Observability = logging/tracing/metrics pipeline | **No redundancy** — overlapping domain, distinct focus |
+| METRICS.md ↔ UX_IMPACT_METRICS.md | Metrics = infra/app metrics; UX Impact = UX-specific measurement | **No redundancy** — different audiences |
+| PERFORMANCE_REPORT.md ↔ PERFORMANCE_GUARDRAILS.md | Report = audit findings; Guardrails = policy/budgets | **No redundancy** — snapshot vs policy |
+
+## Obsolete Reference Check
+
+Files checked for references to deprecated elements (`compute_unhealthiness_v31`, `scored_at`, `column_metadata`):
+
+| File | Hits | Assessment |
+|---|---|---|
+| FEATURE_SUNSETTING.md | 2 | `column_metadata` referenced as **already-cleaned-up example** — intentional |
+| SCORING_ENGINE.md | 5 | References to v3.1 as **historical context** in version evolution — intentional |
+| SCORING_METHODOLOGY.md | 4 | References to v3.1 as **previous version** in changelog section — intentional |
+| SECURITY_AUDIT.md | 2 | References to scoring version history — intentional |
+| UX_UI_DESIGN.md | 1 | Minor v3.1 reference in historical context — intentional |
+
+**Result:** No stale or misleading obsolete references found. All hits are intentional historical context.
+
+## Removed Documents (No Longer Present)
+
+The following files were referenced in early project phases but have been superseded or consolidated:
+
+| Former File | Status | Successor |
+|---|---|---|
+| `DATA_ACQUISITION_WORKFLOW.md` | Superseded | Content merged into RESEARCH_WORKFLOW.md |
+| `EAN_EXPANSION_PLAN.md` | Superseded | Content merged into EAN_VALIDATION_STATUS.md |
+| `FULL_PROJECT_AUDIT.md` | Superseded | One-time audit; findings incorporated into GOVERNANCE_BLUEPRINT.md |
+| `TABLE_AUDIT_2026-02-12.md` | Superseded | One-time snapshot; findings incorporated into current schema documentation |
+| `PLATFORM_MATURITY_MODEL.md` | Superseded | Content absorbed into GOVERNANCE_BLUEPRINT.md |
+
+---
+
+## Documentation Standards
+
+### Required Frontmatter
+
+Every active document in `docs/` should include a header block:
+
+```markdown
+# Document Title
+
+> **Last updated:** YYYY-MM-DD
+> **Status:** Active | Deprecated | Archived
+> **Owner issue:** #NNN (or "—" if no specific issue)
+```
+
+### Update Triggers
+
+When modifying code in a domain, check the corresponding doc:
+
+| Code Change | Document to Check |
+|---|---|
+| Scoring formula weights/ceilings | SCORING_METHODOLOGY.md |
+| API function signature or response | API_CONTRACTS.md, FRONTEND_API_MAP.md |
+| New migration | copilot-instructions.md (schema section) |
+| New country added | COUNTRY_EXPANSION_GUIDE.md |
+| New user-facing table | PRIVACY_CHECKLIST.md, ACCESS_AUDIT.md |
+| Environment configuration | ENVIRONMENT_STRATEGY.md |
+| CI workflow changes | CI_ARCHITECTURE_PROPOSAL.md |
+
+### Adding a New Document
+
+1. Create in `docs/` with frontmatter header
+2. Add entry to this INDEX.md in the appropriate domain section
+3. Add entry to `copilot-instructions.md` project layout (docs section)
+4. Add CHANGELOG.md entry under `[Unreleased]` → Documentation
+
+### Archiving a Document
+
+1. Add `> **Status:** Archived — [reason]` to the document header
+2. Move the INDEX.md entry to the "Removed Documents" section
+3. Optionally move the file to `docs/archive/` (create directory if needed)
+4. Update `copilot-instructions.md` project layout


### PR DESCRIPTION
Closes #200 — Documentation Audit and Redundancy Elimination.

Deliverables:
- docs/INDEX.md: Canonical documentation map classifying all 44 markdown files across 10 domains, redundancy assessment (7 pairs investigated, no actual redundancy found), obsolete reference audit (5 files with historical context confirmed intentional), removed documents tracking, and documentation standards
- copilot-instructions.md: Restructured project layout docs section from 25 to 41 entries, alphabetically sorted, added 14 previously-unlisted documents
- CHANGELOG.md: Updated with doc audit entries

Audit findings:
- No actual redundancy across 7 investigated pairs
- 5 files with v3.1/column_metadata references are intentional historical context
- 5 formerly-referenced docs confirmed removed/superseded