### PR TITLE
schema(migration): add alert escalation, query regression detection and index drift monitoring (#211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Schema & Migrations
 
+- Add alert escalation & query regression detection: `query_performance_snapshots` table,
+  `snapshot_query_performance()` function (SECURITY DEFINER), `v_query_regressions` view,
+  `v_unused_indexes` / `v_missing_indexes` / `v_index_bloat_estimate` index drift monitoring
+  views, RLS Pattern B on snapshot table (#211)
 - Add structured log schema & error taxonomy: `log_level_ref` table (5 severity levels with
   retention/escalation policy), `error_code_registry` table (13 starter error codes across 8
   domains), `validate_log_entry()` validation function (SECURITY DEFINER), RLS Pattern B
@@ -71,6 +75,9 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+- Add `docs/ALERT_POLICY.md`: alert escalation policy with P0–P3 severity tiers,
+  escalation chain, on-call rules, slow query thresholds, query regression detection
+  architecture, index drift monitoring cadence and action matrix (#211)
 - Add `docs/LOG_SCHEMA.md`: structured log schema specification, error code format
   (`{DOMAIN}_{CATEGORY}_{NNN}`), 8 registered domains, severity/escalation matrix,
   retention policy (0d–indefinite), domain-specific logging conventions (#210)

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -114,7 +114,7 @@ poland-food-db/
 │       └── VIEW__master_product_view.sql  # v_master definition (reference copy)
 ├── supabase/
 │   ├── config.toml
-│   └── migrations/                  # 135 append-only schema migrations
+│   └── migrations/                  # 136 append-only schema migrations
 │       ├── 20260207000100_create_schema.sql
 │       ├── 20260207000200_baseline.sql
 │       ├── 20260207000300_add_chip_metadata.sql
@@ -171,6 +171,7 @@ poland-food-db/
 │   ├── API_CONVENTIONS.md           # RPC naming convention, breaking change definition, security standards
 │   ├── API_VERSIONING.md            # API deprecation & versioning policy
 │   ├── ACCESS_AUDIT.md              # Data access pattern audit & quarterly review
+│   ├── ALERT_POLICY.md              # Alert escalation, query regression, index drift monitoring
 │   ├── BACKFILL_STANDARD.md         # Backfill orchestration standard & migration templates
 │   ├── CI_ARCHITECTURE_PROPOSAL.md  # CI pipeline design
 │   ├── CONTRACT_TESTING.md          # API contract testing strategy & pgTAP patterns
@@ -189,7 +190,7 @@ poland-food-db/
 │   ├── FRONTEND_API_MAP.md          # Frontend ↔ API mapping reference
 │   ├── GOVERNANCE_BLUEPRINT.md      # Execution governance blueprint (master GOV plan)
 │   ├── INCIDENT_RESPONSE.md         # Incident response playbook (severity, escalation, runbooks)
-│   ├── INDEX.md                     # Canonical documentation map (42 docs, domain-classified)
+│   ├── INDEX.md                     # Canonical documentation map (43 docs, domain-classified)
 │   ├── LABELS.md                    # Labeling conventions
 │   ├── LOG_SCHEMA.md                # Structured log schema & error taxonomy
 │   ├── METRICS.md                   # Application, infrastructure & business metrics catalog

--- a/docs/ALERT_POLICY.md
+++ b/docs/ALERT_POLICY.md
@@ -1,0 +1,157 @@
+# Alert Escalation & Query Regression Detection
+
+> **Last updated:** 2026-03-04
+> **Status:** Active
+> **Owner issue:** [#211](https://github.com/ericsocrat/poland-food-db/issues/211)
+> **Dependencies:** OBSERVABILITY.md (logging), LOG_SCHEMA.md (error codes), PERFORMANCE_GUARDRAILS.md (budgets)
+
+---
+
+## 1. Alert Escalation Policy
+
+### Severity Tiers
+
+| Tier              | Condition                               | Duration         | Channel                  | Response Time | Escalation                      |
+| ----------------- | --------------------------------------- | ---------------- | ------------------------ | ------------- | ------------------------------- |
+| **P0 — Critical** | Any CRITICAL error code (LOG_SCHEMA.md) | 1 occurrence     | Page on-call immediately | 5 min         | Automatic incident              |
+| **P0 — Critical** | Migration lock > 30s                    | 1 occurrence     | Page on-call             | 5 min         | Prepare rollback                |
+| **P1 — High**     | API P95 > 2000ms                        | 1 min sustained  | Page on-call             | 5 min         | Treat as incident               |
+| **P1 — High**     | Database connections > 80% pool         | 5 min sustained  | Slack alert              | 15 min        | Investigate connection leaks    |
+| **P2 — Medium**   | API P95 > 1000ms                        | 3 min sustained  | Slack alert              | 30 min        | → Page if no ack in 30 min      |
+| **P2 — Medium**   | Search zero-result rate > 20%           | 1 hour sustained | Slack alert              | 4 hours       | Investigate query patterns      |
+| **P2 — Medium**   | Provenance conflicts > 50 unresolved    | Daily check      | Slack alert              | 24 hours      | Assign to data team             |
+| **P3 — Low**      | API P95 > 500ms                         | 5 min sustained  | Dashboard amber          | 1 hour        | → Slack if still amber after 1h |
+| **P3 — Low**      | Scoring version drift > 5% products     | Daily check      | Dashboard amber          | 24 hours      | Schedule re-score batch         |
+| **P3 — Low**      | Disk usage > 80%                        | Daily check      | Slack alert              | 24 hours      | Plan cleanup or expansion       |
+
+### Escalation Chain
+
+```
+Dashboard amber (P3)
+  ↓ (if unresolved after response time)
+Slack #alerts channel (P2)
+  ↓ (if unresolved after response time)
+Page on-call engineer (P1/P0)
+  ↓ (if unresolved in 30 min)
+Incident declared → INCIDENT_RESPONSE.md playbook
+```
+
+### On-Call Rules
+
+- **Rotation:** Weekly, starting Monday 09:00 CET
+- **Response:** Acknowledge within response time or auto-escalate
+- **Handoff:** Document open alerts in handoff notes at rotation boundary
+- **Override:** Any team member can self-assign an alert regardless of rotation
+
+---
+
+## 2. Slow Query Telemetry
+
+Slow query monitoring uses `report_slow_queries()` from migration `20260222050000_query_performance_guardrails.sql`.
+
+### Thresholds
+
+| Category | Mean Execution Time | Action                                |
+| -------- | ------------------- | ------------------------------------- |
+| OK       | < 100ms             | No action                             |
+| Warning  | 100–500ms           | Log, review weekly                    |
+| Slow     | 500ms–1s            | Slack alert, investigate within 24h   |
+| Critical | > 1s                | Page on-call, investigate immediately |
+
+### Existing Infrastructure
+
+- `report_slow_queries(p_threshold_ms)` — returns queries above threshold with category classification
+- `check_plan_quality(p_query_text)` — EXPLAIN ANALYZE with plan node flagging
+- Both restricted to `service_role` (SECURITY DEFINER)
+
+---
+
+## 3. Query Regression Detection
+
+### Architecture
+
+```
+pg_stat_statements
+       │
+       ▼
+snapshot_query_performance()  ←── weekly cron / manual call
+       │
+       ▼
+query_performance_snapshots   (historical data)
+       │
+       ▼
+v_query_regressions           (compare current vs previous week)
+```
+
+### Detection Rules
+
+| Regression Level | Condition                          | Alert           |
+| ---------------- | ---------------------------------- | --------------- |
+| OK               | Current mean ≤ previous mean × 1.3 | None            |
+| WARNING          | Current mean > previous mean × 1.5 | Dashboard amber |
+| CRITICAL         | Current mean > previous mean × 2.0 | Slack alert     |
+
+### Retention
+
+- Keep weekly snapshots for 12 weeks (84 days)
+- After 12 weeks, aggregate to monthly summaries or delete
+- Estimated storage: ~50 rows/week × 12 weeks = ~600 rows max
+
+---
+
+## 4. Index Drift Monitoring
+
+### Detection Views
+
+| View                     | Purpose                                | Alert Condition                   |
+| ------------------------ | -------------------------------------- | --------------------------------- |
+| `v_unused_indexes`       | Indexes with zero or very few scans    | UNUSED index > 10MB               |
+| `v_missing_indexes`      | Tables with excessive sequential scans | NEEDS_INDEX status on large table |
+| `v_index_bloat_estimate` | Index size vs table size ratio         | Index > 2× table size             |
+
+### Review Cadence
+
+- **Weekly:** Review `v_unused_indexes` for zero-scan indexes
+- **Weekly:** Review `v_missing_indexes` for sequential scan patterns
+- **Monthly:** Review `v_index_bloat_estimate` for fragmentation
+- **After migrations:** Run all three views to verify index health
+
+### Action Matrix
+
+| Finding                        | Action                                          | Urgency |
+| ------------------------------ | ----------------------------------------------- | ------- |
+| Unused index (0 scans, > 10MB) | Consider DROP INDEX after 4 weeks of inactivity | Low     |
+| Rarely used index (< 10 scans) | Monitor for 2 more weeks, then decide           | Low     |
+| Missing index (high seq scans) | Create index, EXPLAIN ANALYZE to verify         | Medium  |
+| Bloated index (> 2× table)     | REINDEX or DROP + CREATE                        | Low     |
+
+---
+
+## 5. Database Schema
+
+### Tables
+
+- `query_performance_snapshots` — Weekly snapshots of query performance metrics
+
+### Functions
+
+- `snapshot_query_performance()` — Captures current pg_stat_statements data into snapshots table (SECURITY DEFINER, service_role only)
+
+### Views
+
+- `v_query_regressions` — Compares current vs previous snapshot to detect performance regressions
+- `v_unused_indexes` — Identifies indexes with zero or very few scans
+- `v_missing_indexes` — Identifies tables with excessive sequential scans relative to index scans
+- `v_index_bloat_estimate` — Estimates index bloat by comparing index size to table size
+
+---
+
+## 6. Integration Points
+
+| System                    | Integration                                                            |
+| ------------------------- | ---------------------------------------------------------------------- |
+| LOG_SCHEMA.md             | Error codes: `SEARCH_QUERY_002` (timeout), `MIGRATION_LOCK_001` (lock) |
+| OBSERVABILITY.md          | Structured log format for alert events                                 |
+| PERFORMANCE_GUARDRAILS.md | Query budget definitions, statement timeouts                           |
+| INCIDENT_RESPONSE.md      | Escalation leads to incident declaration                               |
+| Admin Dashboard (#206)    | Views feed dashboard cards (future)                                    |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,7 +2,7 @@
 
 > **Last updated:** 2026-03-01
 > **Status:** Active — update when adding, renaming, or archiving docs
-> **Total documents:** 42 in `docs/` + 5 elsewhere in repo
+> **Total documents:** 43 in `docs/` + 5 elsewhere in repo
 > **Reference:** Issue [#200](https://github.com/ericsocrat/poland-food-db/issues/200), [#201](https://github.com/ericsocrat/poland-food-db/issues/201)
 
 ---
@@ -16,7 +16,7 @@
 | [Scoring](#scoring)                                      | 2     | Methodology (formula), engine (architecture)                                                             |
 | [Data & Provenance](#data--provenance)                   | 5     | Sources, provenance, integrity audits, EAN validation, production data                                   |
 | [Security & Compliance](#security--compliance)           | 5     | Root policy, audit report, access audit, privacy checklist, rate limiting                                |
-| [Observability & Operations](#observability--operations) | 7     | Monitoring, observability, log schema, SLOs, metrics, incident response, disaster drill                  |
+| [Observability & Operations](#observability--operations) | 8     | Monitoring, observability, log schema, alerts, SLOs, metrics, incident response, disaster drill          |
 | [DevOps & Environment](#devops--environment)             | 3     | Environment strategy, staging setup, Sonar config                                                        |
 | [Frontend & UX](#frontend--ux)                           | 4     | UX/UI design, UX impact metrics, design system, frontend README                                          |
 | [Process & Workflow](#process--workflow)                 | 6     | Research workflow, viewing & testing, backfill standard, migration conventions, labels, country expansion |
@@ -88,6 +88,7 @@
 | [METRICS.md](METRICS.md)                             | Metrics catalog — application metrics, infrastructure metrics, business metrics | Observability domain                                            | 2026-02-24   |
 | [INCIDENT_RESPONSE.md](INCIDENT_RESPONSE.md)         | Incident response playbook — severity, escalation, runbooks, post-mortem        | [#231](https://github.com/ericsocrat/poland-food-db/issues/231) | 2026-02-24   |
 | [LOG_SCHEMA.md](LOG_SCHEMA.md)                       | Structured log schema & error taxonomy — error codes, severity, retention, validation | [#210](https://github.com/ericsocrat/poland-food-db/issues/210) | 2026-03-04   |
+| [ALERT_POLICY.md](ALERT_POLICY.md)                   | Alert escalation policy, query regression detection, index drift monitoring      | [#211](https://github.com/ericsocrat/poland-food-db/issues/211) | 2026-03-04   |
 | [DISASTER_DRILL_REPORT.md](DISASTER_DRILL_REPORT.md) | Disaster recovery drill report — test results, findings, remediation            | Observability domain                                            | 2026-02-23   |
 
 ## DevOps & Environment

--- a/supabase/migrations/20260304000100_alert_escalation_query_regression.sql
+++ b/supabase/migrations/20260304000100_alert_escalation_query_regression.sql
@@ -1,0 +1,251 @@
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Migration: Alert Escalation & Query Regression Detection
+-- Issue: #211 (GOV-F2)
+--
+-- Creates:
+--   1. query_performance_snapshots — weekly query performance history
+--   2. snapshot_query_performance() — captures pg_stat_statements into snapshots
+--   3. v_query_regressions — detects week-over-week performance regressions
+--   4. v_unused_indexes — identifies unused or rarely used indexes
+--   5. v_missing_indexes — identifies tables needing index coverage
+--   6. v_index_bloat_estimate — estimates index fragmentation
+--
+-- Dependencies: pg_stat_statements extension (enabled in 20260222050000)
+--
+-- Rollback:
+--   DROP VIEW IF EXISTS v_index_bloat_estimate;
+--   DROP VIEW IF EXISTS v_missing_indexes;
+--   DROP VIEW IF EXISTS v_unused_indexes;
+--   DROP VIEW IF EXISTS v_query_regressions;
+--   DROP FUNCTION IF EXISTS snapshot_query_performance();
+--   DROP TABLE IF EXISTS query_performance_snapshots;
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+-- ─── Step 1: query_performance_snapshots table ───────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.query_performance_snapshots (
+    id              uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    snapshot_date   date NOT NULL DEFAULT CURRENT_DATE,
+    queryid         bigint NOT NULL,
+    query_preview   text,
+    calls           bigint,
+    mean_ms         numeric(10,2),
+    max_ms          numeric(10,2),
+    cache_hit_pct   numeric(5,1),
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (snapshot_date, queryid)
+);
+
+COMMENT ON TABLE public.query_performance_snapshots IS
+    'Weekly snapshots of pg_stat_statements query performance. Retention: 12 weeks. Used for regression detection.';
+
+-- ─── Step 2: RLS (Pattern B: service-write / auth-read) ─────────────────────
+
+ALTER TABLE public.query_performance_snapshots ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'query_performance_snapshots' AND policyname = 'qps_service_all') THEN
+        CREATE POLICY qps_service_all ON public.query_performance_snapshots
+            FOR ALL TO service_role USING (true) WITH CHECK (true);
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'query_performance_snapshots' AND policyname = 'qps_auth_read') THEN
+        CREATE POLICY qps_auth_read ON public.query_performance_snapshots
+            FOR SELECT TO authenticated USING (true);
+    END IF;
+END $$;
+
+-- ─── Step 3: snapshot_query_performance() ────────────────────────────────────
+--    Captures current pg_stat_statements data for queries with > 10 calls.
+--    SECURITY DEFINER: pg_stat_statements requires elevated access.
+--    Restricted to service_role.
+
+CREATE OR REPLACE FUNCTION public.snapshot_query_performance()
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $fn$
+DECLARE
+    v_count integer := 0;
+BEGIN
+    -- Guard: pg_stat_statements may not be available in CI/test environments
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+        WHERE n.nspname = 'pg_catalog' AND c.relname = 'pg_stat_statements'
+    ) THEN
+        RETURN jsonb_build_object(
+            'status', 'skipped',
+            'reason', 'pg_stat_statements not available',
+            'rows_inserted', 0
+        );
+    END IF;
+
+    INSERT INTO public.query_performance_snapshots
+        (snapshot_date, queryid, query_preview, calls, mean_ms, max_ms, cache_hit_pct)
+    SELECT
+        CURRENT_DATE,
+        s.queryid,
+        LEFT(s.query, 200),
+        s.calls,
+        ROUND(s.mean_exec_time::numeric, 2),
+        ROUND(s.max_exec_time::numeric, 2),
+        ROUND(
+            s.shared_blks_hit * 100.0
+            / NULLIF(s.shared_blks_hit + s.shared_blks_read, 0),
+            1
+        )
+    FROM pg_stat_statements s
+    WHERE s.calls > 10
+    ON CONFLICT (snapshot_date, queryid) DO UPDATE SET
+        calls         = EXCLUDED.calls,
+        mean_ms       = EXCLUDED.mean_ms,
+        max_ms        = EXCLUDED.max_ms,
+        cache_hit_pct = EXCLUDED.cache_hit_pct;
+
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+
+    -- Retention: delete snapshots older than 12 weeks
+    DELETE FROM public.query_performance_snapshots
+    WHERE snapshot_date < CURRENT_DATE - 84;
+
+    RETURN jsonb_build_object(
+        'status', 'ok',
+        'snapshot_date', CURRENT_DATE,
+        'rows_inserted', v_count
+    );
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.snapshot_query_performance() IS
+    'Captures pg_stat_statements performance data into query_performance_snapshots. '
+    'Run weekly. Deletes data older than 12 weeks. Restricted to service_role.';
+
+REVOKE EXECUTE ON FUNCTION public.snapshot_query_performance() FROM anon, public;
+GRANT EXECUTE ON FUNCTION public.snapshot_query_performance() TO service_role;
+
+-- ─── Step 4: v_query_regressions view ────────────────────────────────────────
+--    Compares latest snapshot against the snapshot from 7 days prior.
+
+CREATE OR REPLACE VIEW public.v_query_regressions AS
+SELECT
+    c.queryid,
+    c.query_preview,
+    p.mean_ms                                                       AS prev_mean_ms,
+    c.mean_ms                                                       AS curr_mean_ms,
+    ROUND((c.mean_ms - p.mean_ms) / NULLIF(p.mean_ms, 0) * 100, 1) AS regression_pct,
+    c.calls                                                         AS curr_calls,
+    CASE
+        WHEN c.mean_ms > p.mean_ms * 2   THEN 'CRITICAL'
+        WHEN c.mean_ms > p.mean_ms * 1.5 THEN 'WARNING'
+        ELSE 'OK'
+    END                                                             AS status
+FROM public.query_performance_snapshots c
+JOIN public.query_performance_snapshots p
+    ON  c.queryid = p.queryid
+    AND p.snapshot_date = (
+        SELECT MAX(snapshot_date)
+        FROM public.query_performance_snapshots
+        WHERE snapshot_date < c.snapshot_date
+    )
+WHERE c.snapshot_date = (
+    SELECT MAX(snapshot_date) FROM public.query_performance_snapshots
+)
+AND c.mean_ms > p.mean_ms * 1.3  -- only show > 30% regressions
+ORDER BY regression_pct DESC;
+
+COMMENT ON VIEW public.v_query_regressions IS
+    'Compares query performance between the latest two snapshots. '
+    'Shows regressions > 30% with WARNING/CRITICAL status classification.';
+
+-- ─── Step 5: v_unused_indexes ────────────────────────────────────────────────
+
+CREATE OR REPLACE VIEW public.v_unused_indexes AS
+SELECT
+    schemaname,
+    relname                                      AS tablename,
+    indexrelname                                 AS indexname,
+    idx_scan,
+    pg_size_pretty(pg_relation_size(indexrelid)) AS index_size,
+    pg_relation_size(indexrelid)                 AS index_size_bytes,
+    CASE
+        WHEN idx_scan = 0  THEN 'UNUSED'
+        WHEN idx_scan < 10 THEN 'RARELY_USED'
+        ELSE 'ACTIVE'
+    END AS status
+FROM pg_stat_user_indexes
+WHERE schemaname = 'public'
+ORDER BY idx_scan ASC, pg_relation_size(indexrelid) DESC;
+
+COMMENT ON VIEW public.v_unused_indexes IS
+    'Lists public-schema indexes ranked by scan count. UNUSED = 0 scans since stats reset.';
+
+-- ─── Step 6: v_missing_indexes ───────────────────────────────────────────────
+
+CREATE OR REPLACE VIEW public.v_missing_indexes AS
+SELECT
+    schemaname,
+    relname                                      AS table_name,
+    seq_scan,
+    seq_tup_read,
+    idx_scan,
+    CASE
+        WHEN seq_scan > 100 AND COALESCE(idx_scan, 0) = 0 THEN 'NEEDS_INDEX'
+        WHEN seq_scan > COALESCE(idx_scan, 0) * 10        THEN 'INDEX_UNDERUSED'
+        ELSE 'OK'
+    END AS status,
+    pg_size_pretty(pg_relation_size(relid))      AS table_size,
+    pg_relation_size(relid)                      AS table_size_bytes
+FROM pg_stat_user_tables
+WHERE schemaname = 'public'
+  AND seq_scan > 50
+ORDER BY seq_tup_read DESC;
+
+COMMENT ON VIEW public.v_missing_indexes IS
+    'Identifies tables with high sequential scan counts relative to index scans. '
+    'NEEDS_INDEX: > 100 seq scans with 0 index scans.';
+
+-- ─── Step 7: v_index_bloat_estimate ──────────────────────────────────────────
+
+CREATE OR REPLACE VIEW public.v_index_bloat_estimate AS
+SELECT
+    t.relname                                                       AS tablename,
+    i.indexrelname                                                  AS indexname,
+    pg_size_pretty(pg_relation_size(i.indexrelid))                  AS index_size,
+    pg_size_pretty(pg_relation_size(t.relid))                       AS table_size,
+    ROUND(
+        pg_relation_size(i.indexrelid)::numeric
+        / NULLIF(pg_relation_size(t.relid), 0) * 100,
+        1
+    ) AS index_to_table_pct,
+    CASE
+        WHEN pg_relation_size(i.indexrelid) > pg_relation_size(t.relid) * 2
+            THEN 'POSSIBLY_BLOATED'
+        ELSE 'OK'
+    END AS status
+FROM pg_stat_user_indexes i
+JOIN pg_stat_user_tables t ON i.relid = t.relid
+WHERE i.schemaname = 'public'
+ORDER BY pg_relation_size(i.indexrelid) DESC;
+
+COMMENT ON VIEW public.v_index_bloat_estimate IS
+    'Estimates index bloat by comparing index size to table size. '
+    'POSSIBLY_BLOATED: index > 2x table size.';
+
+-- ─── Step 8: Access control for monitoring views ─────────────────────────────
+--    These views read from pg_stat_* system catalogs.
+--    Grant SELECT to authenticated users (read-only monitoring).
+--    Revoke from anon (no public access to performance data).
+
+REVOKE ALL ON public.v_query_regressions    FROM anon;
+REVOKE ALL ON public.v_unused_indexes       FROM anon;
+REVOKE ALL ON public.v_missing_indexes      FROM anon;
+REVOKE ALL ON public.v_index_bloat_estimate FROM anon;
+
+GRANT SELECT ON public.v_query_regressions    TO authenticated, service_role;
+GRANT SELECT ON public.v_unused_indexes       TO authenticated, service_role;
+GRANT SELECT ON public.v_missing_indexes      TO authenticated, service_role;
+GRANT SELECT ON public.v_index_bloat_estimate TO authenticated, service_role;
+GRANT SELECT ON public.query_performance_snapshots TO authenticated, service_role;

--- a/supabase/tests/schema_contracts.test.sql
+++ b/supabase/tests/schema_contracts.test.sql
@@ -7,7 +7,7 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 
 BEGIN;
-SELECT plan(117);
+SELECT plan(123);
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 1. Core data tables exist
@@ -179,6 +179,14 @@ SELECT has_function('public', 'complete_backfill',               'function compl
 SELECT has_table('public', 'log_level_ref',                      'table log_level_ref exists');
 SELECT has_table('public', 'error_code_registry',                'table error_code_registry exists');
 SELECT has_function('public', 'validate_log_entry',              'function validate_log_entry exists');
+
+-- ─── Alert Escalation & Query Regression (#211) ─────────────────────────────────
+SELECT has_table('public', 'query_performance_snapshots',        'table query_performance_snapshots exists');
+SELECT has_function('public', 'snapshot_query_performance',      'function snapshot_query_performance exists');
+SELECT has_view('public', 'v_query_regressions',                 'view v_query_regressions exists');
+SELECT has_view('public', 'v_unused_indexes',                    'view v_unused_indexes exists');
+SELECT has_view('public', 'v_missing_indexes',                   'view v_missing_indexes exists');
+SELECT has_view('public', 'v_index_bloat_estimate',              'view v_index_bloat_estimate exists');
 
 SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
## Summary Adds alert escalation policy, query regression detection infrastructure, and index drift monitoring for Issue #211 (GOV-F2). ## Changes - **docs/ALERT_POLICY.md** (NEW): Alert escalation policy with P0-P3 severity tiers, escalation chain, on-call rules, slow query thresholds, query regression detection architecture, index drift monitoring cadence and action matrix - **Migration 20260304000100**: query_performance_snapshots table with RLS Pattern B, snapshot_query_performance() function (SECURITY DEFINER, service_role only), v_query_regressions view, v_unused_indexes / v_missing_indexes / v_index_bloat_estimate monitoring views - **schema_contracts.test.sql**: +6 tests (plan 117 to 123) for new table, function, and 4 views - **docs/INDEX.md**: Added ALERT_POLICY.md to Observability section (42 to 43 docs, 7 to 8 in domain) - **CHANGELOG.md**: Schema and Documentation entries - **copilot-instructions.md**: Updated docs layout, migration count ## Existing Infrastructure Leveraged - report_slow_queries() from migration 20260222050000 (not duplicated) - pg_stat_statements extension (already enabled) ## Closes #211