### PR TITLE
docs(config): sync copilot-instructions §3 project layout with actual file tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,19 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+- Sync `copilot-instructions.md` §3 project layout with actual file tree: add `scripts/` directory
+  (7 utility scripts), `trust/` component directory, 6 missing root files (`BACKUP.ps1`,
+  `RUN_DR_DRILL.ps1`, `run_data_audit.py`, `test_data_audit.py`, `requirements.txt`,
+  `.editorconfig`), 10 missing workflow files, 2 missing pipeline files (`image_importer.py`,
+  `test_validator.py`), `REPO_GOVERNANCE.md` to docs listing, supabase sub-directories
+  (`seed/`, `sanity/`, `tests/`, `functions/`, `dr-drill/`, `seed.sql`) (#318)
+- Add `docs/REPO_GOVERNANCE.md`: 6-section governance standard covering structure rules,
+  doc update checklists, root cleanliness, CI integrity, Copilot enforcement, maintenance
+  cadence (#316)
+- Add `copilot-instructions.md` §16 Repo Hygiene Checklist: 5 enforcement subsections
+  (structural changes, API changes, root cleanliness, CI green, PR discipline) (#316)
+- Fix stale QA check counts in README: 429/421 → 460 across 33 suites, add 11 missing
+  suite listings to Additional Suites section (#316)
 - Add `docs/ALERT_POLICY.md`: alert escalation policy with P0–P3 severity tiers,
   escalation chain, on-call rules, slow query thresholds, query regression detection
   architecture, index drift monitoring cadence and action matrix (#211)


### PR DESCRIPTION
## Summary

Sync `copilot-instructions.md` §3 project layout tree with the actual file tree. Part of #318 (Phase 2 hygiene pass).

## Changes

### copilot-instructions.md §3

**Pipeline section** — add 2 missing files:
- `test_validator.py` — Validator unit tests
- `image_importer.py` — Product image import utility

**Supabase section** — expand from 2 entries to full sub-tree:
- `seed.sql`, `seed/001_reference_data.sql`, `sanity/sanity_checks.sql`
- `tests/` with all 13 pgTAP test files
- `functions/send-push-notification/`, `dr-drill/`

**Scripts directory** — add entirely new section (7 tracked utility files):
- `backfill_template.py`, `check_doc_counts.py`, `check_doc_drift.py`
- `check_migration_conventions.py`, `check_migration_order.py`
- `export_user_data.ps1`, `import_user_data.ps1`

**Workflows section** — add 10 missing of 15 total:
- `api-contract.yml`, `bundle-size.yml`, `codeql.yml`
- `dependabot-auto-merge.yml`, `dependency-audit.yml`, `deploy.yml`
- `license-compliance.yml`, `nightly.yml`, `quality-gate.yml`, `smoke-test.yml`

**Components section** — add `trust/` directory (merged in #205)

**Docs section** — add `REPO_GOVERNANCE.md` (merged in #316), fix INDEX.md count (44→45)

**Root files section** — add 6 missing files:
- `BACKUP.ps1`, `RUN_DR_DRILL.ps1`
- `run_data_audit.py`, `test_data_audit.py`
- `requirements.txt`, `.editorconfig`

### CHANGELOG.md

- Add entries for #316 (governance, §16, README fixes) and #318 (this PR)

## Safety

- Docs-only — zero runtime changes
- No schema, API, or logic changes
- TypeScript compiles clean (`npx tsc --noEmit` = 0 errors)

Refs #318