### PR TITLE
docs(governance): add documentation ownership, versioning policy, and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Related Issue
+
+<!-- Closes #NNN -->
+
+## Changes
+
+<!-- Bullet list of key changes -->
+
+## Testing
+
+<!-- How was this tested? -->
+
+- [ ] Tests added/updated for all changes
+- [ ] Local test suite passes (`npx vitest run` / `.\RUN_QA.ps1` as applicable)
+
+## Documentation Checklist
+
+<!-- Check all that apply. See docs/DOCUMENTATION_GOVERNANCE.md for details. -->
+
+- [ ] No new `api_*` function without `API_CONTRACTS.md` update
+- [ ] No scoring change without `SCORING_METHODOLOGY.md` update
+- [ ] No new migration without `copilot-instructions.md` schema check
+- [ ] `Last updated` refreshed on any modified doc
+- [ ] New `.md` files added to `docs/INDEX.md`
+- [ ] CHANGELOG.md updated under `[Unreleased]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+- Add documentation governance policy (`docs/DOCUMENTATION_GOVERNANCE.md`): ownership model with
+  11 domains, 14 update trigger rules, versioning policy with frontmatter requirements,
+  deprecation & archival process, drift prevention cadence, 4 health metrics (#201)
+- Add PR documentation checklist template (`.github/PULL_REQUEST_TEMPLATE.md`) with
+  6-item documentation compliance checklist (#201)
+- Enrich `docs/INDEX.md` with owner issue assignments for all 40+ documents and add
+  DOCUMENTATION_GOVERNANCE.md entry (#201)
 - Add drift detection automation guide (`docs/DRIFT_DETECTION.md`): 8-check catalog, severity
   levels, CI integration plan, documentation freshness script, migration ordering validator,
   monthly cadence, historical results schema (#199)

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -179,7 +179,9 @@ poland-food-db/
 │   ├── DATA_PROVENANCE.md           # Data provenance & freshness governance
 │   ├── DATA_SOURCES.md              # Source hierarchy & validation workflow
 │   ├── DISASTER_DRILL_REPORT.md     # Disaster recovery drill report & findings
+│   ├── DOCUMENTATION_GOVERNANCE.md  # Documentation ownership, versioning, deprecation, drift prevention
 │   ├── DOMAIN_BOUNDARIES.md         # Domain boundary enforcement & ownership mapping
+│   ├── DRIFT_DETECTION.md           # 8-check drift detection catalog, severity levels, CI plan
 │   ├── EAN_VALIDATION_STATUS.md     # 997/1,025 coverage (97.3%)
 │   ├── ENVIRONMENT_STRATEGY.md      # Local/staging/production environment strategy
 │   ├── FEATURE_FLAGS.md             # Feature flag architecture & toggle registry
@@ -208,7 +210,7 @@ poland-food-db/
 │   ├── UX_IMPACT_METRICS.md         # UX measurement standard, metric catalog, SQL templates
 │   ├── UX_UI_DESIGN.md              # UI/UX guidelines
 │   ├── VIEWING_AND_TESTING.md       # Queries, Studio UI, test runner
-│   └── api-registry.yaml            # Structured registry of all 107 functions (YAML)
+│   └── api-registry.yaml            # Structured registry of all 109 functions (YAML)
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
 ├── RUN_QA.ps1                       # QA test runner (429 checks across 30 suites)
 ├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (23 injection tests)

--- a/docs/DOCUMENTATION_GOVERNANCE.md
+++ b/docs/DOCUMENTATION_GOVERNANCE.md
@@ -1,0 +1,181 @@
+# Documentation Governance
+
+> **Last updated:** 2026-03-01
+> **Status:** Active
+> **Owner issue:** [#201](https://github.com/ericsocrat/poland-food-db/issues/201)
+
+---
+
+## 1. Purpose
+
+This document defines the ongoing governance that prevents documentation entropy.
+It establishes ownership, update triggers, versioning policy, deprecation process,
+and drift prevention cadence. The canonical list of all documents lives in
+[INDEX.md](INDEX.md) — this document governs *how* that index is maintained.
+
+---
+
+## 2. Ownership Model
+
+Every document has an **owner** — identified by the GitHub issue that created or
+most recently restructured it. The owner issue is responsible for the document's
+accuracy. When an issue is closed, ownership transfers to the domain (e.g.,
+"scoring domain" or "API domain").
+
+### Domain Ownership Map
+
+| Domain | Documents | Primary Owner |
+|---|---|---|
+| **Scoring** | SCORING_METHODOLOGY.md, SCORING_ENGINE.md | #189 (Scoring Engine) |
+| **API** | API_CONTRACTS.md, API_VERSIONING.md, FRONTEND_API_MAP.md, CONTRACT_TESTING.md | #197 (API Registry) |
+| **Search** | SEARCH_ARCHITECTURE.md | #192 (Search Architecture) |
+| **Data & Provenance** | DATA_SOURCES.md, DATA_PROVENANCE.md, DATA_INTEGRITY_AUDITS.md, EAN_VALIDATION_STATUS.md, PRODUCTION_DATA.md | #193 (Data Provenance) |
+| **Security** | SECURITY.md, SECURITY_AUDIT.md, ACCESS_AUDIT.md, PRIVACY_CHECKLIST.md, RATE_LIMITING.md | #235 (Access Audit) |
+| **Observability** | MONITORING.md, OBSERVABILITY.md, SLO.md, METRICS.md, INCIDENT_RESPONSE.md, DISASTER_DRILL_REPORT.md | #231 (Incident Response) |
+| **Architecture** | GOVERNANCE_BLUEPRINT.md, DOMAIN_BOUNDARIES.md, FEATURE_FLAGS.md, CI_ARCHITECTURE_PROPOSAL.md, DRIFT_DETECTION.md | #195 (Governance Blueprint) |
+| **Frontend** | UX_UI_DESIGN.md, UX_IMPACT_METRICS.md, DESIGN_SYSTEM.md | Frontend domain |
+| **DevOps** | ENVIRONMENT_STRATEGY.md, STAGING_SETUP.md, SONAR.md | DevOps domain |
+| **Process** | RESEARCH_WORKFLOW.md, VIEWING_AND_TESTING.md, BACKFILL_STANDARD.md, LABELS.md, COUNTRY_EXPANSION_GUIDE.md | Process domain |
+| **Governance** | FEATURE_SUNSETTING.md, PERFORMANCE_GUARDRAILS.md, INDEX.md, this file | #201 (Doc Governance) |
+
+---
+
+## 3. Update Triggers
+
+When modifying code in a domain, the corresponding documents **must** be checked
+and updated if affected. This is enforced via the PR checklist.
+
+| Code Change | Documents to Check | Priority |
+|---|---|---|
+| Scoring formula weights or ceilings | SCORING_METHODOLOGY.md | Mandatory |
+| New scoring version or factor | SCORING_ENGINE.md, SCORING_METHODOLOGY.md | Mandatory |
+| New/modified `api_*` function | API_CONTRACTS.md, FRONTEND_API_MAP.md, api-registry.yaml | Mandatory |
+| API parameter or response shape change | API_CONTRACTS.md | Mandatory |
+| New migration | copilot-instructions.md (schema section) | Mandatory |
+| New country activated | COUNTRY_EXPANSION_GUIDE.md | Mandatory |
+| New user-facing table with PII | PRIVACY_CHECKLIST.md, ACCESS_AUDIT.md | Mandatory |
+| RLS policy change | ACCESS_AUDIT.md, SECURITY_AUDIT.md | Mandatory |
+| Environment configuration | ENVIRONMENT_STRATEGY.md | Recommended |
+| CI workflow changes | CI_ARCHITECTURE_PROPOSAL.md | Recommended |
+| New feature flag | FEATURE_FLAGS.md | Mandatory |
+| Search ranking or synonym change | SEARCH_ARCHITECTURE.md | Mandatory |
+| New QA suite or check count change | copilot-instructions.md (QA section) | Mandatory |
+| Drift check addition | DRIFT_DETECTION.md | Mandatory |
+
+---
+
+## 4. Versioning Policy
+
+### 4.1 Frontmatter Requirements
+
+Every active document in `docs/` must include:
+
+```markdown
+# Document Title
+
+> **Last updated:** YYYY-MM-DD
+> **Status:** Active | Deprecated | Archived
+> **Owner issue:** #NNN (or domain name)
+```
+
+### 4.2 Update Rules
+
+1. **Every document edit** must update the `Last updated` date.
+2. **Substantive changes** (new sections, policy changes) must also update the
+   corresponding INDEX.md entry's `Last Updated` column.
+3. **Typo/formatting fixes** update the date but do not require INDEX.md update.
+4. **New documents** must be added to INDEX.md in the appropriate domain section
+   and to `copilot-instructions.md` project layout.
+
+### 4.3 Per-Document Changelog (Optional)
+
+For complex documents (SCORING_ENGINE.md, API_CONTRACTS.md), maintain a changelog
+section at the bottom:
+
+```markdown
+## Changelog
+
+| Date | Change | Issue |
+|---|---|---|
+| 2026-03-01 | Added formula registry section | #198 |
+| 2026-02-24 | Initial creation | #189 |
+```
+
+This is **optional** for simple policy documents but **recommended** for
+technical reference documents that evolve frequently.
+
+---
+
+## 5. Deprecation & Archival Process
+
+### 5.1 Deprecation (Sprint 1)
+
+1. Add deprecation notice at the top of the document:
+   ```markdown
+   > **Status:** Deprecated — superseded by [NEW_DOC.md](NEW_DOC.md)
+   > **Removal date:** YYYY-MM-DD (end of next sprint)
+   ```
+2. Update INDEX.md entry status to `Deprecated`.
+3. Add CHANGELOG.md entry: `docs: deprecate OLD_DOC.md in favor of NEW_DOC.md`
+
+### 5.2 Archival (Sprint 2)
+
+1. Move file to `docs/archive/` (create directory if needed).
+2. Move INDEX.md entry from active section to "Removed Documents" table.
+3. Update all cross-references in other docs to point to the replacement.
+4. Update `copilot-instructions.md` project layout.
+
+### 5.3 Permanent Removal
+
+Files in `docs/archive/` are kept for historical reference. They are not
+actively maintained. Remove only if they cause confusion or contain outdated
+security-sensitive information.
+
+---
+
+## 6. PR Documentation Checklist
+
+Every PR must include the documentation checklist defined in
+`.github/PULL_REQUEST_TEMPLATE.md`. The checklist is:
+
+- [ ] No new `api_*` function without `API_CONTRACTS.md` update
+- [ ] No scoring change without `SCORING_METHODOLOGY.md` update
+- [ ] No new migration without `copilot-instructions.md` schema check
+- [ ] `Last updated` refreshed on any modified doc
+- [ ] New `.md` files added to `docs/INDEX.md`
+- [ ] CHANGELOG.md updated under `[Unreleased]`
+
+This checklist is advisory (self-attested by PR author), not CI-enforced.
+The documentation freshness script (`scripts/check_doc_drift.py`) provides
+the automated enforcement layer.
+
+---
+
+## 7. Drift Prevention Cadence
+
+| Frequency | Action | Tool | Owner |
+|---|---|---|---|
+| **Every PR** | Complete documentation checklist | PR template | PR author |
+| **Every QA run** | SQL drift checks pass | `QA__governance_drift.sql` | CI |
+| **Weekly** | Documentation freshness check | `scripts/check_doc_drift.py` | Maintainer |
+| **Weekly** | Migration ordering check | `scripts/check_migration_order.py` | Maintainer |
+| **Monthly** | Full INDEX.md review — verify all entries current | Manual | Maintainer |
+| **Monthly** | Run `SELECT log_drift_check()` and review trends | SQL | Maintainer |
+| **Quarterly** | Archive stale deprecated docs | Manual | Maintainer |
+
+**Automation target:** Move weekly checks to CI via `governance-drift.yml`
+after all GOV-* issues are complete (see [DRIFT_DETECTION.md](DRIFT_DETECTION.md)
+section 5 for the planned workflow).
+
+---
+
+## 8. Metrics
+
+Track these documentation health metrics over time:
+
+| Metric | Target | Measurement |
+|---|---|---|
+| Documents with owner assigned | 100% | INDEX.md `Owner Issue` column — no `—` entries |
+| Documents within 90-day freshness | 100% | `scripts/check_doc_drift.py` output |
+| PR documentation checklist completion | > 90% | Manual audit of merged PRs |
+| INDEX.md accuracy (matches `docs/` dir) | 100% | `QA__governance_drift.sql` (future check) |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,9 +1,9 @@
 # Documentation Index
 
-> **Last updated:** 2026-02-28
+> **Last updated:** 2026-03-01
 > **Status:** Active — update when adding, renaming, or archiving docs
-> **Total documents:** 39 in `docs/` + 5 elsewhere in repo
-> **Reference:** Issue [#200](https://github.com/ericsocrat/poland-food-db/issues/200)
+> **Total documents:** 40 in `docs/` + 5 elsewhere in repo
+> **Reference:** Issue [#200](https://github.com/ericsocrat/poland-food-db/issues/200), [#201](https://github.com/ericsocrat/poland-food-db/issues/201)
 
 ---
 
@@ -20,7 +20,7 @@
 | [DevOps & Environment](#devops--environment)             | 3     | Environment strategy, staging setup, Sonar config                                                        |
 | [Frontend & UX](#frontend--ux)                           | 4     | UX/UI design, UX impact metrics, design system, frontend README                                          |
 | [Process & Workflow](#process--workflow)                 | 5     | Research workflow, viewing & testing, backfill standard, labels, country expansion                       |
-| [Governance & Policy](#governance--policy)               | 4     | Feature sunsetting, performance guardrails, this index, governance blueprint                             |
+| [Governance & Policy](#governance--policy)               | 5     | Feature sunsetting, performance guardrails, doc governance, this index, governance blueprint             |
 
 ---
 
@@ -40,16 +40,16 @@
 
 | Document                                   | Purpose                                                                          | Owner Issue                                                     | Last Updated |
 | ------------------------------------------ | -------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------ |
-| [API_CONTRACTS.md](API_CONTRACTS.md)       | API surface contracts — response shapes, hidden columns, 20+ RPC functions       | —                                                               | 2026-02-24   |
+| [API_CONTRACTS.md](API_CONTRACTS.md)       | API surface contracts — response shapes, hidden columns, 20+ RPC functions       | [#197](https://github.com/ericsocrat/poland-food-db/issues/197) | 2026-02-24   |
 | [API_VERSIONING.md](API_VERSIONING.md)     | API deprecation & versioning policy — function-name versioning, sunset timelines | [#234](https://github.com/ericsocrat/poland-food-db/issues/234) | 2026-02-24   |
-| [FRONTEND_API_MAP.md](FRONTEND_API_MAP.md) | Frontend-to-API mapping reference — which pages call which RPCs                  | —                                                               | 2026-02-13   |
-| [CONTRACT_TESTING.md](CONTRACT_TESTING.md) | API contract testing strategy — pgTAP patterns, response shape validation        | —                                                               | 2026-02-24   |
+| [FRONTEND_API_MAP.md](FRONTEND_API_MAP.md) | Frontend-to-API mapping reference — which pages call which RPCs                  | [#197](https://github.com/ericsocrat/poland-food-db/issues/197) | 2026-02-13   |
+| [CONTRACT_TESTING.md](CONTRACT_TESTING.md) | API contract testing strategy — pgTAP patterns, response shape validation        | [#197](https://github.com/ericsocrat/poland-food-db/issues/197) | 2026-02-24   |
 
 ## Scoring
 
 | Document                                         | Purpose                                                               | Owner Issue                                                     | Last Updated |
 | ------------------------------------------------ | --------------------------------------------------------------------- | --------------------------------------------------------------- | ------------ |
-| [SCORING_METHODOLOGY.md](SCORING_METHODOLOGY.md) | v3.2 scoring formula — 9 factors, weights, ceilings, bands            | —                                                               | 2026-02-12   |
+| [SCORING_METHODOLOGY.md](SCORING_METHODOLOGY.md) | v3.2 scoring formula — 9 factors, weights, ceilings, bands            | [#189](https://github.com/ericsocrat/poland-food-db/issues/189) | 2026-02-12   |
 | [SCORING_ENGINE.md](SCORING_ENGINE.md)           | Scoring engine architecture — function versioning, regression testing | [#189](https://github.com/ericsocrat/poland-food-db/issues/189) | 2026-02-24   |
 
 > **Relationship:** SCORING_METHODOLOGY.md defines the **formula** (what is computed). SCORING_ENGINE.md defines the **architecture** (how it is maintained, versioned, and tested). No redundancy — they serve different audiences.
@@ -58,11 +58,11 @@
 
 | Document                                             | Purpose                                                                          | Owner Issue                                                     | Last Updated |
 | ---------------------------------------------------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------ |
-| [DATA_SOURCES.md](DATA_SOURCES.md)                   | Source hierarchy & validation workflow — OFF API, manual entry                   | —                                                               | 2026-02-12   |
+| [DATA_SOURCES.md](DATA_SOURCES.md)                   | Source hierarchy & validation workflow — OFF API, manual entry                   | [#193](https://github.com/ericsocrat/poland-food-db/issues/193) | 2026-02-12   |
 | [DATA_PROVENANCE.md](DATA_PROVENANCE.md)             | Data provenance & freshness governance — lineage tracking, staleness detection   | [#193](https://github.com/ericsocrat/poland-food-db/issues/193) | 2026-02-24   |
 | [DATA_INTEGRITY_AUDITS.md](DATA_INTEGRITY_AUDITS.md) | Ongoing data integrity audit framework — nightly checks, contradiction detection | [#184](https://github.com/ericsocrat/poland-food-db/issues/184) | 2026-02-22   |
-| [EAN_VALIDATION_STATUS.md](EAN_VALIDATION_STATUS.md) | EAN coverage tracking — 997/1,025 (97.3%)                                        | —                                                               | 2026-02-24   |
-| [PRODUCTION_DATA.md](PRODUCTION_DATA.md)             | Production data management — sync, backup, restore procedures                    | —                                                               | 2026-02-24   |
+| [EAN_VALIDATION_STATUS.md](EAN_VALIDATION_STATUS.md) | EAN coverage tracking — 997/1,025 (97.3%)                                        | Data domain                                                     | 2026-02-24   |
+| [PRODUCTION_DATA.md](PRODUCTION_DATA.md)             | Production data management — sync, backup, restore procedures                    | DevOps domain                                                   | 2026-02-24   |
 
 > **Relationship:** DATA_SOURCES.md catalogs **where** data comes from. DATA_PROVENANCE.md governs **how freshness and lineage are tracked**. No redundancy.
 
@@ -70,11 +70,11 @@
 
 | Document                                     | Purpose                                                                    | Owner Issue                                                     | Last Updated |
 | -------------------------------------------- | -------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------ |
-| [../SECURITY.md](../SECURITY.md)             | Root security policy — vulnerability table, reporting process              | —                                                               | 2026-02-24   |
-| [SECURITY_AUDIT.md](SECURITY_AUDIT.md)       | Full security audit report — RLS, function security, headers, dependencies | —                                                               | 2026-02-23   |
+| [../SECURITY.md](../SECURITY.md)             | Root security policy — vulnerability table, reporting process              | Security domain                                                 | 2026-02-24   |
+| [SECURITY_AUDIT.md](SECURITY_AUDIT.md)       | Full security audit report — RLS, function security, headers, dependencies | [#232](https://github.com/ericsocrat/poland-food-db/issues/232) | 2026-02-23   |
 | [ACCESS_AUDIT.md](ACCESS_AUDIT.md)           | Data access pattern audit — table-by-role matrix, quarterly review process | [#235](https://github.com/ericsocrat/poland-food-db/issues/235) | 2026-02-24   |
 | [PRIVACY_CHECKLIST.md](PRIVACY_CHECKLIST.md) | GDPR/RODO compliance checklist — data inventory, retention, subject rights | [#236](https://github.com/ericsocrat/poland-food-db/issues/236) | 2026-02-24   |
-| [RATE_LIMITING.md](RATE_LIMITING.md)         | Rate limiting strategy — API abuse prevention, throttle tiers              | —                                                               | 2026-02-23   |
+| [RATE_LIMITING.md](RATE_LIMITING.md)         | Rate limiting strategy — API abuse prevention, throttle tiers              | Security domain                                                 | 2026-02-23   |
 
 > **Relationship:** SECURITY.md (root) is a **policy overview** (required by GitHub security features). SECURITY_AUDIT.md is a **detailed audit report**. ACCESS_AUDIT.md focuses on **access patterns**. No redundancy — each has distinct scope.
 
@@ -82,20 +82,20 @@
 
 | Document                                             | Purpose                                                                         | Owner Issue                                                     | Last Updated |
 | ---------------------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------ |
-| [MONITORING.md](MONITORING.md)                       | Runtime monitoring — alerts, dashboards, health checks                          | —                                                               | 2026-02-24   |
-| [OBSERVABILITY.md](OBSERVABILITY.md)                 | Observability strategy — structured logging, tracing, metrics pipeline          | —                                                               | 2026-02-23   |
-| [SLO.md](SLO.md)                                     | Service Level Objectives — availability, latency, error rate targets            | —                                                               | 2026-02-24   |
-| [METRICS.md](METRICS.md)                             | Metrics catalog — application metrics, infrastructure metrics, business metrics | —                                                               | 2026-02-24   |
+| [MONITORING.md](MONITORING.md)                       | Runtime monitoring — alerts, dashboards, health checks                          | Observability domain                                            | 2026-02-24   |
+| [OBSERVABILITY.md](OBSERVABILITY.md)                 | Observability strategy — structured logging, tracing, metrics pipeline          | Observability domain                                            | 2026-02-23   |
+| [SLO.md](SLO.md)                                     | Service Level Objectives — availability, latency, error rate targets            | Observability domain                                            | 2026-02-24   |
+| [METRICS.md](METRICS.md)                             | Metrics catalog — application metrics, infrastructure metrics, business metrics | Observability domain                                            | 2026-02-24   |
 | [INCIDENT_RESPONSE.md](INCIDENT_RESPONSE.md)         | Incident response playbook — severity, escalation, runbooks, post-mortem        | [#231](https://github.com/ericsocrat/poland-food-db/issues/231) | 2026-02-24   |
-| [DISASTER_DRILL_REPORT.md](DISASTER_DRILL_REPORT.md) | Disaster recovery drill report — test results, findings, remediation            | —                                                               | 2026-02-23   |
+| [DISASTER_DRILL_REPORT.md](DISASTER_DRILL_REPORT.md) | Disaster recovery drill report — test results, findings, remediation            | Observability domain                                            | 2026-02-23   |
 
 ## DevOps & Environment
 
 | Document                                           | Purpose                                                                 | Owner Issue | Last Updated |
 | -------------------------------------------------- | ----------------------------------------------------------------------- | ----------- | ------------ |
-| [ENVIRONMENT_STRATEGY.md](ENVIRONMENT_STRATEGY.md) | Local/staging/production environment strategy                           | —           | 2026-02-22   |
-| [STAGING_SETUP.md](STAGING_SETUP.md)               | Staging environment setup guide — scripts, sync workflow, configuration | —           | 2026-02-24   |
-| [SONAR.md](SONAR.md)                               | SonarCloud configuration & quality gates                                | —           | 2026-02-23   |
+| [ENVIRONMENT_STRATEGY.md](ENVIRONMENT_STRATEGY.md) | Local/staging/production environment strategy                           | DevOps domain | 2026-02-22   |
+| [STAGING_SETUP.md](STAGING_SETUP.md)               | Staging environment setup guide — scripts, sync workflow, configuration | DevOps domain | 2026-02-24   |
+| [SONAR.md](SONAR.md)                               | SonarCloud configuration & quality gates                                | DevOps domain | 2026-02-23   |
 
 > **Relationship:** ENVIRONMENT_STRATEGY.md defines the **overall strategy** (3 environments). STAGING_SETUP.md provides **operational setup steps** for staging specifically. Complementary, not redundant.
 
@@ -103,28 +103,29 @@
 
 | Document                                                               | Purpose                                                                       | Owner Issue | Last Updated |
 | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------- | ------------ |
-| [UX_UI_DESIGN.md](UX_UI_DESIGN.md)                                     | UI/UX design guidelines — color system, components, layouts                   | —           | 2026-02-24   |
-| [UX_IMPACT_METRICS.md](UX_IMPACT_METRICS.md)                           | UX measurement standard — event catalog, metric templates, performance budget | —           | 2026-02-24   |
-| [../frontend/docs/DESIGN_SYSTEM.md](../frontend/docs/DESIGN_SYSTEM.md) | Frontend design system — Tailwind tokens, component patterns                  | —           | 2026-02-17   |
-| [../frontend/README.md](../frontend/README.md)                         | Frontend project overview — setup, scripts, architecture                      | —           | 2026-02-24   |
+| [UX_UI_DESIGN.md](UX_UI_DESIGN.md)                                     | UI/UX design guidelines — color system, components, layouts                   | Frontend domain | 2026-02-24   |
+| [UX_IMPACT_METRICS.md](UX_IMPACT_METRICS.md)                           | UX measurement standard — event catalog, metric templates, performance budget | Frontend domain | 2026-02-24   |
+| [../frontend/docs/DESIGN_SYSTEM.md](../frontend/docs/DESIGN_SYSTEM.md) | Frontend design system — Tailwind tokens, component patterns                  | Frontend domain | 2026-02-17   |
+| [../frontend/README.md](../frontend/README.md)                         | Frontend project overview — setup, scripts, architecture                      | Frontend domain | 2026-02-24   |
 
 ## Process & Workflow
 
 | Document                                                 | Purpose                                                                    | Owner Issue | Last Updated |
 | -------------------------------------------------------- | -------------------------------------------------------------------------- | ----------- | ------------ |
-| [RESEARCH_WORKFLOW.md](RESEARCH_WORKFLOW.md)             | Data collection lifecycle — manual + automated OFF pipeline                | —           | 2026-02-24   |
-| [VIEWING_AND_TESTING.md](VIEWING_AND_TESTING.md)         | Queries, Studio UI, test runner guide                                      | —           | 2026-02-24   |
-| [BACKFILL_STANDARD.md](BACKFILL_STANDARD.md)             | Backfill orchestration standard — migration templates, validation patterns | —           | 2026-02-24   |
-| [LABELS.md](LABELS.md)                                   | GitHub labeling conventions — issue/PR label taxonomy                      | —           | 2026-02-23   |
-| [COUNTRY_EXPANSION_GUIDE.md](COUNTRY_EXPANSION_GUIDE.md) | Multi-country expansion protocol — PL active, DE micro-pilot               | —           | 2026-02-24   |
+| [RESEARCH_WORKFLOW.md](RESEARCH_WORKFLOW.md)             | Data collection lifecycle — manual + automated OFF pipeline                | Process domain | 2026-02-24   |
+| [VIEWING_AND_TESTING.md](VIEWING_AND_TESTING.md)         | Queries, Studio UI, test runner guide                                      | Process domain | 2026-02-24   |
+| [BACKFILL_STANDARD.md](BACKFILL_STANDARD.md)             | Backfill orchestration standard — migration templates, validation patterns | Process domain | 2026-02-24   |
+| [LABELS.md](LABELS.md)                                   | GitHub labeling conventions — issue/PR label taxonomy                      | Process domain | 2026-02-23   |
+| [COUNTRY_EXPANSION_GUIDE.md](COUNTRY_EXPANSION_GUIDE.md) | Multi-country expansion protocol — PL active, DE micro-pilot               | [#148](https://github.com/ericsocrat/poland-food-db/issues/148) | 2026-02-24   |
 
 ## Governance & Policy
 
 | Document                                               | Purpose                                                                 | Owner Issue                                                     | Last Updated |
 | ------------------------------------------------------ | ----------------------------------------------------------------------- | --------------------------------------------------------------- | ------------ |
 | [FEATURE_SUNSETTING.md](FEATURE_SUNSETTING.md)         | Feature retirement criteria, cleanup policy, quarterly hygiene review   | [#237](https://github.com/ericsocrat/poland-food-db/issues/237) | 2026-02-24   |
-| [PERFORMANCE_GUARDRAILS.md](PERFORMANCE_GUARDRAILS.md) | Performance guardrails — query budgets, index policy, scale projections | —                                                               | 2026-02-23   |
-| INDEX.md                                               | This file — canonical documentation map                                 | [#200](https://github.com/ericsocrat/poland-food-db/issues/200) | 2026-02-28   |
+| [PERFORMANCE_GUARDRAILS.md](PERFORMANCE_GUARDRAILS.md)                     | Performance guardrails — query budgets, index policy, scale projections    | Governance domain                                                | 2026-02-23   |
+| [DOCUMENTATION_GOVERNANCE.md](DOCUMENTATION_GOVERNANCE.md)                 | Documentation ownership, versioning, deprecation, drift prevention cadence | [#201](https://github.com/ericsocrat/poland-food-db/issues/201) | 2026-03-01   |
+| INDEX.md                                                                   | This file — canonical documentation map                                    | [#200](https://github.com/ericsocrat/poland-food-db/issues/200) | 2026-03-01   |
 
 ## Other Repository Documents
 


### PR DESCRIPTION
Closes #201

## Summary

Establishes documentation governance policy with ownership model, versioning rules, deprecation process, and automated drift prevention.

## Changes

### New files
- docs/DOCUMENTATION_GOVERNANCE.md - Comprehensive governance policy:
  - 11-domain ownership map covering all 40+ documents
  - 14 update trigger rules (code change to doc update mapping)
  - Versioning policy with frontmatter requirements
  - 3-phase deprecation and archival process
  - Drift prevention cadence (7 frequency levels)
  - 4 documentation health metrics with targets

- .github/PULL_REQUEST_TEMPLATE.md - PR template with:
  - Summary, Related Issue, Changes, Testing sections
  - 6-item documentation compliance checklist

### Updated files
- docs/INDEX.md - Added DOCUMENTATION_GOVERNANCE.md entry, filled in owner issue assignments for all documents (replaced dashes with domain references or issue links)
- copilot-instructions.md - Added DOCUMENTATION_GOVERNANCE.md and DRIFT_DETECTION.md to project layout, updated api-registry count to 109
- CHANGELOG.md - Added 3 documentation entries for governance policy, PR template, and INDEX.md enrichment

## Testing

- Documentation-only change (no code, no schema, no tests affected)
- All existing CI gates unaffected
- PR template will auto-populate on future PRs

## Acceptance Criteria (from issue)
- [x] Every document has an assigned owner (DOCUMENTATION_GOVERNANCE.md S2)
- [x] Update triggers defined per document (S3, 14 rules)
- [x] Deprecation process documented (S5, 3 phases)
- [x] PR checklist includes documentation compliance items (PR_TEMPLATE + S6)
- [x] docs/INDEX.md maintained with owner assignments
- [x] Drift prevention cadence established (S7, 7 levels)