### PR TITLE
docs(api): add API contract registry, naming conventions, and 107-function audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,14 @@ Adheres to [Semantic Versioning](https://semver.org/).
   and documentation standards (frontmatter, update triggers, add/archive procedures)
 - Restructure `copilot-instructions.md` project layout: alphabetically sort docs
   listing, expand from 25 to 41 entries with 14 previously-unlisted documents
+- Add RPC naming convention and security standards (`docs/API_CONVENTIONS.md`) with
+  visibility prefix system (api/admin/metric/trg/internal), 16 domain classifications,
+  parameter conventions, breaking change definition (6 breaking + 6 non-breaking rules),
+  breaking change protocol, and naming compliance audit of all 107 functions
+- Add structured API registry (`docs/api-registry.yaml`) with all 107 public-schema
+  functions classified by domain, visibility, auth requirement, parameters, return type,
+  and P95 latency targets (63 api_*, 7 admin_*, 10 metric_*, 7 trigger, 20 internal)
+- Cross-reference API_CONTRACTS.md and FRONTEND_API_MAP.md to conventions and registry
 
 ### CI/CD & Infrastructure
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -168,6 +168,7 @@ poland-food-db/
 ├── docs/
 │   ├── SCORING_METHODOLOGY.md       # v3.2 algorithm (9 factors, ceilings, bands)
 │   ├── API_CONTRACTS.md             # API surface contracts (6 endpoints) — response shapes, hidden columns
+│   ├── API_CONVENTIONS.md           # RPC naming convention, breaking change definition, security standards
 │   ├── API_VERSIONING.md            # API deprecation & versioning policy
 │   ├── ACCESS_AUDIT.md              # Data access pattern audit & quarterly review
 │   ├── BACKFILL_STANDARD.md         # Backfill orchestration standard & migration templates
@@ -206,7 +207,8 @@ poland-food-db/
 │   ├── STAGING_SETUP.md             # Staging environment setup
 │   ├── UX_IMPACT_METRICS.md         # UX measurement standard, metric catalog, SQL templates
 │   ├── UX_UI_DESIGN.md              # UI/UX guidelines
-│   └── VIEWING_AND_TESTING.md       # Queries, Studio UI, test runner
+│   ├── VIEWING_AND_TESTING.md       # Queries, Studio UI, test runner
+│   └── api-registry.yaml            # Structured registry of all 107 functions (YAML)
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
 ├── RUN_QA.ps1                       # QA test runner (429 checks across 30 suites)
 ├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (23 injection tests)

--- a/docs/API_CONTRACTS.md
+++ b/docs/API_CONTRACTS.md
@@ -2,7 +2,9 @@
 
 > **Version:** 1.0 · **Date:** 2026-02-13
 > **Stability:** Stable — these surfaces are safe for frontend consumption.
-> **Versioning & Deprecation:** See [docs/API_VERSIONING.md](API_VERSIONING.md) for breaking change protocol, sunset windows, and version strategy.
+> **Versioning & Deprecation:** See [API_VERSIONING.md](API_VERSIONING.md) for breaking change protocol, sunset windows, and version strategy.
+> **Naming Conventions:** See [API_CONVENTIONS.md](API_CONVENTIONS.md) for RPC naming patterns, parameter standards, and security requirements.
+> **Canonical Registry:** See [api-registry.yaml](api-registry.yaml) for structured, machine-readable registry of all 107 functions.
 
 ---
 

--- a/docs/API_CONVENTIONS.md
+++ b/docs/API_CONVENTIONS.md
@@ -1,0 +1,308 @@
+# API Conventions — RPC Naming & Contract Standards
+
+> **Last updated:** 2026-02-28
+> **Status:** Active — enforced for all new functions
+> **Related:** [API_CONTRACTS.md](API_CONTRACTS.md) · [FRONTEND_API_MAP.md](FRONTEND_API_MAP.md) · [api-registry.yaml](api-registry.yaml) · [API_VERSIONING.md](API_VERSIONING.md)
+
+---
+
+## 1. Naming Convention
+
+All public schema functions follow a strict naming pattern:
+
+```
+{visibility}_{domain}_{action}[_{version}]
+```
+
+### 1.1 Visibility Prefixes
+
+| Prefix        | Meaning                                    | Auth Requirement     | Example                          |
+| ------------- | ------------------------------------------ | -------------------- | -------------------------------- |
+| `api_`        | Public-facing, called by frontend          | `authenticated`      | `api_search_products`            |
+| `api_admin_`  | Admin-only, called by admin panel          | `authenticated` + admin check | `api_admin_get_submissions` |
+| `admin_`      | Admin/ops tooling (not exposed via PostgREST) | Direct DB access  | `admin_rescore_batch`            |
+| `metric_`     | Analytics/metrics aggregation              | Direct DB access     | `metric_dau`                     |
+| `trg_`        | Trigger functions (not callable directly)  | N/A (trigger-fired)  | `trg_set_updated_at`             |
+| _(none/internal)_ | Internal helpers, not exposed as RPC   | N/A                  | `compute_unhealthiness_v32`      |
+
+### 1.2 Domain Names
+
+| Domain         | Scope                                               | Examples                                                |
+| -------------- | --------------------------------------------------- | ------------------------------------------------------- |
+| `products`     | Product identity, detail, listing, alternatives      | `api_product_detail`, `api_better_alternatives`         |
+| `category`     | Category listing, overview, statistics               | `api_category_listing`, `api_category_overview`         |
+| `scoring`      | Score computation, explanation, history               | `api_score_explanation`, `api_score_history`             |
+| `search`       | Full-text search, autocomplete, filters               | `api_search_products`, `api_search_autocomplete`        |
+| `health`       | Health profiles, warnings, daily values               | `api_create_health_profile`, `api_product_health_warnings` |
+| `lists`        | User product lists (CRUD, sharing)                    | `api_create_list`, `api_get_lists`, `api_add_to_list`   |
+| `compare`      | Product comparisons                                   | `api_get_products_for_compare`, `api_save_comparison`   |
+| `scanner`      | Barcode scanning, scan history                        | `api_record_scan`, `api_get_scan_history`               |
+| `preferences`  | User preferences, onboarding                          | `api_get_user_preferences`, `api_complete_onboarding`   |
+| `submissions`  | User product submissions                              | `api_submit_product`, `api_get_my_submissions`          |
+| `telemetry`    | Event tracking, analytics                             | `api_track_event`, `api_admin_get_event_summary`        |
+| `dashboard`    | Dashboard data, recently viewed                       | `api_get_dashboard_data`, `api_get_recently_viewed`     |
+| `confidence`   | Data confidence scoring                               | `api_data_confidence`                                   |
+| `provenance`   | Data source tracking, cross-validation                | `admin_provenance_dashboard`                            |
+| `infrastructure` | MV refresh, staleness, search vectors               | `refresh_all_materialized_views`, `mv_staleness_check`  |
+| `flags`        | Feature flags, rollout                                | `admin_toggle_flag`, `expire_stale_flags`               |
+
+### 1.3 Action Naming
+
+Actions use descriptive verb-noun or verb patterns:
+
+| Pattern          | Usage                       | Examples                                        |
+| ---------------- | --------------------------- | ----------------------------------------------- |
+| `get_*`          | Retrieve single/list        | `api_get_lists`, `api_get_scan_history`          |
+| `create_*`       | Insert new record           | `api_create_list`, `api_create_health_profile`   |
+| `update_*`       | Modify existing record      | `api_update_list`, `api_update_health_profile`   |
+| `delete_*`       | Remove record               | `api_delete_list`, `api_delete_comparison`        |
+| `search_*`       | Full-text/fuzzy search      | `api_search_products`, `api_search_autocomplete` |
+| `record_*`       | Log an event/action         | `api_record_scan`, `api_record_product_view`     |
+| `toggle_*`       | Flip boolean state          | `api_toggle_share`, `admin_toggle_flag`          |
+| `compute_*`      | Calculate derived value     | `compute_unhealthiness_v32`, `compute_score`     |
+| `find_*`         | Discovery/similarity        | `find_better_alternatives`, `find_similar_products` |
+| `resolve_*`      | Multi-tier resolution       | `resolve_effective_country`, `resolve_language`   |
+
+### 1.4 Version Suffix
+
+Append `_v{N}` **only** when shipping a breaking change to an existing endpoint:
+
+```sql
+-- Original
+api_search_products(p_query text, ...)
+
+-- Breaking change (removed parameter) → new version
+api_search_products_v2(p_query text, ...)
+-- Keep api_search_products as deprecated alias
+```
+
+Do **not** use version suffixes for new endpoints or non-breaking changes.
+
+---
+
+## 2. Parameter Conventions
+
+### 2.1 Standard Prefixes
+
+| Prefix | Usage                    | Example                        |
+| ------ | ------------------------ | ------------------------------ |
+| `p_`   | Function parameters      | `p_product_id`, `p_query`      |
+| `v_`   | Local variables (plpgsql)| `v_total`, `v_rows`            |
+
+### 2.2 Common Parameters
+
+These parameters appear across multiple functions and must use consistent names:
+
+| Parameter              | Type      | Default | Description                    |
+| ---------------------- | --------- | ------- | ------------------------------ |
+| `p_product_id`         | `bigint`  | —       | Product identifier             |
+| `p_ean`                | `text`    | —       | EAN-13 barcode                 |
+| `p_category`           | `text`    | `NULL`  | Category filter                |
+| `p_country`            | `text`    | `NULL`  | Country code (auto-resolved)   |
+| `p_limit`              | `integer` | `20`    | Result page size               |
+| `p_offset`             | `integer` | `0`     | Result page offset             |
+| `p_query`              | `text`    | —       | Search query text              |
+| `p_sort_by`            | `text`    | `'score'` | Sort column key              |
+| `p_sort_dir`           | `text`    | `'asc'` | Sort direction (asc/desc)      |
+| `p_diet_preference`    | `text`    | `NULL`  | Diet filter                    |
+| `p_avoid_allergens`    | `text[]`  | `NULL`  | Allergen exclusion list        |
+| `p_strict_diet`        | `boolean` | `false` | Strict diet matching           |
+| `p_strict_allergen`    | `boolean` | `false` | Strict allergen matching       |
+| `p_treat_may_contain`  | `boolean` | `false` | Treat traces as contains       |
+
+### 2.3 Pagination Clamping
+
+All paginated functions must clamp:
+- `p_limit`: `LEAST(GREATEST(p_limit, 1), 100)` — range 1–100
+- `p_offset`: `GREATEST(p_offset, 0)` — non-negative
+
+### 2.4 Country Resolution
+
+Functions accepting `p_country` use `resolve_effective_country()` internally:
+1. If `p_country` is non-NULL → use it directly
+2. Else → look up `user_preferences.country` for `auth.uid()`
+3. If neither → return `NULL` (frontend must ensure onboarding is complete)
+
+---
+
+## 3. Return Value Conventions
+
+### 3.1 Standard JSONB Envelope
+
+All `api_*` functions return structured JSONB with:
+
+```jsonc
+{
+  "api_version": "1.0",
+  // ... endpoint-specific fields
+}
+```
+
+### 3.2 Error Handling (Auth-Required Functions)
+
+Functions requiring authentication return:
+
+```jsonc
+{
+  "api_version": "1.0",
+  "error": "Authentication required"
+}
+```
+
+When `auth.uid()` is `NULL`.
+
+### 3.3 Score Bands
+
+All score-related responses use consistent band labels:
+
+| Band         | Score Range | Key Value     |
+| ------------ | ----------- | ------------- |
+| Low risk     | 1–25        | `"low"`       |
+| Moderate     | 26–50       | `"moderate"`  |
+| High         | 51–75       | `"high"`      |
+| Very high    | 76–100      | `"very_high"` |
+
+### 3.4 Boolean Conversion
+
+Internal `'YES'`/`'NO'` text flags are always converted to proper JSON booleans in API responses.
+
+---
+
+## 4. Breaking Change Definition
+
+A change is **breaking** if it:
+
+1. **Removes or renames** a parameter
+2. **Changes** a parameter from optional to required
+3. **Removes** a key from the return JSONB
+4. **Changes** the data type of a returned key
+5. **Changes** auth requirements (anon → authenticated)
+6. **Narrows** valid input values (e.g., smaller enum set)
+
+A change is **non-breaking** (safe to ship without version bump):
+
+1. Adds a new **optional** parameter with a default value
+2. Adds a new **key** to the return JSONB
+3. **Relaxes** auth requirements (authenticated → anon)
+4. Improves performance or reduces latency
+5. Adds new enum values to an existing parameter
+6. Fixes a bug (response now matches documented contract)
+
+### 4.1 Breaking Change Protocol
+
+When a breaking change is necessary:
+
+1. Create a new version: `api_function_v2(...)` with the new signature
+2. Keep the old version as a deprecated alias (forward to v2 if possible)
+3. Add deprecation notice to `docs/API_VERSIONING.md`
+4. Set sunset window: minimum 2 releases or 30 days
+5. Update `api-registry.yaml` with `deprecated: true` on old version
+6. After sunset: remove old version in a new migration
+
+### 4.2 Breaking Change Detection
+
+Compare `docs/api-registry.yaml` between branches:
+- Parameter removed/renamed → breaking
+- Return key removed → breaking
+- Auth requirement changed → breaking
+- New optional parameter with default → non-breaking
+
+---
+
+## 5. Security Standards
+
+### 5.1 SECURITY DEFINER
+
+All `api_*` functions use `SECURITY DEFINER` with explicit `search_path`:
+
+```sql
+CREATE OR REPLACE FUNCTION public.api_example(...)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$ ... $function$;
+```
+
+### 5.2 Auth Checking
+
+Auth-required functions must check `auth.uid()` at the top:
+
+```sql
+IF auth.uid() IS NULL THEN
+    RETURN jsonb_build_object('api_version', '1.0', 'error', 'Authentication required');
+END IF;
+```
+
+### 5.3 Input Validation
+
+- Clamp numeric inputs (`p_limit`, `p_offset`) to safe ranges
+- Validate enum inputs (`p_sort_by`, `p_sort_dir`) with `CASE` fallbacks
+- Minimum length checks on search queries (typically 2 characters)
+
+---
+
+## 6. Documentation Requirements
+
+When adding a new function:
+
+1. Add entry to `docs/api-registry.yaml` (see registry format)
+2. If frontend-facing: add documentation to `docs/FRONTEND_API_MAP.md`
+3. If part of a contract: update `docs/API_CONTRACTS.md`
+4. Whitelist in `QA__security_posture.sql` check 9
+5. Add pgTAP test in `supabase/tests/`
+6. Update `copilot-instructions.md` Key Functions table if significant
+
+---
+
+## 7. Existing Naming Compliance Audit
+
+### 7.1 Compliant Functions (Follow Convention)
+
+All 64 `api_*` functions, 7 `admin_*` functions, 10 `metric_*` functions,
+and 7 `trg_*` functions follow the naming convention correctly.
+
+### 7.2 Legacy Internal Functions
+
+These internal functions predate the convention but are **not exposed as RPCs**,
+so renaming is unnecessary:
+
+| Function                        | Domain         | Notes                              |
+| ------------------------------- | -------------- | ---------------------------------- |
+| `compute_unhealthiness_v31`     | scoring        | Superseded by v32, kept for audit  |
+| `compute_unhealthiness_v32`     | scoring        | Active scoring function            |
+| `assign_confidence`             | confidence     | Called by `score_category()`       |
+| `find_better_alternatives`      | products       | Called by `api_better_alternatives` |
+| `find_similar_products`         | products       | Similarity engine                  |
+| `build_search_vector`           | search         | Trigger helper                     |
+| `expand_search_query`           | search         | Query expansion                    |
+| `search_rank`                   | search         | Ranking function                   |
+| `resolve_effective_country`     | preferences    | Country resolution                 |
+| `resolve_language`              | preferences    | Language resolution                |
+| `score_category` (PROCEDURE)    | scoring        | Batch scoring orchestrator         |
+| `compute_score`                 | scoring        | Config-driven scoring              |
+
+These are all internal helpers that follow implicit domain conventions.
+No renaming action needed — the `api_*` / `admin_*` / `metric_*` / `trg_*`
+prefix system provides sufficient clarity for the RPC surface.
+
+---
+
+## 8. Function Count Summary
+
+| Visibility     | Count | Description                              |
+| -------------- | ----: | ---------------------------------------- |
+| `api_*`        |    57 | Public frontend-facing (incl. `api_admin_*`) |
+| `api_admin_*`  |     7 | Admin panel (subset of `api_*`)          |
+| `admin_*`      |     7 | Ops tooling (not RPC-exposed)            |
+| `metric_*`     |    10 | Analytics aggregation                    |
+| `trg_*`        |     7 | Trigger functions                        |
+| _(internal)_   |    26 | Internal helpers, compute, resolve       |
+| **Total**      | **107** |                                        |
+
+---
+
+> **Canonical registry:** See [api-registry.yaml](api-registry.yaml) for the structured,
+> machine-readable registry of all 107 functions with parameters, return types,
+> auth requirements, domain classification, and performance targets.

--- a/docs/FRONTEND_API_MAP.md
+++ b/docs/FRONTEND_API_MAP.md
@@ -4,8 +4,15 @@
 > All functions are called via Supabase RPC: `supabase.rpc('function_name', { params })`.
 > All return `jsonb` with `api_version: '1.0'`.
 >
-> **Auth-only platform:** All 9 API functions require authentication.
-> Anonymous (unauthenticated) access is blocked for all endpoints.
+> **Auth-only platform:** All 9 core API functions require authentication.
+> Anonymous (unauthenticated) access is blocked for all endpoints except shared views.
+>
+> **Canonical registry:** See [api-registry.yaml](api-registry.yaml) for the structured,
+> machine-readable registry of all 107 functions with parameters, return types,
+> auth requirements, domain classification, and P95 targets.
+>
+> **Naming conventions:** See [API_CONVENTIONS.md](API_CONVENTIONS.md) for the RPC naming
+> convention, breaking change definition, and security standards.
 
 ---
 

--- a/docs/api-registry.yaml
+++ b/docs/api-registry.yaml
@@ -1,0 +1,1256 @@
+# API Registry — Poland Food DB
+#
+# Canonical registry of all 107 public-schema functions.
+# Last updated: 2026-02-28
+# Naming convention: docs/API_CONVENTIONS.md
+# Contract details: docs/API_CONTRACTS.md
+# Frontend mapping: docs/FRONTEND_API_MAP.md
+#
+# Structure per endpoint:
+#   domain:      Logical domain (products, scoring, search, etc.)
+#   visibility:  public | admin | metric | trigger | internal
+#   auth:        anon | authenticated | service_role | n/a
+#   params:      Parameter name → { type, required, default }
+#   returns:     Return type
+#   p95_target:  Latency target in ms (null = no SLA)
+#   deprecated:  true/false
+#   notes:       Additional context
+
+# ═══════════════════════════════════════════════════════════════════
+# PRODUCTS DOMAIN
+# ═══════════════════════════════════════════════════════════════════
+
+api_product_detail:
+  domain: products
+  visibility: public
+  auth: authenticated
+  params:
+    p_product_id: { type: bigint, required: true }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+  notes: >
+    Full product detail for Product Detail screen.
+    Returns identity, scores, flags, nutrition (per-100g + per-serving),
+    ingredients, allergens, and trust metadata.
+
+api_product_detail_by_ean:
+  domain: products
+  visibility: public
+  auth: authenticated
+  params:
+    p_ean: { type: text, required: true }
+    p_country: { type: text, required: false, default: "NULL" }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+  notes: Barcode scanner lookup. Uses resolve_effective_country() for p_country.
+
+api_better_alternatives:
+  domain: products
+  visibility: public
+  auth: authenticated
+  params:
+    p_product_id: { type: bigint, required: true }
+    p_same_category: { type: boolean, required: false, default: true }
+    p_limit: { type: integer, required: false, default: 5 }
+  returns: jsonb
+  p95_target: 200
+  deprecated: false
+  notes: >
+    Healthier substitutes ranked by score improvement and ingredient overlap.
+    Uses Jaccard similarity via find_better_alternatives().
+
+api_get_product_profile:
+  domain: products
+  visibility: public
+  auth: authenticated
+  params:
+    p_product_id: { type: bigint, required: true }
+    p_language: { type: text, required: false, default: "'en'" }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+  notes: Extended product profile with language support.
+
+api_get_product_profile_by_ean:
+  domain: products
+  visibility: public
+  auth: authenticated
+  params:
+    p_ean: { type: text, required: true }
+    p_language: { type: text, required: false, default: "'en'" }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+  notes: EAN-based product profile lookup.
+
+api_get_product_allergens:
+  domain: products
+  visibility: public
+  auth: anon
+  params:
+    p_product_ids: { type: "bigint[]", required: true }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+  notes: Batch allergen lookup for multiple products. Open to anon.
+
+api_get_ingredient_profile:
+  domain: products
+  visibility: public
+  auth: authenticated
+  params:
+    p_product_id: { type: bigint, required: true }
+    p_language: { type: text, required: false, default: "'en'" }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+  notes: Detailed ingredient breakdown for a product.
+
+api_product_health_warnings:
+  domain: products
+  visibility: public
+  auth: authenticated
+  params:
+    p_product_id: { type: bigint, required: true }
+    p_profile_id: { type: uuid, required: false, default: "NULL" }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+  notes: Health warnings based on user's active health profile.
+
+# ═══════════════════════════════════════════════════════════════════
+# CATEGORY DOMAIN
+# ═══════════════════════════════════════════════════════════════════
+
+api_category_overview:
+  domain: category
+  visibility: public
+  auth: authenticated
+  params:
+    p_country: { type: text, required: false, default: "NULL" }
+    p_language: { type: text, required: false, default: "'en'" }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+  notes: >
+    Dashboard — category statistics with product counts and score distribution.
+    Also available as v_api_category_overview view.
+
+api_category_listing:
+  domain: category
+  visibility: public
+  auth: authenticated
+  params:
+    p_category: { type: text, required: true }
+    p_sort_by: { type: text, required: false, default: "'score'" }
+    p_sort_dir: { type: text, required: false, default: "'asc'" }
+    p_limit: { type: integer, required: false, default: 20 }
+    p_offset: { type: integer, required: false, default: 0 }
+    p_country: { type: text, required: false, default: "NULL" }
+    p_diet_preference: { type: text, required: false, default: "NULL" }
+    p_avoid_allergens: { type: "text[]", required: false, default: "NULL" }
+    p_strict_diet: { type: boolean, required: false, default: false }
+    p_strict_allergen: { type: boolean, required: false, default: false }
+    p_treat_may_contain: { type: boolean, required: false, default: false }
+    p_language: { type: text, required: false, default: "'en'" }
+  returns: jsonb
+  p95_target: 150
+  deprecated: false
+  notes: Paged category listing with sort, diet, and allergen filters.
+
+# ═══════════════════════════════════════════════════════════════════
+# SCORING DOMAIN
+# ═══════════════════════════════════════════════════════════════════
+
+api_score_explanation:
+  domain: scoring
+  visibility: public
+  auth: authenticated
+  params:
+    p_product_id: { type: bigint, required: true }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+  notes: >
+    Score breakdown with 9 factors, human-readable headline,
+    contextual warnings, and category context (rank, avg, relative position).
+
+api_score_history:
+  domain: scoring
+  visibility: public
+  auth: authenticated
+  params:
+    p_product_id: { type: bigint, required: true }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+  notes: Historical score changes for a product.
+
+api_data_confidence:
+  domain: scoring
+  visibility: public
+  auth: authenticated
+  params:
+    p_product_id: { type: bigint, required: true }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+  notes: >
+    Composite data confidence score (0-100) with 6 components
+    (nutrition, ingredients, source, EAN, allergens, serving).
+
+# ═══════════════════════════════════════════════════════════════════
+# SEARCH DOMAIN
+# ═══════════════════════════════════════════════════════════════════
+
+api_search_products:
+  domain: search
+  visibility: public
+  auth: authenticated
+  params:
+    p_query: { type: text, required: true }
+    p_filters: { type: jsonb, required: false, default: "NULL" }
+    p_limit: { type: integer, required: false, default: 20 }
+    p_offset: { type: integer, required: false, default: 0 }
+    p_explain: { type: boolean, required: false, default: false }
+  returns: jsonb
+  p95_target: 150
+  deprecated: false
+  notes: >
+    Full-text + trigram search across products.
+    Uses pg_trgm GIN indexes. Min query length: 2 chars.
+    Limit clamped to 1-100.
+
+api_search_autocomplete:
+  domain: search
+  visibility: public
+  auth: authenticated
+  params:
+    p_query: { type: text, required: true }
+    p_limit: { type: integer, required: false, default: 8 }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+  notes: Fast typeahead suggestions for search input.
+
+api_get_filter_options:
+  domain: search
+  visibility: public
+  auth: authenticated
+  params:
+    p_country: { type: text, required: false, default: "NULL" }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+  notes: Available filter options (categories, brands, diet types) for search UI.
+
+api_save_search:
+  domain: search
+  visibility: public
+  auth: authenticated
+  params:
+    p_name: { type: text, required: true }
+    p_query: { type: text, required: true }
+    p_filters: { type: jsonb, required: false, default: "NULL" }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+  notes: Save a search query with filters for later recall.
+
+api_get_saved_searches:
+  domain: search
+  visibility: public
+  auth: authenticated
+  params: {}
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+  notes: List user's saved searches.
+
+api_delete_saved_search:
+  domain: search
+  visibility: public
+  auth: authenticated
+  params:
+    p_search_id: { type: uuid, required: true }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+  notes: Delete a saved search by ID.
+
+# ═══════════════════════════════════════════════════════════════════
+# HEALTH DOMAIN
+# ═══════════════════════════════════════════════════════════════════
+
+api_create_health_profile:
+  domain: health
+  visibility: public
+  auth: authenticated
+  params:
+    p_profile_name: { type: text, required: true }
+    p_conditions: { type: "text[]", required: false, default: "'{}'" }
+    p_is_active: { type: boolean, required: false, default: true }
+    p_max_sodium_mg: { type: numeric, required: false, default: "NULL" }
+    p_max_sugar_g: { type: numeric, required: false, default: "NULL" }
+    p_max_sat_fat_g: { type: numeric, required: false, default: "NULL" }
+    p_max_calories: { type: numeric, required: false, default: "NULL" }
+    p_notes: { type: text, required: false, default: "NULL" }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+
+api_update_health_profile:
+  domain: health
+  visibility: public
+  auth: authenticated
+  params:
+    p_profile_id: { type: uuid, required: true }
+    p_profile_name: { type: text, required: false }
+    p_conditions: { type: "text[]", required: false }
+    p_is_active: { type: boolean, required: false }
+    p_max_sodium_mg: { type: numeric, required: false }
+    p_max_sugar_g: { type: numeric, required: false }
+    p_max_sat_fat_g: { type: numeric, required: false }
+    p_max_calories: { type: numeric, required: false }
+    p_notes: { type: text, required: false }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+
+api_delete_health_profile:
+  domain: health
+  visibility: public
+  auth: authenticated
+  params:
+    p_profile_id: { type: uuid, required: true }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_get_active_health_profile:
+  domain: health
+  visibility: public
+  auth: authenticated
+  params: {}
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_list_health_profiles:
+  domain: health
+  visibility: public
+  auth: authenticated
+  params: {}
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+# ═══════════════════════════════════════════════════════════════════
+# LISTS DOMAIN
+# ═══════════════════════════════════════════════════════════════════
+
+api_create_list:
+  domain: lists
+  visibility: public
+  auth: authenticated
+  params:
+    p_name: { type: text, required: true }
+    p_description: { type: text, required: false, default: "NULL" }
+    p_icon: { type: text, required: false, default: "NULL" }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+
+api_update_list:
+  domain: lists
+  visibility: public
+  auth: authenticated
+  params:
+    p_list_id: { type: uuid, required: true }
+    p_name: { type: text, required: false }
+    p_description: { type: text, required: false }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+
+api_delete_list:
+  domain: lists
+  visibility: public
+  auth: authenticated
+  params:
+    p_list_id: { type: uuid, required: true }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_get_lists:
+  domain: lists
+  visibility: public
+  auth: authenticated
+  params: {}
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_get_list_items:
+  domain: lists
+  visibility: public
+  auth: authenticated
+  params:
+    p_list_id: { type: uuid, required: true }
+    p_limit: { type: integer, required: false, default: 50 }
+    p_offset: { type: integer, required: false, default: 0 }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+
+api_add_to_list:
+  domain: lists
+  visibility: public
+  auth: authenticated
+  params:
+    p_list_id: { type: uuid, required: true }
+    p_product_id: { type: bigint, required: true }
+    p_notes: { type: text, required: false, default: "NULL" }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+
+api_remove_from_list:
+  domain: lists
+  visibility: public
+  auth: authenticated
+  params:
+    p_list_id: { type: uuid, required: true }
+    p_product_id: { type: bigint, required: true }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_reorder_list:
+  domain: lists
+  visibility: public
+  auth: authenticated
+  params:
+    p_list_id: { type: uuid, required: true }
+    p_product_ids: { type: "bigint[]", required: true }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+
+api_toggle_share:
+  domain: lists
+  visibility: public
+  auth: authenticated
+  params:
+    p_list_id: { type: uuid, required: true }
+    p_is_public: { type: boolean, required: true }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_revoke_share:
+  domain: lists
+  visibility: public
+  auth: authenticated
+  params:
+    p_list_id: { type: uuid, required: true }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_get_shared_list:
+  domain: lists
+  visibility: public
+  auth: anon
+  params:
+    p_share_token: { type: text, required: true }
+    p_limit: { type: integer, required: false, default: 50 }
+    p_offset: { type: integer, required: false, default: 0 }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+  notes: Public access — no auth required for shared lists.
+
+api_get_product_list_membership:
+  domain: lists
+  visibility: public
+  auth: authenticated
+  params:
+    p_product_id: { type: bigint, required: true }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_get_favorite_product_ids:
+  domain: lists
+  visibility: public
+  auth: authenticated
+  params: {}
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_get_avoid_product_ids:
+  domain: lists
+  visibility: public
+  auth: authenticated
+  params: {}
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+# ═══════════════════════════════════════════════════════════════════
+# COMPARE DOMAIN
+# ═══════════════════════════════════════════════════════════════════
+
+api_get_products_for_compare:
+  domain: compare
+  visibility: public
+  auth: authenticated
+  params:
+    p_product_ids: { type: "bigint[]", required: true }
+  returns: jsonb
+  p95_target: 150
+  deprecated: false
+  notes: Returns comparison data for 2-4 products.
+
+api_save_comparison:
+  domain: compare
+  visibility: public
+  auth: authenticated
+  params:
+    p_product_ids: { type: "bigint[]", required: true }
+    p_title: { type: text, required: false, default: "NULL" }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+
+api_get_saved_comparisons:
+  domain: compare
+  visibility: public
+  auth: authenticated
+  params:
+    p_limit: { type: integer, required: false, default: 20 }
+    p_offset: { type: integer, required: false, default: 0 }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_delete_comparison:
+  domain: compare
+  visibility: public
+  auth: authenticated
+  params:
+    p_comparison_id: { type: uuid, required: true }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_get_shared_comparison:
+  domain: compare
+  visibility: public
+  auth: anon
+  params:
+    p_share_token: { type: text, required: true }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+  notes: Public access — no auth required for shared comparisons.
+
+# ═══════════════════════════════════════════════════════════════════
+# SCANNER DOMAIN
+# ═══════════════════════════════════════════════════════════════════
+
+api_record_scan:
+  domain: scanner
+  visibility: public
+  auth: authenticated
+  params:
+    p_ean: { type: text, required: true }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+  notes: Records a barcode scan and returns matched product (if any).
+
+api_get_scan_history:
+  domain: scanner
+  visibility: public
+  auth: authenticated
+  params:
+    p_limit: { type: integer, required: false, default: 20 }
+    p_offset: { type: integer, required: false, default: 0 }
+    p_sort: { type: text, required: false, default: "'recent'" }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+
+# ═══════════════════════════════════════════════════════════════════
+# PREFERENCES & ONBOARDING DOMAIN
+# ═══════════════════════════════════════════════════════════════════
+
+api_get_user_preferences:
+  domain: preferences
+  visibility: public
+  auth: authenticated
+  params: {}
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_set_user_preferences:
+  domain: preferences
+  visibility: public
+  auth: authenticated
+  params:
+    p_country: { type: text, required: false }
+    p_diet: { type: text, required: false }
+    p_allergens: { type: "text[]", required: false }
+    p_strict_diet: { type: boolean, required: false }
+    p_strict_allergen: { type: boolean, required: false }
+    p_treat_may_contain: { type: boolean, required: false }
+    p_language: { type: text, required: false }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+
+api_get_onboarding_status:
+  domain: preferences
+  visibility: public
+  auth: authenticated
+  params: {}
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_complete_onboarding:
+  domain: preferences
+  visibility: public
+  auth: authenticated
+  params:
+    p_data: { type: jsonb, required: true }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+
+api_skip_onboarding:
+  domain: preferences
+  visibility: public
+  auth: authenticated
+  params: {}
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+# ═══════════════════════════════════════════════════════════════════
+# SUBMISSIONS DOMAIN
+# ═══════════════════════════════════════════════════════════════════
+
+api_submit_product:
+  domain: submissions
+  visibility: public
+  auth: authenticated
+  params:
+    p_ean: { type: text, required: true }
+    p_product_name: { type: text, required: true }
+    p_brand: { type: text, required: false }
+    p_category: { type: text, required: false }
+    p_photo_url: { type: text, required: false }
+    p_notes: { type: text, required: false }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+
+api_get_my_submissions:
+  domain: submissions
+  visibility: public
+  auth: authenticated
+  params:
+    p_limit: { type: integer, required: false, default: 20 }
+    p_offset: { type: integer, required: false, default: 0 }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+# ═══════════════════════════════════════════════════════════════════
+# TELEMETRY & DASHBOARD DOMAIN
+# ═══════════════════════════════════════════════════════════════════
+
+api_track_event:
+  domain: telemetry
+  visibility: public
+  auth: authenticated
+  params:
+    p_event_name: { type: text, required: true }
+    p_properties: { type: jsonb, required: false, default: "NULL" }
+    p_page: { type: text, required: false, default: "NULL" }
+    p_component: { type: text, required: false, default: "NULL" }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_record_product_view:
+  domain: telemetry
+  visibility: public
+  auth: authenticated
+  params:
+    p_product_id: { type: bigint, required: true }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_get_recently_viewed:
+  domain: dashboard
+  visibility: public
+  auth: authenticated
+  params:
+    p_limit: { type: integer, required: false, default: 10 }
+  returns: jsonb
+  p95_target: 50
+  deprecated: false
+
+api_get_dashboard_data:
+  domain: dashboard
+  visibility: public
+  auth: authenticated
+  params: {}
+  returns: jsonb
+  p95_target: 200
+  deprecated: false
+  notes: Aggregated dashboard data including recent activity and recommendations.
+
+api_dashboard_insights:
+  domain: dashboard
+  visibility: public
+  auth: authenticated
+  params: {}
+  returns: jsonb
+  p95_target: 200
+  deprecated: false
+  notes: Dashboard insights and trends.
+
+# ═══════════════════════════════════════════════════════════════════
+# USER DATA DOMAIN
+# ═══════════════════════════════════════════════════════════════════
+
+api_delete_user_data:
+  domain: preferences
+  visibility: public
+  auth: authenticated
+  params: {}
+  returns: jsonb
+  p95_target: 500
+  deprecated: false
+  notes: GDPR Art. 17 — right to erasure. Deletes all user data.
+
+# ═══════════════════════════════════════════════════════════════════
+# ADMIN — TELEMETRY
+# ═══════════════════════════════════════════════════════════════════
+
+api_admin_get_event_summary:
+  domain: telemetry
+  visibility: admin
+  auth: authenticated
+  params:
+    p_period: { type: text, required: false, default: "'7d'" }
+    p_limit: { type: integer, required: false, default: 50 }
+    p_group_by: { type: text, required: false, default: "'event'" }
+  returns: jsonb
+  p95_target: 200
+  deprecated: false
+
+api_admin_get_top_events:
+  domain: telemetry
+  visibility: admin
+  auth: authenticated
+  params:
+    p_days: { type: integer, required: false, default: 7 }
+    p_limit: { type: integer, required: false, default: 20 }
+  returns: jsonb
+  p95_target: 200
+  deprecated: false
+
+api_admin_get_funnel:
+  domain: telemetry
+  visibility: admin
+  auth: authenticated
+  params:
+    p_steps: { type: "text[]", required: true }
+    p_days: { type: integer, required: false, default: 30 }
+  returns: jsonb
+  p95_target: 500
+  deprecated: false
+
+api_admin_get_business_metrics:
+  domain: telemetry
+  visibility: admin
+  auth: authenticated
+  params:
+    p_since: { type: date, required: false }
+    p_days: { type: integer, required: false, default: 30 }
+  returns: jsonb
+  p95_target: 500
+  deprecated: false
+
+# ═══════════════════════════════════════════════════════════════════
+# ADMIN — SUBMISSIONS
+# ═══════════════════════════════════════════════════════════════════
+
+api_admin_get_submissions:
+  domain: submissions
+  visibility: admin
+  auth: service_role
+  params:
+    p_status: { type: text, required: false, default: "'pending'" }
+    p_limit: { type: integer, required: false, default: 20 }
+    p_offset: { type: integer, required: false, default: 0 }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+
+api_admin_review_submission:
+  domain: submissions
+  visibility: admin
+  auth: service_role
+  params:
+    p_submission_id: { type: uuid, required: true }
+    p_decision: { type: text, required: true }
+    p_product_id: { type: bigint, required: false, default: "NULL" }
+  returns: jsonb
+  p95_target: 100
+  deprecated: false
+  notes: "Decision must be 'approved' or 'rejected'."
+
+# ═══════════════════════════════════════════════════════════════════
+# ADMIN — OPS TOOLING (not exposed via PostgREST)
+# ═══════════════════════════════════════════════════════════════════
+
+admin_activate_scoring_version:
+  domain: scoring
+  visibility: admin
+  auth: direct_db
+  returns: void
+  p95_target: null
+  deprecated: false
+  notes: Activate a scoring version for rollout.
+
+admin_flag_overview:
+  domain: flags
+  visibility: admin
+  auth: direct_db
+  returns: jsonb
+  p95_target: null
+  deprecated: false
+
+admin_rescore_batch:
+  domain: scoring
+  visibility: admin
+  auth: direct_db
+  returns: void
+  p95_target: null
+  deprecated: false
+  notes: Re-score a batch of products using current scoring config.
+
+admin_score_drift_report:
+  domain: scoring
+  visibility: admin
+  auth: direct_db
+  returns: jsonb
+  p95_target: null
+  deprecated: false
+
+admin_scoring_versions:
+  domain: scoring
+  visibility: admin
+  auth: direct_db
+  returns: jsonb
+  p95_target: null
+  deprecated: false
+
+admin_set_rollout:
+  domain: flags
+  visibility: admin
+  auth: direct_db
+  returns: void
+  p95_target: null
+  deprecated: false
+
+admin_toggle_flag:
+  domain: flags
+  visibility: admin
+  auth: direct_db
+  returns: void
+  p95_target: null
+  deprecated: false
+
+# ═══════════════════════════════════════════════════════════════════
+# METRIC FUNCTIONS (direct DB access — analytics queries)
+# ═══════════════════════════════════════════════════════════════════
+
+metric_allergen_distribution:
+  domain: metrics
+  visibility: metric
+  auth: direct_db
+  returns: table
+  p95_target: null
+  deprecated: false
+
+metric_category_popularity:
+  domain: metrics
+  visibility: metric
+  auth: direct_db
+  returns: table
+  p95_target: null
+  deprecated: false
+
+metric_dau:
+  domain: metrics
+  visibility: metric
+  auth: direct_db
+  returns: numeric
+  p95_target: null
+  deprecated: false
+
+metric_failed_searches:
+  domain: metrics
+  visibility: metric
+  auth: direct_db
+  returns: table
+  p95_target: null
+  deprecated: false
+
+metric_feature_usage:
+  domain: metrics
+  visibility: metric
+  auth: direct_db
+  returns: table
+  p95_target: null
+  deprecated: false
+
+metric_onboarding_funnel:
+  domain: metrics
+  visibility: metric
+  auth: direct_db
+  returns: table
+  p95_target: null
+  deprecated: false
+
+metric_scan_vs_search:
+  domain: metrics
+  visibility: metric
+  auth: direct_db
+  returns: table
+  p95_target: null
+  deprecated: false
+
+metric_searches_per_day:
+  domain: metrics
+  visibility: metric
+  auth: direct_db
+  returns: table
+  p95_target: null
+  deprecated: false
+
+metric_top_products:
+  domain: metrics
+  visibility: metric
+  auth: direct_db
+  returns: table
+  p95_target: null
+  deprecated: false
+
+metric_top_queries:
+  domain: metrics
+  visibility: metric
+  auth: direct_db
+  returns: table
+  p95_target: null
+  deprecated: false
+
+# ═══════════════════════════════════════════════════════════════════
+# INTERNAL HELPERS (not exposed as RPC)
+# ═══════════════════════════════════════════════════════════════════
+
+_compute_from_config:
+  domain: scoring
+  visibility: internal
+  auth: n/a
+  returns: numeric
+  deprecated: false
+  notes: Config-driven scoring helper.
+
+_explain_from_config:
+  domain: scoring
+  visibility: internal
+  auth: n/a
+  returns: jsonb
+  deprecated: false
+  notes: Config-driven score explanation helper.
+
+aggregate_daily_metrics:
+  domain: metrics
+  visibility: internal
+  auth: n/a
+  returns: void
+  deprecated: false
+  notes: Aggregates daily metrics into summary table.
+
+assign_confidence:
+  domain: scoring
+  visibility: internal
+  auth: n/a
+  params:
+    p_data_completeness_pct: { type: numeric, required: true }
+    p_source_type: { type: text, required: true }
+  returns: text
+  deprecated: false
+  notes: "Returns 'verified'/'estimated'/'low' from data completeness."
+
+build_search_vector:
+  domain: search
+  visibility: internal
+  auth: n/a
+  returns: tsvector
+  deprecated: false
+  notes: Builds tsvector for product search indexing.
+
+capture_score_distribution:
+  domain: scoring
+  visibility: internal
+  auth: n/a
+  returns: void
+  deprecated: false
+
+check_product_preferences:
+  domain: preferences
+  visibility: internal
+  auth: n/a
+  returns: jsonb
+  deprecated: false
+  notes: Checks product against user preference/allergen filters.
+
+compute_daily_value_pct:
+  domain: health
+  visibility: internal
+  auth: n/a
+  returns: numeric
+  deprecated: false
+
+compute_health_warnings:
+  domain: health
+  visibility: internal
+  auth: n/a
+  returns: jsonb
+  deprecated: false
+
+compute_score:
+  domain: scoring
+  visibility: internal
+  auth: n/a
+  returns: integer
+  deprecated: false
+  notes: Config-driven scoring function.
+
+compute_unhealthiness_v31:
+  domain: scoring
+  visibility: internal
+  auth: n/a
+  returns: integer
+  deprecated: true
+  notes: Legacy v3.1 scoring — superseded by v3.2. Kept for audit trail.
+
+compute_unhealthiness_v32:
+  domain: scoring
+  visibility: internal
+  auth: n/a
+  returns: integer
+  deprecated: false
+  notes: Active v3.2 scoring — 9-factor weighted formula.
+
+compute_data_confidence:
+  domain: scoring
+  visibility: internal
+  auth: n/a
+  params:
+    p_product_id: { type: bigint, required: true }
+  returns: jsonb
+  deprecated: false
+  notes: "Composite confidence score (0-100). Called by api_data_confidence()."
+
+detect_score_drift:
+  domain: scoring
+  visibility: internal
+  auth: n/a
+  returns: table
+  deprecated: false
+
+expand_search_query:
+  domain: search
+  visibility: internal
+  auth: n/a
+  returns: text
+  deprecated: false
+
+expire_stale_flags:
+  domain: flags
+  visibility: internal
+  auth: n/a
+  returns: void
+  deprecated: false
+
+find_better_alternatives:
+  domain: products
+  visibility: internal
+  auth: n/a
+  params:
+    p_product_id: { type: bigint, required: true }
+    p_same_category: { type: boolean, required: false, default: true }
+    p_limit: { type: integer, required: false, default: 5 }
+  returns: table
+  deprecated: false
+  notes: Called by api_better_alternatives(). Jaccard similarity.
+
+find_similar_products:
+  domain: products
+  visibility: internal
+  auth: n/a
+  params:
+    p_product_id: { type: bigint, required: true }
+    p_limit: { type: integer, required: false, default: 5 }
+  returns: table
+  deprecated: false
+
+flag_health_report:
+  domain: health
+  visibility: internal
+  auth: n/a
+  returns: jsonb
+  deprecated: false
+
+mv_staleness_check:
+  domain: infrastructure
+  visibility: internal
+  auth: n/a
+  returns: jsonb
+  deprecated: false
+  notes: Checks if materialized views are stale.
+
+refresh_all_materialized_views:
+  domain: infrastructure
+  visibility: internal
+  auth: n/a
+  returns: jsonb
+  deprecated: false
+  notes: Refreshes all MVs concurrently with timing report.
+
+rescore_batch:
+  domain: scoring
+  visibility: internal
+  auth: n/a
+  returns: void
+  deprecated: false
+
+resolve_effective_country:
+  domain: preferences
+  visibility: internal
+  auth: n/a
+  returns: text
+  deprecated: false
+  notes: "2-tier resolution: explicit param → user_preferences.country."
+
+resolve_language:
+  domain: preferences
+  visibility: internal
+  auth: n/a
+  returns: text
+  deprecated: false
+  notes: "Language resolution with fallback to 'en'."
+
+score_category:
+  domain: scoring
+  visibility: internal
+  auth: n/a
+  returns: void
+  deprecated: false
+  notes: >
+    PROCEDURE. Batch scoring orchestrator — Steps 0/1/4/5
+    (concern defaults, unhealthiness, flags + completeness, confidence).
+
+search_quality_report:
+  domain: search
+  visibility: internal
+  auth: n/a
+  returns: jsonb
+  deprecated: false
+
+search_rank:
+  domain: search
+  visibility: internal
+  auth: n/a
+  returns: numeric
+  deprecated: false
+
+validate_country_profile:
+  domain: preferences
+  visibility: internal
+  auth: n/a
+  returns: boolean
+  deprecated: false
+
+# ═══════════════════════════════════════════════════════════════════
+# TRIGGER FUNCTIONS
+# ═══════════════════════════════════════════════════════════════════
+
+trg_create_default_lists:
+  domain: lists
+  visibility: trigger
+  auth: n/a
+  returns: trigger
+  deprecated: false
+  notes: Creates Favorites + Avoid lists for new users.
+
+trg_flag_audit:
+  domain: flags
+  visibility: trigger
+  auth: n/a
+  returns: trigger
+  deprecated: false
+
+trg_limit_comparisons:
+  domain: compare
+  visibility: trigger
+  auth: n/a
+  returns: trigger
+  deprecated: false
+  notes: Enforces max comparison count per user.
+
+trg_products_search_vector:
+  domain: search
+  visibility: trigger
+  auth: n/a
+  returns: trigger
+  deprecated: false
+  notes: Updates search_vector on product INSERT/UPDATE.
+
+trg_score_audit:
+  domain: scoring
+  visibility: trigger
+  auth: n/a
+  returns: trigger
+  deprecated: false
+
+trg_set_updated_at:
+  domain: infrastructure
+  visibility: trigger
+  auth: n/a
+  returns: trigger
+  deprecated: false
+
+trg_update_list_timestamp:
+  domain: lists
+  visibility: trigger
+  auth: n/a
+  returns: trigger
+  deprecated: false


### PR DESCRIPTION
Closes #197 — API Contract Registry and RPC Naming Conventions.

Deliverables:
- docs/API_CONVENTIONS.md: RPC naming convention with visibility prefix system (api/admin/metric/trg/internal), 16 domain classifications, parameter conventions, breaking change definition (6 breaking + 6 non-breaking rules), breaking change protocol, and naming compliance audit
- docs/api-registry.yaml: Structured registry of all 107 public-schema functions with domain, visibility, auth, params, return type, P95 targets (63 api_*, 7 admin_*, 10 metric_*, 7 trigger, 20 internal)
- Updated API_CONTRACTS.md and FRONTEND_API_MAP.md with cross-references to conventions and registry
- Updated copilot-instructions.md with new doc references
- CHANGELOG.md updated