### PR TITLE
docs(observability): add structured log schema and error taxonomy with DB registry (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Schema & Migrations
 
+- Add structured log schema & error taxonomy: `log_level_ref` table (5 severity levels with
+  retention/escalation policy), `error_code_registry` table (13 starter error codes across 8
+  domains), `validate_log_entry()` validation function (SECURITY DEFINER), RLS Pattern B
+  (service-write / auth-read) (#210)
 - Add backfill orchestration framework: `backfill_registry` table with RLS, 5 lifecycle
   functions (`register_backfill`, `start_backfill`, `update_backfill_progress`,
   `complete_backfill`, `fail_backfill`), `v_backfill_status` monitoring view,
@@ -67,6 +71,9 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+- Add `docs/LOG_SCHEMA.md`: structured log schema specification, error code format
+  (`{DOMAIN}_{CATEGORY}_{NNN}`), 8 registered domains, severity/escalation matrix,
+  retention policy (0d–indefinite), domain-specific logging conventions (#210)
 - Extend `docs/BACKFILL_STANDARD.md` with backfill registry reference (table schema,
   helper functions, monitoring view, RLS, script template usage) (#208)
 - Extend `docs/MIGRATION_CONVENTIONS.md` with index naming convention, trigger domain range

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,7 +2,7 @@
 
 > **Last updated:** 2026-03-01
 > **Status:** Active — update when adding, renaming, or archiving docs
-> **Total documents:** 41 in `docs/` + 5 elsewhere in repo
+> **Total documents:** 42 in `docs/` + 5 elsewhere in repo
 > **Reference:** Issue [#200](https://github.com/ericsocrat/poland-food-db/issues/200), [#201](https://github.com/ericsocrat/poland-food-db/issues/201)
 
 ---
@@ -16,7 +16,7 @@
 | [Scoring](#scoring)                                      | 2     | Methodology (formula), engine (architecture)                                                             |
 | [Data & Provenance](#data--provenance)                   | 5     | Sources, provenance, integrity audits, EAN validation, production data                                   |
 | [Security & Compliance](#security--compliance)           | 5     | Root policy, audit report, access audit, privacy checklist, rate limiting                                |
-| [Observability & Operations](#observability--operations) | 6     | Monitoring, observability, SLOs, metrics, incident response, disaster drill                              |
+| [Observability & Operations](#observability--operations) | 7     | Monitoring, observability, log schema, SLOs, metrics, incident response, disaster drill                  |
 | [DevOps & Environment](#devops--environment)             | 3     | Environment strategy, staging setup, Sonar config                                                        |
 | [Frontend & UX](#frontend--ux)                           | 4     | UX/UI design, UX impact metrics, design system, frontend README                                          |
 | [Process & Workflow](#process--workflow)                 | 6     | Research workflow, viewing & testing, backfill standard, migration conventions, labels, country expansion |
@@ -87,6 +87,7 @@
 | [SLO.md](SLO.md)                                     | Service Level Objectives — availability, latency, error rate targets            | Observability domain                                            | 2026-02-24   |
 | [METRICS.md](METRICS.md)                             | Metrics catalog — application metrics, infrastructure metrics, business metrics | Observability domain                                            | 2026-02-24   |
 | [INCIDENT_RESPONSE.md](INCIDENT_RESPONSE.md)         | Incident response playbook — severity, escalation, runbooks, post-mortem        | [#231](https://github.com/ericsocrat/poland-food-db/issues/231) | 2026-02-24   |
+| [LOG_SCHEMA.md](LOG_SCHEMA.md)                       | Structured log schema & error taxonomy — error codes, severity, retention, validation | [#210](https://github.com/ericsocrat/poland-food-db/issues/210) | 2026-03-04   |
 | [DISASTER_DRILL_REPORT.md](DISASTER_DRILL_REPORT.md) | Disaster recovery drill report — test results, findings, remediation            | Observability domain                                            | 2026-02-23   |
 
 ## DevOps & Environment
@@ -152,6 +153,7 @@ Pairs investigated for overlap during the 2026-02-28 audit:
 | SCORING_METHODOLOGY.md ↔ SCORING_ENGINE.md        | Methodology = formula; Engine = architecture                                     | **No redundancy** — what vs how                        |
 | ENVIRONMENT_STRATEGY.md ↔ STAGING_SETUP.md        | Strategy = overall design; Setup = operational steps                             | **No redundancy** — complements                        |
 | MONITORING.md ↔ OBSERVABILITY.md                  | Monitoring = alerts/dashboards; Observability = logging/tracing/metrics pipeline | **No redundancy** — overlapping domain, distinct focus |
+| OBSERVABILITY.md ↔ LOG_SCHEMA.md                  | Observability = strategy/format; Log Schema = error codes/taxonomy/DB registry  | **No redundancy** — format vs taxonomy                 |
 | METRICS.md ↔ UX_IMPACT_METRICS.md                 | Metrics = infra/app metrics; UX Impact = UX-specific measurement                 | **No redundancy** — different audiences                |
 | PERFORMANCE_REPORT.md ↔ PERFORMANCE_GUARDRAILS.md | Report = audit findings; Guardrails = policy/budgets                             | **No redundancy** — snapshot vs policy                 |
 

--- a/docs/LOG_SCHEMA.md
+++ b/docs/LOG_SCHEMA.md
@@ -1,0 +1,265 @@
+# Structured Log Schema & Error Taxonomy
+
+> **Last updated:** 2026-03-04
+> **Status:** Active
+> **Owner issue:** [#210](https://github.com/ericsocrat/poland-food-db/issues/210)
+
+---
+
+## Overview
+
+This document defines the structured log schema, error taxonomy, and severity
+classification used across all workstreams. It extends the frontend structured
+log format documented in [OBSERVABILITY.md](OBSERVABILITY.md) to cover backend
+(pipeline, migration, scoring) and database-level operations.
+
+**Relationship to OBSERVABILITY.md:** OBSERVABILITY.md defines the frontend/API
+structured log format, Sentry integration, and health check endpoints.
+LOG_SCHEMA.md defines the **error code taxonomy**, **severity escalation rules**,
+**retention policy**, and **domain-specific logging requirements**.
+
+---
+
+## 1. Structured Log Schema
+
+All logs — frontend, backend, and pipeline — MUST use JSON with these fields:
+
+```json
+{
+  "timestamp": "2026-03-01T12:00:00.000Z",
+  "level": "ERROR",
+  "domain": "scoring",
+  "action": "recompute_health_score",
+  "message": "Division by zero in nutrient ratio calculation",
+  "error_code": "SCORING_CALC_001",
+  "product_id": 42,
+  "country": "PL",
+  "context": {
+    "formula_version": "3.2",
+    "nutrient": "fiber",
+    "input_value": 0
+  },
+  "duration_ms": 45,
+  "user_id": null,
+  "request_id": "550e8400-e29b-41d4-a716-446655440000",
+  "trace_id": "trace-uuid-here"
+}
+```
+
+### Required Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `timestamp` | ISO 8601 string | YES | When the event occurred |
+| `level` | enum | YES | `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL` |
+| `domain` | enum | YES | One of the registered domains (see §3) |
+| `action` | string | YES | What operation was being performed |
+| `message` | string | YES | Human-readable description |
+
+### Conditional Fields
+
+| Field | Type | When Required | Description |
+|---|---|---|---|
+| `error_code` | string | If level ≥ ERROR | Unique error identifier (see §2) |
+| `product_id` | bigint | If applicable | Which product was involved |
+| `country` | string | If applicable | Which country context (PL, DE) |
+
+### Optional Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `context` | object | Additional structured key-value data |
+| `duration_ms` | integer | Operation duration in milliseconds |
+| `user_id` | UUID | Which user triggered the operation |
+| `request_id` | UUID | HTTP request correlation ID |
+| `trace_id` | UUID | Distributed trace correlation ID |
+
+---
+
+## 2. Error Code Format & Registry
+
+### Format
+
+```
+{DOMAIN}_{CATEGORY}_{NNN}
+```
+
+- **Domain:** SCORING, SEARCH, PROVENANCE, PIPELINE, MIGRATION, AUTH, FRONTEND, CONFIG
+- **Category:** CALC, QUERY, CONFLICT, TIMEOUT, VALIDATION, IO, LOCK, TOKEN, INDEX, VERSION
+- **NNN:** Three-digit sequential number within domain+category
+
+### Error Code Registry (Starter Set)
+
+Stored in the `error_code_registry` table for programmatic access.
+
+| Code | Domain | Category | Severity | Description | Action |
+|---|---|---|---|---|---|
+| `SCORING_CALC_001` | scoring | calculation | ERROR | Division by zero in formula | Skip product, log, alert |
+| `SCORING_CALC_002` | scoring | calculation | WARN | Negative score computed | Clamp to 1, log |
+| `SCORING_VERSION_001` | scoring | version | ERROR | Product references non-existent scoring version | Default to active version |
+| `SEARCH_QUERY_001` | search | query | WARN | Zero results returned for non-empty query | Log for analysis |
+| `SEARCH_QUERY_002` | search | query | ERROR | Query exceeded timeout threshold (>2s) | Return partial results |
+| `SEARCH_INDEX_001` | search | index | CRITICAL | tsvector or pg_trgm index missing/invalid | Alert immediately |
+| `PROVENANCE_CONFLICT_001` | provenance | conflict | WARN | Two sources disagree on field value | Queue for resolution |
+| `PROVENANCE_STALE_001` | provenance | freshness | INFO | Product data older than 90 days | Schedule re-check |
+| `PIPELINE_IO_001` | pipeline | io | ERROR | OFF API unreachable | Retry with exponential backoff |
+| `PIPELINE_IO_002` | pipeline | io | WARN | OFF API returned incomplete data | Log missing fields |
+| `MIGRATION_LOCK_001` | migration | lock | CRITICAL | AccessExclusiveLock held >5s | Alert, prepare rollback |
+| `AUTH_TOKEN_001` | auth | token | WARN | Expired JWT presented | Return 401 |
+| `AUTH_RLS_001` | auth | access | ERROR | RLS policy violation / unauthorized access | Log, return 403 |
+
+### Adding New Error Codes
+
+1. Insert into `error_code_registry` table via migration
+2. Follow the `{DOMAIN}_{CATEGORY}_{NNN}` format
+3. Document the expected action (what the system should do)
+4. Assign appropriate severity (see §4)
+
+---
+
+## 3. Domains
+
+| Domain | Code Prefix | Description | Examples |
+|---|---|---|---|
+| `scoring` | `SCORING_` | Unhealthiness score computation, formula versioning | Score calculation, drift detection |
+| `search` | `SEARCH_` | Product search, autocomplete, ranking | Query execution, index management |
+| `provenance` | `PROVENANCE_` | Data source tracking, freshness, conflicts | Source updates, staleness checks |
+| `pipeline` | `PIPELINE_` | OFF API data ingestion, SQL generation | API calls, data validation |
+| `migration` | `MIGRATION_` | Schema migrations, backfills | Lock acquisition, rollback |
+| `auth` | `AUTH_` | Authentication, authorization, RLS | JWT validation, role checks |
+| `frontend` | `FRONTEND_` | Client-side errors, rendering failures | Component errors, API call failures |
+| `config` | `CONFIG_` | Feature flags, environment configuration | Flag evaluation, config loading |
+
+---
+
+## 4. Severity Levels & Escalation
+
+Stored in the `log_level_ref` table for programmatic access.
+
+| Level | Numeric | When to Use | Escalation | Example |
+|---|---|---|---|---|
+| `DEBUG` | 0 | Development tracing | None | "Entered scoring calculation for product 42" |
+| `INFO` | 1 | Normal operations | None | "Backfill completed: 1000 rows processed" |
+| `WARN` | 2 | Unexpected but recoverable | Dashboard amber indicator | "Scoring produced value < 1, clamped to 1" |
+| `ERROR` | 3 | Operation failed, system continues | Alert (Slack/email) within 15min | "Query timeout on search — returned partial results" |
+| `CRITICAL` | 4 | System-wide impact, immediate action | Page on-call within 5min | "tsvector index missing, search fully degraded" |
+
+### Escalation Rules
+
+```
+CRITICAL → Page on-call via PagerDuty/OpsGenie within 5min
+           Bridge call opened if not acknowledged in 15min
+
+ERROR    → Slack #alerts channel within 15min
+           If >5 ERRORs in 1h from same domain → escalate to CRITICAL
+
+WARN     → Dashboard indicator (amber dot)
+           If >50 WARNs in 1h from same domain → escalate to ERROR
+
+INFO     → Dashboard log viewer only
+           No escalation
+
+DEBUG    → Local dev console only
+           Never stored in production
+```
+
+---
+
+## 5. Log Retention Policy
+
+| Level | Retention | Storage Tier | Notes |
+|---|---|---|---|
+| `DEBUG` | 0 days (production) | Not stored in prod | Development/local only |
+| `INFO` | 30 days | Standard (Vercel Logs) | Auto-pruned after 30d |
+| `WARN` | 90 days | Standard | Queryable for trend analysis |
+| `ERROR` | 365 days | Standard + backup | Required for annual audit |
+| `CRITICAL` | Indefinite | Standard + cold backup | Preserved for post-mortems |
+
+### Storage Guidelines
+
+- **Vercel Logs** (frontend/API): captured via stdout JSON, 30-day default
+- **Supabase Logs** (database): `pg_stat_statements`, audit logs
+- **Pipeline Logs** (Python): written to `pipeline/logs/` locally; CI artifacts preserved 90 days
+- **Sentry** (errors): retained per Sentry plan (90 days default)
+
+---
+
+## 6. Domain-Specific Log Conventions
+
+Each domain must log at minimum:
+
+| Domain | INFO Events | ERROR Events |
+|---|---|---|
+| **Scoring** | Score computed (product_id, version, result, duration_ms) | Calculation failure, version mismatch |
+| **Search** | Query executed (query, result_count, duration_ms) | Timeout, index failure |
+| **Provenance** | Source update (product_id, field, old_source, new_source) | Conflict detected |
+| **Pipeline** | Product imported (ean, source, category) | Import failure, API error |
+| **Migration** | Migration started/completed (name, duration_ms) | Lock timeout, rollback |
+| **Auth** | Login success (user_id, method) | Token expired, RLS violation |
+| **Frontend** | Page loaded (route, duration_ms) | Component render failure |
+| **Config** | Flag evaluated (flag_key, result) | Flag config invalid |
+
+---
+
+## 7. Database Schema
+
+### Tables
+
+Two reference tables support programmatic access to the taxonomy:
+
+```sql
+-- log_level_ref: severity level definitions
+CREATE TABLE log_level_ref (
+    level      text PRIMARY KEY,      -- DEBUG, INFO, WARN, ERROR, CRITICAL
+    numeric_level integer NOT NULL UNIQUE,
+    description text NOT NULL,
+    retention_days integer,           -- NULL = indefinite
+    escalation_target text            -- NULL, 'dashboard', 'slack', 'pager'
+);
+
+-- error_code_registry: all known error codes
+CREATE TABLE error_code_registry (
+    error_code  text PRIMARY KEY,     -- e.g., SCORING_CALC_001
+    domain      text NOT NULL,
+    category    text NOT NULL,
+    severity    text NOT NULL REFERENCES log_level_ref(level),
+    description text NOT NULL,
+    action      text NOT NULL,        -- What the system should do
+    created_at  timestamptz NOT NULL DEFAULT now()
+);
+```
+
+### Validation Function
+
+```sql
+-- validate_log_entry(jsonb) → jsonb
+-- Returns { valid: true } or { valid: false, errors: [...] }
+SELECT validate_log_entry('{
+    "timestamp": "2026-03-01T12:00:00Z",
+    "level": "ERROR",
+    "domain": "scoring",
+    "action": "compute_score",
+    "message": "Test"
+}'::jsonb);
+```
+
+---
+
+## 8. Integration with Existing Infrastructure
+
+| System | Integration Point |
+|---|---|
+| **OBSERVABILITY.md** (frontend logs) | Shares severity levels; LOG_SCHEMA.md adds error codes and domain taxonomy |
+| **Sentry** | ERROR/CRITICAL → captured as Sentry events with `error_code` tag |
+| **Dashboard** | WARN → amber indicator; ERROR/CRITICAL → red with count badge |
+| **INCIDENT_RESPONSE.md** | CRITICAL → triggers incident workflow defined in playbook |
+| **DRIFT_DETECTION.md** | Drift check failures → logged as WARN with `CONFIG_DRIFT_001` |
+
+---
+
+## Related Documents
+
+- [OBSERVABILITY.md](OBSERVABILITY.md) — Frontend structured log format, Sentry integration
+- [INCIDENT_RESPONSE.md](INCIDENT_RESPONSE.md) — Incident escalation playbook
+- [MONITORING.md](MONITORING.md) — Runtime health checks and dashboards
+- [METRICS.md](METRICS.md) — Application and infrastructure metrics catalog

--- a/supabase/migrations/20260304000000_log_schema_error_taxonomy.sql
+++ b/supabase/migrations/20260304000000_log_schema_error_taxonomy.sql
@@ -1,0 +1,193 @@
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Migration: Structured Log Schema & Error Taxonomy
+-- Issue: #210 (GOV-F1)
+--
+-- Creates:
+--   1. log_level_ref — severity level reference table (5 rows)
+--   2. error_code_registry — known error codes with domain/category/severity
+--   3. validate_log_entry() — validates log JSON against schema
+--
+-- Rollback:
+--   DROP FUNCTION IF EXISTS validate_log_entry(jsonb);
+--   DROP TABLE IF EXISTS error_code_registry;
+--   DROP TABLE IF EXISTS log_level_ref;
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+-- ─── Step 1: log_level_ref table ─────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.log_level_ref (
+    level              text PRIMARY KEY,
+    numeric_level      integer NOT NULL UNIQUE,
+    description        text NOT NULL,
+    retention_days     integer,          -- NULL = indefinite
+    escalation_target  text              -- NULL, 'dashboard', 'slack', 'pager'
+);
+
+COMMENT ON TABLE public.log_level_ref IS 'Severity level definitions for structured logging. 5 levels: DEBUG→CRITICAL.';
+
+-- Seed levels (idempotent)
+INSERT INTO public.log_level_ref (level, numeric_level, description, retention_days, escalation_target)
+VALUES
+    ('DEBUG',    0, 'Development tracing — local dev only, never stored in production',        0,    NULL),
+    ('INFO',     1, 'Normal operations — request completed, backfill finished',                30,   NULL),
+    ('WARN',     2, 'Unexpected but recoverable — clamped value, degraded fallback',           90,   'dashboard'),
+    ('ERROR',    3, 'Operation failed, system continues — query timeout, API error',           365,  'slack'),
+    ('CRITICAL', 4, 'System-wide impact, immediate attention — missing index, data corruption', NULL, 'pager')
+ON CONFLICT (level) DO UPDATE SET
+    numeric_level     = EXCLUDED.numeric_level,
+    description       = EXCLUDED.description,
+    retention_days    = EXCLUDED.retention_days,
+    escalation_target = EXCLUDED.escalation_target;
+
+-- ─── Step 2: error_code_registry table ───────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.error_code_registry (
+    error_code  text PRIMARY KEY,
+    domain      text NOT NULL,
+    category    text NOT NULL,
+    severity    text NOT NULL REFERENCES public.log_level_ref(level),
+    description text NOT NULL,
+    action      text NOT NULL,
+    created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.error_code_registry IS 'Registry of all known error codes following {DOMAIN}_{CATEGORY}_{NNN} format.';
+
+-- Seed starter error codes (idempotent)
+INSERT INTO public.error_code_registry (error_code, domain, category, severity, description, action)
+VALUES
+    ('SCORING_CALC_001',       'scoring',    'calculation', 'ERROR',    'Division by zero in scoring formula',                          'Skip product, log, alert'),
+    ('SCORING_CALC_002',       'scoring',    'calculation', 'WARN',     'Negative score computed (below floor)',                         'Clamp to 1, log'),
+    ('SCORING_VERSION_001',    'scoring',    'version',     'ERROR',    'Product references non-existent scoring version',               'Default to active version'),
+    ('SEARCH_QUERY_001',       'search',     'query',       'WARN',     'Zero results returned for non-empty query',                     'Log for analysis'),
+    ('SEARCH_QUERY_002',       'search',     'query',       'ERROR',    'Query exceeded timeout threshold (>2s)',                         'Return partial results'),
+    ('SEARCH_INDEX_001',       'search',     'index',       'CRITICAL', 'tsvector or pg_trgm index missing or invalid',                  'Alert immediately'),
+    ('PROVENANCE_CONFLICT_001','provenance', 'conflict',    'WARN',     'Two sources disagree on field value',                           'Queue for resolution'),
+    ('PROVENANCE_STALE_001',   'provenance', 'freshness',   'INFO',     'Product data older than 90 days',                               'Schedule re-check'),
+    ('PIPELINE_IO_001',        'pipeline',   'io',          'ERROR',    'OFF API unreachable',                                           'Retry with exponential backoff'),
+    ('PIPELINE_IO_002',        'pipeline',   'io',          'WARN',     'OFF API returned incomplete data',                              'Log missing fields'),
+    ('MIGRATION_LOCK_001',     'migration',  'lock',        'CRITICAL', 'AccessExclusiveLock held >5s during migration',                 'Alert, prepare rollback'),
+    ('AUTH_TOKEN_001',         'auth',       'token',       'WARN',     'Expired JWT presented',                                         'Return 401'),
+    ('AUTH_RLS_001',           'auth',       'access',      'ERROR',    'RLS policy violation or unauthorized access attempt',            'Log, return 403')
+ON CONFLICT (error_code) DO UPDATE SET
+    domain      = EXCLUDED.domain,
+    category    = EXCLUDED.category,
+    severity    = EXCLUDED.severity,
+    description = EXCLUDED.description,
+    action      = EXCLUDED.action;
+
+-- ─── Step 3: validate_log_entry() function ───────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.validate_log_entry(p_entry jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql IMMUTABLE
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+    v_errors text[] := '{}';
+    v_level  text;
+    v_domain text;
+BEGIN
+    -- 1. Required fields
+    IF p_entry IS NULL THEN
+        RETURN jsonb_build_object('valid', false, 'errors', jsonb_build_array('Entry is NULL'));
+    END IF;
+
+    IF NOT (p_entry ? 'timestamp') THEN
+        v_errors := array_append(v_errors, 'Missing required field: timestamp');
+    END IF;
+
+    IF NOT (p_entry ? 'level') THEN
+        v_errors := array_append(v_errors, 'Missing required field: level');
+    ELSE
+        v_level := UPPER(p_entry->>'level');
+        IF v_level NOT IN ('DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL') THEN
+            v_errors := array_append(v_errors, 'Invalid level: ' || (p_entry->>'level') || '. Must be one of: DEBUG, INFO, WARN, ERROR, CRITICAL');
+        END IF;
+    END IF;
+
+    IF NOT (p_entry ? 'domain') THEN
+        v_errors := array_append(v_errors, 'Missing required field: domain');
+    ELSE
+        v_domain := LOWER(p_entry->>'domain');
+        IF v_domain NOT IN ('scoring', 'search', 'provenance', 'pipeline', 'migration', 'auth', 'frontend', 'config') THEN
+            v_errors := array_append(v_errors, 'Invalid domain: ' || (p_entry->>'domain') || '. Must be one of: scoring, search, provenance, pipeline, migration, auth, frontend, config');
+        END IF;
+    END IF;
+
+    IF NOT (p_entry ? 'action') THEN
+        v_errors := array_append(v_errors, 'Missing required field: action');
+    END IF;
+
+    IF NOT (p_entry ? 'message') THEN
+        v_errors := array_append(v_errors, 'Missing required field: message');
+    END IF;
+
+    -- 2. Conditional: error_code required for ERROR/CRITICAL
+    IF v_level IN ('ERROR', 'CRITICAL') AND NOT (p_entry ? 'error_code') THEN
+        v_errors := array_append(v_errors, 'error_code is required when level is ERROR or CRITICAL');
+    END IF;
+
+    -- 3. Type checks for optional fields
+    IF (p_entry ? 'duration_ms') AND jsonb_typeof(p_entry->'duration_ms') != 'number' THEN
+        v_errors := array_append(v_errors, 'duration_ms must be a number');
+    END IF;
+
+    IF (p_entry ? 'context') AND jsonb_typeof(p_entry->'context') != 'object' THEN
+        v_errors := array_append(v_errors, 'context must be an object');
+    END IF;
+
+    -- Return result
+    IF array_length(v_errors, 1) IS NULL OR array_length(v_errors, 1) = 0 THEN
+        RETURN jsonb_build_object('valid', true);
+    ELSE
+        RETURN jsonb_build_object(
+            'valid', false,
+            'errors', to_jsonb(v_errors)
+        );
+    END IF;
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.validate_log_entry(jsonb) IS 'Validates a structured log entry against the LOG_SCHEMA.md specification. Returns {valid: true} or {valid: false, errors: [...]}.';
+
+-- ─── Step 4: Security ────────────────────────────────────────────────────────
+
+-- validate_log_entry is SECURITY DEFINER → restrict access
+REVOKE EXECUTE ON FUNCTION public.validate_log_entry(jsonb) FROM anon, public;
+GRANT EXECUTE ON FUNCTION public.validate_log_entry(jsonb) TO service_role, authenticated;
+
+-- Tables: service-write / auth-read (RLS Pattern B)
+ALTER TABLE public.log_level_ref ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.error_code_registry ENABLE ROW LEVEL SECURITY;
+
+-- service_role: full access
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'log_level_ref' AND policyname = 'log_level_ref_service_all') THEN
+        CREATE POLICY log_level_ref_service_all ON public.log_level_ref
+            FOR ALL TO service_role USING (true) WITH CHECK (true);
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'error_code_registry' AND policyname = 'error_code_registry_service_all') THEN
+        CREATE POLICY error_code_registry_service_all ON public.error_code_registry
+            FOR ALL TO service_role USING (true) WITH CHECK (true);
+    END IF;
+END $$;
+
+-- authenticated: read-only
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'log_level_ref' AND policyname = 'log_level_ref_auth_read') THEN
+        CREATE POLICY log_level_ref_auth_read ON public.log_level_ref
+            FOR SELECT TO authenticated USING (true);
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'error_code_registry' AND policyname = 'error_code_registry_auth_read') THEN
+        CREATE POLICY error_code_registry_auth_read ON public.error_code_registry
+            FOR SELECT TO authenticated USING (true);
+    END IF;
+END $$;

--- a/supabase/tests/schema_contracts.test.sql
+++ b/supabase/tests/schema_contracts.test.sql
@@ -7,7 +7,7 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 
 BEGIN;
-SELECT plan(114);
+SELECT plan(117);
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 1. Core data tables exist
@@ -174,6 +174,11 @@ SELECT has_view('public', 'v_backfill_status',                   'view v_backfil
 SELECT has_function('public', 'register_backfill',               'function register_backfill exists');
 SELECT has_function('public', 'start_backfill',                  'function start_backfill exists');
 SELECT has_function('public', 'complete_backfill',               'function complete_backfill exists');
+
+-- ─── Log Schema & Error Taxonomy (#210) ───────────────────────────────────────
+SELECT has_table('public', 'log_level_ref',                      'table log_level_ref exists');
+SELECT has_table('public', 'error_code_registry',                'table error_code_registry exists');
+SELECT has_function('public', 'validate_log_entry',              'function validate_log_entry exists');
 
 SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
## Summary Adds structured log schema specification and error taxonomy infrastructure for Issue #210 (GOV-F1). ## Changes - **docs/LOG_SCHEMA.md** (NEW): Comprehensive structured log schema specification with error code format, 8 registered domains, severity/escalation matrix, retention policy, domain-specific logging conventions - **Migration 20260304000000**: log_level_ref table (5 severity levels), error_code_registry table (13 starter error codes), validate_log_entry() validation function (SECURITY DEFINER), RLS Pattern B - **schema_contracts.test.sql**: +3 tests (plan 114 to 117) for log_level_ref, error_code_registry, validate_log_entry - **docs/INDEX.md**: Added LOG_SCHEMA.md to Observability section (41 to 42 docs, 6 to 7 in domain) - **CHANGELOG.md**: Schema and Documentation entries - **copilot-instructions.md**: Updated docs layout, tables, functions, migration count ## Closes #210