### PR TITLE
schema(scoring): add unified formula registry, drift detection, and weight governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Schema & Migrations
 
+- Add unified formula registry: `v_formula_registry` view, `formula_source_hashes` table,
+  fingerprint columns on `scoring_model_versions` and `search_ranking_config`, auto-fingerprint
+  triggers, `check_formula_drift()` and `check_function_source_drift()` sentinel functions (#198)
+
 ### Scoring & Methodology
 
 ### Data & Pipeline
@@ -29,7 +33,15 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Testing & QA
 
+- Extend `QA__scoring_engine.sql` from 17 to 25 checks: add T18-T25 for formula registry view,
+  active scoring/search formulas, fingerprint population, drift detection, source hash verification,
+  and auto-fingerprint trigger validation (#198)
+
 ### Documentation
+
+- Add formula registry governance to `docs/SCORING_ENGINE.md`: unified registry view documentation,
+  fingerprint-based drift detection guide, 7-step weight change protocol, weight change checklist
+  template, and registered function source hashes reference (#198)
 
 - Add incident response playbook (`docs/INCIDENT_RESPONSE.md`) with severity definitions (SEV-1–4),
   escalation ladder, communication templates, blameless post-mortem format, 6 scenario-specific

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -349,6 +349,8 @@ poland-food-db/
 | `api_search_products()`            | Full-text + trigram search across product_name and brand; uses pg_trgm GIN indexes                                                                        |
 | `refresh_all_materialized_views()` | Refreshes all MVs concurrently; returns timing report JSONB                                                                                               |
 | `mv_staleness_check()`             | Checks if MVs are stale by comparing row counts to source tables                                                                                          |
+| `check_formula_drift()`            | Compares stored SHA-256 fingerprints against recomputed hashes for active scoring/search formulas                                                         |
+| `check_function_source_drift()`    | Compares registered pg_proc source hashes against actual function bodies for critical functions                                                            |
 
 ### Views
 
@@ -357,6 +359,8 @@ poland-food-db/
 **`v_api_category_overview`** — Dashboard-ready category statistics. One row per active category (20 total). Includes product_count, avg/min/max/median score, pct_nutri_a_b, pct_nova_4, display metadata from category_ref.
 
 **`v_product_confidence`** — Materialized view of data confidence scores for all active products. Columns: product_id, product_name, brand, category, nutrition_pts(0-30), ingredient_pts(0-25), source_pts(0-20), ean_pts(0-10), allergen_pts(0-10), serving_pts(0-5), confidence_score(0-100), confidence_band(high/medium/low). Unique index on product_id.
+
+**`v_formula_registry`** — Unified view across `scoring_model_versions` and `search_ranking_config`. Columns: domain, version, formula_name, status, weights_config (JSONB), fingerprint (SHA-256), change_reason, is_active. Both scoring and search formulas in one query surface.
 
 ---
 

--- a/db/qa/QA__security_posture.sql
+++ b/db/qa/QA__security_posture.sql
@@ -142,7 +142,8 @@ WHERE n.nspname = 'public'
     'assign_confidence','find_similar_products','find_better_alternatives',
     'refresh_all_materialized_views','mv_staleness_check',
     'check_product_preferences','resolve_effective_country',
-    'compute_health_warnings'
+    'compute_health_warnings',
+    'check_formula_drift','check_function_source_drift'
   )
   AND has_function_privilege('anon', p.oid, 'EXECUTE');
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,7 +31,7 @@
 | [GOVERNANCE_BLUEPRINT.md](GOVERNANCE_BLUEPRINT.md) | Execution governance blueprint — master plan for all GOV-* issues | [#195](https://github.com/ericsocrat/poland-food-db/issues/195) | 2026-02-24 |
 | [DOMAIN_BOUNDARIES.md](DOMAIN_BOUNDARIES.md) | Domain boundary enforcement, 13 domains, ownership mapping, interface contracts | [#196](https://github.com/ericsocrat/poland-food-db/issues/196) | 2026-02-24 |
 | [FEATURE_FLAGS.md](FEATURE_FLAGS.md) | Feature flag architecture — toggle registry, rollout strategy | [#191](https://github.com/ericsocrat/poland-food-db/issues/191) | 2026-02-24 |
-| [SCORING_ENGINE.md](SCORING_ENGINE.md) | Scoring engine architecture — versioned function design, regression anchor products | [#189](https://github.com/ericsocrat/poland-food-db/issues/189) | 2026-02-24 |
+| [SCORING_ENGINE.md](SCORING_ENGINE.md) | Scoring engine architecture — versioned function design, formula registry, weight governance, drift detection | [#189](https://github.com/ericsocrat/poland-food-db/issues/189), [#198](https://github.com/ericsocrat/poland-food-db/issues/198) | 2026-02-28 |
 | [SEARCH_ARCHITECTURE.md](SEARCH_ARCHITECTURE.md) | Search architecture — pg_trgm, tsvector, ranking, synonym management | [#192](https://github.com/ericsocrat/poland-food-db/issues/192) | 2026-02-24 |
 | [CI_ARCHITECTURE_PROPOSAL.md](CI_ARCHITECTURE_PROPOSAL.md) | CI pipeline design proposal | — | 2026-02-23 |
 

--- a/docs/api-registry.yaml
+++ b/docs/api-registry.yaml
@@ -1086,6 +1086,22 @@ detect_score_drift:
   returns: table
   deprecated: false
 
+check_formula_drift:
+  domain: scoring
+  visibility: internal
+  auth: authenticated, service_role
+  returns: table(domain, formula_name, version, registered_fp, recomputed_fp, status)
+  deprecated: false
+  notes: "Compares stored SHA-256 fingerprints against recomputed hashes for active scoring/search formulas. Returns 'match' or 'drift_detected'. Issue #198."
+
+check_function_source_drift:
+  domain: scoring
+  visibility: internal
+  auth: authenticated, service_role
+  returns: table(function_name, expected_hash, actual_hash, status)
+  deprecated: false
+  notes: "Compares registered pg_proc source hashes against actual function bodies for critical functions. Issue #198."
+
 expand_search_query:
   domain: search
   visibility: internal

--- a/supabase/migrations/20260228000000_formula_registry.sql
+++ b/supabase/migrations/20260228000000_formula_registry.sql
@@ -1,0 +1,354 @@
+-- ══════════════════════════════════════════════════════════════════════════
+-- Migration: Unified Formula Registry & Drift Detection
+-- Issue:     #198 — Scoring & Search Formula Registry (GOV-A3)
+-- ══════════════════════════════════════════════════════════════════════════
+--
+-- Extends the existing scoring_model_versions and search_ranking_config
+-- tables with fingerprint-based drift detection, then unifies them under
+-- a single v_formula_registry view.
+--
+-- Deliverables:
+--   1. weights_fingerprint column on both tables (auto-computed SHA-256)
+--   2. version column on search_ranking_config for uniform versioning
+--   3. Auto-fingerprint trigger (recomputes on INSERT/UPDATE)
+--   4. v_formula_registry — unified view across scoring + search
+--   5. check_formula_drift() — sentinel function for CI/QA
+--   6. check_function_source_drift() — pg_proc source hash comparison
+--
+-- Rollback:
+--   DROP VIEW IF EXISTS v_formula_registry;
+--   DROP FUNCTION IF EXISTS check_formula_drift();
+--   DROP FUNCTION IF EXISTS check_function_source_drift();
+--   DROP FUNCTION IF EXISTS trg_auto_fingerprint();
+--   DROP TRIGGER IF EXISTS auto_fingerprint_smv ON scoring_model_versions;
+--   DROP TRIGGER IF EXISTS auto_fingerprint_src ON search_ranking_config;
+--   ALTER TABLE scoring_model_versions DROP COLUMN IF EXISTS weights_fingerprint;
+--   ALTER TABLE search_ranking_config DROP COLUMN IF EXISTS weights_fingerprint;
+--   ALTER TABLE search_ranking_config DROP COLUMN IF EXISTS version;
+--   ALTER TABLE search_ranking_config DROP COLUMN IF EXISTS change_reason;
+--   DROP TABLE IF EXISTS formula_source_hashes;
+-- ══════════════════════════════════════════════════════════════════════════
+
+BEGIN;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 1. Add fingerprint column to scoring_model_versions
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+ALTER TABLE public.scoring_model_versions
+    ADD COLUMN IF NOT EXISTS weights_fingerprint text;
+
+COMMENT ON COLUMN public.scoring_model_versions.weights_fingerprint
+    IS 'SHA-256 of config JSONB for drift detection. Auto-computed on INSERT/UPDATE.';
+
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 2. Add fingerprint, version, and change_reason to search_ranking_config
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+ALTER TABLE public.search_ranking_config
+    ADD COLUMN IF NOT EXISTS weights_fingerprint text,
+    ADD COLUMN IF NOT EXISTS version text,
+    ADD COLUMN IF NOT EXISTS change_reason text;
+
+COMMENT ON COLUMN public.search_ranking_config.weights_fingerprint
+    IS 'SHA-256 of weights JSONB for drift detection. Auto-computed on INSERT/UPDATE.';
+COMMENT ON COLUMN public.search_ranking_config.version
+    IS 'Semantic version string (e.g. v1.0.0) for registry uniformity.';
+COMMENT ON COLUMN public.search_ranking_config.change_reason
+    IS 'Why this config version was created.';
+
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 3. Backfill fingerprints for existing rows
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+-- Scoring: fingerprint the full config JSONB
+UPDATE public.scoring_model_versions
+SET    weights_fingerprint = encode(sha256(config::text::bytea), 'hex')
+WHERE  weights_fingerprint IS NULL;
+
+-- Search: fingerprint the weights JSONB + backfill version
+UPDATE public.search_ranking_config
+SET    weights_fingerprint = encode(sha256(weights::text::bytea), 'hex'),
+       version = COALESCE(version, 'v1.0.0'),
+       change_reason = COALESCE(change_reason, 'Initial registration')
+WHERE  weights_fingerprint IS NULL;
+
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 4. Auto-fingerprint triggers
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+-- Generic trigger function for scoring_model_versions
+CREATE OR REPLACE FUNCTION public.trg_auto_fingerprint_smv()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $fn$
+BEGIN
+    NEW.weights_fingerprint := encode(sha256(NEW.config::text::bytea), 'hex');
+    RETURN NEW;
+END;
+$fn$;
+
+-- Trigger on scoring_model_versions
+DROP TRIGGER IF EXISTS auto_fingerprint_smv ON public.scoring_model_versions;
+CREATE TRIGGER auto_fingerprint_smv
+    BEFORE INSERT OR UPDATE OF config ON public.scoring_model_versions
+    FOR EACH ROW
+    EXECUTE FUNCTION trg_auto_fingerprint_smv();
+
+-- Generic trigger function for search_ranking_config
+CREATE OR REPLACE FUNCTION public.trg_auto_fingerprint_src()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $fn$
+BEGIN
+    NEW.weights_fingerprint := encode(sha256(NEW.weights::text::bytea), 'hex');
+    RETURN NEW;
+END;
+$fn$;
+
+-- Trigger on search_ranking_config
+DROP TRIGGER IF EXISTS auto_fingerprint_src ON public.search_ranking_config;
+CREATE TRIGGER auto_fingerprint_src
+    BEFORE INSERT OR UPDATE OF weights ON public.search_ranking_config
+    FOR EACH ROW
+    EXECUTE FUNCTION trg_auto_fingerprint_src();
+
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 5. Unified formula registry view
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE VIEW public.v_formula_registry AS
+
+-- Scoring formulas
+SELECT
+    'scoring'::text                    AS domain,
+    smv.version                        AS version,
+    'compute_unhealthiness'::text      AS formula_name,
+    smv.status                         AS status,
+    smv.config                         AS weights_config,
+    smv.weights_fingerprint            AS fingerprint,
+    smv.description                    AS change_reason,
+    smv.created_by                     AS created_by,
+    smv.activated_at                   AS activated_at,
+    smv.created_at                     AS created_at,
+    (smv.status = 'active')            AS is_active
+FROM public.scoring_model_versions smv
+
+UNION ALL
+
+-- Search ranking formulas
+SELECT
+    'search'::text                     AS domain,
+    src.version                        AS version,
+    src.config_name                    AS formula_name,
+    CASE WHEN src.active THEN 'active' ELSE 'inactive' END AS status,
+    src.weights                        AS weights_config,
+    src.weights_fingerprint            AS fingerprint,
+    COALESCE(src.change_reason, src.description) AS change_reason,
+    'system'::text                     AS created_by,
+    CASE WHEN src.active THEN src.updated_at END AS activated_at,
+    src.created_at                     AS created_at,
+    src.active                         AS is_active
+FROM public.search_ranking_config src;
+
+COMMENT ON VIEW public.v_formula_registry IS
+    'Unified read-only registry of all scoring and search formulas with version, '
+    'fingerprint, and activation status. Source: scoring_model_versions + search_ranking_config.';
+
+GRANT SELECT ON public.v_formula_registry TO authenticated, anon, service_role;
+
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 6. Formula source hash registry
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+-- Stores the expected pg_proc source hash for each critical function.
+-- check_function_source_drift() compares against actual pg_proc.
+
+CREATE TABLE IF NOT EXISTS public.formula_source_hashes (
+    id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    function_name   text   NOT NULL UNIQUE,
+    expected_hash   text   NOT NULL,
+    description     text,
+    registered_at   timestamptz NOT NULL DEFAULT now(),
+    updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.formula_source_hashes IS
+    'Expected pg_proc source hashes for critical scoring/search functions. '
+    'Used by check_function_source_drift() to detect unregistered code changes.';
+
+ALTER TABLE public.formula_source_hashes ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE tablename = 'formula_source_hashes'
+          AND policyname = 'fsh_read_all'
+    ) THEN
+        CREATE POLICY "fsh_read_all"
+            ON public.formula_source_hashes FOR SELECT
+            USING (true);
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE tablename = 'formula_source_hashes'
+          AND policyname = 'fsh_write_service'
+    ) THEN
+        CREATE POLICY "fsh_write_service"
+            ON public.formula_source_hashes FOR ALL
+            TO service_role
+            USING (true)
+            WITH CHECK (true);
+    END IF;
+END $$;
+
+GRANT SELECT ON public.formula_source_hashes TO authenticated, anon, service_role;
+
+-- Seed current function source hashes
+INSERT INTO public.formula_source_hashes (function_name, expected_hash, description)
+SELECT
+    p.proname::text,
+    encode(sha256(p.prosrc::bytea), 'hex'),
+    'Auto-registered during formula_registry migration'
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+  AND p.proname IN (
+      'compute_unhealthiness_v32',
+      'explain_score_v32',
+      'compute_score',
+      '_compute_from_config',
+      '_explain_from_config',
+      'search_rank'
+  )
+ON CONFLICT (function_name) DO UPDATE
+SET expected_hash = EXCLUDED.expected_hash,
+    updated_at    = now();
+
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 7. check_formula_drift() — JSONB fingerprint drift detection
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION public.check_formula_drift()
+RETURNS TABLE(
+    domain          text,
+    formula_name    text,
+    version         text,
+    registered_fp   text,
+    recomputed_fp   text,
+    status          text    -- 'match' | 'drift_detected' | 'no_fingerprint'
+)
+LANGUAGE plpgsql STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+BEGIN
+    RETURN QUERY
+
+    -- Check scoring formulas
+    SELECT
+        'scoring'::text           AS domain,
+        'compute_unhealthiness'   AS formula_name,
+        smv.version               AS version,
+        smv.weights_fingerprint   AS registered_fp,
+        encode(sha256(smv.config::text::bytea), 'hex') AS recomputed_fp,
+        CASE
+            WHEN smv.weights_fingerprint IS NULL THEN 'no_fingerprint'
+            WHEN smv.weights_fingerprint = encode(sha256(smv.config::text::bytea), 'hex')
+                THEN 'match'
+            ELSE 'drift_detected'
+        END                       AS status
+    FROM scoring_model_versions smv
+    WHERE smv.status = 'active'
+
+    UNION ALL
+
+    -- Check search formulas
+    SELECT
+        'search'::text            AS domain,
+        src.config_name           AS formula_name,
+        src.version               AS version,
+        src.weights_fingerprint   AS registered_fp,
+        encode(sha256(src.weights::text::bytea), 'hex') AS recomputed_fp,
+        CASE
+            WHEN src.weights_fingerprint IS NULL THEN 'no_fingerprint'
+            WHEN src.weights_fingerprint = encode(sha256(src.weights::text::bytea), 'hex')
+                THEN 'match'
+            ELSE 'drift_detected'
+        END                       AS status
+    FROM search_ranking_config src
+    WHERE src.active = true;
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.check_formula_drift() IS
+    'Returns drift status for all active scoring and search formulas by comparing '
+    'stored fingerprints against recomputed SHA-256 of current JSONB config.';
+
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 8. check_function_source_drift() — pg_proc source hash comparison
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION public.check_function_source_drift()
+RETURNS TABLE(
+    function_name    text,
+    expected_hash    text,
+    actual_hash      text,
+    status           text    -- 'match' | 'drift_detected' | 'function_missing'
+)
+LANGUAGE plpgsql STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+BEGIN
+    RETURN QUERY
+    SELECT
+        fsh.function_name,
+        fsh.expected_hash,
+        COALESCE(encode(sha256(p.prosrc::bytea), 'hex'), 'MISSING') AS actual_hash,
+        CASE
+            WHEN p.prosrc IS NULL THEN 'function_missing'
+            WHEN fsh.expected_hash = encode(sha256(p.prosrc::bytea), 'hex')
+                THEN 'match'
+            ELSE 'drift_detected'
+        END AS status
+    FROM formula_source_hashes fsh
+    LEFT JOIN pg_proc p
+        ON p.proname = fsh.function_name
+       AND p.pronamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+    ORDER BY fsh.function_name;
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.check_function_source_drift() IS
+    'Compares registered pg_proc source hashes against actual function bodies to '
+    'detect unregistered code changes to critical scoring/search functions.';
+
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 9. Grants
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+GRANT EXECUTE ON FUNCTION public.check_formula_drift()          TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.check_function_source_drift()  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.trg_auto_fingerprint_smv()     TO service_role;
+GRANT EXECUTE ON FUNCTION public.trg_auto_fingerprint_src()     TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.check_formula_drift()          FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.check_function_source_drift()  FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.trg_auto_fingerprint_smv()     FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.trg_auto_fingerprint_src()     FROM PUBLIC, anon;
+
+COMMIT;

--- a/supabase/tests/schema_contracts.test.sql
+++ b/supabase/tests/schema_contracts.test.sql
@@ -7,7 +7,7 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 
 BEGIN;
-SELECT plan(95);
+SELECT plan(101);
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 1. Core data tables exist
@@ -149,6 +149,14 @@ SELECT has_function('public', 'compute_daily_value_pct',         'function compu
 -- ─── Ingredient Profile API (#36) ───────────────────────────────────────────
 SELECT has_function('public', 'api_get_ingredient_profile',      'function api_get_ingredient_profile exists');
 SELECT volatility_is('public', 'api_get_ingredient_profile', ARRAY['bigint','text'], 'stable', 'api_get_ingredient_profile is STABLE');
+
+-- ─── Formula Registry (#198) ─────────────────────────────────────────────
+SELECT has_table('public', 'formula_source_hashes',               'table formula_source_hashes exists');
+SELECT has_view('public', 'v_formula_registry',                   'view v_formula_registry exists');
+SELECT has_function('public', 'check_formula_drift',              'function check_formula_drift exists');
+SELECT has_function('public', 'check_function_source_drift',      'function check_function_source_drift exists');
+SELECT has_column('public', 'scoring_model_versions', 'weights_fingerprint', 'scoring_model_versions.weights_fingerprint exists');
+SELECT has_column('public', 'search_ranking_config', 'weights_fingerprint', 'search_ranking_config.weights_fingerprint exists');
 
 SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
Closes #198 -- Scoring and Search Formula Registry (GOV-A3).

Deliverables:
- Migration 20260228000000_formula_registry.sql: weights_fingerprint columns on scoring_model_versions and search_ranking_config, auto-fingerprint triggers, v_formula_registry unified view, check_formula_drift() and check_function_source_drift() sentinel functions, formula_source_hashes table with pg_proc source tracking
- QA__scoring_engine.sql extended from 17 to 25 checks (T18-T25: registry view, active formulas, fingerprints, drift detection, source hashes, triggers)
- schema_contracts.test.sql extended from 95 to 101 assertions (formula_source_hashes table, v_formula_registry view, drift functions, fingerprint columns)
- SCORING_ENGINE.md updated with sections 14-15: unified formula registry docs, weight change governance protocol, 7-step change process, checklist template
- Security posture whitelist updated for check_formula_drift and check_function_source_drift
- api-registry.yaml updated with new drift detection functions
- INDEX.md and copilot-instructions.md updated with new schema objects