### PR TITLE
schema(migration): add idempotent design standard, index naming, and validation tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Schema & Migrations
 
+- Add migration convention standard: index naming convention `idx_{table}_{columns}[_{type}]`,
+  trigger domain range assignments (10–99 by domain), migration file naming format with header
+  block standard, `_TEMPLATE.sql` reference template, `check_migration_conventions.py` validation
+  script (133/133 naming compliant) (#207)
 - Rename non-conforming triggers on `products` table: `score_change_audit` →
   `trg_products_score_audit`, `trg_record_score_change` → `trg_products_score_history`;
   all 5 products triggers now pass `governance_drift_check()` naming validation (#203)
@@ -48,6 +52,9 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+- Extend `docs/MIGRATION_CONVENTIONS.md` with index naming convention, trigger domain range
+  assignments, migration file naming format, header block standard, and link to `_TEMPLATE.sql`;
+  add `scripts/check_migration_conventions.py` validation script (#207)
 - Add documentation governance policy (`docs/DOCUMENTATION_GOVERNANCE.md`): ownership model with
   11 domains, 14 update trigger rules, versioning policy with frontmatter requirements,
   deprecation & archival process, drift prevention cadence, 4 health metrics (#201)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -115,7 +115,7 @@
 | [RESEARCH_WORKFLOW.md](RESEARCH_WORKFLOW.md)             | Data collection lifecycle — manual + automated OFF pipeline                | Process domain | 2026-02-24   |
 | [VIEWING_AND_TESTING.md](VIEWING_AND_TESTING.md)         | Queries, Studio UI, test runner guide                                      | Process domain | 2026-02-24   |
 | [BACKFILL_STANDARD.md](BACKFILL_STANDARD.md)             | Backfill orchestration standard — migration templates, validation patterns | Process domain | 2026-02-24   |
-| [MIGRATION_CONVENTIONS.md](MIGRATION_CONVENTIONS.md)     | Migration safety, trigger naming, lock risk, idempotency standards         | [#203](https://github.com/ericsocrat/poland-food-db/issues/203) | 2026-03-01   |
+| [MIGRATION_CONVENTIONS.md](MIGRATION_CONVENTIONS.md)     | Migration safety, trigger naming, lock risk, idempotency standards         | [#203](https://github.com/ericsocrat/poland-food-db/issues/203), [#207](https://github.com/ericsocrat/poland-food-db/issues/207) | 2026-03-02   |
 | [LABELS.md](LABELS.md)                                   | GitHub labeling conventions — issue/PR label taxonomy                      | Process domain | 2026-02-23   |
 | [COUNTRY_EXPANSION_GUIDE.md](COUNTRY_EXPANSION_GUIDE.md) | Multi-country expansion protocol — PL active, DE micro-pilot               | [#148](https://github.com/ericsocrat/poland-food-db/issues/148) | 2026-02-24   |
 

--- a/docs/MIGRATION_CONVENTIONS.md
+++ b/docs/MIGRATION_CONVENTIONS.md
@@ -2,7 +2,7 @@
 
 > **Last updated:** 2026-03-01
 > **Status:** Active
-> **Reference:** Issue [#203](https://github.com/ericsocrat/poland-food-db/issues/203)
+> **Reference:** Issues [#203](https://github.com/ericsocrat/poland-food-db/issues/203), [#207](https://github.com/ericsocrat/poland-food-db/issues/207)
 
 ---
 
@@ -26,22 +26,22 @@ To enforce deterministic ordering, all triggers on shared tables must follow a n
 trg_{table}_{purpose}                — legacy pattern (acceptable for single-domain tables)
 ```
 
-| Component | Description | Example |
-|-----------|-------------|---------|
-| `{table}` | Target table name | `products`, `user_preferences` |
-| `{NN}` | Two-digit ordering number (10, 20, 30…) | `10`, `20`, `30` |
-| `{domain}` | Owning domain | `search`, `meta`, `provenance`, `scoring` |
-| `{action}` | What the trigger does | `vector_update`, `updated_at`, `audit` |
+| Component  | Description                             | Example                                   |
+| ---------- | --------------------------------------- | ----------------------------------------- |
+| `{table}`  | Target table name                       | `products`, `user_preferences`            |
+| `{NN}`     | Two-digit ordering number (10, 20, 30…) | `10`, `20`, `30`                          |
+| `{domain}` | Owning domain                           | `search`, `meta`, `provenance`, `scoring` |
+| `{action}` | What the trigger does                   | `vector_update`, `updated_at`, `audit`    |
 
 ### 2.2 Ordering Numbers (products table)
 
-| Number | Timing | Domain | Purpose |
-|--------|--------|--------|---------|
-| 10 | BEFORE | Search | Update search vector |
-| 20 | BEFORE | Meta | Set `updated_at` timestamp |
-| 30 | AFTER | Provenance | Log field changes to `product_change_log` |
-| 40 | AFTER | Scoring | Audit score changes to `score_audit_log` |
-| 50 | AFTER | Scoring | Record score history for notifications |
+| Number | Timing | Domain     | Purpose                                   |
+| ------ | ------ | ---------- | ----------------------------------------- |
+| 10     | BEFORE | Search     | Update search vector                      |
+| 20     | BEFORE | Meta       | Set `updated_at` timestamp                |
+| 30     | AFTER  | Provenance | Log field changes to `product_change_log` |
+| 40     | AFTER  | Scoring    | Audit score changes to `score_audit_log`  |
+| 50     | AFTER  | Scoring    | Record score history for notifications    |
 
 **Gap between numbers:** Use increments of 10 to allow future insertions (e.g., 15, 25).
 
@@ -64,40 +64,139 @@ are legacy and documented as non-conforming (see §2.5).
 
 ### 2.5 Current Trigger Inventory (products table)
 
-| Trigger Name | Timing | Event | Function | Status |
-|---|---|---|---|---|
-| `trg_products_search_vector_update` | BEFORE | INSERT OR UPDATE | `trg_products_search_vector()` | Conforming |
-| `trg_products_updated_at` | BEFORE | UPDATE | `trg_set_updated_at()` | Conforming |
-| `products_30_change_audit` | AFTER | UPDATE | `trg_product_change_log()` | Conforming |
-| `trg_products_score_audit` | AFTER | UPDATE | `trg_score_audit()` | Conforming (renamed from `score_change_audit`) |
-| `trg_products_score_history` | AFTER | UPDATE OF unhealthiness_score | `record_score_change()` | Conforming (renamed from `trg_record_score_change`) |
+| Trigger Name                        | Timing | Event                         | Function                       | Status                                              |
+| ----------------------------------- | ------ | ----------------------------- | ------------------------------ | --------------------------------------------------- |
+| `trg_products_search_vector_update` | BEFORE | INSERT OR UPDATE              | `trg_products_search_vector()` | Conforming                                          |
+| `trg_products_updated_at`           | BEFORE | UPDATE                        | `trg_set_updated_at()`         | Conforming                                          |
+| `products_30_change_audit`          | AFTER  | UPDATE                        | `trg_product_change_log()`     | Conforming                                          |
+| `trg_products_score_audit`          | AFTER  | UPDATE                        | `trg_score_audit()`            | Conforming (renamed from `score_change_audit`)      |
+| `trg_products_score_history`        | AFTER  | UPDATE OF unhealthiness_score | `record_score_change()`        | Conforming (renamed from `trg_record_score_change`) |
 
 ### 2.6 All Triggers (full inventory)
 
-| Table | Trigger Name | Timing | Event | Function |
-|---|---|---|---|---|
-| `products` | `trg_products_search_vector_update` | BEFORE | INSERT OR UPDATE | `trg_products_search_vector()` |
-| `products` | `trg_products_updated_at` | BEFORE | UPDATE | `trg_set_updated_at()` |
-| `products` | `products_30_change_audit` | AFTER | UPDATE | `trg_product_change_log()` |
-| `products` | `trg_products_score_audit` | AFTER | UPDATE | `trg_score_audit()` |
-| `products` | `trg_products_score_history` | AFTER | UPDATE OF unhealthiness_score | `record_score_change()` |
-| `user_preferences` | `user_preferences_updated_at` | BEFORE | UPDATE | `trg_set_updated_at()` |
-| `user_preferences` | `trg_auto_create_lists` | AFTER | INSERT | `trg_create_default_lists()` |
-| `user_preferences` | `trg_validate_fav_cats` | BEFORE | INSERT OR UPDATE | `trg_validate_favorite_categories()` |
-| `user_health_profiles` | `trg_health_profile_active` | BEFORE | INSERT OR UPDATE | `trg_enforce_single_active_profile()` |
-| `user_product_lists` | `trg_user_product_lists_updated_at` | BEFORE | UPDATE | `trg_update_list_timestamp()` |
-| `user_comparisons` | `trg_limit_user_comparisons` | BEFORE | INSERT | `trg_limit_comparisons()` |
-| `user_saved_searches` | `trg_limit_saved_searches` | BEFORE | INSERT | `trg_limit_saved_searches()` |
-| `product_score_history` | `trg_queue_score_notifications` | AFTER | INSERT | `queue_score_change_notifications()` |
-| `feature_flags` | `flag_changes` | AFTER | INSERT OR UPDATE OR DELETE | `trg_flag_audit()` |
-| `scoring_model_versions` | `auto_fingerprint_smv` | BEFORE | INSERT OR UPDATE OF config | `trg_auto_fingerprint_smv()` |
-| `search_ranking_config` | `auto_fingerprint_src` | BEFORE | INSERT OR UPDATE OF weights | `trg_auto_fingerprint_src()` |
+| Table                    | Trigger Name                        | Timing | Event                         | Function                              |
+| ------------------------ | ----------------------------------- | ------ | ----------------------------- | ------------------------------------- |
+| `products`               | `trg_products_search_vector_update` | BEFORE | INSERT OR UPDATE              | `trg_products_search_vector()`        |
+| `products`               | `trg_products_updated_at`           | BEFORE | UPDATE                        | `trg_set_updated_at()`                |
+| `products`               | `products_30_change_audit`          | AFTER  | UPDATE                        | `trg_product_change_log()`            |
+| `products`               | `trg_products_score_audit`          | AFTER  | UPDATE                        | `trg_score_audit()`                   |
+| `products`               | `trg_products_score_history`        | AFTER  | UPDATE OF unhealthiness_score | `record_score_change()`               |
+| `user_preferences`       | `user_preferences_updated_at`       | BEFORE | UPDATE                        | `trg_set_updated_at()`                |
+| `user_preferences`       | `trg_auto_create_lists`             | AFTER  | INSERT                        | `trg_create_default_lists()`          |
+| `user_preferences`       | `trg_validate_fav_cats`             | BEFORE | INSERT OR UPDATE              | `trg_validate_favorite_categories()`  |
+| `user_health_profiles`   | `trg_health_profile_active`         | BEFORE | INSERT OR UPDATE              | `trg_enforce_single_active_profile()` |
+| `user_product_lists`     | `trg_user_product_lists_updated_at` | BEFORE | UPDATE                        | `trg_update_list_timestamp()`         |
+| `user_comparisons`       | `trg_limit_user_comparisons`        | BEFORE | INSERT                        | `trg_limit_comparisons()`             |
+| `user_saved_searches`    | `trg_limit_saved_searches`          | BEFORE | INSERT                        | `trg_limit_saved_searches()`          |
+| `product_score_history`  | `trg_queue_score_notifications`     | AFTER  | INSERT                        | `queue_score_change_notifications()`  |
+| `feature_flags`          | `flag_changes`                      | AFTER  | INSERT OR UPDATE OR DELETE    | `trg_flag_audit()`                    |
+| `scoring_model_versions` | `auto_fingerprint_smv`              | BEFORE | INSERT OR UPDATE OF config    | `trg_auto_fingerprint_smv()`          |
+| `search_ranking_config`  | `auto_fingerprint_src`              | BEFORE | INSERT OR UPDATE OF weights   | `trg_auto_fingerprint_src()`          |
 
 **Total:** 16 active triggers across 9 tables.
 
+### 2.7 Trigger Domain Ranges (products table)
+
+When using the numbered `products_NN_` pattern, use these reserved ranges:
+
+| Range | Domain                 | Timing         | Purpose                                     |
+| ----- | ---------------------- | -------------- | ------------------------------------------- |
+| 10–19 | Search                 | BEFORE         | Search vector updates, tsvector maintenance |
+| 20–29 | Meta / Provenance      | BEFORE / AFTER | Timestamps, field-level provenance tracking |
+| 30–39 | Provenance / Audit     | AFTER          | Change logging, audit trail                 |
+| 40–49 | Scoring                | AFTER          | Score auditing, score history               |
+| 50–59 | Events / Notifications | AFTER          | Event queuing, push notifications           |
+| 60–99 | Reserved               | —              | Future domains                              |
+
 ---
 
-## 3. Migration Safety Checklist
+## 3. Migration Naming Convention
+
+### 3.1 File Naming
+
+```
+Format: YYYYMMDDHHMMSS_{description}.sql
+
+Timestamp: Supabase CLI format (14-digit UTC timestamp)
+Description: snake_case, action-oriented
+
+Examples:
+  20260302000000_migration_safety_conventions.sql
+  20260301000000_drift_detection_automation.sql
+  20260228000000_formula_registry.sql
+```
+
+### 3.2 Migration Header Block
+
+Every migration file **should** include a metadata header block:
+
+```sql
+-- Migration: YYYYMMDDHHMMSS_{description}.sql
+-- Issue: #{issue_number}
+-- Rollback: DROP TABLE IF EXISTS {table}; / ALTER TABLE DROP COLUMN IF EXISTS {col};
+-- Runtime estimate: < {N}s
+-- Lock risk: none | LOW | MEDIUM | HIGH | CRITICAL (see §7)
+```
+
+For complex migrations, include additional metadata:
+
+```sql
+-- Migration: YYYYMMDDHHMMSS_{description}.sql
+-- Domain: {scoring | search | provenance | governance | ...}
+-- Issue: #{issue_number}
+-- Dependencies: {none | migration_names}
+-- Rollback: {rollback SQL or "NOT POSSIBLE — restore from backup"}
+-- Runtime estimate: < {N}s
+-- Lock risk: {none | LOW | MEDIUM | HIGH | CRITICAL}
+-- Idempotent: YES
+-- Description: {one-line description}
+```
+
+A full template file is available at `supabase/migrations/_TEMPLATE.sql`.
+
+---
+
+## 4. Index Naming Convention
+
+### 4.1 Standard Pattern
+
+```
+idx_{table}_{columns}[_{type}]
+
+{table}     = target table name
+{columns}   = column name(s), joined with underscore for composites
+{type}      = index type suffix (omit for btree/default)
+              gin  — GIN indexes (tsvector, JSONB, arrays)
+              gist — GiST indexes (trigram similarity)
+              hash — Hash indexes (exact equality only)
+              brin — BRIN indexes (range-correlated data)
+```
+
+### 4.2 Examples
+
+| Index Name                        | Type  | Columns               | Purpose            |
+| --------------------------------- | ----- | --------------------- | ------------------ |
+| `idx_products_ean`                | btree | `ean`                 | EAN barcode lookup |
+| `idx_products_category`           | btree | `category`            | Category filtering |
+| `idx_products_search_vector_gin`  | GIN   | `search_vector`       | Full-text search   |
+| `idx_products_name_trgm_gist`     | GiST  | `product_name`        | Trigram similarity |
+| `idx_products_category_country`   | btree | `(category, country)` | Composite filter   |
+| `idx_field_provenance_product_id` | btree | `product_id`          | FK lookup          |
+
+### 4.3 Special Patterns
+
+- **Unique indexes**: Use `_uniq` suffix — `products_ean_uniq`, `products_country_brand_name_uniq`
+- **Partial indexes**: Append condition hint — `products_active_idx` (WHERE `is_deprecated IS NOT TRUE`)
+- **Primary keys**: Use `_pkey` suffix (PostgreSQL default) — `products_pkey`
+
+### 4.4 Current Index Inventory
+
+Existing indexes use mixed naming (legacy). New indexes **must** follow §4.1.
+Renaming existing indexes is low priority and tracked in §12 (Future Work).
+
+---
+
+## 5. Migration Safety Checklist
 
 Every migration **must** satisfy these checks before merge:
 
@@ -114,14 +213,14 @@ Every migration **must** satisfy these checks before merge:
 
 ---
 
-## 4. Migration File Template
+## 6. Migration File Template
 
 ```sql
 -- Migration: YYYYMMDDHHMMSS_{description}.sql
 -- Issue: #{issue_number}
 -- Rollback: DROP TABLE IF EXISTS {table}; / ALTER TABLE DROP COLUMN IF EXISTS {col};
 -- Runtime estimate: < {N}s
--- Lock risk: none | row | table (see §6)
+-- Lock risk: none | row | table (see §8)
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- Step 1: Schema change (idempotent)
@@ -149,18 +248,18 @@ END $$;
 
 ---
 
-## 5. Idempotency Patterns
+## 7. Idempotency Patterns
 
-| Operation | Idempotent Pattern |
-|---|---|
-| Create table | `CREATE TABLE IF NOT EXISTS` |
-| Add column | `ALTER TABLE ADD COLUMN IF NOT EXISTS` |
-| Drop column | `ALTER TABLE DROP COLUMN IF EXISTS` |
-| Create index | `CREATE INDEX IF NOT EXISTS ... CONCURRENTLY` |
-| Create function | `CREATE OR REPLACE FUNCTION` |
-| Create trigger | `DROP TRIGGER IF EXISTS ... ; CREATE TRIGGER ...` |
-| Insert row | `INSERT ... ON CONFLICT DO NOTHING` or `ON CONFLICT DO UPDATE` |
-| Create view | `CREATE OR REPLACE VIEW` |
+| Operation       | Idempotent Pattern                                             |
+| --------------- | -------------------------------------------------------------- |
+| Create table    | `CREATE TABLE IF NOT EXISTS`                                   |
+| Add column      | `ALTER TABLE ADD COLUMN IF NOT EXISTS`                         |
+| Drop column     | `ALTER TABLE DROP COLUMN IF EXISTS`                            |
+| Create index    | `CREATE INDEX IF NOT EXISTS ... CONCURRENTLY`                  |
+| Create function | `CREATE OR REPLACE FUNCTION`                                   |
+| Create trigger  | `DROP TRIGGER IF EXISTS ... ; CREATE TRIGGER ...`              |
+| Insert row      | `INSERT ... ON CONFLICT DO NOTHING` or `ON CONFLICT DO UPDATE` |
+| Create view     | `CREATE OR REPLACE VIEW`                                       |
 
 ### Trigger Idempotency
 
@@ -178,20 +277,22 @@ CREATE TRIGGER products_10_search_vector_update
 
 ---
 
-## 6. Lock Risk Analysis
+## 8. Lock Risk Analysis
 
-| Operation | Lock Type | Duration | Risk at 2.5K rows | Risk at 50K rows |
-|---|---|---|---|---|
-| `ADD COLUMN` (nullable, no default) | `ACCESS EXCLUSIVE` | ~instant | Low | Low |
-| `ADD COLUMN` (with DEFAULT) | `ACCESS EXCLUSIVE` | ~instant (PG 11+) | Low | Low |
-| `CREATE INDEX CONCURRENTLY` | `SHARE UPDATE EXCLUSIVE` | seconds | Low | Medium |
-| `CREATE INDEX` (non-concurrent) | `SHARE` | seconds | Medium | High |
-| `ALTER COLUMN TYPE` | `ACCESS EXCLUSIVE` | table rewrite | High | High |
-| `ADD CONSTRAINT` (with validation) | `SHARE ROW EXCLUSIVE` | full scan | Medium | High |
-| `ADD CONSTRAINT ... NOT VALID` | `SHARE ROW EXCLUSIVE` | ~instant | Low | Low |
-| `VALIDATE CONSTRAINT` | `SHARE UPDATE EXCLUSIVE` | full scan | Medium | Medium |
-| `DROP COLUMN` | `ACCESS EXCLUSIVE` | ~instant | Medium | Medium |
-| `DROP TABLE` | `ACCESS EXCLUSIVE` | ~instant | Low | Low |
+| Operation                           | Lock Type                | Duration          | Risk at 2.5K rows | Risk at 50K rows |
+| ----------------------------------- | ------------------------ | ----------------- | ----------------- | ---------------- |
+| `ADD COLUMN` (nullable, no default) | `ACCESS EXCLUSIVE`       | ~instant          | Low               | Low              |
+| `ADD COLUMN` (with DEFAULT)         | `ACCESS EXCLUSIVE`       | ~instant (PG 11+) | Low               | Low              |
+| `CREATE INDEX CONCURRENTLY`         | `SHARE UPDATE EXCLUSIVE` | seconds           | Low               | Medium           |
+| `CREATE INDEX` (non-concurrent)     | `SHARE`                  | seconds           | Medium            | High             |
+| `ALTER COLUMN TYPE`                 | `ACCESS EXCLUSIVE`       | table rewrite     | High              | High             |
+| `ADD CONSTRAINT` (with validation)  | `SHARE ROW EXCLUSIVE`    | full scan         | Medium            | High             |
+| `ADD CONSTRAINT ... NOT VALID`      | `SHARE ROW EXCLUSIVE`    | ~instant          | Low               | Low              |
+| `VALIDATE CONSTRAINT`               | `SHARE UPDATE EXCLUSIVE` | full scan         | Medium            | Medium           |
+| `DROP COLUMN`                       | `ACCESS EXCLUSIVE`       | ~instant          | Medium            | Medium           |
+| `DROP TABLE`                        | `ACCESS EXCLUSIVE`       | ~instant          | Low               | Low              |
+| `CREATE TRIGGER`                    | `SHARE ROW EXCLUSIVE`    | ~instant          | Low               | Low              |
+| `ALTER TABLE SET NOT NULL`          | `ACCESS EXCLUSIVE`       | scans table       | High              | High             |
 
 ### Mitigation Strategies
 
@@ -203,17 +304,17 @@ CREATE TRIGGER products_10_search_vector_update
 
 ---
 
-## 7. Rollback Procedures
+## 9. Rollback Procedures
 
 Every migration must include rollback instructions in its header comment. Common patterns:
 
-| Migration Type | Rollback Pattern |
-|---|---|
-| New table | `DROP TABLE IF EXISTS {table} CASCADE;` |
-| New column | `ALTER TABLE {table} DROP COLUMN IF EXISTS {col};` |
-| New function | `DROP FUNCTION IF EXISTS {func}();` |
-| New trigger | `DROP TRIGGER IF EXISTS {trigger} ON {table};` |
-| New index | `DROP INDEX IF EXISTS {index};` |
+| Migration Type | Rollback Pattern                                        |
+| -------------- | ------------------------------------------------------- |
+| New table      | `DROP TABLE IF EXISTS {table} CASCADE;`                 |
+| New column     | `ALTER TABLE {table} DROP COLUMN IF EXISTS {col};`      |
+| New function   | `DROP FUNCTION IF EXISTS {func}();`                     |
+| New trigger    | `DROP TRIGGER IF EXISTS {trigger} ON {table};`          |
+| New index      | `DROP INDEX IF EXISTS {index};`                         |
 | New constraint | `ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {name};` |
 
 ### Rollback Testing
@@ -227,7 +328,7 @@ Before a migration is considered complete, verify:
 
 ---
 
-## 8. Trigger Interaction Testing
+## 10. Trigger Interaction Testing
 
 When adding or modifying triggers on the `products` table:
 
@@ -254,20 +355,20 @@ ORDER BY
 
 ---
 
-## 9. Verified Idempotency Examples
+## 11. Verified Idempotency Examples
 
 The following existing migrations have been verified as idempotent (can be re-run safely):
 
-| Migration | Key Pattern | Safe to Re-run |
-|---|---|---|
-| `20260207000100_create_schema.sql` | `CREATE TABLE IF NOT EXISTS` | Yes |
-| `20260210001300_ingredient_normalization.sql` | `CREATE TABLE IF NOT EXISTS` + `ON CONFLICT DO NOTHING` | Yes |
-| `20260213001300_close_roadmap_gaps.sql` | `ADD COLUMN IF NOT EXISTS` + `CREATE OR REPLACE FUNCTION` | Yes |
-| `20260301000000_drift_detection_automation.sql` | `CREATE TABLE IF NOT EXISTS` + `CREATE OR REPLACE FUNCTION` | Yes |
+| Migration                                       | Key Pattern                                                 | Safe to Re-run |
+| ----------------------------------------------- | ----------------------------------------------------------- | -------------- |
+| `20260207000100_create_schema.sql`              | `CREATE TABLE IF NOT EXISTS`                                | Yes            |
+| `20260210001300_ingredient_normalization.sql`   | `CREATE TABLE IF NOT EXISTS` + `ON CONFLICT DO NOTHING`     | Yes            |
+| `20260213001300_close_roadmap_gaps.sql`         | `ADD COLUMN IF NOT EXISTS` + `CREATE OR REPLACE FUNCTION`   | Yes            |
+| `20260301000000_drift_detection_automation.sql` | `CREATE TABLE IF NOT EXISTS` + `CREATE OR REPLACE FUNCTION` | Yes            |
 
 ---
 
-## 10. Future Work
+## 12. Future Work
 
 - **Standardize all products triggers** to `products_NN_domain_action` numbered convention
   (currently 2 use `trg_products_*` pattern and 3 use numbered; both are valid per governance check)

--- a/scripts/check_migration_conventions.py
+++ b/scripts/check_migration_conventions.py
@@ -1,0 +1,237 @@
+"""Validate migration file naming conventions and header block standards.
+
+Scans supabase/migrations/*.sql to verify compliance with the standards
+documented in docs/MIGRATION_CONVENTIONS.md §3 (Migration Naming Convention).
+
+Checks:
+  1. File naming: YYYYMMDDHHMMSS_description.sql
+     - Timestamp is 14 digits
+     - Separator is underscore
+     - Description is lowercase, words separated by underscores
+  2. Header block: must contain at least "Migration:" and "Rollback:" lines
+     within the first 20 lines of the file
+  3. _TEMPLATE.sql is ignored (not a real migration)
+
+Usage:
+    python scripts/check_migration_conventions.py            # check all
+    python scripts/check_migration_conventions.py --strict   # also require Issue: line
+    python scripts/check_migration_conventions.py --report   # summary report only
+
+Exit codes:
+    0 — all checks pass (or report-only mode)
+    1 — violations found
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+MIGRATIONS_ROOT = Path(__file__).resolve().parent.parent / "supabase" / "migrations"
+
+# ── Naming convention ─────────────────────────────────────────────────────
+
+# Valid: 20260301000000_drift_detection_automation.sql
+# Invalid: 2026_03_01_drift.sql, migration_v2.sql
+_FILENAME_RE = re.compile(r"^(\d{14})_([a-z][a-z0-9_]*)\.sql$")
+
+# Timestamp: first 8 digits = YYYYMMDD (basic sanity)
+_MIN_DATE = 20250101
+_MAX_DATE = 20291231
+
+# Description should not contain double underscores or trailing underscore
+_BAD_DESC_RE = re.compile(r"__|_$")
+
+# ── Header block ──────────────────────────────────────────────────────────
+
+# We look in the first 20 lines for these markers.  They may appear
+# as part of a decorated comment block (═══, ───, etc.) or bare "-- Key: ...".
+_MIGRATION_LINE = re.compile(r"^--\s*Migration:", re.IGNORECASE)
+_ROLLBACK_LINE = re.compile(r"^--\s*Rollback:", re.IGNORECASE)
+_ISSUE_LINE = re.compile(r"^--\s*Issue:", re.IGNORECASE)
+
+HEADER_SCAN_LINES = 20
+
+# Files to skip
+SKIP_FILES = {"_TEMPLATE.sql"}
+
+
+def _check_filename(name: str) -> list[str]:
+    """Validate a single migration filename. Returns list of violations."""
+    violations: list[str] = []
+
+    m = _FILENAME_RE.match(name)
+    if not m:
+        violations.append(
+            f"[{name}] Filename does not match YYYYMMDDHHMMSS_description.sql pattern"
+        )
+        return violations  # can't check further
+
+    timestamp_str, description = m.group(1), m.group(2)
+
+    # Basic date sanity
+    date_part = int(timestamp_str[:8])
+    if date_part < _MIN_DATE or date_part > _MAX_DATE:
+        violations.append(
+            f"[{name}] Date portion {date_part} out of expected range "
+            f"({_MIN_DATE}–{_MAX_DATE})"
+        )
+
+    # Month 01–12
+    month = int(timestamp_str[4:6])
+    if month < 1 or month > 12:
+        violations.append(f"[{name}] Invalid month: {month:02d}")
+
+    # Day 01–31
+    day = int(timestamp_str[6:8])
+    if day < 1 or day > 31:
+        violations.append(f"[{name}] Invalid day: {day:02d}")
+
+    # Description quality
+    if _BAD_DESC_RE.search(description):
+        violations.append(
+            f"[{name}] Description contains double underscores or trailing underscore"
+        )
+
+    if len(description) < 3:
+        violations.append(f"[{name}] Description too short (min 3 chars)")
+
+    return violations
+
+
+def _check_header(name: str, content: str, *, strict: bool = False) -> list[str]:
+    """Validate header block in the first N lines. Returns violations."""
+    violations: list[str] = []
+    lines = content.split("\n")[:HEADER_SCAN_LINES]
+
+    has_migration = any(_MIGRATION_LINE.search(line) for line in lines)
+    has_rollback = any(_ROLLBACK_LINE.search(line) for line in lines)
+    has_issue = any(_ISSUE_LINE.search(line) for line in lines)
+
+    if not has_migration:
+        violations.append(
+            f"[{name}] Missing 'Migration:' in header (first {HEADER_SCAN_LINES} lines)"
+        )
+
+    if not has_rollback:
+        violations.append(
+            f"[{name}] Missing 'Rollback:' in header (first {HEADER_SCAN_LINES} lines)"
+        )
+
+    if strict and not has_issue:
+        violations.append(f"[{name}] Missing 'Issue:' in header (strict mode)")
+
+    return violations
+
+
+def check_migration(path: Path, *, strict: bool = False) -> list[str]:
+    """Check a single migration file. Returns list of violations."""
+    violations: list[str] = []
+    name = path.name
+
+    if name in SKIP_FILES:
+        return []
+
+    # Filename checks
+    violations.extend(_check_filename(name))
+
+    # Header block checks
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        violations.append(f"[{name}] Cannot read file: {exc}")
+        return violations
+
+    violations.extend(_check_header(name, content, strict=strict))
+
+    return violations
+
+
+def main() -> None:
+    strict = "--strict" in sys.argv
+    report_only = "--report" in sys.argv
+
+    if not MIGRATIONS_ROOT.is_dir():
+        print(f"ERROR: Migrations directory not found: {MIGRATIONS_ROOT}")
+        sys.exit(1)
+
+    sql_files = sorted(MIGRATIONS_ROOT.glob("*.sql"))
+    sql_files = [f for f in sql_files if f.name not in SKIP_FILES]
+
+    if not sql_files:
+        print("ERROR: No migration files found.")
+        sys.exit(1)
+
+    all_violations: list[str] = []
+    name_ok = 0
+    name_fail = 0
+    header_ok = 0
+    header_missing_migration = 0
+    header_missing_rollback = 0
+    header_missing_issue = 0
+
+    for path in sql_files:
+        name = path.name
+        violations = check_migration(path, strict=strict)
+
+        # Categorize — use specific markers from _check_filename messages
+        fname_violations = [
+            v
+            for v in violations
+            if "does not match" in v
+            or "out of expected range" in v
+            or "Invalid month" in v
+            or "Invalid day" in v
+            or "double underscores" in v
+            or "trailing underscore" in v
+            or "too short" in v
+        ]
+        if fname_violations:
+            name_fail += 1
+        else:
+            name_ok += 1
+
+        for v in violations:
+            if "Migration:" in v:
+                header_missing_migration += 1
+            elif "Rollback:" in v:
+                header_missing_rollback += 1
+            elif "Issue:" in v:
+                header_missing_issue += 1
+
+        if not any(
+            "Migration:" in v or "Rollback:" in v or "Issue:" in v for v in violations
+        ):
+            header_ok += 1
+
+        all_violations.extend(violations)
+
+    total = len(sql_files)
+
+    if report_only:
+        print(f"Migration Convention Report — {total} files scanned")
+        print(f"  Naming: {name_ok}/{total} compliant ({name_fail} violations)")
+        print(f"  Header: {header_ok}/{total} have complete header block")
+        print(f"    Missing 'Migration:' line: {header_missing_migration}")
+        print(f"    Missing 'Rollback:' line: {header_missing_rollback}")
+        if strict:
+            print(f"    Missing 'Issue:' line: {header_missing_issue}")
+        sys.exit(0)
+
+    if all_violations:
+        print(
+            f"Migration convention check — {len(all_violations)} violations in {total} files:"
+        )
+        for v in all_violations:
+            print(f"  x {v}")
+        print(f"\nSummary: {name_ok}/{total} naming OK, {header_ok}/{total} header OK")
+        sys.exit(1)
+    else:
+        mode = " (strict)" if strict else ""
+        print(f"Migration convention check PASSED{mode} — {total} files verified.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/migrations/_TEMPLATE.sql
+++ b/supabase/migrations/_TEMPLATE.sql
@@ -1,0 +1,74 @@
+-- ============================================================================
+-- Migration: YYYYMMDDHHMMSS_{description}.sql
+-- Issue: #{issue_number}
+-- Rollback: {DROP TABLE IF EXISTS ... / ALTER TABLE DROP COLUMN IF EXISTS ...}
+-- Runtime estimate: < {N}s
+-- Lock risk: {none | LOW | MEDIUM | HIGH | CRITICAL}
+-- Idempotent: YES
+-- Description: {one-line description of what this migration does}
+-- ============================================================================
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Step 1: Schema change (idempotent)
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- Example: CREATE TABLE IF NOT EXISTS public.new_table ( ... );
+-- Example: ALTER TABLE products ADD COLUMN IF NOT EXISTS new_column text;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Step 2: Functions (idempotent via CREATE OR REPLACE)
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- Example:
+-- CREATE OR REPLACE FUNCTION my_function()
+-- RETURNS void
+-- LANGUAGE plpgsql
+-- SECURITY INVOKER
+-- AS $$
+-- BEGIN
+--   -- function body
+-- END $$;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Step 3: Triggers (idempotent via DROP IF EXISTS + CREATE)
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- Example:
+-- DROP TRIGGER IF EXISTS products_NN_domain_action ON products;
+-- CREATE TRIGGER products_NN_domain_action
+--   BEFORE|AFTER INSERT|UPDATE|DELETE ON products
+--   FOR EACH ROW
+--   EXECUTE FUNCTION trg_my_function();
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Step 4: Indexes (use CONCURRENTLY on populated tables)
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- Example:
+-- CREATE INDEX IF NOT EXISTS idx_table_column ON table (column);
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Step 5: Grants & RLS
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- Example:
+-- ALTER TABLE new_table ENABLE ROW LEVEL SECURITY;
+-- GRANT SELECT ON new_table TO authenticated;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Step 6: Validation (verify migration applied)
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- DO $$
+-- BEGIN
+--   ASSERT EXISTS (
+--     SELECT 1 FROM information_schema.columns
+--     WHERE table_schema = 'public'
+--       AND table_name   = 'new_table'
+--       AND column_name  = 'expected_column'
+--   ), 'Migration validation FAILED: expected_column not found';
+--   RAISE NOTICE '✅ Migration validated';
+-- END $$;
+
+-- NOTE: Data backfills go in a SEPARATE migration file.
+-- See docs/MIGRATION_CONVENTIONS.md for full standards.


### PR DESCRIPTION
Closes #207 (GOV-E1: Migration Convention and Idempotent Design Standard)

## Summary

Extends the migration conventions documentation (created in #203) with three new governance standards and adds developer tooling for compliance checking.

## Changes

### docs/MIGRATION_CONVENTIONS.md (extended)
- S2.7: Trigger domain range assignments (10-19 search, 20-29 meta/provenance, 30-39 audit, 40-49 scoring, 50-59 events, 60-99 reserved)
- S3: Migration naming convention with file naming format and header block standard (basic + extended templates)
- S4: Index naming convention (pattern idx_{table}_{columns}[_{type}], special patterns for unique/partial/PK)
- S8: Lock risk table expanded with CREATE TRIGGER and ALTER TABLE SET NOT NULL operations
- All subsequent sections renumbered S5-S12

### supabase/migrations/_TEMPLATE.sql (new)
- Standalone migration template with full header block (Migration, Issue, Rollback, Runtime, Lock risk)
- 6-step structure: schema, functions, triggers, indexes, grants/RLS, validation
- Referenced from MIGRATION_CONVENTIONS.md S3.2

### scripts/check_migration_conventions.py (new)
- Validates all migration filenames match YYYYMMDDHHMMSS_description.sql
- Checks header block presence (Migration: and Rollback: lines in first 20 lines)
- Three modes: default (violations exit 1), --strict (also requires Issue:), --report (summary only)
- Current results: 133/133 naming compliant, 8/133 have complete headers (legacy migrations grandfathered)
- Modeled after check_pipeline_structure.py

### Supporting updates
- CHANGELOG.md: 2 entries (Schema + Documentation)
- docs/INDEX.md: Updated MIGRATION_CONVENTIONS.md owner to reference both #203 and #207

## Verification
- python scripts/check_migration_conventions.py --report: 133/133 naming OK
- py_compile: clean
- check_pipeline_structure.py: unchanged, passes
- 5 files changed, +504 / -85 lines