### PR TITLE
schema(migration): add backfill orchestration framework with registry and lifecycle functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Schema & Migrations
 
+- Add backfill orchestration framework: `backfill_registry` table with RLS, 5 lifecycle
+  functions (`register_backfill`, `start_backfill`, `update_backfill_progress`,
+  `complete_backfill`, `fail_backfill`), `v_backfill_status` monitoring view,
+  `scripts/backfill_template.py` Python template (#208)
 - Add migration convention standard: index naming convention `idx_{table}_{columns}[_{type}]`,
   trigger domain range assignments (10–99 by domain), migration file naming format with header
   block standard, `_TEMPLATE.sql` reference template, `check_migration_conventions.py` validation
@@ -52,6 +56,8 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+- Extend `docs/BACKFILL_STANDARD.md` with backfill registry reference (table schema,
+  helper functions, monitoring view, RLS, script template usage) (#208)
 - Extend `docs/MIGRATION_CONVENTIONS.md` with index naming convention, trigger domain range
   assignments, migration file naming format, header block standard, and link to `_TEMPLATE.sql`;
   add `scripts/check_migration_conventions.py` validation script (#207)

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -114,7 +114,7 @@ poland-food-db/
 │       └── VIEW__master_product_view.sql  # v_master definition (reference copy)
 ├── supabase/
 │   ├── config.toml
-│   └── migrations/                  # 133 append-only schema migrations
+│   └── migrations/                  # 134 append-only schema migrations
 │       ├── 20260207000100_create_schema.sql
 │       ├── 20260207000200_baseline.sql
 │       ├── 20260207000300_add_chip_metadata.sql
@@ -314,6 +314,7 @@ poland-food-db/
 | `user_saved_searches`     | Saved search queries                            | `search_id` (identity)                  | Query text, filters JSONB, notification preferences. RLS by user                                                                          |
 | `scan_history`            | Barcode scan history                            | `scan_id` (identity)                    | user_id, ean, scanned_at, product_id (if matched). RLS by user                                                                            |
 | `product_submissions`     | User-submitted products                         | `submission_id` (identity)              | ean, product_name, brand, photo_url, status ('pending'/'approved'/'rejected'). Admin-reviewable                                           |
+| `backfill_registry`       | Batch data operation tracking                   | `backfill_id` (uuid PK)                | name (unique), status, rows_processed/expected, batch_size, rollback_sql, validation_passed. RLS: service-write / auth-read              |
 
 ### Products Columns (key)
 

--- a/db/qa/QA__security_posture.sql
+++ b/db/qa/QA__security_posture.sql
@@ -144,7 +144,9 @@ WHERE n.nspname = 'public'
     'check_product_preferences','resolve_effective_country',
     'compute_health_warnings',
     'check_formula_drift','check_function_source_drift',
-    'governance_drift_check','log_drift_check'
+    'governance_drift_check','log_drift_check',
+    'register_backfill','start_backfill','update_backfill_progress',
+    'complete_backfill','fail_backfill'
   )
   AND has_function_privilege('anon', p.oid, 'EXECUTE');
 
@@ -154,7 +156,8 @@ SELECT '11. service_role has full table privileges' AS check_name,
 FROM (
     SELECT unnest(ARRAY[
         'products','nutrition_facts','product_allergen_info','product_ingredient',
-        'ingredient_ref','category_ref','country_ref','nutri_score_ref','concern_tier_ref'
+        'ingredient_ref','category_ref','country_ref','nutri_score_ref','concern_tier_ref',
+        'backfill_registry'
     ]) AS tbl
 ) t
 WHERE NOT (

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -114,7 +114,7 @@
 | -------------------------------------------------------- | -------------------------------------------------------------------------- | ----------- | ------------ |
 | [RESEARCH_WORKFLOW.md](RESEARCH_WORKFLOW.md)             | Data collection lifecycle — manual + automated OFF pipeline                | Process domain | 2026-02-24   |
 | [VIEWING_AND_TESTING.md](VIEWING_AND_TESTING.md)         | Queries, Studio UI, test runner guide                                      | Process domain | 2026-02-24   |
-| [BACKFILL_STANDARD.md](BACKFILL_STANDARD.md)             | Backfill orchestration standard — migration templates, validation patterns | Process domain | 2026-02-24   |
+| [BACKFILL_STANDARD.md](BACKFILL_STANDARD.md)             | Backfill orchestration standard — migration templates, validation patterns | [#208](https://github.com/ericsocrat/poland-food-db/issues/208) | 2026-03-03   |
 | [MIGRATION_CONVENTIONS.md](MIGRATION_CONVENTIONS.md)     | Migration safety, trigger naming, lock risk, idempotency standards         | [#203](https://github.com/ericsocrat/poland-food-db/issues/203), [#207](https://github.com/ericsocrat/poland-food-db/issues/207) | 2026-03-02   |
 | [LABELS.md](LABELS.md)                                   | GitHub labeling conventions — issue/PR label taxonomy                      | Process domain | 2026-02-23   |
 | [COUNTRY_EXPANSION_GUIDE.md](COUNTRY_EXPANSION_GUIDE.md) | Multi-country expansion protocol — PL active, DE micro-pilot               | [#148](https://github.com/ericsocrat/poland-food-db/issues/148) | 2026-02-24   |

--- a/scripts/backfill_template.py
+++ b/scripts/backfill_template.py
@@ -1,0 +1,249 @@
+"""Backfill Template — Batch data operations with registry integration.
+
+Usage:
+    python scripts/backfill_template.py --name "my_backfill_v1" --dry-run
+    python scripts/backfill_template.py --name "my_backfill_v1" --batch-size 500
+
+This is a TEMPLATE.  Copy to scripts/backfill_{name}.py and customise:
+  1. BACKFILL_NAME, DESCRIPTION, SOURCE_ISSUE
+  2. NEEDS_BACKFILL_QUERY (which rows to update)
+  3. UPDATE_SQL (what to set)
+  4. VALIDATION_QUERIES (pre/post checks)
+
+Requirements:
+  - Register in backfill_registry BEFORE execution
+  - Run pre-validation
+  - Execute in batches with SKIP LOCKED
+  - Run post-validation
+  - Update registry with final status
+
+See docs/BACKFILL_STANDARD.md for full governance standard.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+# ---------------------------------------------------------------------------
+# Configuration — EDIT THESE for your backfill
+# ---------------------------------------------------------------------------
+
+BACKFILL_NAME = "template_backfill_v1"
+DESCRIPTION = "Template backfill — replace with your description"
+SOURCE_ISSUE = "#000"
+DEFAULT_BATCH_SIZE = 1000
+PAUSE_SECONDS = 0.1  # Pause between batches to reduce lock contention
+
+# SQL: count rows that need backfilling
+COUNT_QUERY = """
+SELECT count(*) FROM products
+WHERE 1 = 0;  -- REPLACE: your needs-backfill condition
+"""
+
+# SQL: batched update (must include FOR UPDATE SKIP LOCKED)
+# Use $1 for batch_size parameter
+BATCH_UPDATE_SQL = """
+WITH batch AS (
+    SELECT product_id
+    FROM products
+    WHERE 1 = 0  -- REPLACE: your needs-backfill condition
+    ORDER BY product_id
+    LIMIT $1
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE products p
+SET    updated_at = now()  -- REPLACE: your actual column updates
+FROM   batch b
+WHERE  p.product_id = b.product_id;
+"""
+
+# SQL: pre-validation (run before backfill, results printed)
+PRE_VALIDATION_SQL = """
+SELECT
+    count(*) AS total_rows,
+    count(*) FILTER (WHERE 1 = 0) AS needs_backfill  -- REPLACE
+FROM products;
+"""
+
+# SQL: post-validation (run after backfill, results printed)
+POST_VALIDATION_SQL = """
+SELECT
+    count(*) AS total_rows,
+    count(*) FILTER (WHERE 1 = 0) AS still_needs_backfill  -- REPLACE: should be 0
+FROM products;
+"""
+
+# SQL: rollback (stored in registry, executed manually if needed)
+ROLLBACK_SQL = """
+-- REPLACE: SQL to undo this backfill
+-- Example: UPDATE products SET target_column = NULL WHERE target_column IS NOT NULL;
+"""
+
+# ---------------------------------------------------------------------------
+# Implementation — typically no edits needed below
+# ---------------------------------------------------------------------------
+
+def get_db_url() -> str:
+    """Get database URL from environment or use local default."""
+    return os.environ.get(
+        "DATABASE_URL",
+        "postgresql://postgres:postgres@127.0.0.1:54322/postgres",
+    )
+
+
+def run_backfill(batch_size: int, dry_run: bool) -> None:
+    """Execute the backfill with registry tracking."""
+    try:
+        import psycopg2  # type: ignore[import-untyped]
+    except ImportError:
+        print("ERROR: psycopg2 not installed. Run: pip install psycopg2-binary")
+        sys.exit(1)
+
+    db_url = get_db_url()
+    conn = psycopg2.connect(db_url)
+    conn.autocommit = True
+
+    try:
+        cur = conn.cursor()
+
+        # 1. Count rows to process
+        cur.execute(COUNT_QUERY)
+        rows_expected = cur.fetchone()[0]
+        print(f"Rows to backfill: {rows_expected}")
+
+        if rows_expected == 0:
+            print("Nothing to backfill. Exiting.")
+            return
+
+        if dry_run:
+            print(f"DRY RUN: Would process {rows_expected} rows in batches of {batch_size}")
+            print(f"Estimated batches: {(rows_expected + batch_size - 1) // batch_size}")
+            return
+
+        # 2. Register backfill
+        cur.execute(
+            "SELECT register_backfill(%s, %s, %s, %s, %s, %s, %s)",
+            (
+                BACKFILL_NAME,
+                DESCRIPTION,
+                SOURCE_ISSUE,
+                rows_expected,
+                batch_size,
+                ROLLBACK_SQL.strip(),
+                os.environ.get("GITHUB_ACTOR", "local"),
+            ),
+        )
+        backfill_id = cur.fetchone()[0]
+        print(f"Registered backfill: {backfill_id}")
+
+        # 3. Pre-validation
+        print("\n--- Pre-validation ---")
+        cur.execute(PRE_VALIDATION_SQL)
+        cols = [desc[0] for desc in cur.description]
+        row = cur.fetchone()
+        for col, val in zip(cols, row):
+            print(f"  {col}: {val}")
+
+        # 4. Start backfill
+        cur.execute("SELECT start_backfill(%s)", (backfill_id,))
+        total_processed = 0
+        batch_num = 0
+        start_time = time.time()
+
+        # 5. Execute in batches
+        while True:
+            cur.execute(BATCH_UPDATE_SQL, (batch_size,))
+            affected = cur.rowcount
+            if affected == 0:
+                break
+
+            batch_num += 1
+            total_processed += affected
+            elapsed = time.time() - start_time
+            pct = (total_processed / rows_expected * 100) if rows_expected > 0 else 0
+            print(
+                f"  Batch {batch_num}: +{affected} rows "
+                f"({total_processed}/{rows_expected} = {pct:.1f}%) "
+                f"[{elapsed:.1f}s]"
+            )
+
+            # Update registry progress
+            cur.execute(
+                "SELECT update_backfill_progress(%s, %s)",
+                (backfill_id, total_processed),
+            )
+
+            time.sleep(PAUSE_SECONDS)
+
+        elapsed = time.time() - start_time
+        print(f"\nBackfill complete: {total_processed} rows in {elapsed:.1f}s")
+
+        # 6. Post-validation
+        print("\n--- Post-validation ---")
+        cur.execute(POST_VALIDATION_SQL)
+        cols = [desc[0] for desc in cur.description]
+        row = cur.fetchone()
+        validation_ok = True
+        for col, val in zip(cols, row):
+            print(f"  {col}: {val}")
+            if col == "still_needs_backfill" and val > 0:
+                validation_ok = False
+
+        # 7. Complete backfill
+        cur.execute(
+            "SELECT complete_backfill(%s, %s, %s)",
+            (backfill_id, total_processed, validation_ok),
+        )
+        status = "PASSED" if validation_ok else "FAILED"
+        print(f"\nValidation: {status}")
+        print(f"Registry updated: {backfill_id}")
+
+    except Exception as exc:
+        print(f"\nERROR: {exc}")
+        # Try to mark as failed
+        try:
+            cur.execute(
+                "SELECT fail_backfill(%s, %s)",
+                (backfill_id, str(exc)[:500]),
+            )
+        except Exception:
+            pass
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a registered backfill operation")
+    parser.add_argument(
+        "--name",
+        default=BACKFILL_NAME,
+        help=f"Backfill name (default: {BACKFILL_NAME})",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help=f"Rows per batch (default: {DEFAULT_BATCH_SIZE})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Count rows and estimate work without executing",
+    )
+    args = parser.parse_args()
+
+    print(f"Backfill: {args.name}")
+    print(f"Batch size: {args.batch_size}")
+    print(f"Dry run: {args.dry_run}")
+    print(f"DB: {get_db_url().split('@')[1] if '@' in get_db_url() else 'local'}")
+    print()
+
+    run_backfill(args.batch_size, args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/migrations/20260303000000_backfill_registry.sql
+++ b/supabase/migrations/20260303000000_backfill_registry.sql
@@ -1,0 +1,282 @@
+-- ============================================================================
+-- Migration: 20260303000000_backfill_registry.sql
+-- Issue: #208
+-- Rollback: DROP TABLE IF EXISTS public.backfill_registry CASCADE;
+-- Runtime estimate: < 1s
+-- Lock risk: none (new table creation)
+-- Idempotent: YES
+-- Description: Create backfill_registry table for tracking batch data operations
+-- ============================================================================
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Step 1: Create backfill_registry table
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Tracks all backfill operations: batch data updates, scoring re-computations,
+-- search vector regenerations, etc.  Every backfill MUST register here before
+-- execution and update status upon completion.
+--
+-- See docs/BACKFILL_STANDARD.md for full governance standard.
+
+CREATE TABLE IF NOT EXISTS public.backfill_registry (
+    backfill_id     uuid        DEFAULT gen_random_uuid() PRIMARY KEY,
+    name            text        NOT NULL,
+    description     text,
+    source_issue    text,                       -- e.g., '#193'
+    status          text        NOT NULL DEFAULT 'pending',
+    started_at      timestamptz,
+    completed_at    timestamptz,
+    rows_processed  integer     NOT NULL DEFAULT 0,
+    rows_expected   integer,
+    batch_size      integer     NOT NULL DEFAULT 1000,
+    error_message   text,
+    executed_by     text,                       -- github username or 'automation'
+    rollback_sql    text,                       -- SQL to undo this backfill
+    validation_passed boolean,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+
+    -- Domain constraints
+    CONSTRAINT chk_backfill_status
+        CHECK (status IN ('pending', 'running', 'completed', 'failed', 'rolled_back')),
+    CONSTRAINT chk_backfill_rows_non_negative
+        CHECK (rows_processed >= 0),
+    CONSTRAINT chk_backfill_batch_size_positive
+        CHECK (batch_size > 0),
+    CONSTRAINT backfill_registry_name_unique UNIQUE (name)
+);
+
+-- Comment
+COMMENT ON TABLE public.backfill_registry IS
+    'Tracks all backfill operations — batch data updates, scoring re-computations, etc. See docs/BACKFILL_STANDARD.md.';
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Step 2: Indexes
+-- ═══════════════════════════════════════════════════════════════════════════
+
+CREATE INDEX IF NOT EXISTS idx_backfill_registry_status
+    ON public.backfill_registry (status);
+
+CREATE INDEX IF NOT EXISTS idx_backfill_registry_created
+    ON public.backfill_registry (created_at DESC);
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Step 3: RLS — service-write / authenticated-read
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Follows Pattern B from drift_check_results: service_role gets full access,
+-- authenticated users get read-only, anon gets nothing.
+
+ALTER TABLE public.backfill_registry ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE tablename = 'backfill_registry'
+          AND policyname = 'backfill_service_all'
+    ) THEN
+        CREATE POLICY backfill_service_all ON public.backfill_registry
+            FOR ALL TO service_role USING (true) WITH CHECK (true);
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE tablename = 'backfill_registry'
+          AND policyname = 'backfill_auth_read'
+    ) THEN
+        CREATE POLICY backfill_auth_read ON public.backfill_registry
+            FOR SELECT TO authenticated USING (true);
+    END IF;
+END $$;
+
+GRANT ALL ON public.backfill_registry TO service_role;
+GRANT SELECT ON public.backfill_registry TO authenticated;
+REVOKE ALL ON public.backfill_registry FROM anon;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Step 4: Helper functions
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- Register a new backfill (returns the backfill_id)
+CREATE OR REPLACE FUNCTION register_backfill(
+    p_name text,
+    p_description text DEFAULT NULL,
+    p_source_issue text DEFAULT NULL,
+    p_rows_expected integer DEFAULT NULL,
+    p_batch_size integer DEFAULT 1000,
+    p_rollback_sql text DEFAULT NULL,
+    p_executed_by text DEFAULT 'automation'
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_id uuid;
+BEGIN
+    INSERT INTO backfill_registry (name, description, source_issue, rows_expected,
+                                   batch_size, rollback_sql, executed_by)
+    VALUES (p_name, p_description, p_source_issue, p_rows_expected,
+            p_batch_size, p_rollback_sql, p_executed_by)
+    ON CONFLICT (name) DO UPDATE SET
+        description    = EXCLUDED.description,
+        source_issue   = EXCLUDED.source_issue,
+        rows_expected  = EXCLUDED.rows_expected,
+        batch_size     = EXCLUDED.batch_size,
+        rollback_sql   = EXCLUDED.rollback_sql,
+        executed_by    = EXCLUDED.executed_by,
+        status         = 'pending',
+        rows_processed = 0,
+        started_at     = NULL,
+        completed_at   = NULL,
+        error_message  = NULL,
+        validation_passed = NULL
+    RETURNING backfill_id INTO v_id;
+
+    RETURN v_id;
+END $$;
+
+-- Mark a backfill as started
+CREATE OR REPLACE FUNCTION start_backfill(p_backfill_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    UPDATE backfill_registry
+    SET status     = 'running',
+        started_at = now()
+    WHERE backfill_id = p_backfill_id
+      AND status = 'pending';
+END $$;
+
+-- Update progress during execution
+CREATE OR REPLACE FUNCTION update_backfill_progress(
+    p_backfill_id uuid,
+    p_rows_processed integer
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    UPDATE backfill_registry
+    SET rows_processed = p_rows_processed
+    WHERE backfill_id = p_backfill_id
+      AND status = 'running';
+END $$;
+
+-- Complete a backfill
+CREATE OR REPLACE FUNCTION complete_backfill(
+    p_backfill_id uuid,
+    p_rows_processed integer DEFAULT NULL,
+    p_validation_passed boolean DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    UPDATE backfill_registry
+    SET status            = 'completed',
+        completed_at      = now(),
+        rows_processed    = COALESCE(p_rows_processed, rows_processed),
+        validation_passed = p_validation_passed
+    WHERE backfill_id = p_backfill_id
+      AND status = 'running';
+END $$;
+
+-- Fail a backfill
+CREATE OR REPLACE FUNCTION fail_backfill(
+    p_backfill_id uuid,
+    p_error_message text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    UPDATE backfill_registry
+    SET status        = 'failed',
+        completed_at  = now(),
+        error_message = p_error_message
+    WHERE backfill_id = p_backfill_id
+      AND status = 'running';
+END $$;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Step 4b: Revoke anon access to internal backfill functions
+-- ═══════════════════════════════════════════════════════════════════════════
+
+REVOKE EXECUTE ON FUNCTION public.register_backfill(text, text, text, integer, integer, text, text) FROM anon, public;
+REVOKE EXECUTE ON FUNCTION public.start_backfill(uuid) FROM anon, public;
+REVOKE EXECUTE ON FUNCTION public.update_backfill_progress(uuid, integer) FROM anon, public;
+REVOKE EXECUTE ON FUNCTION public.complete_backfill(uuid, integer, boolean) FROM anon, public;
+REVOKE EXECUTE ON FUNCTION public.fail_backfill(uuid, text) FROM anon, public;
+
+-- Grant to service_role only (these are machine-only functions)
+GRANT EXECUTE ON FUNCTION public.register_backfill(text, text, text, integer, integer, text, text) TO service_role;
+GRANT EXECUTE ON FUNCTION public.start_backfill(uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.update_backfill_progress(uuid, integer) TO service_role;
+GRANT EXECUTE ON FUNCTION public.complete_backfill(uuid, integer, boolean) TO service_role;
+GRANT EXECUTE ON FUNCTION public.fail_backfill(uuid, text) TO service_role;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Step 5: Monitoring view
+-- ═══════════════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE VIEW public.v_backfill_status AS
+SELECT
+    backfill_id,
+    name,
+    status,
+    rows_processed,
+    rows_expected,
+    CASE WHEN rows_expected > 0
+         THEN round(rows_processed * 100.0 / rows_expected, 1)
+         ELSE NULL
+    END AS pct_complete,
+    batch_size,
+    started_at,
+    completed_at,
+    CASE WHEN started_at IS NOT NULL AND completed_at IS NULL
+         THEN extract(epoch FROM (now() - started_at))::integer
+         WHEN started_at IS NOT NULL AND completed_at IS NOT NULL
+         THEN extract(epoch FROM (completed_at - started_at))::integer
+         ELSE NULL
+    END AS elapsed_seconds,
+    validation_passed,
+    error_message,
+    executed_by,
+    source_issue,
+    created_at
+FROM public.backfill_registry
+ORDER BY created_at DESC;
+
+GRANT SELECT ON public.v_backfill_status TO authenticated;
+GRANT SELECT ON public.v_backfill_status TO service_role;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Step 6: Validation
+-- ═══════════════════════════════════════════════════════════════════════════
+
+DO $$
+BEGIN
+    ASSERT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name   = 'backfill_registry'
+    ), 'Migration validation FAILED: backfill_registry table not found';
+
+    ASSERT EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE proname = 'register_backfill'
+          AND pronamespace = 'public'::regnamespace
+    ), 'Migration validation FAILED: register_backfill function not found';
+
+    RAISE NOTICE 'Migration validated: backfill_registry + 5 functions + monitoring view';
+END $$;

--- a/supabase/tests/schema_contracts.test.sql
+++ b/supabase/tests/schema_contracts.test.sql
@@ -7,7 +7,7 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 
 BEGIN;
-SELECT plan(105);
+SELECT plan(114);
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 1. Core data tables exist
@@ -163,6 +163,17 @@ SELECT has_table('public', 'drift_check_results',                 'table drift_c
 SELECT has_column('public', 'drift_check_results', 'run_id',     'column drift_check_results.run_id exists');
 SELECT has_function('public', 'governance_drift_check',           'function governance_drift_check exists');
 SELECT has_function('public', 'log_drift_check',                  'function log_drift_check exists');
+
+-- ─── Backfill Orchestration (#208) ────────────────────────────────────────────
+SELECT has_table('public', 'backfill_registry',                   'table backfill_registry exists');
+SELECT has_column('public', 'backfill_registry', 'backfill_id',  'column backfill_registry.backfill_id exists');
+SELECT has_column('public', 'backfill_registry', 'name',         'column backfill_registry.name exists');
+SELECT has_column('public', 'backfill_registry', 'status',       'column backfill_registry.status exists');
+SELECT has_column('public', 'backfill_registry', 'rows_processed','column backfill_registry.rows_processed exists');
+SELECT has_view('public', 'v_backfill_status',                   'view v_backfill_status exists');
+SELECT has_function('public', 'register_backfill',               'function register_backfill exists');
+SELECT has_function('public', 'start_backfill',                  'function start_backfill exists');
+SELECT has_function('public', 'complete_backfill',               'function complete_backfill exists');
 
 SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
Closes #208 (GOV-E2: Backfill Orchestration and Validation Framework)

## Summary

Creates a complete backfill orchestration framework: a registry table for tracking batch data operations, lifecycle management functions, a monitoring view, and a Python script template.

## Changes

### supabase/migrations/20260303000000_backfill_registry.sql (new)
- backfill_registry table with UUID PK, status tracking, batch metadata, rollback SQL
- CHECK constraints: status domain (pending/running/completed/failed/rolled_back), non-negative rows, positive batch_size
- RLS: Pattern B (service-write / authenticated-read), matching drift_check_results pattern
- 5 lifecycle functions (all SECURITY DEFINER):
  - register_backfill() - upsert registration, returns backfill_id
  - start_backfill() - marks running + sets started_at
  - update_backfill_progress() - updates rows_processed during execution
  - complete_backfill() - marks completed + validation_passed
  - fail_backfill() - marks failed + records error_message
- v_backfill_status monitoring view (with pct_complete, elapsed_seconds)
- Validation assertions at end of migration

### scripts/backfill_template.py (new)
- Copy-and-customize template for any backfill operation
- Handles: registry integration, pre/post validation, batched execution, progress updates
- Supports --dry-run and --batch-size flags
- Uses psycopg2 for direct DB access

### docs/BACKFILL_STANDARD.md (extended)
- Added S8: Backfill Registry (table schema, helper functions, monitoring view, RLS, script usage)

### Test and QA updates
- schema_contracts.test.sql: plan(105) to plan(114) - added 9 assertions for backfill_registry table, columns, view, and 3 functions
- QA__security_posture.sql check 10: added 5 backfill functions to anon-blocked list
- QA__security_posture.sql check 11: added backfill_registry to service_role table list

### Supporting docs
- CHANGELOG.md: 2 entries (schema + documentation)
- docs/INDEX.md: updated BACKFILL_STANDARD.md owner to #208
- copilot-instructions.md: added backfill_registry to Tables table, updated migration count 133 to 134

## Verification
- py_compile: both Python scripts compile clean
- 8 files changed, +607 / -6 lines