### PR TITLE
docs(governance): add ADR framework with 7 retroactive decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- Add ADR framework: `docs/decisions/` with MADR 3.0 template + 7 retroactive
+  Architecture Decision Records covering PostgreSQL-only stack, scoring formula,
+  country isolation, pipeline architecture, API versioning, append-only migrations,
+  and English canonical ingredients (#322)
+
 ### Schema & Migrations
 
 - Add alert escalation & query regression detection: `query_performance_snapshots` table,

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -239,7 +239,16 @@ poland-food-db/
 │   ├── UX_IMPACT_METRICS.md         # UX measurement standard, metric catalog, SQL templates
 │   ├── UX_UI_DESIGN.md              # UI/UX guidelines
 │   ├── VIEWING_AND_TESTING.md       # Queries, Studio UI, test runner
-│   └── api-registry.yaml            # Structured registry of all 109 functions (YAML)
+│   ├── api-registry.yaml            # Structured registry of all 109 functions (YAML)
+│   └── decisions/                   # Architecture Decision Records (MADR 3.0)
+│       ├── 000-template.md          # ADR template
+│       ├── 001-postgresql-only-stack.md
+│       ├── 002-weighted-scoring-formula.md
+│       ├── 003-country-scoped-isolation.md
+│       ├── 004-pipeline-generates-sql.md
+│       ├── 005-api-function-name-versioning.md
+│       ├── 006-append-only-migrations.md
+│       └── 007-english-canonical-ingredients.md
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
 ├── RUN_QA.ps1                       # QA test runner (460 checks across 33 suites)
 ├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (23 injection tests)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,7 +2,7 @@
 
 > **Last updated:** 2026-03-01
 > **Status:** Active — update when adding, renaming, or archiving docs
-> **Total documents:** 45 in `docs/` + 5 elsewhere in repo
+> **Total documents:** 45 in `docs/` + 8 in `docs/decisions/` + 5 elsewhere in repo
 > **Reference:** Issue [#200](https://github.com/ericsocrat/poland-food-db/issues/200), [#201](https://github.com/ericsocrat/poland-food-db/issues/201)
 
 ---
@@ -21,6 +21,7 @@
 | [Frontend & UX](#frontend--ux)                           | 4     | UX/UI design, UX impact metrics, design system, frontend README                                                 |
 | [Process & Workflow](#process--workflow)                 | 6     | Research workflow, viewing & testing, backfill standard, migration conventions, labels, country expansion       |
 | [Governance & Policy](#governance--policy)               | 6     | Feature sunsetting, performance guardrails, doc governance, repo governance, this index, governance blueprint   |
+| [Architecture Decisions](#architecture-decisions-adrs)   | 8     | MADR template + 7 retroactive ADRs (stack, scoring, country isolation, pipeline, API versioning, migrations, ingredients) |
 
 ---
 
@@ -131,6 +132,25 @@
 | [REPO_GOVERNANCE.md](REPO_GOVERNANCE.md)                   | Repo structure rules, root cleanliness, change checklists, CI alignment    | Governance domain                                               | 2026-02-25   |
 | [DOCUMENTATION_GOVERNANCE.md](DOCUMENTATION_GOVERNANCE.md) | Documentation ownership, versioning, deprecation, drift prevention cadence | [#201](https://github.com/ericsocrat/poland-food-db/issues/201) | 2026-03-01   |
 | INDEX.md                                                   | This file — canonical documentation map                                    | [#200](https://github.com/ericsocrat/poland-food-db/issues/200) | 2026-03-01   |
+
+## Architecture Decisions (ADRs)
+
+> **Location:** `docs/decisions/`
+> **Template:** [MADR 3.0](https://adr.github.io/madr/) (Markdown Any Decision Records)
+> **Convention:** Files named `NNN-short-title.md` with sequential numbering
+
+| Document | Decision | Status | Date |
+|----------|----------|--------|------|
+| [000-template.md](decisions/000-template.md) | MADR 3.0 template for new ADRs | — | 2026-02-25 |
+| [001-postgresql-only-stack.md](decisions/001-postgresql-only-stack.md) | Use PostgreSQL as sole backend via Supabase — no ORM, no API server | accepted | 2026-02-07 |
+| [002-weighted-scoring-formula.md](decisions/002-weighted-scoring-formula.md) | 9-factor weighted unhealthiness score (v3.2) with EFSA-based ingredient concerns | accepted | 2026-02-10 |
+| [003-country-scoped-isolation.md](decisions/003-country-scoped-isolation.md) | Single-table country isolation with FK + CHECK + QA enforcement | accepted | 2026-02-13 |
+| [004-pipeline-generates-sql.md](decisions/004-pipeline-generates-sql.md) | Python pipeline generates SQL files; never writes to DB directly | accepted | 2026-02-07 |
+| [005-api-function-name-versioning.md](decisions/005-api-function-name-versioning.md) | API versioning via function-name suffixes, not URL paths | accepted | 2026-02-13 |
+| [006-append-only-migrations.md](decisions/006-append-only-migrations.md) | Strict append-only migration strategy — never modify existing files | accepted | 2026-02-07 |
+| [007-english-canonical-ingredients.md](decisions/007-english-canonical-ingredients.md) | All 2,740 ingredients stored as clean ASCII English canonical names | accepted | 2026-02-10 |
+
+---
 
 ## Other Repository Documents
 

--- a/docs/decisions/000-template.md
+++ b/docs/decisions/000-template.md
@@ -1,0 +1,31 @@
+# ADR-NNN: Title
+
+> **Date:** YYYY-MM-DD
+> **Status:** proposed | accepted | superseded | deprecated
+> **Deciders:** [list of people involved]
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+### Positive
+
+- What becomes easier because of this change?
+
+### Negative
+
+- What becomes harder because of this change?
+
+### Neutral
+
+- What other changes does this decision require?
+
+---
+
+> **Template:** Based on [MADR 3.0](https://adr.github.io/madr/) (Markdown Any Decision Records)

--- a/docs/decisions/001-postgresql-only-stack.md
+++ b/docs/decisions/001-postgresql-only-stack.md
@@ -1,0 +1,46 @@
+# ADR-001: Use PostgreSQL-Only Stack via Supabase
+
+> **Date:** 2026-02-07 (retroactive — original decision at project inception)
+> **Status:** accepted
+> **Deciders:** @ericsocrat
+
+## Context
+
+The project needed a backend for a food quality database with complex scoring algorithms, full-text search, allergen filtering, and ingredient analytics. Common approaches include:
+
+1. **Traditional API layer** (Express/Fastify + ORM + PostgreSQL) — familiar but adds a server to maintain, deploy, and secure.
+2. **Serverless functions** (Vercel/Netlify functions + managed DB) — auto-scaling but cold starts, limited SQL expressiveness, vendor lock-in on compute.
+3. **PostgreSQL-only via Supabase** — all business logic as SQL functions, Supabase provides auth, RLS, and REST/realtime APIs out of the box.
+
+The scoring algorithm requires multi-table JOINs, LATERAL subqueries, window functions, and JSONB aggregation. Expressing this in an ORM would be fragile and slower. The search layer uses `pg_trgm` and `tsvector` — native PostgreSQL features with no ORM equivalent.
+
+## Decision
+
+Use **PostgreSQL as the sole application backend**, accessed via Supabase client libraries. All business logic lives in SQL functions (`api_*` RPCs). No separate API server. No ORM.
+
+- Frontend calls Supabase RPC functions directly
+- Auth handled by Supabase Auth (GoTrue)
+- Row-Level Security (RLS) enforces access control at the database layer
+- Migrations managed by Supabase CLI (`supabase/migrations/`)
+
+## Consequences
+
+### Positive
+
+- **Zero API server** — no Express/Fastify to maintain, deploy, or patch
+- **Single source of truth** — all logic is version-controlled SQL, testable via pgTAP
+- **Native performance** — scoring, search, and analytics run inside PostgreSQL without network hops
+- **Strong typing** — CHECK constraints, FKs, and domain types enforce data integrity at the DB level
+- **Supabase provides** auth, realtime, storage, and edge functions for free tier
+
+### Negative
+
+- **SQL-heavy codebase** — contributors need strong PostgreSQL skills, not just JavaScript
+- **Testing requires running DB** — pgTAP tests need a live PostgreSQL instance
+- **Vendor coupling** — Supabase CLI, config.toml, and migration format are specific to Supabase (though the SQL itself is portable)
+- **Limited mocking** — frontend tests must mock Supabase client rather than a standard REST API
+
+### Neutral
+
+- Frontend uses Next.js App Router with TanStack Query for data fetching
+- Pipeline (Python) generates SQL files, not direct DB writes — maintaining the SQL-first principle

--- a/docs/decisions/002-weighted-scoring-formula.md
+++ b/docs/decisions/002-weighted-scoring-formula.md
@@ -1,0 +1,52 @@
+# ADR-002: Weighted 9-Factor Unhealthiness Scoring Formula (v3.2)
+
+> **Date:** 2026-02-10 (retroactive — v3.2 finalized in migration `20260210001900`)
+> **Status:** accepted
+> **Deciders:** @ericsocrat
+
+## Context
+
+The project needs a single composite score (1–100) to rank products by health risk. Existing systems like Nutri-Score (A–E) are useful but coarse — they don't capture processing risk, additive concerns, or preparation method impact.
+
+Approaches considered:
+
+1. **Use Nutri-Score directly** — simple but only 5 buckets, doesn't penalize ultra-processing or additives.
+2. **Binary good/bad classification** — too simplistic for 1,000+ products across 20 categories.
+3. **Custom weighted formula** — more engineering effort but captures the specific risk dimensions consumers care about.
+
+The formula evolved through versions: v1.0 (3 factors), v2.0 (5 factors), v3.0 (7 factors), v3.1 (8 factors), v3.2 (9 factors with EFSA-based ingredient concern scoring).
+
+## Decision
+
+Use a **9-factor weighted sum** where each factor is normalized to 0–100 with per-100g ceilings based on WHO/EFSA daily limits, then combined:
+
+```
+unhealthiness_score =
+  sat_fat(0.17) + sugars(0.17) + salt(0.17) + calories(0.10) +
+  trans_fat(0.11) + additives(0.07) + prep_method(0.08) +
+  controversies(0.08) + ingredient_concern(0.05)
+```
+
+Implemented as `compute_unhealthiness_v32()` SQL function. Scoring is **never inlined** — always called via `score_category()` procedure which handles all 5 scoring steps.
+
+## Consequences
+
+### Positive
+
+- **Fine-grained ranking** — 100-point scale enables meaningful sorting within categories
+- **Transparent** — `explain_score_v32()` returns per-factor breakdowns as JSONB
+- **Extensible** — adding a new factor is a weight rebalance + migration, not a rewrite
+- **Science-grounded** — each ceiling tied to WHO/EFSA daily guideline thresholds
+- **Regression-tested** — 11 anchor products with expected scores in QA suite
+
+### Negative
+
+- **Weights are editorial** — reasonable people can disagree on sat_fat vs. salt importance
+- **Formula drift risk** — any change requires updating all 1,076 products; mitigated by `check_formula_drift()` and `governance_drift_check()`
+- **Per-100g bias** — products consumed in small quantities (spices, condiments) may score misleadingly high
+
+### Neutral
+
+- Nutri-Score and NOVA are stored as separate dimensions, not replaced by this score
+- Full methodology documented in `docs/SCORING_METHODOLOGY.md`
+- Version history tracked in `scoring_model_versions` table with SHA-256 fingerprint

--- a/docs/decisions/003-country-scoped-isolation.md
+++ b/docs/decisions/003-country-scoped-isolation.md
@@ -1,0 +1,45 @@
+# ADR-003: Country-Scoped Data Isolation
+
+> **Date:** 2026-02-13 (retroactive — implemented in migration `20260213001200`)
+> **Status:** accepted
+> **Deciders:** @ericsocrat
+
+## Context
+
+The database started as Poland-only but needs to support multiple countries (Germany micro-pilot launched with 51 Chips products). Two architectural approaches were considered:
+
+1. **Single global product table, filter by country at query time** — simpler schema but requires discipline to always include `WHERE country = ...` in every query, view, and function.
+2. **Separate schemas or databases per country** — strong isolation but complex cross-country queries, duplicated functions, harder to maintain.
+
+The project chose option 1 with strict enforcement mechanisms.
+
+## Decision
+
+All product data lives in a **single set of tables** with a `country` column on `products` that references `country_ref(country_code)`. Isolation is enforced at multiple layers:
+
+- **Schema layer:** `country_ref` table with `is_active` flag; FK from `products.country`
+- **CHECK constraint:** `chk_products_country` limits values to active country codes
+- **Query layer:** All views (`v_master`, `v_api_category_overview`) and API functions filter by country parameter
+- **Pipeline layer:** Each country gets its own pipeline folder (`chips-pl/`, `chips-de/`)
+- **QA layer:** `QA__country_isolation.sql` (11 checks) verifies no cross-contamination
+- **CI layer:** `QA__multi_country_consistency.sql` (10 checks) validates consistency rules
+
+## Consequences
+
+### Positive
+
+- **Single schema** — no function duplication, shared scoring logic, unified migrations
+- **Easy expansion** — adding a country is `INSERT INTO country_ref` + pipeline folder + data
+- **Cross-country queries possible** — useful for comparison features (e.g., same brand in PL vs DE)
+- **Well-documented** — `docs/COUNTRY_EXPANSION_GUIDE.md` provides step-by-step protocol
+
+### Negative
+
+- **Requires discipline** — every new query/function must include country filtering
+- **Risk of data leakage** — if a developer forgets `WHERE country = $1`, users see mixed data
+- **QA overhead** — 21 checks across 2 QA suites exist specifically to catch isolation failures
+
+### Neutral
+
+- Currently 2 active countries: PL (primary, 1,025 products) and DE (micro-pilot, 51 products)
+- Pipeline auto-detects country from folder naming convention (`*-pl/`, `*-de/`)

--- a/docs/decisions/004-pipeline-generates-sql.md
+++ b/docs/decisions/004-pipeline-generates-sql.md
@@ -1,0 +1,56 @@
+# ADR-004: Pipeline Architecture — Python Generates SQL, Never Writes Directly
+
+> **Date:** 2026-02-07 (retroactive — original pipeline design)
+> **Status:** accepted
+> **Deciders:** @ericsocrat
+
+## Context
+
+The project imports food product data from Open Food Facts (OFF) API into PostgreSQL. Three pipeline approaches were considered:
+
+1. **Direct DB writes from Python** (using psycopg2/SQLAlchemy) — fast to implement but SQL is invisible, not version-controlled, and not reproducible.
+2. **ETL tool** (dbt, Airflow, Dagster) — powerful but heavy dependency for a relatively simple pipeline. Adds operational complexity.
+3. **Python generates SQL files, executed separately via psql** — SQL is version-controlled, reviewable, and idempotent. Python handles only API calls and data transformation.
+
+## Decision
+
+The pipeline follows a **generate-then-execute** architecture:
+
+```
+OFF API → Python (pipeline/) → SQL files (db/pipelines/) → psql → PostgreSQL
+```
+
+- `pipeline/run.py` fetches data from OFF API, validates it, and calls `sql_generator.py`
+- `sql_generator.py` writes 4–5 SQL files per category into `db/pipelines/{category}/`
+- SQL files are committed to Git and executed via `psql` (locally or in CI)
+- Python **never** connects to the database directly
+
+File naming follows strict convention:
+```
+PIPELINE__{category}__01_insert_products.sql
+PIPELINE__{category}__03_add_nutrition.sql
+PIPELINE__{category}__04_scoring.sql
+PIPELINE__{category}__05_source_provenance.sql
+```
+
+## Consequences
+
+### Positive
+
+- **Full auditability** — every data change is a reviewable SQL file in Git
+- **Reproducibility** — `supabase db reset` + execute all pipeline SQL = exact same database state
+- **Idempotency** — all SQL uses `ON CONFLICT DO UPDATE`, safe to re-run
+- **Separation of concerns** — Python handles API interaction, SQL handles data operations
+- **CI-friendly** — `check_pipeline_structure.py` validates folder/file structure in CI
+
+### Negative
+
+- **Two-step workflow** — must run Python, then execute SQL (automated via `RUN_LOCAL.ps1`)
+- **Large file counts** — 21 categories × 4–5 files = ~90 SQL files to manage
+- **SQL generation complexity** — `sql_generator.py` must produce correct, idempotent SQL for all edge cases
+
+### Neutral
+
+- Each category gets its own folder under `db/pipelines/`
+- Execution order matters: products (01) → nutrition (03) → scoring (04) → provenance (05)
+- `RUN_LOCAL.ps1` automates the full pipeline-then-execute-then-QA workflow

--- a/docs/decisions/005-api-function-name-versioning.md
+++ b/docs/decisions/005-api-function-name-versioning.md
@@ -1,0 +1,53 @@
+# ADR-005: API Versioning via Function-Name Suffixes
+
+> **Date:** 2026-02-13 (retroactive — formalized in `docs/API_VERSIONING.md`)
+> **Status:** accepted
+> **Deciders:** @ericsocrat
+
+## Context
+
+As the API surface grew to 109 functions, a versioning strategy became necessary. Three approaches were evaluated:
+
+1. **URL-based versioning** (`/api/v1/products`, `/api/v2/products`) — standard for REST APIs but Supabase RPC calls go through a single `/rest/v1/rpc/{function_name}` endpoint. URL versioning doesn't apply naturally.
+2. **Header-based versioning** (`Accept-Version: v2`) — requires custom middleware. Supabase doesn't natively support this.
+3. **Function-name versioning** (`api_product_detail` → `api_v2_product_detail`) — works natively with Supabase RPC. No middleware needed. Old and new functions coexist in the database.
+
+## Decision
+
+Use **function-name suffixes** for API versioning:
+
+- Current (unversioned) functions: `api_product_detail()`, `api_search_products()`
+- Next version: `api_v2_product_detail()`, `api_v2_search_products()`
+- All functions return `api_version` key in their response JSONB
+
+**Deprecation policy:**
+- Deprecated functions emit a `deprecated_at` field in response
+- 90-day sunset window before removal
+- CI enforces via `QA__api_contract.sql` that all active functions return `api_version`
+
+**Breaking change definition:**
+- Removing a response key
+- Changing a response key's type
+- Adding a required parameter without a default
+- Changing function name without alias
+
+## Consequences
+
+### Positive
+
+- **Zero middleware** — works natively with Supabase's RPC endpoint
+- **Coexistence** — old and new versions run simultaneously in the same database
+- **Client migration** — consumers can migrate at their own pace during the sunset window
+- **CI-enforced** — `QA__api_contract.sql` (33 checks) validates versioning compliance
+
+### Negative
+
+- **Function proliferation** — a major version bump duplicates all `api_*` functions temporarily
+- **No automatic routing** — clients must know the exact function name (no middleware to route `v1` → `v2`)
+- **Naming convention burden** — developers must follow `api_v{N}_*` naming strictly
+
+### Neutral
+
+- Documented in `docs/API_VERSIONING.md` with deprecation timeline examples
+- `docs/api-registry.yaml` tracks all 109 functions with version metadata
+- Response shape contracts documented in `docs/API_CONTRACTS.md`

--- a/docs/decisions/006-append-only-migrations.md
+++ b/docs/decisions/006-append-only-migrations.md
@@ -1,0 +1,48 @@
+# ADR-006: Append-Only Migration Strategy
+
+> **Date:** 2026-02-07 (retroactive — enforced since first migration)
+> **Status:** accepted
+> **Deciders:** @ericsocrat
+
+## Context
+
+Database schema evolution can be managed in two ways:
+
+1. **Mutable migrations** — edit existing migration files to fix issues, squash migrations periodically. Simpler history but loses auditability. Risk of divergence between environments if a migration has already been applied.
+2. **Append-only migrations** — never modify an existing migration file. Fixes and changes always go in a new file. Preserves full history and ensures deterministic replay.
+
+Supabase CLI's migration system applies migrations in timestamp order and records which have been applied. Modifying an already-applied migration would cause checksum mismatches and deployment failures.
+
+## Decision
+
+All migrations in `supabase/migrations/` are **strictly append-only**:
+
+- **Never modify** an existing migration file (even to fix a typo)
+- **Never delete** a migration file
+- **Never change** a migration's timestamp
+- Fixes go in a **new migration** with the next timestamp
+- Each migration uses idempotent patterns: `IF NOT EXISTS`, `CREATE OR REPLACE`, `ADD COLUMN IF NOT EXISTS`
+- Every migration includes a rollback comment: `-- To roll back: DROP TABLE/COLUMN IF EXISTS ...`
+
+Currently **137 migrations** spanning 2026-02-07 to 2026-02-15.
+
+## Consequences
+
+### Positive
+
+- **Deterministic replay** — `supabase db reset` always produces the same schema
+- **Environment safety** — no risk of checksum mismatch between local, staging, and production
+- **Full audit trail** — every schema change is traceable to a specific timestamp and commit
+- **CI-validatable** — `check_migration_conventions.py` and `check_migration_order.py` enforce naming and ordering in CI
+
+### Negative
+
+- **Migration count grows** — 137 files and counting; may need squashing strategy eventually
+- **Small fixes are verbose** — a one-line column rename requires a full migration file
+- **Rollback is manual** — no automated rollback; rollback SQL is documented in comments
+
+### Neutral
+
+- Convention: `YYYYMMDDHHMMSS_description.sql` (Supabase timestamp format)
+- Documented in `docs/MIGRATION_CONVENTIONS.md`
+- Pipeline data files (`db/pipelines/`) are separate from schema migrations

--- a/docs/decisions/007-english-canonical-ingredients.md
+++ b/docs/decisions/007-english-canonical-ingredients.md
@@ -1,0 +1,59 @@
+# ADR-007: Ingredient Data in English Canonical Names
+
+> **Date:** 2026-02-10 (retroactive — implemented in migration `20260210001600`)
+> **Status:** accepted
+> **Deciders:** @ericsocrat
+
+## Context
+
+Product labels in Poland use Polish ingredient names. Open Food Facts provides ingredients in the product's original language (often Polish, sometimes mixed Polish/English/German). The database needs a canonical ingredient dictionary for:
+
+- Cross-product comparison (is "sól" the same as "salt"?)
+- Allergen inference from ingredients
+- Additive classification (EFSA concern tiers)
+- Dietary filtering (vegan, vegetarian, palm oil)
+
+Three approaches were considered:
+
+1. **Store in original language** — preserves label fidelity but prevents cross-product analysis. "Sól morska" and "sea salt" would be separate entries.
+2. **Multi-language with translation table** — comprehensive but high maintenance. Requires ongoing translation effort for every new ingredient.
+3. **English canonical + provenance** — normalize all ingredients to clean ASCII English names. Store the original label text in `ingredients_raw` for reference.
+
+## Decision
+
+All 2,740 ingredients in `ingredient_ref` are stored as **clean ASCII English** names:
+
+- Polish names translated to English during pipeline import
+- Mixed-language names normalized (e.g., "sól morska" → "sea salt")
+- Diacritics stripped for consistency (`name_en` column is ASCII-safe)
+- Original label text preserved in `products.ingredients_raw`
+- Migration `20260210001600` translated 375 foreign ingredient names
+
+Each ingredient has classification flags:
+- `is_additive` — boolean (E-number additives)
+- `concern_tier` — 0–3 (EFSA-based risk classification)
+- `vegan` / `vegetarian` — 'yes'/'no'/'maybe'
+- `contains_palm_oil` — 'yes'/'no'/'maybe'
+
+## Consequences
+
+### Positive
+
+- **Cross-product analysis** — all products use the same ingredient dictionary regardless of label language
+- **Allergen inference** — matching against English canonical names is reliable
+- **Additive classification** — EFSA concern tiers work on standardized names
+- **Search consistency** — users search in one language, not multiple
+- **2,740 unique ingredients** across 859 products with full classification
+
+### Negative
+
+- **Translation maintenance** — new Polish/German products may introduce untranslated ingredients requiring manual mapping
+- **Lossy normalization** — some nuance may be lost (e.g., "ser żółty" vs "yellow cheese" vs "semi-hard cheese")
+- **English bias** — non-English-speaking contributors may find the ingredient dictionary less intuitive
+
+### Neutral
+
+- `ingredient_ref` table has unique constraint on `name_en`
+- `product_ingredient` junction table tracks position, percent, sub-ingredient relationships
+- QA suite `QA__ingredient_quality.sql` (14 checks) validates data quality
+- 4-tier concern system documented in `concern_tier_ref` table with EFSA guidance


### PR DESCRIPTION
## Summary

Implements #322 — adds a complete ADR (Architecture Decision Records) framework to address the single biggest maturity gap (L1→L5).

## Changes

### New files (8)
- `docs/decisions/000-template.md` — MADR 3.0 template for new ADRs
- `docs/decisions/001-postgresql-only-stack.md` — PostgreSQL-only stack via Supabase
- `docs/decisions/002-weighted-scoring-formula.md` — 9-factor v3.2 scoring formula
- `docs/decisions/003-country-scoped-isolation.md` — Country-scoped data isolation
- `docs/decisions/004-pipeline-generates-sql.md` — Python generates SQL, never writes directly
- `docs/decisions/005-api-function-name-versioning.md` — API versioning via function names
- `docs/decisions/006-append-only-migrations.md` — Append-only migration strategy
- `docs/decisions/007-english-canonical-ingredients.md` — English canonical ingredient names

### Modified files (3)
- `docs/INDEX.md` — Added "Architecture Decisions (ADRs)" section with all 8 files
- `copilot-instructions.md` — Updated §3 project layout with `docs/decisions/` directory
- `CHANGELOG.md` — Added documentation entry under [Unreleased]

## Safety
- ❌ No runtime behavior changes
- ❌ No API changes
- ❌ No schema changes
- ✅ Docs-only

## Checklist
- [x] `docs/INDEX.md` updated
- [x] `copilot-instructions.md` §3 updated
- [x] `CHANGELOG.md` updated
- [x] All ADRs contain real content (not boilerplate)
- [x] MADR 3.0 template provided

Closes #322