### PR TITLE
data(pipeline): expand DE micro-pilot to 5 categories (252 products)

### DIFF
--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,8 +1,8 @@
 # Copilot Instructions — Poland Food Quality Database
 
 > **Last updated:** 2026-02-28
-> **Scope:** Poland (`PL`) primary + Germany (`DE`) micro-pilot (51 Chips products)
-> **Products:** ~1,076 active (20 PL categories + 1 DE category), 38 deprecated
+> **Scope:** Poland (`PL`) primary + Germany (`DE`) micro-pilot (252 products across 5 categories)
+> **Products:** ~1,281 active (20 PL categories + 5 DE categories), 51 deprecated
 > **EAN coverage:** 997/1,025 (97.3%)
 > **Scoring:** v3.2 — 9-factor weighted formula via `compute_unhealthiness_v32()` (added ingredient concern scoring)
 > **Servings:** removed as separate table — all nutrition data is per-100g on nutrition_facts
@@ -43,6 +43,7 @@ countries_tags_en=poland) sql_generator.py 03_add_nutrition ingredient_ref
 $env:PYTHONIOENCODING="utf-8"
 .\.venv\Scripts\python.exe -m pipeline.run --category "Dairy" --max-products 28
 .\.venv\Scripts\python.exe -m pipeline.run --category "Chips" --dry-run
+.\.venv\Scripts\python.exe -m pipeline.run --category "Dairy" --country DE --max-products 51
 ````
 
 **Execute generated SQL:**
@@ -77,9 +78,13 @@ poland-food-db/
 │   ├── image_importer.py            # Product image import utility
 │   └── categories.py               # 20 category definitions + OFF tag mappings
 ├── db/
-│   ├── pipelines/                   # 21 category folders (20 PL + 1 DE), 4-5 SQL files each
+│   ├── pipelines/                   # 25 category folders (20 PL + 5 DE), 4-5 SQL files each
 │   │   ├── chips-pl/                # Reference PL implementation (copy for new categories)
 │   │   ├── chips-de/                # Germany micro-pilot (51 products)
+│   │   ├── bread-de/                # DE Bread (51 products)
+│   │   ├── dairy-de/                # DE Dairy (51 products)
+│   │   ├── drinks-de/               # DE Drinks (51 products)
+│   │   ├── sweets-de/               # DE Sweets (51 products)
 │   │   └── ... (19 more PL)         # Variable product counts per category
 │   ├── qa/                          # Test suites
 │   │   ├── QA__null_checks.sql      # 29 data integrity checks
@@ -435,9 +440,9 @@ poland-food-db/
 
 ---
 
-## 5. Categories (20)
+## 5. Categories (20 PL + 5 DE)
 
-All categories have **variable product counts** (28–95 active products). Categories are expanded by running the pipeline with `--max-products N`.
+All categories have **variable product counts** (28–95 active products). Categories are expanded by running the pipeline with `--max-products N`. DE categories target ~51 products each.
 
 | Category                   | Folder slug                 |
 | -------------------------- | --------------------------- |
@@ -447,11 +452,17 @@ All categories have **variable product counts** (28–95 active products). Categ
 | Breakfast & Grain-Based    | `breakfast-grain-based/`    |
 | Canned Goods               | `canned-goods/`             |
 | Cereals                    | `cereals/`                  |
+| Bread (DE)                 | `bread-de/`                 |
+| Breakfast & Grain-Based    | `breakfast-grain-based/`    |
+| Canned Goods               | `canned-goods/`             |
+| Cereals                    | `cereals/`                  |
 | Chips (PL)                 | `chips-pl/`                 |
 | Chips (DE)                 | `chips-de/`                 |
 | Condiments                 | `condiments/`               |
 | Dairy                      | `dairy/`                    |
+| Dairy (DE)                 | `dairy-de/`                 |
 | Drinks                     | `drinks/`                   |
+| Drinks (DE)                | `drinks-de/`                |
 | Frozen & Prepared          | `frozen-prepared/`          |
 | Instant & Frozen           | `instant-frozen/`           |
 | Meat                       | `meat/`                     |
@@ -461,9 +472,10 @@ All categories have **variable product counts** (28–95 active products). Categ
 | Seafood & Fish             | `seafood-fish/`             |
 | Snacks                     | `snacks/`                   |
 | Sweets                     | `sweets/`                   |
+| Sweets (DE)                | `sweets-de/`                |
 | Żabka                      | `zabka/`                    |
 
-**21 pipeline folders** (20 PL + 1 DE). Category-to-OFF tag mappings live in `pipeline/categories.py`. Each category has multiple OFF tags and search terms for comprehensive coverage.
+**25 pipeline folders** (20 PL + 5 DE). Category-to-OFF tag mappings live in `pipeline/categories.py`. Each category has multiple OFF tags and search terms for comprehensive coverage.
 
 ---
 

--- a/db/pipelines/bread-de/PIPELINE__bread-de__01_insert_products.sql
+++ b/db/pipelines/bread-de/PIPELINE__bread-de__01_insert_products.sql
@@ -1,0 +1,85 @@
+-- PIPELINE (Bread): insert products
+-- Source: Open Food Facts API (automated pipeline)
+-- Generated: 2026-02-25
+
+-- 0a. DEPRECATE old products in this category & release their EANs
+update products
+set is_deprecated = true, deprecated_reason = 'Replaced by pipeline refresh', ean = null
+where country = 'DE'
+  and category = 'Bread'
+  and is_deprecated is not true;
+
+-- 0b. Release EANs across ALL categories to prevent unique constraint conflicts
+update products set ean = null
+where ean in ('4056489206026', '4071800038810', '4009249001843', '4009249002277', '4071800058269', '4071800057637', '4061461077563', '4008577006315', '4009249002550', '4061458046046', '4061459698992', '4000446001018', '4061458227650', '4061458176323', '4008577006186', '4068706471902', '4009097010691', '4071800038568', '4061462968624', '4056489183631', '4061458022040', '4009249019923', '4071800001012', '4061458045759', '4061458055734', '4061462084256', '4061458045797', '4061458236928', '4061459425697', '4067796162462', '4061458022033', '4071800000633', '4013752019004', '4071800000879', '4009249001171', '4006170001676', '4061458169066', '4000446015497', '4071800038803', '4071800034508', '4009249022565', '4071800000824', '4009249019916', '4013752019547', '4071800001081', '4071800052618', '4061458054263', '4009249038184', '4015427111112', '4061458045827', '4061459712001')
+  and ean is not null;
+
+-- 1. INSERT products
+insert into products (country, brand, product_type, category, product_name, prep_method, store_availability, controversies, ean)
+values
+  ('DE', 'Gräfschafter', 'Grocery', 'Bread', 'Eiweißreiches Weizenvollkornbrot', 'not-applicable', 'Lidl', 'none', '4056489206026'),
+  ('DE', 'Harry', 'Grocery', 'Bread', 'Körner Balance Sandwich', 'not-applicable', 'Lidl', 'none', '4071800038810'),
+  ('DE', 'Golden Toast', 'Grocery', 'Bread', 'Sandwich Körner-Harmonie', 'not-applicable', null, 'none', '4009249001843'),
+  ('DE', 'Lieken Urkorn', 'Grocery', 'Bread', 'Fitnessbrot mit 5 % Ölsaaten', 'not-applicable', 'Netto', 'none', '4009249002277'),
+  ('DE', 'Harry', 'Grocery', 'Bread', 'Eiweißbrot', 'not-applicable', null, 'none', '4071800058269'),
+  ('DE', 'Harry', 'Grocery', 'Bread', 'Harry Dinkel Krüstchen 4071800057637', 'not-applicable', 'Kaufland', 'none', '4071800057637'),
+  ('DE', 'Aldi', 'Grocery', 'Bread', 'Das Pure - Bio-Haferbrot mit 29% Ölsaaten', 'not-applicable', 'Aldi', 'none', '4061461077563'),
+  ('DE', 'Conditorei Coppenrath & Wiese', 'Grocery', 'Bread', 'Weizenbrötchen', 'not-applicable', 'Lidl', 'none', '4008577006315'),
+  ('DE', 'Lieken', 'Grocery', 'Bread', 'Roggenbäcker', 'not-applicable', 'Netto', 'none', '4009249002550'),
+  ('DE', 'Goldähren', 'Grocery', 'Bread', 'Französisches Steinofen-Baguette', 'baked', 'Aldi', 'none', '4061458046046'),
+  ('DE', 'Goldähren', 'Grocery', 'Bread', 'Laugen-Brioche vorgeschnitten, 6 Stück', 'not-applicable', 'Aldi', 'none', '4061459698992'),
+  ('DE', 'Mestemacher', 'Grocery', 'Bread', 'Westfälischen Pumpernickel', 'not-applicable', null, 'none', '4000446001018'),
+  ('DE', 'Goldähren', 'Grocery', 'Bread', 'Toast-Brötchen Protein', 'not-applicable', 'Aldi', 'none', '4061458227650'),
+  ('DE', 'GutBio', 'Grocery', 'Bread', 'Das Pure - Haferbrot mit 27% Ölsaaten', 'not-applicable', null, 'none', '4061458176323'),
+  ('DE', 'Coppenrath & Wiese', 'Grocery', 'Bread', 'Dinkelbrötchen', 'not-applicable', null, 'none', '4008577006186'),
+  ('DE', 'Aldi', 'Grocery', 'Bread', 'Bio-Landbrötchen - Kernig', 'baked', null, 'none', '4068706471902'),
+  ('DE', 'Sinnack', 'Grocery', 'Bread', 'Brot Protein Brötchen', 'not-applicable', null, 'none', '4009097010691'),
+  ('DE', 'Harry', 'Grocery', 'Bread', 'Körner Balance Toastbrötchen', 'not-applicable', null, 'none', '4071800038568'),
+  ('DE', 'Gut bio', 'Grocery', 'Bread', 'Finnkorn Toastbrötchen', 'not-applicable', null, 'none', '4061462968624'),
+  ('DE', 'Grafschafter', 'Grocery', 'Bread', 'Pure Kornkraft Haferbrot', 'not-applicable', 'Lidl', 'none', '4056489183631'),
+  ('DE', 'Goldähren', 'Grocery', 'Bread', 'Vollkorn-Sandwich', 'not-applicable', 'Aldi', 'none', '4061458022040'),
+  ('DE', 'Golden Toast', 'Grocery', 'Bread', 'Vollkorn-Toast', 'not-applicable', 'Lidl', 'none', '4009249019923'),
+  ('DE', 'Harry', 'Grocery', 'Bread', 'Harry Brot Vital + Fit', 'not-applicable', null, 'none', '4071800001012'),
+  ('DE', 'Goldähren', 'Grocery', 'Bread', 'Vollkorntoast', 'not-applicable', 'Aldi', 'none', '4061458045759'),
+  ('DE', 'Goldähren', 'Grocery', 'Bread', 'Eiweiss Brot', 'baked', 'Aldi', 'none', '4061458055734'),
+  ('DE', 'Meierbaer & Albro', 'Grocery', 'Bread', 'Das Pure - Bio-Haferbrot', 'not-applicable', 'Aldi', 'none', '4061462084256'),
+  ('DE', 'Goldähren', 'Grocery', 'Bread', 'Mehrkorn Wraps', 'not-applicable', 'Aldi', 'none', '4061458045797'),
+  ('DE', 'Goldähren', 'Grocery', 'Bread', 'Protein-Wraps', 'not-applicable', 'Aldi', 'none', '4061458236928'),
+  ('DE', 'Nur Nur Natur', 'Grocery', 'Bread', 'Bio-Roggenvollkornbrot', 'not-applicable', 'Aldi', 'none', '4061459425697'),
+  ('DE', 'DmBio', 'Grocery', 'Bread', 'Das Pure Hafer - und Saatenbrot', 'not-applicable', null, 'none', '4067796162462'),
+  ('DE', 'Goldähren', 'Grocery', 'Bread', 'American Sandwich - Weizen', 'not-applicable', 'Aldi', 'none', '4061458022033'),
+  ('DE', 'Harry', 'Grocery', 'Bread', 'Vollkorn Toast', 'not-applicable', null, 'none', '4071800000633'),
+  ('DE', 'Brandt', 'Grocery', 'Bread', 'Brandt Markenzwieback', 'not-applicable', null, 'none', '4013752019004'),
+  ('DE', 'Harry', 'Grocery', 'Bread', 'Unser Mildes (Weizenmischbrot)', 'not-applicable', 'Netto', 'none', '4071800000879'),
+  ('DE', 'Lieken', 'Grocery', 'Bread', 'Bauernmild Brot', 'not-applicable', 'Lidl', 'none', '4009249001171'),
+  ('DE', 'Lieken Urkorn', 'Grocery', 'Bread', 'Vollkornsaftiges fein', 'not-applicable', 'Netto', 'none', '4006170001676'),
+  ('DE', 'Goldähren', 'Grocery', 'Bread', 'Mehrkornschnitten', 'not-applicable', 'Aldi', 'none', '4061458169066'),
+  ('DE', 'Mestemacher', 'Grocery', 'Bread', 'Dinkel Wraps', 'not-applicable', null, 'none', '4000446015497'),
+  ('DE', 'Harry', 'Grocery', 'Bread', 'Toastbrot', 'not-applicable', 'Kaufland', 'none', '4071800038803'),
+  ('DE', 'Harry', 'Grocery', 'Bread', 'Vollkorn Urtyp', 'not-applicable', null, 'none', '4071800034508'),
+  ('DE', 'Golden Toast', 'Grocery', 'Bread', 'Vollkorn Toast', 'not-applicable', 'Netto', 'none', '4009249022565'),
+  ('DE', 'Harry', 'Grocery', 'Bread', 'Harry 1688 Korn an Korn', 'not-applicable', null, 'none', '4071800000824'),
+  ('DE', 'Golden Toast', 'Grocery', 'Bread', 'Buttertoast', 'not-applicable', 'Lidl', 'none', '4009249019916'),
+  ('DE', 'Brandt', 'Grocery', 'Bread', 'Der Markenzwieback', 'not-applicable', 'Netto', 'none', '4013752019547'),
+  ('DE', 'Gutes aus der Bäckerei', 'Grocery', 'Bread', 'Weissbrot', 'not-applicable', 'Kaufland', 'none', '4071800001081'),
+  ('DE', 'Harry', 'Grocery', 'Bread', 'Mischbrot Anno 1688 Klassisch, Harry', 'not-applicable', null, 'none', '4071800052618'),
+  ('DE', 'Goldähren', 'Grocery', 'Bread', 'Dreisaatbrot - Roggenvollkornbrot', 'not-applicable', 'Aldi', 'none', '4061458054263'),
+  ('DE', 'Golden Toast', 'Grocery', 'Bread', 'Dinkel-Harmonie Sandwich', 'not-applicable', null, 'none', '4009249038184'),
+  ('DE', 'Filinchen', 'Grocery', 'Bread', 'Das Knusperbrot Original', 'not-applicable', 'Netto', 'none', '4015427111112'),
+  ('DE', 'Goldähren', 'Grocery', 'Bread', 'Saaten-Sandwich', 'not-applicable', 'Aldi', 'none', '4061458045827'),
+  ('DE', 'Cucina', 'Grocery', 'Bread', 'Pinsa', 'not-applicable', 'Aldi', 'none', '4061459712001')
+on conflict (country, brand, product_name) do update set
+  category = excluded.category,
+  ean = excluded.ean,
+  product_type = excluded.product_type,
+  store_availability = excluded.store_availability,
+  controversies = excluded.controversies,
+  prep_method = excluded.prep_method,
+  is_deprecated = false;
+
+-- 2. DEPRECATE removed products
+update products
+set is_deprecated = true, deprecated_reason = 'Removed from pipeline batch'
+where country = 'DE' and category = 'Bread'
+  and is_deprecated is not true
+  and product_name not in ('Eiweißreiches Weizenvollkornbrot', 'Körner Balance Sandwich', 'Sandwich Körner-Harmonie', 'Fitnessbrot mit 5 % Ölsaaten', 'Eiweißbrot', 'Harry Dinkel Krüstchen 4071800057637', 'Das Pure - Bio-Haferbrot mit 29% Ölsaaten', 'Weizenbrötchen', 'Roggenbäcker', 'Französisches Steinofen-Baguette', 'Laugen-Brioche vorgeschnitten, 6 Stück', 'Westfälischen Pumpernickel', 'Toast-Brötchen Protein', 'Das Pure - Haferbrot mit 27% Ölsaaten', 'Dinkelbrötchen', 'Bio-Landbrötchen - Kernig', 'Brot Protein Brötchen', 'Körner Balance Toastbrötchen', 'Finnkorn Toastbrötchen', 'Pure Kornkraft Haferbrot', 'Vollkorn-Sandwich', 'Vollkorn-Toast', 'Harry Brot Vital + Fit', 'Vollkorntoast', 'Eiweiss Brot', 'Das Pure - Bio-Haferbrot', 'Mehrkorn Wraps', 'Protein-Wraps', 'Bio-Roggenvollkornbrot', 'Das Pure Hafer - und Saatenbrot', 'American Sandwich - Weizen', 'Vollkorn Toast', 'Brandt Markenzwieback', 'Unser Mildes (Weizenmischbrot)', 'Bauernmild Brot', 'Vollkornsaftiges fein', 'Mehrkornschnitten', 'Dinkel Wraps', 'Toastbrot', 'Vollkorn Urtyp', 'Vollkorn Toast', 'Harry 1688 Korn an Korn', 'Buttertoast', 'Der Markenzwieback', 'Weissbrot', 'Mischbrot Anno 1688 Klassisch, Harry', 'Dreisaatbrot - Roggenvollkornbrot', 'Dinkel-Harmonie Sandwich', 'Das Knusperbrot Original', 'Saaten-Sandwich', 'Pinsa');

--- a/db/pipelines/bread-de/PIPELINE__bread-de__03_add_nutrition.sql
+++ b/db/pipelines/bread-de/PIPELINE__bread-de__03_add_nutrition.sql
@@ -1,0 +1,87 @@
+-- PIPELINE (Bread): add nutrition facts
+-- Source: Open Food Facts verified per-100g data
+
+-- 1) Remove existing
+delete from nutrition_facts
+where product_id in (
+  select p.product_id
+  from products p
+  where p.country = 'DE' and p.category = 'Bread'
+    and p.is_deprecated is not true
+);
+
+-- 2) Insert
+insert into nutrition_facts
+  (product_id, calories, total_fat_g, saturated_fat_g, trans_fat_g,
+   carbs_g, sugars_g, fibre_g, protein_g, salt_g)
+select
+  p.product_id,
+  d.calories, d.total_fat_g, d.saturated_fat_g, d.trans_fat_g,
+  d.carbs_g, d.sugars_g, d.fibre_g, d.protein_g, d.salt_g
+from (
+  values
+    ('Gräfschafter', 'Eiweißreiches Weizenvollkornbrot', 267.7, 11.1, 1.7, 0, 15.7, 1.4, 6.9, 23.1, 1.1),
+    ('Harry', 'Körner Balance Sandwich', 258.0, 6.0, 0.5, 0, 39.5, 3.4, 6.0, 8.7, 0.4),
+    ('Golden Toast', 'Sandwich Körner-Harmonie', 299.0, 8.5, 0.8, 0, 42.7, 3.5, 5.3, 10.1, 1.1),
+    ('Lieken Urkorn', 'Fitnessbrot mit 5 % Ölsaaten', 232.7, 5.3, 0.5, 0, 34.0, 4.4, 7.1, 9.1, 1.1),
+    ('Harry', 'Eiweißbrot', 256.0, 7.5, 1.1, 0, 29.0, 2.5, 6.1, 15.0, 1.0),
+    ('Harry', 'Harry Dinkel Krüstchen 4071800057637', 257.0, 1.5, 0.7, 0, 49.0, 2.6, 3.5, 10.0, 1.3),
+    ('Aldi', 'Das Pure - Bio-Haferbrot mit 29% Ölsaaten', 296.0, 18.1, 2.5, 0, 18.3, 0.7, 8.1, 10.9, 1.0),
+    ('Conditorei Coppenrath & Wiese', 'Weizenbrötchen', 271.0, 1.9, 0.4, 0, 53.0, 2.2, 0, 9.0, 1.5),
+    ('Lieken', 'Roggenbäcker', 223.0, 1.1, 0.2, 0, 42.0, 2.3, 5.3, 8.6, 1.1),
+    ('Goldähren', 'Französisches Steinofen-Baguette', 251.0, 1.0, 0.3, 0, 50.0, 2.8, 3.4, 8.3, 1.2),
+    ('Goldähren', 'Laugen-Brioche vorgeschnitten, 6 Stück', 305.0, 6.2, 0.8, 0, 51.9, 10.7, 3.0, 8.8, 1.5),
+    ('Mestemacher', 'Westfälischen Pumpernickel', 181.0, 1.0, 0.2, 0, 32.8, 6.2, 11.5, 4.6, 1.1),
+    ('Goldähren', 'Toast-Brötchen Protein', 273.0, 10.8, 1.4, 0, 16.0, 4.1, 9.0, 23.5, 1.2),
+    ('GutBio', 'Das Pure - Haferbrot mit 27% Ölsaaten', 283.0, 15.8, 2.3, 0, 19.9, 0.9, 8.9, 10.8, 1.0),
+    ('Coppenrath & Wiese', 'Dinkelbrötchen', 308.0, 8.6, 1.1, 0, 43.0, 4.4, 0, 12.0, 1.1),
+    ('Aldi', 'Bio-Landbrötchen - Kernig', 249.0, 1.9, 0.3, 0, 47.0, 2.4, 4.2, 8.8, 1.0),
+    ('Sinnack', 'Brot Protein Brötchen', 275.0, 8.6, 1.0, 0, 25.0, 2.9, 6.7, 21.0, 1.0),
+    ('Harry', 'Körner Balance Toastbrötchen', 223.2, 3.2, 0.6, 0, 38.0, 2.4, 4.7, 8.5, 1.0),
+    ('Gut bio', 'Finnkorn Toastbrötchen', 232.0, 1.4, 0.2, 0, 43.0, 2.9, 0, 7.4, 1.2),
+    ('Grafschafter', 'Pure Kornkraft Haferbrot', 286.0, 15.1, 2.2, 0, 20.1, 0.7, 11.9, 11.4, 1.0),
+    ('Goldähren', 'Vollkorn-Sandwich', 239.0, 3.2, 0.3, 0, 40.7, 3.2, 6.6, 8.6, 0.0),
+    ('Golden Toast', 'Vollkorn-Toast', 268.0, 5.2, 0.4, 0, 43.2, 4.4, 6.4, 8.8, 1.1),
+    ('Harry', 'Harry Brot Vital + Fit', 241.0, 4.9, 0.8, 0, 35.0, 2.3, 6.9, 7.7, 1.0),
+    ('Goldähren', 'Vollkorntoast', 268.0, 5.3, 0.5, 0, 43.0, 4.3, 6.5, 8.8, 1.1),
+    ('Goldähren', 'Eiweiss Brot', 628.2, 12.0, 1.7, 0, 10.6, 2.0, 7.7, 23.1, 1.1),
+    ('Meierbaer & Albro', 'Das Pure - Bio-Haferbrot', 296.0, 18.1, 2.5, 0, 18.3, 0.7, 8.1, 10.9, 1.0),
+    ('Goldähren', 'Mehrkorn Wraps', 311.0, 7.3, 1.3, 0, 51.0, 1.4, 5.3, 7.7, 1.0),
+    ('Goldähren', 'Protein-Wraps', 318.0, 8.7, 1.1, 0, 38.5, 3.0, 6.1, 18.4, 1.1),
+    ('Nur Nur Natur', 'Bio-Roggenvollkornbrot', 184.0, 1.2, 0.1, 0, 34.0, 2.5, 9.0, 4.2, 0.9),
+    ('DmBio', 'Das Pure Hafer - und Saatenbrot', 296.0, 18.0, 2.5, 0, 18.0, 0.7, 8.1, 11.0, 1.0),
+    ('Goldähren', 'American Sandwich - Weizen', 254.7, 3.7, 0.5, 0, 44.8, 3.9, 3.6, 8.5, 1.0),
+    ('Harry', 'Vollkorn Toast', 250.0, 4.0, 0.4, 0, 42.0, 3.2, 6.0, 8.5, 1.0),
+    ('Brandt', 'Brandt Markenzwieback', 395.0, 0.7, 0.7, 0, 74.0, 14.0, 0.0, 11.0, 0.7),
+    ('Harry', 'Unser Mildes (Weizenmischbrot)', 242.0, 2.7, 0.3, 0, 45.0, 2.9, 3.8, 7.5, 1.0),
+    ('Lieken', 'Bauernmild Brot', 239.0, 2.2, 0.3, 0, 45.0, 3.1, 4.0, 7.7, 1.3),
+    ('Lieken Urkorn', 'Vollkornsaftiges fein', 206.0, 1.2, 0.2, 0, 38.5, 2.8, 9.2, 5.7, 1.1),
+    ('Goldähren', 'Mehrkornschnitten', 612.2, 6.1, 0.9, 0, 39.0, 2.3, 6.4, 9.7, 1.2),
+    ('Mestemacher', 'Dinkel Wraps', 304.0, 8.6, 1.1, 0, 45.7, 1.0, 3.1, 9.5, 1.1),
+    ('Harry', 'Toastbrot', 259.1, 6.0, 0.6, 0, 39.0, 3.5, 6.0, 8.8, 1.0),
+    ('Harry', 'Vollkorn Urtyp', 194.0, 1.1, 0.2, 0, 36.0, 3.7, 9.3, 5.4, 1.0),
+    ('Golden Toast', 'Vollkorn Toast', 267.0, 5.3, 0.5, 0, 43.0, 4.3, 6.5, 8.8, 1.1),
+    ('Harry', 'Harry 1688 Korn an Korn', 203.6, 1.1, 0.2, 0, 39.0, 4.6, 8.3, 5.3, 1.0),
+    ('Golden Toast', 'Buttertoast', 265.0, 3.8, 2.1, 0, 48.0, 4.0, 3.0, 8.2, 1.1),
+    ('Brandt', 'Der Markenzwieback', 395.0, 5.2, 0.7, 0, 74.0, 14.0, 0, 11.0, 0.7),
+    ('Gutes aus der Bäckerei', 'Weissbrot', 247.0, 3.0, 0.4, 0, 45.0, 4.0, 3.0, 8.5, 1.0),
+    ('Harry', 'Mischbrot Anno 1688 Klassisch, Harry', 248.0, 2.8, 0.5, 0, 45.0, 3.1, 5.2, 8.1, 1.3),
+    ('Goldähren', 'Dreisaatbrot - Roggenvollkornbrot', 215.0, 5.2, 0.6, 0, 29.4, 2.4, 11.8, 6.7, 0.9),
+    ('Golden Toast', 'Dinkel-Harmonie Sandwich', 264.0, 3.8, 0.4, 0, 45.5, 4.0, 3.5, 10.3, 1.1),
+    ('Filinchen', 'Das Knusperbrot Original', 406.0, 6.0, 4.0, 0, 75.0, 2.0, 4.0, 11.0, 0.2),
+    ('Goldähren', 'Saaten-Sandwich', 298.7, 8.7, 0.9, 0, 42.7, 3.5, 5.3, 10.0, 1.0),
+    ('Cucina', 'Pinsa', 263.0, 4.8, 0.9, 0, 43.9, 3.1, 3.3, 9.6, 1.8)
+) as d(brand, product_name, calories, total_fat_g, saturated_fat_g, trans_fat_g,
+       carbs_g, sugars_g, fibre_g, protein_g, salt_g)
+join products p on p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name
+  and p.category = 'Bread' and p.is_deprecated is not true
+on conflict (product_id) do update set
+  calories = excluded.calories,
+  total_fat_g = excluded.total_fat_g,
+  saturated_fat_g = excluded.saturated_fat_g,
+  trans_fat_g = excluded.trans_fat_g,
+  carbs_g = excluded.carbs_g,
+  sugars_g = excluded.sugars_g,
+  fibre_g = excluded.fibre_g,
+  protein_g = excluded.protein_g,
+  salt_g = excluded.salt_g;

--- a/db/pipelines/bread-de/PIPELINE__bread-de__04_scoring.sql
+++ b/db/pipelines/bread-de/PIPELINE__bread-de__04_scoring.sql
@@ -1,0 +1,123 @@
+-- PIPELINE (Bread): scoring
+-- Generated: 2026-02-25
+
+-- 2. Nutri-Score
+update products p set
+  nutri_score_label = d.ns
+from (
+  values
+    ('Gräfschafter', 'Eiweißreiches Weizenvollkornbrot', 'A'),
+    ('Harry', 'Körner Balance Sandwich', 'A'),
+    ('Golden Toast', 'Sandwich Körner-Harmonie', 'B'),
+    ('Lieken Urkorn', 'Fitnessbrot mit 5 % Ölsaaten', 'B'),
+    ('Harry', 'Eiweißbrot', 'A'),
+    ('Harry', 'Harry Dinkel Krüstchen 4071800057637', 'D'),
+    ('Aldi', 'Das Pure - Bio-Haferbrot mit 29% Ölsaaten', 'B'),
+    ('Conditorei Coppenrath & Wiese', 'Weizenbrötchen', 'C'),
+    ('Lieken', 'Roggenbäcker', 'B'),
+    ('Goldähren', 'Französisches Steinofen-Baguette', 'C'),
+    ('Goldähren', 'Laugen-Brioche vorgeschnitten, 6 Stück', 'D'),
+    ('Mestemacher', 'Westfälischen Pumpernickel', 'B'),
+    ('Goldähren', 'Toast-Brötchen Protein', 'A'),
+    ('GutBio', 'Das Pure - Haferbrot mit 27% Ölsaaten', 'A'),
+    ('Coppenrath & Wiese', 'Dinkelbrötchen', 'C'),
+    ('Aldi', 'Bio-Landbrötchen - Kernig', 'B'),
+    ('Sinnack', 'Brot Protein Brötchen', 'A'),
+    ('Harry', 'Körner Balance Toastbrötchen', 'B'),
+    ('Gut bio', 'Finnkorn Toastbrötchen', 'C'),
+    ('Grafschafter', 'Pure Kornkraft Haferbrot', 'A'),
+    ('Goldähren', 'Vollkorn-Sandwich', 'A'),
+    ('Golden Toast', 'Vollkorn-Toast', 'B'),
+    ('Harry', 'Harry Brot Vital + Fit', 'A'),
+    ('Goldähren', 'Vollkorntoast', 'B'),
+    ('Goldähren', 'Eiweiss Brot', 'C'),
+    ('Meierbaer & Albro', 'Das Pure - Bio-Haferbrot', 'B'),
+    ('Goldähren', 'Mehrkorn Wraps', 'B'),
+    ('Goldähren', 'Protein-Wraps', 'A'),
+    ('Nur Nur Natur', 'Bio-Roggenvollkornbrot', 'A'),
+    ('DmBio', 'Das Pure Hafer - und Saatenbrot', 'A'),
+    ('Goldähren', 'American Sandwich - Weizen', 'C'),
+    ('Harry', 'Vollkorn Toast', 'B'),
+    ('Brandt', 'Brandt Markenzwieback', 'C'),
+    ('Harry', 'Unser Mildes (Weizenmischbrot)', 'C'),
+    ('Lieken', 'Bauernmild Brot', 'C'),
+    ('Lieken Urkorn', 'Vollkornsaftiges fein', 'A'),
+    ('Goldähren', 'Mehrkornschnitten', 'C'),
+    ('Mestemacher', 'Dinkel Wraps', 'C'),
+    ('Harry', 'Toastbrot', 'B'),
+    ('Harry', 'Vollkorn Urtyp', 'A'),
+    ('Golden Toast', 'Vollkorn Toast', 'B'),
+    ('Harry', 'Harry 1688 Korn an Korn', 'A'),
+    ('Golden Toast', 'Buttertoast', 'D'),
+    ('Brandt', 'Der Markenzwieback', 'C'),
+    ('Gutes aus der Bäckerei', 'Weissbrot', 'C'),
+    ('Harry', 'Mischbrot Anno 1688 Klassisch, Harry', 'C'),
+    ('Goldähren', 'Dreisaatbrot - Roggenvollkornbrot', 'A'),
+    ('Golden Toast', 'Dinkel-Harmonie Sandwich', 'C'),
+    ('Filinchen', 'Das Knusperbrot Original', 'C'),
+    ('Goldähren', 'Saaten-Sandwich', 'B'),
+    ('Cucina', 'Pinsa', 'D')
+) as d(brand, product_name, ns)
+where p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name;
+
+-- 3. NOVA classification
+update products p set
+  nova_classification = d.nova
+from (
+  values
+    ('Gräfschafter', 'Eiweißreiches Weizenvollkornbrot', '4'),
+    ('Harry', 'Körner Balance Sandwich', '4'),
+    ('Golden Toast', 'Sandwich Körner-Harmonie', '3'),
+    ('Lieken Urkorn', 'Fitnessbrot mit 5 % Ölsaaten', '3'),
+    ('Harry', 'Eiweißbrot', '4'),
+    ('Harry', 'Harry Dinkel Krüstchen 4071800057637', '4'),
+    ('Aldi', 'Das Pure - Bio-Haferbrot mit 29% Ölsaaten', '4'),
+    ('Conditorei Coppenrath & Wiese', 'Weizenbrötchen', '3'),
+    ('Lieken', 'Roggenbäcker', '4'),
+    ('Goldähren', 'Französisches Steinofen-Baguette', '4'),
+    ('Goldähren', 'Laugen-Brioche vorgeschnitten, 6 Stück', '4'),
+    ('Mestemacher', 'Westfälischen Pumpernickel', '3'),
+    ('Goldähren', 'Toast-Brötchen Protein', '3'),
+    ('GutBio', 'Das Pure - Haferbrot mit 27% Ölsaaten', '4'),
+    ('Coppenrath & Wiese', 'Dinkelbrötchen', '3'),
+    ('Aldi', 'Bio-Landbrötchen - Kernig', '4'),
+    ('Sinnack', 'Brot Protein Brötchen', '4'),
+    ('Harry', 'Körner Balance Toastbrötchen', '4'),
+    ('Gut bio', 'Finnkorn Toastbrötchen', '4'),
+    ('Grafschafter', 'Pure Kornkraft Haferbrot', '4'),
+    ('Goldähren', 'Vollkorn-Sandwich', '3'),
+    ('Golden Toast', 'Vollkorn-Toast', '3'),
+    ('Harry', 'Harry Brot Vital + Fit', '4'),
+    ('Goldähren', 'Vollkorntoast', '3'),
+    ('Goldähren', 'Eiweiss Brot', '3'),
+    ('Meierbaer & Albro', 'Das Pure - Bio-Haferbrot', '4'),
+    ('Goldähren', 'Mehrkorn Wraps', '4'),
+    ('Goldähren', 'Protein-Wraps', '4'),
+    ('Nur Nur Natur', 'Bio-Roggenvollkornbrot', '3'),
+    ('DmBio', 'Das Pure Hafer - und Saatenbrot', '4'),
+    ('Goldähren', 'American Sandwich - Weizen', '3'),
+    ('Harry', 'Vollkorn Toast', '4'),
+    ('Brandt', 'Brandt Markenzwieback', '4'),
+    ('Harry', 'Unser Mildes (Weizenmischbrot)', '4'),
+    ('Lieken', 'Bauernmild Brot', '3'),
+    ('Lieken Urkorn', 'Vollkornsaftiges fein', '3'),
+    ('Goldähren', 'Mehrkornschnitten', '3'),
+    ('Mestemacher', 'Dinkel Wraps', '4'),
+    ('Harry', 'Toastbrot', '4'),
+    ('Harry', 'Vollkorn Urtyp', '4'),
+    ('Golden Toast', 'Vollkorn Toast', '3'),
+    ('Harry', 'Harry 1688 Korn an Korn', '4'),
+    ('Golden Toast', 'Buttertoast', '3'),
+    ('Brandt', 'Der Markenzwieback', '4'),
+    ('Gutes aus der Bäckerei', 'Weissbrot', '4'),
+    ('Harry', 'Mischbrot Anno 1688 Klassisch, Harry', '4'),
+    ('Goldähren', 'Dreisaatbrot - Roggenvollkornbrot', '3'),
+    ('Golden Toast', 'Dinkel-Harmonie Sandwich', '3'),
+    ('Filinchen', 'Das Knusperbrot Original', '4'),
+    ('Goldähren', 'Saaten-Sandwich', '3'),
+    ('Cucina', 'Pinsa', '3')
+) as d(brand, product_name, nova)
+where p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name;
+
+-- 0/1/4/5. Score category (concern defaults, unhealthiness, flags, confidence)
+CALL score_category('Bread', 100, 'DE');

--- a/db/pipelines/bread-de/PIPELINE__bread-de__05_source_provenance.sql
+++ b/db/pipelines/bread-de/PIPELINE__bread-de__05_source_provenance.sql
@@ -1,0 +1,65 @@
+-- PIPELINE (Bread): source provenance
+-- Generated: 2026-02-25
+
+-- 1. Update source info on products
+UPDATE products p SET
+  source_type = 'off_api',
+  source_url = d.source_url,
+  source_ean = d.source_ean
+FROM (
+  VALUES
+    ('Gräfschafter', 'Eiweißreiches Weizenvollkornbrot', 'https://world.openfoodfacts.org/product/4056489206026', '4056489206026'),
+    ('Harry', 'Körner Balance Sandwich', 'https://world.openfoodfacts.org/product/4071800038810', '4071800038810'),
+    ('Golden Toast', 'Sandwich Körner-Harmonie', 'https://world.openfoodfacts.org/product/4009249001843', '4009249001843'),
+    ('Lieken Urkorn', 'Fitnessbrot mit 5 % Ölsaaten', 'https://world.openfoodfacts.org/product/4009249002277', '4009249002277'),
+    ('Harry', 'Eiweißbrot', 'https://world.openfoodfacts.org/product/4071800058269', '4071800058269'),
+    ('Harry', 'Harry Dinkel Krüstchen 4071800057637', 'https://world.openfoodfacts.org/product/4071800057637', '4071800057637'),
+    ('Aldi', 'Das Pure - Bio-Haferbrot mit 29% Ölsaaten', 'https://world.openfoodfacts.org/product/4061461077563', '4061461077563'),
+    ('Conditorei Coppenrath & Wiese', 'Weizenbrötchen', 'https://world.openfoodfacts.org/product/4008577006315', '4008577006315'),
+    ('Lieken', 'Roggenbäcker', 'https://world.openfoodfacts.org/product/4009249002550', '4009249002550'),
+    ('Goldähren', 'Französisches Steinofen-Baguette', 'https://world.openfoodfacts.org/product/4061458046046', '4061458046046'),
+    ('Goldähren', 'Laugen-Brioche vorgeschnitten, 6 Stück', 'https://world.openfoodfacts.org/product/4061459698992', '4061459698992'),
+    ('Mestemacher', 'Westfälischen Pumpernickel', 'https://world.openfoodfacts.org/product/4000446001018', '4000446001018'),
+    ('Goldähren', 'Toast-Brötchen Protein', 'https://world.openfoodfacts.org/product/4061458227650', '4061458227650'),
+    ('GutBio', 'Das Pure - Haferbrot mit 27% Ölsaaten', 'https://world.openfoodfacts.org/product/4061458176323', '4061458176323'),
+    ('Coppenrath & Wiese', 'Dinkelbrötchen', 'https://world.openfoodfacts.org/product/4008577006186', '4008577006186'),
+    ('Aldi', 'Bio-Landbrötchen - Kernig', 'https://world.openfoodfacts.org/product/4068706471902', '4068706471902'),
+    ('Sinnack', 'Brot Protein Brötchen', 'https://world.openfoodfacts.org/product/4009097010691', '4009097010691'),
+    ('Harry', 'Körner Balance Toastbrötchen', 'https://world.openfoodfacts.org/product/4071800038568', '4071800038568'),
+    ('Gut bio', 'Finnkorn Toastbrötchen', 'https://world.openfoodfacts.org/product/4061462968624', '4061462968624'),
+    ('Grafschafter', 'Pure Kornkraft Haferbrot', 'https://world.openfoodfacts.org/product/4056489183631', '4056489183631'),
+    ('Goldähren', 'Vollkorn-Sandwich', 'https://world.openfoodfacts.org/product/4061458022040', '4061458022040'),
+    ('Golden Toast', 'Vollkorn-Toast', 'https://world.openfoodfacts.org/product/4009249019923', '4009249019923'),
+    ('Harry', 'Harry Brot Vital + Fit', 'https://world.openfoodfacts.org/product/4071800001012', '4071800001012'),
+    ('Goldähren', 'Vollkorntoast', 'https://world.openfoodfacts.org/product/4061458045759', '4061458045759'),
+    ('Goldähren', 'Eiweiss Brot', 'https://world.openfoodfacts.org/product/4061458055734', '4061458055734'),
+    ('Meierbaer & Albro', 'Das Pure - Bio-Haferbrot', 'https://world.openfoodfacts.org/product/4061462084256', '4061462084256'),
+    ('Goldähren', 'Mehrkorn Wraps', 'https://world.openfoodfacts.org/product/4061458045797', '4061458045797'),
+    ('Goldähren', 'Protein-Wraps', 'https://world.openfoodfacts.org/product/4061458236928', '4061458236928'),
+    ('Nur Nur Natur', 'Bio-Roggenvollkornbrot', 'https://world.openfoodfacts.org/product/4061459425697', '4061459425697'),
+    ('DmBio', 'Das Pure Hafer - und Saatenbrot', 'https://world.openfoodfacts.org/product/4067796162462', '4067796162462'),
+    ('Goldähren', 'American Sandwich - Weizen', 'https://world.openfoodfacts.org/product/4061458022033', '4061458022033'),
+    ('Harry', 'Vollkorn Toast', 'https://world.openfoodfacts.org/product/4071800000633', '4071800000633'),
+    ('Brandt', 'Brandt Markenzwieback', 'https://world.openfoodfacts.org/product/4013752019004', '4013752019004'),
+    ('Harry', 'Unser Mildes (Weizenmischbrot)', 'https://world.openfoodfacts.org/product/4071800000879', '4071800000879'),
+    ('Lieken', 'Bauernmild Brot', 'https://world.openfoodfacts.org/product/4009249001171', '4009249001171'),
+    ('Lieken Urkorn', 'Vollkornsaftiges fein', 'https://world.openfoodfacts.org/product/4006170001676', '4006170001676'),
+    ('Goldähren', 'Mehrkornschnitten', 'https://world.openfoodfacts.org/product/4061458169066', '4061458169066'),
+    ('Mestemacher', 'Dinkel Wraps', 'https://world.openfoodfacts.org/product/4000446015497', '4000446015497'),
+    ('Harry', 'Toastbrot', 'https://world.openfoodfacts.org/product/4071800038803', '4071800038803'),
+    ('Harry', 'Vollkorn Urtyp', 'https://world.openfoodfacts.org/product/4071800034508', '4071800034508'),
+    ('Golden Toast', 'Vollkorn Toast', 'https://world.openfoodfacts.org/product/4009249022565', '4009249022565'),
+    ('Harry', 'Harry 1688 Korn an Korn', 'https://world.openfoodfacts.org/product/4071800000824', '4071800000824'),
+    ('Golden Toast', 'Buttertoast', 'https://world.openfoodfacts.org/product/4009249019916', '4009249019916'),
+    ('Brandt', 'Der Markenzwieback', 'https://world.openfoodfacts.org/product/4013752019547', '4013752019547'),
+    ('Gutes aus der Bäckerei', 'Weissbrot', 'https://world.openfoodfacts.org/product/4071800001081', '4071800001081'),
+    ('Harry', 'Mischbrot Anno 1688 Klassisch, Harry', 'https://world.openfoodfacts.org/product/4071800052618', '4071800052618'),
+    ('Goldähren', 'Dreisaatbrot - Roggenvollkornbrot', 'https://world.openfoodfacts.org/product/4061458054263', '4061458054263'),
+    ('Golden Toast', 'Dinkel-Harmonie Sandwich', 'https://world.openfoodfacts.org/product/4009249038184', '4009249038184'),
+    ('Filinchen', 'Das Knusperbrot Original', 'https://world.openfoodfacts.org/product/4015427111112', '4015427111112'),
+    ('Goldähren', 'Saaten-Sandwich', 'https://world.openfoodfacts.org/product/4061458045827', '4061458045827'),
+    ('Cucina', 'Pinsa', 'https://world.openfoodfacts.org/product/4061459712001', '4061459712001')
+) AS d(brand, product_name, source_url, source_ean)
+WHERE p.country = 'DE' AND p.brand = d.brand
+  AND p.product_name = d.product_name
+  AND p.category = 'Bread' AND p.is_deprecated IS NOT TRUE;

--- a/db/pipelines/bread-de/PIPELINE__bread-de__06_add_images.sql
+++ b/db/pipelines/bread-de/PIPELINE__bread-de__06_add_images.sql
@@ -1,0 +1,79 @@
+-- PIPELINE (Bread): add product images
+-- Source: Open Food Facts API image URLs
+-- Generated: 2026-02-25
+
+-- 1. Remove existing OFF images for this category
+DELETE FROM product_images
+WHERE source = 'off_api'
+  AND product_id IN (
+    SELECT p.product_id FROM products p
+    WHERE p.country = 'DE' AND p.category = 'Bread'
+      AND p.is_deprecated IS NOT TRUE
+  );
+
+-- 2. Insert images
+INSERT INTO product_images
+  (product_id, url, source, image_type, is_primary, alt_text, off_image_id)
+SELECT
+  p.product_id, d.url, d.source, d.image_type, d.is_primary, d.alt_text, d.off_image_id
+FROM (
+  VALUES
+    ('Gräfschafter', 'Eiweißreiches Weizenvollkornbrot', 'https://images.openfoodfacts.org/images/products/405/648/920/6026/front_de.34.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489206026', 'front_4056489206026'),
+    ('Harry', 'Körner Balance Sandwich', 'https://images.openfoodfacts.org/images/products/407/180/003/8810/front_de.67.400.jpg', 'off_api', 'front', true, 'Front — EAN 4071800038810', 'front_4071800038810'),
+    ('Golden Toast', 'Sandwich Körner-Harmonie', 'https://images.openfoodfacts.org/images/products/400/924/900/1843/front_de.65.400.jpg', 'off_api', 'front', true, 'Front — EAN 4009249001843', 'front_4009249001843'),
+    ('Lieken Urkorn', 'Fitnessbrot mit 5 % Ölsaaten', 'https://images.openfoodfacts.org/images/products/400/924/900/2277/front_de.104.400.jpg', 'off_api', 'front', true, 'Front — EAN 4009249002277', 'front_4009249002277'),
+    ('Harry', 'Eiweißbrot', 'https://images.openfoodfacts.org/images/products/407/180/005/8269/front_de.14.400.jpg', 'off_api', 'front', true, 'Front — EAN 4071800058269', 'front_4071800058269'),
+    ('Harry', 'Harry Dinkel Krüstchen 4071800057637', 'https://images.openfoodfacts.org/images/products/407/180/005/7637/front_de.23.400.jpg', 'off_api', 'front', true, 'Front — EAN 4071800057637', 'front_4071800057637'),
+    ('Aldi', 'Das Pure - Bio-Haferbrot mit 29% Ölsaaten', 'https://images.openfoodfacts.org/images/products/406/146/107/7563/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061461077563', 'front_4061461077563'),
+    ('Conditorei Coppenrath & Wiese', 'Weizenbrötchen', 'https://images.openfoodfacts.org/images/products/400/857/700/6315/front_en.173.400.jpg', 'off_api', 'front', true, 'Front — EAN 4008577006315', 'front_4008577006315'),
+    ('Lieken', 'Roggenbäcker', 'https://images.openfoodfacts.org/images/products/400/924/900/2550/front_fr.56.400.jpg', 'off_api', 'front', true, 'Front — EAN 4009249002550', 'front_4009249002550'),
+    ('Goldähren', 'Französisches Steinofen-Baguette', 'https://images.openfoodfacts.org/images/products/406/145/804/6046/front_de.36.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458046046', 'front_4061458046046'),
+    ('Goldähren', 'Laugen-Brioche vorgeschnitten, 6 Stück', 'https://images.openfoodfacts.org/images/products/406/145/969/8992/front_de.10.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061459698992', 'front_4061459698992'),
+    ('Mestemacher', 'Westfälischen Pumpernickel', 'https://images.openfoodfacts.org/images/products/400/044/600/1018/front_de.78.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000446001018', 'front_4000446001018'),
+    ('Goldähren', 'Toast-Brötchen Protein', 'https://images.openfoodfacts.org/images/products/406/145/822/7650/front_de.8.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458227650', 'front_4061458227650'),
+    ('GutBio', 'Das Pure - Haferbrot mit 27% Ölsaaten', 'https://images.openfoodfacts.org/images/products/406/145/817/6323/front_en.7.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458176323', 'front_4061458176323'),
+    ('Coppenrath & Wiese', 'Dinkelbrötchen', 'https://images.openfoodfacts.org/images/products/400/857/700/6186/front_de.185.400.jpg', 'off_api', 'front', true, 'Front — EAN 4008577006186', 'front_4008577006186'),
+    ('Aldi', 'Bio-Landbrötchen - Kernig', 'https://images.openfoodfacts.org/images/products/406/870/647/1902/front_de.7.400.jpg', 'off_api', 'front', true, 'Front — EAN 4068706471902', 'front_4068706471902'),
+    ('Sinnack', 'Brot Protein Brötchen', 'https://images.openfoodfacts.org/images/products/400/909/701/0691/front_en.10.400.jpg', 'off_api', 'front', true, 'Front — EAN 4009097010691', 'front_4009097010691'),
+    ('Harry', 'Körner Balance Toastbrötchen', 'https://images.openfoodfacts.org/images/products/407/180/003/8568/front_de.54.400.jpg', 'off_api', 'front', true, 'Front — EAN 4071800038568', 'front_4071800038568'),
+    ('Gut bio', 'Finnkorn Toastbrötchen', 'https://images.openfoodfacts.org/images/products/406/146/296/8624/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061462968624', 'front_4061462968624'),
+    ('Grafschafter', 'Pure Kornkraft Haferbrot', 'https://images.openfoodfacts.org/images/products/405/648/918/3631/front_de.23.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489183631', 'front_4056489183631'),
+    ('Goldähren', 'Vollkorn-Sandwich', 'https://images.openfoodfacts.org/images/products/406/145/802/2040/front_de.171.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458022040', 'front_4061458022040'),
+    ('Golden Toast', 'Vollkorn-Toast', 'https://images.openfoodfacts.org/images/products/400/924/901/9923/front_de.121.400.jpg', 'off_api', 'front', true, 'Front — EAN 4009249019923', 'front_4009249019923'),
+    ('Harry', 'Harry Brot Vital + Fit', 'https://images.openfoodfacts.org/images/products/407/180/000/1012/front_de.92.400.jpg', 'off_api', 'front', true, 'Front — EAN 4071800001012', 'front_4071800001012'),
+    ('Goldähren', 'Vollkorntoast', 'https://images.openfoodfacts.org/images/products/406/145/804/5759/front_de.64.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458045759', 'front_4061458045759'),
+    ('Goldähren', 'Eiweiss Brot', 'https://images.openfoodfacts.org/images/products/406/145/805/5734/front_en.146.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458055734', 'front_4061458055734'),
+    ('Meierbaer & Albro', 'Das Pure - Bio-Haferbrot', 'https://images.openfoodfacts.org/images/products/406/146/208/4256/front_de.21.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061462084256', 'front_4061462084256'),
+    ('Goldähren', 'Mehrkorn Wraps', 'https://images.openfoodfacts.org/images/products/406/145/804/5797/front_en.151.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458045797', 'front_4061458045797'),
+    ('Goldähren', 'Protein-Wraps', 'https://images.openfoodfacts.org/images/products/406/145/823/6928/front_de.77.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458236928', 'front_4061458236928'),
+    ('Nur Nur Natur', 'Bio-Roggenvollkornbrot', 'https://images.openfoodfacts.org/images/products/406/145/942/5697/front_de.70.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061459425697', 'front_4061459425697'),
+    ('DmBio', 'Das Pure Hafer - und Saatenbrot', 'https://images.openfoodfacts.org/images/products/406/779/616/2462/front_de.7.400.jpg', 'off_api', 'front', true, 'Front — EAN 4067796162462', 'front_4067796162462'),
+    ('Goldähren', 'American Sandwich - Weizen', 'https://images.openfoodfacts.org/images/products/406/145/802/2033/front_de.94.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458022033', 'front_4061458022033'),
+    ('Harry', 'Vollkorn Toast', 'https://images.openfoodfacts.org/images/products/407/180/000/0633/front_de.48.400.jpg', 'off_api', 'front', true, 'Front — EAN 4071800000633', 'front_4071800000633'),
+    ('Brandt', 'Brandt Markenzwieback', 'https://images.openfoodfacts.org/images/products/401/375/201/9004/front_de.112.400.jpg', 'off_api', 'front', true, 'Front — EAN 4013752019004', 'front_4013752019004'),
+    ('Harry', 'Unser Mildes (Weizenmischbrot)', 'https://images.openfoodfacts.org/images/products/407/180/000/0879/front_en.70.400.jpg', 'off_api', 'front', true, 'Front — EAN 4071800000879', 'front_4071800000879'),
+    ('Lieken', 'Bauernmild Brot', 'https://images.openfoodfacts.org/images/products/400/924/900/1171/front_de.49.400.jpg', 'off_api', 'front', true, 'Front — EAN 4009249001171', 'front_4009249001171'),
+    ('Lieken Urkorn', 'Vollkornsaftiges fein', 'https://images.openfoodfacts.org/images/products/400/617/000/1676/front_de.32.400.jpg', 'off_api', 'front', true, 'Front — EAN 4006170001676', 'front_4006170001676'),
+    ('Goldähren', 'Mehrkornschnitten', 'https://images.openfoodfacts.org/images/products/406/145/816/9066/front_de.57.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458169066', 'front_4061458169066'),
+    ('Mestemacher', 'Dinkel Wraps', 'https://images.openfoodfacts.org/images/products/400/044/601/5497/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000446015497', 'front_4000446015497'),
+    ('Harry', 'Toastbrot', 'https://images.openfoodfacts.org/images/products/407/180/003/8803/front_en.5.400.jpg', 'off_api', 'front', true, 'Front — EAN 4071800038803', 'front_4071800038803'),
+    ('Harry', 'Vollkorn Urtyp', 'https://images.openfoodfacts.org/images/products/407/180/003/4508/front_de.32.400.jpg', 'off_api', 'front', true, 'Front — EAN 4071800034508', 'front_4071800034508'),
+    ('Golden Toast', 'Vollkorn Toast', 'https://images.openfoodfacts.org/images/products/400/924/902/2565/front_en.39.400.jpg', 'off_api', 'front', true, 'Front — EAN 4009249022565', 'front_4009249022565'),
+    ('Harry', 'Harry 1688 Korn an Korn', 'https://images.openfoodfacts.org/images/products/407/180/000/0824/front_de.68.400.jpg', 'off_api', 'front', true, 'Front — EAN 4071800000824', 'front_4071800000824'),
+    ('Golden Toast', 'Buttertoast', 'https://images.openfoodfacts.org/images/products/400/924/901/9916/front_de.88.400.jpg', 'off_api', 'front', true, 'Front — EAN 4009249019916', 'front_4009249019916'),
+    ('Brandt', 'Der Markenzwieback', 'https://images.openfoodfacts.org/images/products/401/375/201/9547/front_de.39.400.jpg', 'off_api', 'front', true, 'Front — EAN 4013752019547', 'front_4013752019547'),
+    ('Gutes aus der Bäckerei', 'Weissbrot', 'https://images.openfoodfacts.org/images/products/407/180/000/1081/front_de.34.400.jpg', 'off_api', 'front', true, 'Front — EAN 4071800001081', 'front_4071800001081'),
+    ('Harry', 'Mischbrot Anno 1688 Klassisch, Harry', 'https://images.openfoodfacts.org/images/products/407/180/005/2618/front_en.4.400.jpg', 'off_api', 'front', true, 'Front — EAN 4071800052618', 'front_4071800052618'),
+    ('Goldähren', 'Dreisaatbrot - Roggenvollkornbrot', 'https://images.openfoodfacts.org/images/products/406/145/805/4263/front_de.26.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458054263', 'front_4061458054263'),
+    ('Golden Toast', 'Dinkel-Harmonie Sandwich', 'https://images.openfoodfacts.org/images/products/400/924/903/8184/front_en.59.400.jpg', 'off_api', 'front', true, 'Front — EAN 4009249038184', 'front_4009249038184'),
+    ('Filinchen', 'Das Knusperbrot Original', 'https://images.openfoodfacts.org/images/products/401/542/711/1112/front_de.59.400.jpg', 'off_api', 'front', true, 'Front — EAN 4015427111112', 'front_4015427111112'),
+    ('Goldähren', 'Saaten-Sandwich', 'https://images.openfoodfacts.org/images/products/406/145/804/5827/front_de.77.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458045827', 'front_4061458045827'),
+    ('Cucina', 'Pinsa', 'https://images.openfoodfacts.org/images/products/406/145/971/2001/front_de.30.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061459712001', 'front_4061459712001')
+) AS d(brand, product_name, url, source, image_type, is_primary, alt_text, off_image_id)
+JOIN products p ON p.country = 'DE' AND p.brand = d.brand AND p.product_name = d.product_name
+  AND p.category = 'Bread' AND p.is_deprecated IS NOT TRUE
+ON CONFLICT (off_image_id) WHERE off_image_id IS NOT NULL DO UPDATE SET
+  url = EXCLUDED.url,
+  image_type = EXCLUDED.image_type,
+  is_primary = EXCLUDED.is_primary,
+  alt_text = EXCLUDED.alt_text;

--- a/db/pipelines/dairy-de/PIPELINE__dairy-de__01_insert_products.sql
+++ b/db/pipelines/dairy-de/PIPELINE__dairy-de__01_insert_products.sql
@@ -1,0 +1,85 @@
+-- PIPELINE (Dairy): insert products
+-- Source: Open Food Facts API (automated pipeline)
+-- Generated: 2026-02-25
+
+-- 0a. DEPRECATE old products in this category & release their EANs
+update products
+set is_deprecated = true, deprecated_reason = 'Replaced by pipeline refresh', ean = null
+where country = 'DE'
+  and category = 'Dairy'
+  and is_deprecated is not true;
+
+-- 0b. Release EANs across ALL categories to prevent unique constraint conflicts
+update products set ean = null
+where ean in ('4061458047685', '4002671157751', '4061458047692', '4002468084017', '4006402046192', '4032549018105', '4040900117251', '4023600013511', '4061458280334', '40466002', '4036300005311', '4061458047708', '4061458163903', '4002468210454', '4002468210478', '4002566010703', '4061459193312', '4061458229838', '4019300005307', '4008452027602', '4056489012788', '4016241030603', '4061462842986', '4003490323600', '4003751002848', '4002971243703', '4061459193695', '4061462842764', '4016241030917', '4056489216162', '4061458028820', '4046700001806', '4045357004383', '4061462864803', '4006402020413', '4056489013105', '4061458028813', '4002671151353', '4002971243802', '4002468134361', '4061462865015', '4036300005304', '4056489014003', '4002334113032', '4056489118190', '4008452011007', '4061458018531', '4061458005548', '4056489379850', '4061458244404', '4061462843723')
+  and ean is not null;
+
+-- 1. INSERT products
+insert into products (country, brand, product_type, category, product_name, prep_method, store_availability, controversies, ean)
+values
+  ('DE', 'Milsani', 'Grocery', 'Dairy', 'Frischkäse natur', 'fermented', 'Aldi', 'none', '4061458047685'),
+  ('DE', 'Gervais', 'Grocery', 'Dairy', 'Hüttenkäse Original', 'fermented', null, 'none', '4002671157751'),
+  ('DE', 'Milsani', 'Grocery', 'Dairy', 'Körniger Frischkäse, Halbfettstufe', 'fermented', 'Aldi', 'none', '4061458047692'),
+  ('DE', 'Almette', 'Grocery', 'Dairy', 'Almette Kräuter', 'fermented', 'Netto', 'none', '4002468084017'),
+  ('DE', 'Bergader', 'Grocery', 'Dairy', 'Bergbauern mild nussig Käse', 'fermented', 'Penny', 'none', '4006402046192'),
+  ('DE', 'DOVGAN Family', 'Grocery', 'Dairy', 'Körniger Frischkäse 33 % Fett', 'fermented', 'Lidl', 'none', '4032549018105'),
+  ('DE', 'BMI Biobauern', 'Grocery', 'Dairy', 'Bio-Landkäse mild-nussig', 'fermented', 'Lidl', 'none', '4040900117251'),
+  ('DE', 'Dr. Oetker', 'Grocery', 'Dairy', 'High Protein Pudding Grieß', 'not-applicable', 'Lidl', 'none', '4023600013511'),
+  ('DE', 'Milsan', 'Grocery', 'Dairy', 'Grießpudding High-Protein - Zimt', 'not-applicable', 'Aldi', 'none', '4061458280334'),
+  ('DE', 'Milram', 'Grocery', 'Dairy', 'Frühlingsquark Original', 'fermented', 'Lidl', 'none', '40466002'),
+  ('DE', 'DMK', 'Grocery', 'Dairy', 'Müritzer original', 'fermented', 'Netto', 'none', '4036300005311'),
+  ('DE', 'Milsani', 'Grocery', 'Dairy', 'Körniger Frischkäse - Magerstufe', 'fermented', 'Aldi', 'none', '4061458047708'),
+  ('DE', 'AF Deutschland', 'Grocery', 'Dairy', 'Hirtenkäse', 'fermented', 'Aldi', 'none', '4061458163903'),
+  ('DE', 'Grünländer', 'Grocery', 'Dairy', 'Grünländer Mild & Nussig', 'fermented', 'Kaufland', 'none', '4002468210454'),
+  ('DE', 'Grünländer', 'Grocery', 'Dairy', 'Grünländer Leicht', 'fermented', 'Kaufland', 'none', '4002468210478'),
+  ('DE', 'Gazi', 'Grocery', 'Dairy', 'Grill- und Pfannenkäse', 'grilled', 'Kaufland', 'none', '4002566010703'),
+  ('DE', 'Bio', 'Grocery', 'Dairy', 'ALDI GUT BIO Milch Frische Bio-Milch 1.5 % Fett Aus der Kühlung 1l 1.15€ Fettarme Milch', 'not-applicable', 'Aldi', 'none', '4061459193312'),
+  ('DE', 'Milsani', 'Grocery', 'Dairy', 'ALDI MILSANI Skyr Nach isländischer Art mit viel Eiweiß und wenig Fett Aus der Kühlung 1.49€ 500g Becher 1kg 2.98€', 'fermented', 'Aldi', 'none', '4061458229838'),
+  ('DE', 'Karwendel', 'Grocery', 'Dairy', 'Exquisa Balance Frischkäse', 'fermented', null, 'none', '4019300005307'),
+  ('DE', 'Weihenstephan', 'Grocery', 'Dairy', 'H-Milch 3,5%', 'pasteurized', 'Lidl', 'none', '4008452027602'),
+  ('DE', 'Milbona', 'Grocery', 'Dairy', 'Skyr', 'fermented', 'Lidl', 'none', '4056489012788'),
+  ('DE', 'Arla', 'Grocery', 'Dairy', 'Skyr Natur', 'fermented', 'Kaufland', 'none', '4016241030603'),
+  ('DE', 'Milsani', 'Grocery', 'Dairy', 'H-Vollmilch 3,5 % Fett', 'pasteurized', 'Aldi', 'none', '4061462842986'),
+  ('DE', 'Elinas', 'Grocery', 'Dairy', 'Joghurt Griechischer Art', 'fermented', null, 'none', '4003490323600'),
+  ('DE', 'Alpenhain', 'Grocery', 'Dairy', 'Obazda klassisch', 'fermented', null, 'none', '4003751002848'),
+  ('DE', 'Ehrmann', 'Grocery', 'Dairy', 'High Protein Chocolate Pudding', 'not-applicable', 'Netto', 'none', '4002971243703'),
+  ('DE', 'Bio', 'Grocery', 'Dairy', 'Frische Bio-Vollmilch 3,8 % Fett', 'not-applicable', 'Aldi', 'none', '4061459193695'),
+  ('DE', 'Milsani', 'Grocery', 'Dairy', 'Haltbare Fettarme Milch', 'not-applicable', 'Aldi', 'none', '4061462842764'),
+  ('DE', 'Arla', 'Grocery', 'Dairy', 'Skyr Bourbon Vanille', 'fermented', null, 'none', '4016241030917'),
+  ('DE', 'Milbona', 'Grocery', 'Dairy', 'High Protein Chocolate Flavour Pudding', 'not-applicable', 'Lidl', 'none', '4056489216162'),
+  ('DE', 'Milsani', 'Grocery', 'Dairy', 'Joghurt mild 3,5 % Fett', 'fermented', 'Aldi', 'none', '4061458028820'),
+  ('DE', 'Schwarzwaldmilch', 'Grocery', 'Dairy', 'Protein Milch', 'not-applicable', 'Kaufland', 'none', '4046700001806'),
+  ('DE', 'Bresso', 'Grocery', 'Dairy', 'Bresso', 'fermented', 'Netto', 'none', '4045357004383'),
+  ('DE', 'Milsani', 'Grocery', 'Dairy', 'Milch', 'not-applicable', 'Aldi', 'none', '4061462864803'),
+  ('DE', 'Bergader', 'Grocery', 'Dairy', 'Bavaria Blu', 'fermented', null, 'none', '4006402020413'),
+  ('DE', 'Aldi', 'Grocery', 'Dairy', 'Milch, haltbar, 1,5 %, Bio', 'pasteurized', 'Lidl', 'none', '4056489013105'),
+  ('DE', 'Aldi', 'Grocery', 'Dairy', 'A/Joghurt mild 3,5% Fett', 'fermented', 'Aldi', 'none', '4061458028813'),
+  ('DE', 'Patros', 'Grocery', 'Dairy', 'Patros Natur', 'fermented', null, 'none', '4002671151353'),
+  ('DE', 'Ehrmann', 'Grocery', 'Dairy', 'High-Protein-Pudding - Vanilla', 'not-applicable', 'Netto', 'none', '4002971243802'),
+  ('DE', 'Patros', 'Grocery', 'Dairy', 'Feta (Schaf- & Ziegenmilch)', 'fermented', 'Kaufland', 'none', '4002468134361'),
+  ('DE', 'Milsani', 'Grocery', 'Dairy', 'Frische Vollmilch 3,5%', 'not-applicable', 'Aldi', 'none', '4061462865015'),
+  ('DE', 'Milram', 'Grocery', 'Dairy', 'Benjamin', 'fermented', 'Kaufland', 'none', '4036300005304'),
+  ('DE', 'Milbona', 'Grocery', 'Dairy', 'Bio Fettarmer Joghurt mild', 'fermented', null, 'none', '4056489014003'),
+  ('DE', 'Bauer', 'Grocery', 'Dairy', 'Kirsche', 'fermented', null, 'none', '4002334113032'),
+  ('DE', 'Milbona', 'Grocery', 'Dairy', 'Skyr Vanilla', 'fermented', 'Lidl', 'none', '4056489118190'),
+  ('DE', 'Weihenstephan', 'Grocery', 'Dairy', 'Joghurt Natur 3,5 % Fett', 'fermented', 'Kaufland', 'none', '4008452011007'),
+  ('DE', 'Cucina Nobile', 'Grocery', 'Dairy', 'Mozzarella', 'fermented', 'Aldi', 'none', '4061458018531'),
+  ('DE', 'Bio', 'Grocery', 'Dairy', 'Bio-Feta', 'fermented', 'Aldi', 'none', '4061458005548'),
+  ('DE', 'Ein gutes Stück Bayern', 'Grocery', 'Dairy', 'Haltbare Bio Vollmilch', 'pasteurized', 'Lidl', 'none', '4056489379850'),
+  ('DE', 'Lyttos', 'Grocery', 'Dairy', 'Griechischer Joghurt', 'fermented', 'Aldi', 'none', '4061458244404'),
+  ('DE', 'AF Deutschland', 'Grocery', 'Dairy', 'Fettarme Milch (laktosefrei; 1,5% Fett)', 'pasteurized', 'Aldi', 'none', '4061462843723')
+on conflict (country, brand, product_name) do update set
+  category = excluded.category,
+  ean = excluded.ean,
+  product_type = excluded.product_type,
+  store_availability = excluded.store_availability,
+  controversies = excluded.controversies,
+  prep_method = excluded.prep_method,
+  is_deprecated = false;
+
+-- 2. DEPRECATE removed products
+update products
+set is_deprecated = true, deprecated_reason = 'Removed from pipeline batch'
+where country = 'DE' and category = 'Dairy'
+  and is_deprecated is not true
+  and product_name not in ('Frischkäse natur', 'Hüttenkäse Original', 'Körniger Frischkäse, Halbfettstufe', 'Almette Kräuter', 'Bergbauern mild nussig Käse', 'Körniger Frischkäse 33 % Fett', 'Bio-Landkäse mild-nussig', 'High Protein Pudding Grieß', 'Grießpudding High-Protein - Zimt', 'Frühlingsquark Original', 'Müritzer original', 'Körniger Frischkäse - Magerstufe', 'Hirtenkäse', 'Grünländer Mild & Nussig', 'Grünländer Leicht', 'Grill- und Pfannenkäse', 'ALDI GUT BIO Milch Frische Bio-Milch 1.5 % Fett Aus der Kühlung 1l 1.15€ Fettarme Milch', 'ALDI MILSANI Skyr Nach isländischer Art mit viel Eiweiß und wenig Fett Aus der Kühlung 1.49€ 500g Becher 1kg 2.98€', 'Exquisa Balance Frischkäse', 'H-Milch 3,5%', 'Skyr', 'Skyr Natur', 'H-Vollmilch 3,5 % Fett', 'Joghurt Griechischer Art', 'Obazda klassisch', 'High Protein Chocolate Pudding', 'Frische Bio-Vollmilch 3,8 % Fett', 'Haltbare Fettarme Milch', 'Skyr Bourbon Vanille', 'High Protein Chocolate Flavour Pudding', 'Joghurt mild 3,5 % Fett', 'Protein Milch', 'Bresso', 'Milch', 'Bavaria Blu', 'Milch, haltbar, 1,5 %, Bio', 'A/Joghurt mild 3,5% Fett', 'Patros Natur', 'High-Protein-Pudding - Vanilla', 'Feta (Schaf- & Ziegenmilch)', 'Frische Vollmilch 3,5%', 'Benjamin', 'Bio Fettarmer Joghurt mild', 'Kirsche', 'Skyr Vanilla', 'Joghurt Natur 3,5 % Fett', 'Mozzarella', 'Bio-Feta', 'Haltbare Bio Vollmilch', 'Griechischer Joghurt', 'Fettarme Milch (laktosefrei; 1,5% Fett)');

--- a/db/pipelines/dairy-de/PIPELINE__dairy-de__03_add_nutrition.sql
+++ b/db/pipelines/dairy-de/PIPELINE__dairy-de__03_add_nutrition.sql
@@ -1,0 +1,87 @@
+-- PIPELINE (Dairy): add nutrition facts
+-- Source: Open Food Facts verified per-100g data
+
+-- 1) Remove existing
+delete from nutrition_facts
+where product_id in (
+  select p.product_id
+  from products p
+  where p.country = 'DE' and p.category = 'Dairy'
+    and p.is_deprecated is not true
+);
+
+-- 2) Insert
+insert into nutrition_facts
+  (product_id, calories, total_fat_g, saturated_fat_g, trans_fat_g,
+   carbs_g, sugars_g, fibre_g, protein_g, salt_g)
+select
+  p.product_id,
+  d.calories, d.total_fat_g, d.saturated_fat_g, d.trans_fat_g,
+  d.carbs_g, d.sugars_g, d.fibre_g, d.protein_g, d.salt_g
+from (
+  values
+    ('Milsani', 'Frischkäse natur', 241.0, 23.0, 16.1, 0, 2.9, 2.9, 0, 5.5, 0.7),
+    ('Gervais', 'Hüttenkäse Original', 86.5, 3.2, 2.1, 0, 1.5, 1.5, 0, 12.3, 0.8),
+    ('Milsani', 'Körniger Frischkäse, Halbfettstufe', 103.0, 4.6, 3.0, 0, 2.7, 2.7, 0.0, 12.2, 0.6),
+    ('Almette', 'Almette Kräuter', 251.0, 23.0, 15.0, 0, 4.7, 3.2, 0, 5.4, 1.1),
+    ('Bergader', 'Bergbauern mild nussig Käse', 343.0, 27.0, 18.0, 0, 0.1, 0.1, 0, 25.0, 1.2),
+    ('DOVGAN Family', 'Körniger Frischkäse 33 % Fett', 177.0, 9.0, 6.0, 0, 4.0, 4.0, 0, 20.0, 0.2),
+    ('BMI Biobauern', 'Bio-Landkäse mild-nussig', 361.0, 28.0, 18.2, 0, 0.1, 0.1, 0.0, 26.5, 1.4),
+    ('Dr. Oetker', 'High Protein Pudding Grieß', 81.0, 1.5, 0.9, 0, 9.1, 4.4, 0, 7.5, 0.2),
+    ('Milsan', 'Grießpudding High-Protein - Zimt', 79.2, 1.5, 1.0, 0, 8.6, 4.7, 0, 7.6, 0.1),
+    ('Milram', 'Frühlingsquark Original', 142.0, 10.0, 6.9, 0, 3.7, 3.7, 0, 8.8, 0.8),
+    ('DMK', 'Müritzer original', 386.0, 33.0, 22.8, 0, 0.1, 0.1, 0, 21.0, 1.8),
+    ('Milsani', 'Körniger Frischkäse - Magerstufe', 71.0, 0.4, 0.3, 0, 2.0, 1.9, 0, 11.0, 0.5),
+    ('AF Deutschland', 'Hirtenkäse', 255.0, 19.8, 12.6, 0, 0.6, 0.6, 0, 17.4, 2.5),
+    ('Grünländer', 'Grünländer Mild & Nussig', 364.0, 29.0, 19.0, 0, 0.5, 0.5, 0, 25.0, 0.8),
+    ('Grünländer', 'Grünländer Leicht', 280.0, 17.0, 11.0, 0, 0.5, 0.5, 0.0, 31.0, 0.8),
+    ('Gazi', 'Grill- und Pfannenkäse', 323.0, 25.0, 16.7, 0, 1.0, 1.0, 0, 23.5, 2.4),
+    ('Bio', 'ALDI GUT BIO Milch Frische Bio-Milch 1.5 % Fett Aus der Kühlung 1l 1.15€ Fettarme Milch', 47.0, 1.5, 0.9, 0, 4.9, 4.9, 0, 3.5, 0.0),
+    ('Milsani', 'ALDI MILSANI Skyr Nach isländischer Art mit viel Eiweiß und wenig Fett Aus der Kühlung 1.49€ 500g Becher 1kg 2.98€', 65.0, 0.2, 0.1, 0, 4.4, 4.4, 0, 11.0, 0.1),
+    ('Karwendel', 'Exquisa Balance Frischkäse', 91.0, 4.0, 2.8, 0, 3.1, 3.1, 0.0, 10.0, 0.4),
+    ('Weihenstephan', 'H-Milch 3,5%', 64.0, 3.5, 2.3, 0, 4.7, 4.7, 0, 3.5, 0.1),
+    ('Milbona', 'Skyr', 62.0, 0.2, 0.1, 0, 4.0, 4.0, 0.0, 11.0, 0.1),
+    ('Arla', 'Skyr Natur', 61.0, 0.2, 0.1, 0, 4.0, 4.0, 0, 10.0, 0.1),
+    ('Milsani', 'H-Vollmilch 3,5 % Fett', 64.0, 3.5, 2.3, 0, 4.8, 4.8, 0, 3.3, 0.1),
+    ('Elinas', 'Joghurt Griechischer Art', 116.0, 9.4, 6.3, 0, 3.9, 3.9, 0, 3.3, 0.1),
+    ('Alpenhain', 'Obazda klassisch', 328.0, 29.0, 19.0, 0, 3.0, 1.5, 0, 13.0, 1.7),
+    ('Ehrmann', 'High Protein Chocolate Pudding', 76.0, 1.5, 1.0, 0.0, 5.5, 4.0, 0.0, 10.0, 0.0),
+    ('Bio', 'Frische Bio-Vollmilch 3,8 % Fett', 68.0, 3.9, 2.6, 0, 4.8, 4.8, 0, 3.4, 0.1),
+    ('Milsani', 'Haltbare Fettarme Milch', 47.0, 1.5, 1.1, 0, 5.0, 5.0, 0, 3.4, 0.1),
+    ('Arla', 'Skyr Bourbon Vanille', 73.0, 0.2, 0.1, 0, 8.6, 7.5, 0, 8.6, 0.1),
+    ('Milbona', 'High Protein Chocolate Flavour Pudding', 76.0, 1.5, 1.0, 0, 5.2, 4.0, 0, 10.0, 0.1),
+    ('Milsani', 'Joghurt mild 3,5 % Fett', 70.0, 3.5, 2.4, 0, 4.8, 4.8, 0, 4.3, 0.1),
+    ('Schwarzwaldmilch', 'Protein Milch', 51.0, 0.1, 0.0, 0, 5.0, 5.0, 0.0, 7.5, 0.1),
+    ('Bresso', 'Bresso', 237.0, 21.0, 14.0, 0, 4.9, 2.8, 0, 7.1, 1.2),
+    ('Milsani', 'Milch', 47.0, 1.5, 1.0, 0, 4.9, 4.9, 0, 3.5, 0.1),
+    ('Bergader', 'Bavaria Blu', 392.0, 37.5, 24.4, 0, 0.1, 0.1, 0, 13.6, 1.8),
+    ('Aldi', 'Milch, haltbar, 1,5 %, Bio', 46.0, 1.5, 1.0, 0, 4.8, 4.8, 0, 3.3, 0.1),
+    ('Aldi', 'A/Joghurt mild 3,5% Fett', 69.0, 3.5, 2.4, 0, 4.8, 4.8, 0, 4.0, 0.1),
+    ('Patros', 'Patros Natur', 282.0, 24.0, 16.0, 0, 0.7, 0.7, 0, 15.0, 2.7),
+    ('Ehrmann', 'High-Protein-Pudding - Vanilla', 76.0, 1.5, 1.0, 0, 5.5, 4.0, 0, 10.0, 0.0),
+    ('Patros', 'Feta (Schaf- & Ziegenmilch)', 288.0, 24.0, 17.0, 0, 0.5, 0.5, 0, 18.0, 2.4),
+    ('Milsani', 'Frische Vollmilch 3,5%', 64.0, 3.5, 2.3, 0, 4.8, 4.8, 0, 3.4, 0.1),
+    ('Milram', 'Benjamin', 238.7, 29.0, 20.0, 0, 0.1, 0.1, 0, 23.0, 1.8),
+    ('Milbona', 'Bio Fettarmer Joghurt mild', 54.0, 1.8, 1.2, 0, 3.8, 3.8, 0.0, 4.8, 0.2),
+    ('Bauer', 'Kirsche', 88.0, 2.9, 2.0, 0, 12.2, 11.4, 0, 3.2, 0.0),
+    ('Milbona', 'Skyr Vanilla', 53.6, 0.2, 0.1, 0, 4.1, 3.3, 0.1, 8.8, 0.1),
+    ('Weihenstephan', 'Joghurt Natur 3,5 % Fett', 72.0, 3.5, 2.4, 0, 5.1, 5.1, 0, 4.4, 0.1),
+    ('Cucina Nobile', 'Mozzarella', 246.4, 19.0, 12.0, 0, 1.0, 1.0, 0, 18.0, 0.5),
+    ('Bio', 'Bio-Feta', 276.0, 23.0, 16.0, 0, 0.7, 0.7, 0, 16.5, 2.5),
+    ('Ein gutes Stück Bayern', 'Haltbare Bio Vollmilch', 67.0, 3.9, 2.6, 0, 4.8, 4.8, 0.0, 3.2, 0.1),
+    ('Lyttos', 'Griechischer Joghurt', 117.0, 9.2, 6.1, 0, 4.5, 4.5, 0, 4.1, 0.1),
+    ('AF Deutschland', 'Fettarme Milch (laktosefrei; 1,5% Fett)', 47.0, 1.5, 1.0, 0, 4.8, 4.8, 0, 3.4, 0.1)
+) as d(brand, product_name, calories, total_fat_g, saturated_fat_g, trans_fat_g,
+       carbs_g, sugars_g, fibre_g, protein_g, salt_g)
+join products p on p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name
+  and p.category = 'Dairy' and p.is_deprecated is not true
+on conflict (product_id) do update set
+  calories = excluded.calories,
+  total_fat_g = excluded.total_fat_g,
+  saturated_fat_g = excluded.saturated_fat_g,
+  trans_fat_g = excluded.trans_fat_g,
+  carbs_g = excluded.carbs_g,
+  sugars_g = excluded.sugars_g,
+  fibre_g = excluded.fibre_g,
+  protein_g = excluded.protein_g,
+  salt_g = excluded.salt_g;

--- a/db/pipelines/dairy-de/PIPELINE__dairy-de__04_scoring.sql
+++ b/db/pipelines/dairy-de/PIPELINE__dairy-de__04_scoring.sql
@@ -1,0 +1,123 @@
+-- PIPELINE (Dairy): scoring
+-- Generated: 2026-02-25
+
+-- 2. Nutri-Score
+update products p set
+  nutri_score_label = d.ns
+from (
+  values
+    ('Milsani', 'Frischkäse natur', 'D'),
+    ('Gervais', 'Hüttenkäse Original', 'B'),
+    ('Milsani', 'Körniger Frischkäse, Halbfettstufe', 'A'),
+    ('Almette', 'Almette Kräuter', 'D'),
+    ('Bergader', 'Bergbauern mild nussig Käse', 'D'),
+    ('DOVGAN Family', 'Körniger Frischkäse 33 % Fett', 'B'),
+    ('BMI Biobauern', 'Bio-Landkäse mild-nussig', 'E'),
+    ('Dr. Oetker', 'High Protein Pudding Grieß', 'A'),
+    ('Milsan', 'Grießpudding High-Protein - Zimt', 'A'),
+    ('Milram', 'Frühlingsquark Original', 'D'),
+    ('DMK', 'Müritzer original', 'D'),
+    ('Milsani', 'Körniger Frischkäse - Magerstufe', 'A'),
+    ('AF Deutschland', 'Hirtenkäse', 'D'),
+    ('Grünländer', 'Grünländer Mild & Nussig', 'C'),
+    ('Grünländer', 'Grünländer Leicht', 'C'),
+    ('Gazi', 'Grill- und Pfannenkäse', 'D'),
+    ('Bio', 'ALDI GUT BIO Milch Frische Bio-Milch 1.5 % Fett Aus der Kühlung 1l 1.15€ Fettarme Milch', 'B'),
+    ('Milsani', 'ALDI MILSANI Skyr Nach isländischer Art mit viel Eiweiß und wenig Fett Aus der Kühlung 1.49€ 500g Becher 1kg 2.98€', 'A'),
+    ('Karwendel', 'Exquisa Balance Frischkäse', 'B'),
+    ('Weihenstephan', 'H-Milch 3,5%', 'C'),
+    ('Milbona', 'Skyr', 'A'),
+    ('Arla', 'Skyr Natur', 'A'),
+    ('Milsani', 'H-Vollmilch 3,5 % Fett', 'C'),
+    ('Elinas', 'Joghurt Griechischer Art', 'C'),
+    ('Alpenhain', 'Obazda klassisch', 'D'),
+    ('Ehrmann', 'High Protein Chocolate Pudding', 'A'),
+    ('Bio', 'Frische Bio-Vollmilch 3,8 % Fett', 'C'),
+    ('Milsani', 'Haltbare Fettarme Milch', 'B'),
+    ('Arla', 'Skyr Bourbon Vanille', 'A'),
+    ('Milbona', 'High Protein Chocolate Flavour Pudding', 'A'),
+    ('Milsani', 'Joghurt mild 3,5 % Fett', 'B'),
+    ('Schwarzwaldmilch', 'Protein Milch', 'B'),
+    ('Bresso', 'Bresso', 'D'),
+    ('Milsani', 'Milch', 'B'),
+    ('Bergader', 'Bavaria Blu', 'D'),
+    ('Aldi', 'Milch, haltbar, 1,5 %, Bio', 'B'),
+    ('Aldi', 'A/Joghurt mild 3,5% Fett', 'B'),
+    ('Patros', 'Patros Natur', 'E'),
+    ('Ehrmann', 'High-Protein-Pudding - Vanilla', 'A'),
+    ('Patros', 'Feta (Schaf- & Ziegenmilch)', 'D'),
+    ('Milsani', 'Frische Vollmilch 3,5%', 'C'),
+    ('Milram', 'Benjamin', 'D'),
+    ('Milbona', 'Bio Fettarmer Joghurt mild', 'B'),
+    ('Bauer', 'Kirsche', 'C'),
+    ('Milbona', 'Skyr Vanilla', 'A'),
+    ('Weihenstephan', 'Joghurt Natur 3,5 % Fett', 'B'),
+    ('Cucina Nobile', 'Mozzarella', 'C'),
+    ('Bio', 'Bio-Feta', 'E'),
+    ('Ein gutes Stück Bayern', 'Haltbare Bio Vollmilch', 'C'),
+    ('Lyttos', 'Griechischer Joghurt', 'C'),
+    ('AF Deutschland', 'Fettarme Milch (laktosefrei; 1,5% Fett)', 'B')
+) as d(brand, product_name, ns)
+where p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name;
+
+-- 3. NOVA classification
+update products p set
+  nova_classification = d.nova
+from (
+  values
+    ('Milsani', 'Frischkäse natur', '3'),
+    ('Gervais', 'Hüttenkäse Original', '4'),
+    ('Milsani', 'Körniger Frischkäse, Halbfettstufe', '3'),
+    ('Almette', 'Almette Kräuter', '4'),
+    ('Bergader', 'Bergbauern mild nussig Käse', '3'),
+    ('DOVGAN Family', 'Körniger Frischkäse 33 % Fett', '3'),
+    ('BMI Biobauern', 'Bio-Landkäse mild-nussig', '3'),
+    ('Dr. Oetker', 'High Protein Pudding Grieß', '4'),
+    ('Milsan', 'Grießpudding High-Protein - Zimt', '4'),
+    ('Milram', 'Frühlingsquark Original', '3'),
+    ('DMK', 'Müritzer original', '4'),
+    ('Milsani', 'Körniger Frischkäse - Magerstufe', '3'),
+    ('AF Deutschland', 'Hirtenkäse', '3'),
+    ('Grünländer', 'Grünländer Mild & Nussig', '3'),
+    ('Grünländer', 'Grünländer Leicht', '3'),
+    ('Gazi', 'Grill- und Pfannenkäse', '3'),
+    ('Bio', 'ALDI GUT BIO Milch Frische Bio-Milch 1.5 % Fett Aus der Kühlung 1l 1.15€ Fettarme Milch', '1'),
+    ('Milsani', 'ALDI MILSANI Skyr Nach isländischer Art mit viel Eiweiß und wenig Fett Aus der Kühlung 1.49€ 500g Becher 1kg 2.98€', '1'),
+    ('Karwendel', 'Exquisa Balance Frischkäse', '4'),
+    ('Weihenstephan', 'H-Milch 3,5%', '1'),
+    ('Milbona', 'Skyr', '3'),
+    ('Arla', 'Skyr Natur', '3'),
+    ('Milsani', 'H-Vollmilch 3,5 % Fett', '4'),
+    ('Elinas', 'Joghurt Griechischer Art', '1'),
+    ('Alpenhain', 'Obazda klassisch', '3'),
+    ('Ehrmann', 'High Protein Chocolate Pudding', '4'),
+    ('Bio', 'Frische Bio-Vollmilch 3,8 % Fett', '1'),
+    ('Milsani', 'Haltbare Fettarme Milch', '4'),
+    ('Arla', 'Skyr Bourbon Vanille', '4'),
+    ('Milbona', 'High Protein Chocolate Flavour Pudding', '4'),
+    ('Milsani', 'Joghurt mild 3,5 % Fett', '1'),
+    ('Schwarzwaldmilch', 'Protein Milch', '4'),
+    ('Bresso', 'Bresso', '4'),
+    ('Milsani', 'Milch', '1'),
+    ('Bergader', 'Bavaria Blu', '3'),
+    ('Aldi', 'Milch, haltbar, 1,5 %, Bio', '1'),
+    ('Aldi', 'A/Joghurt mild 3,5% Fett', '1'),
+    ('Patros', 'Patros Natur', '3'),
+    ('Ehrmann', 'High-Protein-Pudding - Vanilla', '4'),
+    ('Patros', 'Feta (Schaf- & Ziegenmilch)', '3'),
+    ('Milsani', 'Frische Vollmilch 3,5%', '1'),
+    ('Milram', 'Benjamin', '4'),
+    ('Milbona', 'Bio Fettarmer Joghurt mild', '1'),
+    ('Bauer', 'Kirsche', '4'),
+    ('Milbona', 'Skyr Vanilla', '4'),
+    ('Weihenstephan', 'Joghurt Natur 3,5 % Fett', '1'),
+    ('Cucina Nobile', 'Mozzarella', '3'),
+    ('Bio', 'Bio-Feta', '3'),
+    ('Ein gutes Stück Bayern', 'Haltbare Bio Vollmilch', '1'),
+    ('Lyttos', 'Griechischer Joghurt', '1'),
+    ('AF Deutschland', 'Fettarme Milch (laktosefrei; 1,5% Fett)', '1')
+) as d(brand, product_name, nova)
+where p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name;
+
+-- 0/1/4/5. Score category (concern defaults, unhealthiness, flags, confidence)
+CALL score_category('Dairy', 100, 'DE');

--- a/db/pipelines/dairy-de/PIPELINE__dairy-de__05_source_provenance.sql
+++ b/db/pipelines/dairy-de/PIPELINE__dairy-de__05_source_provenance.sql
@@ -1,0 +1,65 @@
+-- PIPELINE (Dairy): source provenance
+-- Generated: 2026-02-25
+
+-- 1. Update source info on products
+UPDATE products p SET
+  source_type = 'off_api',
+  source_url = d.source_url,
+  source_ean = d.source_ean
+FROM (
+  VALUES
+    ('Milsani', 'Frischkäse natur', 'https://world.openfoodfacts.org/product/4061458047685', '4061458047685'),
+    ('Gervais', 'Hüttenkäse Original', 'https://world.openfoodfacts.org/product/4002671157751', '4002671157751'),
+    ('Milsani', 'Körniger Frischkäse, Halbfettstufe', 'https://world.openfoodfacts.org/product/4061458047692', '4061458047692'),
+    ('Almette', 'Almette Kräuter', 'https://world.openfoodfacts.org/product/4002468084017', '4002468084017'),
+    ('Bergader', 'Bergbauern mild nussig Käse', 'https://world.openfoodfacts.org/product/4006402046192', '4006402046192'),
+    ('DOVGAN Family', 'Körniger Frischkäse 33 % Fett', 'https://world.openfoodfacts.org/product/4032549018105', '4032549018105'),
+    ('BMI Biobauern', 'Bio-Landkäse mild-nussig', 'https://world.openfoodfacts.org/product/4040900117251', '4040900117251'),
+    ('Dr. Oetker', 'High Protein Pudding Grieß', 'https://world.openfoodfacts.org/product/4023600013511', '4023600013511'),
+    ('Milsan', 'Grießpudding High-Protein - Zimt', 'https://world.openfoodfacts.org/product/4061458280334', '4061458280334'),
+    ('Milram', 'Frühlingsquark Original', 'https://world.openfoodfacts.org/product/40466002', '40466002'),
+    ('DMK', 'Müritzer original', 'https://world.openfoodfacts.org/product/4036300005311', '4036300005311'),
+    ('Milsani', 'Körniger Frischkäse - Magerstufe', 'https://world.openfoodfacts.org/product/4061458047708', '4061458047708'),
+    ('AF Deutschland', 'Hirtenkäse', 'https://world.openfoodfacts.org/product/4061458163903', '4061458163903'),
+    ('Grünländer', 'Grünländer Mild & Nussig', 'https://world.openfoodfacts.org/product/4002468210454', '4002468210454'),
+    ('Grünländer', 'Grünländer Leicht', 'https://world.openfoodfacts.org/product/4002468210478', '4002468210478'),
+    ('Gazi', 'Grill- und Pfannenkäse', 'https://world.openfoodfacts.org/product/4002566010703', '4002566010703'),
+    ('Bio', 'ALDI GUT BIO Milch Frische Bio-Milch 1.5 % Fett Aus der Kühlung 1l 1.15€ Fettarme Milch', 'https://world.openfoodfacts.org/product/4061459193312', '4061459193312'),
+    ('Milsani', 'ALDI MILSANI Skyr Nach isländischer Art mit viel Eiweiß und wenig Fett Aus der Kühlung 1.49€ 500g Becher 1kg 2.98€', 'https://world.openfoodfacts.org/product/4061458229838', '4061458229838'),
+    ('Karwendel', 'Exquisa Balance Frischkäse', 'https://world.openfoodfacts.org/product/4019300005307', '4019300005307'),
+    ('Weihenstephan', 'H-Milch 3,5%', 'https://world.openfoodfacts.org/product/4008452027602', '4008452027602'),
+    ('Milbona', 'Skyr', 'https://world.openfoodfacts.org/product/4056489012788', '4056489012788'),
+    ('Arla', 'Skyr Natur', 'https://world.openfoodfacts.org/product/4016241030603', '4016241030603'),
+    ('Milsani', 'H-Vollmilch 3,5 % Fett', 'https://world.openfoodfacts.org/product/4061462842986', '4061462842986'),
+    ('Elinas', 'Joghurt Griechischer Art', 'https://world.openfoodfacts.org/product/4003490323600', '4003490323600'),
+    ('Alpenhain', 'Obazda klassisch', 'https://world.openfoodfacts.org/product/4003751002848', '4003751002848'),
+    ('Ehrmann', 'High Protein Chocolate Pudding', 'https://world.openfoodfacts.org/product/4002971243703', '4002971243703'),
+    ('Bio', 'Frische Bio-Vollmilch 3,8 % Fett', 'https://world.openfoodfacts.org/product/4061459193695', '4061459193695'),
+    ('Milsani', 'Haltbare Fettarme Milch', 'https://world.openfoodfacts.org/product/4061462842764', '4061462842764'),
+    ('Arla', 'Skyr Bourbon Vanille', 'https://world.openfoodfacts.org/product/4016241030917', '4016241030917'),
+    ('Milbona', 'High Protein Chocolate Flavour Pudding', 'https://world.openfoodfacts.org/product/4056489216162', '4056489216162'),
+    ('Milsani', 'Joghurt mild 3,5 % Fett', 'https://world.openfoodfacts.org/product/4061458028820', '4061458028820'),
+    ('Schwarzwaldmilch', 'Protein Milch', 'https://world.openfoodfacts.org/product/4046700001806', '4046700001806'),
+    ('Bresso', 'Bresso', 'https://world.openfoodfacts.org/product/4045357004383', '4045357004383'),
+    ('Milsani', 'Milch', 'https://world.openfoodfacts.org/product/4061462864803', '4061462864803'),
+    ('Bergader', 'Bavaria Blu', 'https://world.openfoodfacts.org/product/4006402020413', '4006402020413'),
+    ('Aldi', 'Milch, haltbar, 1,5 %, Bio', 'https://world.openfoodfacts.org/product/4056489013105', '4056489013105'),
+    ('Aldi', 'A/Joghurt mild 3,5% Fett', 'https://world.openfoodfacts.org/product/4061458028813', '4061458028813'),
+    ('Patros', 'Patros Natur', 'https://world.openfoodfacts.org/product/4002671151353', '4002671151353'),
+    ('Ehrmann', 'High-Protein-Pudding - Vanilla', 'https://world.openfoodfacts.org/product/4002971243802', '4002971243802'),
+    ('Patros', 'Feta (Schaf- & Ziegenmilch)', 'https://world.openfoodfacts.org/product/4002468134361', '4002468134361'),
+    ('Milsani', 'Frische Vollmilch 3,5%', 'https://world.openfoodfacts.org/product/4061462865015', '4061462865015'),
+    ('Milram', 'Benjamin', 'https://world.openfoodfacts.org/product/4036300005304', '4036300005304'),
+    ('Milbona', 'Bio Fettarmer Joghurt mild', 'https://world.openfoodfacts.org/product/4056489014003', '4056489014003'),
+    ('Bauer', 'Kirsche', 'https://world.openfoodfacts.org/product/4002334113032', '4002334113032'),
+    ('Milbona', 'Skyr Vanilla', 'https://world.openfoodfacts.org/product/4056489118190', '4056489118190'),
+    ('Weihenstephan', 'Joghurt Natur 3,5 % Fett', 'https://world.openfoodfacts.org/product/4008452011007', '4008452011007'),
+    ('Cucina Nobile', 'Mozzarella', 'https://world.openfoodfacts.org/product/4061458018531', '4061458018531'),
+    ('Bio', 'Bio-Feta', 'https://world.openfoodfacts.org/product/4061458005548', '4061458005548'),
+    ('Ein gutes Stück Bayern', 'Haltbare Bio Vollmilch', 'https://world.openfoodfacts.org/product/4056489379850', '4056489379850'),
+    ('Lyttos', 'Griechischer Joghurt', 'https://world.openfoodfacts.org/product/4061458244404', '4061458244404'),
+    ('AF Deutschland', 'Fettarme Milch (laktosefrei; 1,5% Fett)', 'https://world.openfoodfacts.org/product/4061462843723', '4061462843723')
+) AS d(brand, product_name, source_url, source_ean)
+WHERE p.country = 'DE' AND p.brand = d.brand
+  AND p.product_name = d.product_name
+  AND p.category = 'Dairy' AND p.is_deprecated IS NOT TRUE;

--- a/db/pipelines/dairy-de/PIPELINE__dairy-de__06_add_images.sql
+++ b/db/pipelines/dairy-de/PIPELINE__dairy-de__06_add_images.sql
@@ -1,0 +1,79 @@
+-- PIPELINE (Dairy): add product images
+-- Source: Open Food Facts API image URLs
+-- Generated: 2026-02-25
+
+-- 1. Remove existing OFF images for this category
+DELETE FROM product_images
+WHERE source = 'off_api'
+  AND product_id IN (
+    SELECT p.product_id FROM products p
+    WHERE p.country = 'DE' AND p.category = 'Dairy'
+      AND p.is_deprecated IS NOT TRUE
+  );
+
+-- 2. Insert images
+INSERT INTO product_images
+  (product_id, url, source, image_type, is_primary, alt_text, off_image_id)
+SELECT
+  p.product_id, d.url, d.source, d.image_type, d.is_primary, d.alt_text, d.off_image_id
+FROM (
+  VALUES
+    ('Milsani', 'Frischkäse natur', 'https://images.openfoodfacts.org/images/products/406/145/804/7685/front_de.108.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458047685', 'front_4061458047685'),
+    ('Gervais', 'Hüttenkäse Original', 'https://images.openfoodfacts.org/images/products/400/267/115/7751/front_de.95.400.jpg', 'off_api', 'front', true, 'Front — EAN 4002671157751', 'front_4002671157751'),
+    ('Milsani', 'Körniger Frischkäse, Halbfettstufe', 'https://images.openfoodfacts.org/images/products/406/145/804/7692/front_de.114.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458047692', 'front_4061458047692'),
+    ('Almette', 'Almette Kräuter', 'https://images.openfoodfacts.org/images/products/400/246/808/4017/front_de.58.400.jpg', 'off_api', 'front', true, 'Front — EAN 4002468084017', 'front_4002468084017'),
+    ('Bergader', 'Bergbauern mild nussig Käse', 'https://images.openfoodfacts.org/images/products/400/640/204/6192/front_de.67.400.jpg', 'off_api', 'front', true, 'Front — EAN 4006402046192', 'front_4006402046192'),
+    ('DOVGAN Family', 'Körniger Frischkäse 33 % Fett', 'https://images.openfoodfacts.org/images/products/403/254/901/8105/front_en.6.400.jpg', 'off_api', 'front', true, 'Front — EAN 4032549018105', 'front_4032549018105'),
+    ('BMI Biobauern', 'Bio-Landkäse mild-nussig', 'https://images.openfoodfacts.org/images/products/404/090/011/7251/front_de.34.400.jpg', 'off_api', 'front', true, 'Front — EAN 4040900117251', 'front_4040900117251'),
+    ('Dr. Oetker', 'High Protein Pudding Grieß', 'https://images.openfoodfacts.org/images/products/402/360/001/3511/front_en.82.400.jpg', 'off_api', 'front', true, 'Front — EAN 4023600013511', 'front_4023600013511'),
+    ('Milsan', 'Grießpudding High-Protein - Zimt', 'https://images.openfoodfacts.org/images/products/406/145/828/0334/front_en.81.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458280334', 'front_4061458280334'),
+    ('Milram', 'Frühlingsquark Original', 'https://images.openfoodfacts.org/images/products/000/004/046/6002/front_de.42.400.jpg', 'off_api', 'front', true, 'Front — EAN 40466002', 'front_40466002'),
+    ('DMK', 'Müritzer original', 'https://images.openfoodfacts.org/images/products/403/630/000/5311/front_de.45.400.jpg', 'off_api', 'front', true, 'Front — EAN 4036300005311', 'front_4036300005311'),
+    ('Milsani', 'Körniger Frischkäse - Magerstufe', 'https://images.openfoodfacts.org/images/products/406/145/804/7708/front_en.51.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458047708', 'front_4061458047708'),
+    ('AF Deutschland', 'Hirtenkäse', 'https://images.openfoodfacts.org/images/products/406/145/816/3903/front_en.57.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458163903', 'front_4061458163903'),
+    ('Grünländer', 'Grünländer Mild & Nussig', 'https://images.openfoodfacts.org/images/products/400/246/821/0454/front_de.59.400.jpg', 'off_api', 'front', true, 'Front — EAN 4002468210454', 'front_4002468210454'),
+    ('Grünländer', 'Grünländer Leicht', 'https://images.openfoodfacts.org/images/products/400/246/821/0478/front_de.73.400.jpg', 'off_api', 'front', true, 'Front — EAN 4002468210478', 'front_4002468210478'),
+    ('Gazi', 'Grill- und Pfannenkäse', 'https://images.openfoodfacts.org/images/products/400/256/601/0703/front_de.461.400.jpg', 'off_api', 'front', true, 'Front — EAN 4002566010703', 'front_4002566010703'),
+    ('Bio', 'ALDI GUT BIO Milch Frische Bio-Milch 1.5 % Fett Aus der Kühlung 1l 1.15€ Fettarme Milch', 'https://images.openfoodfacts.org/images/products/406/145/919/3312/front_en.43.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061459193312', 'front_4061459193312'),
+    ('Milsani', 'ALDI MILSANI Skyr Nach isländischer Art mit viel Eiweiß und wenig Fett Aus der Kühlung 1.49€ 500g Becher 1kg 2.98€', 'https://images.openfoodfacts.org/images/products/406/145/822/9838/front_de.60.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458229838', 'front_4061458229838'),
+    ('Karwendel', 'Exquisa Balance Frischkäse', 'https://images.openfoodfacts.org/images/products/401/930/000/5307/front_de.28.400.jpg', 'off_api', 'front', true, 'Front — EAN 4019300005307', 'front_4019300005307'),
+    ('Weihenstephan', 'H-Milch 3,5%', 'https://images.openfoodfacts.org/images/products/400/845/202/7602/front_en.166.400.jpg', 'off_api', 'front', true, 'Front — EAN 4008452027602', 'front_4008452027602'),
+    ('Milbona', 'Skyr', 'https://images.openfoodfacts.org/images/products/405/648/901/2788/front_en.33.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489012788', 'front_4056489012788'),
+    ('Arla', 'Skyr Natur', 'https://images.openfoodfacts.org/images/products/401/624/103/0603/front_de.108.400.jpg', 'off_api', 'front', true, 'Front — EAN 4016241030603', 'front_4016241030603'),
+    ('Milsani', 'H-Vollmilch 3,5 % Fett', 'https://images.openfoodfacts.org/images/products/406/146/284/2986/front_de.75.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061462842986', 'front_4061462842986'),
+    ('Elinas', 'Joghurt Griechischer Art', 'https://images.openfoodfacts.org/images/products/400/349/032/3600/front_de.124.400.jpg', 'off_api', 'front', true, 'Front — EAN 4003490323600', 'front_4003490323600'),
+    ('Alpenhain', 'Obazda klassisch', 'https://images.openfoodfacts.org/images/products/400/375/100/2848/front_de.85.400.jpg', 'off_api', 'front', true, 'Front — EAN 4003751002848', 'front_4003751002848'),
+    ('Ehrmann', 'High Protein Chocolate Pudding', 'https://images.openfoodfacts.org/images/products/400/297/124/3703/front_de.192.400.jpg', 'off_api', 'front', true, 'Front — EAN 4002971243703', 'front_4002971243703'),
+    ('Bio', 'Frische Bio-Vollmilch 3,8 % Fett', 'https://images.openfoodfacts.org/images/products/406/145/919/3695/front_de.50.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061459193695', 'front_4061459193695'),
+    ('Milsani', 'Haltbare Fettarme Milch', 'https://images.openfoodfacts.org/images/products/406/146/284/2764/front_de.153.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061462842764', 'front_4061462842764'),
+    ('Arla', 'Skyr Bourbon Vanille', 'https://images.openfoodfacts.org/images/products/401/624/103/0917/front_de.93.400.jpg', 'off_api', 'front', true, 'Front — EAN 4016241030917', 'front_4016241030917'),
+    ('Milbona', 'High Protein Chocolate Flavour Pudding', 'https://images.openfoodfacts.org/images/products/405/648/921/6162/front_en.329.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489216162', 'front_4056489216162'),
+    ('Milsani', 'Joghurt mild 3,5 % Fett', 'https://images.openfoodfacts.org/images/products/406/145/802/8820/front_de.111.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458028820', 'front_4061458028820'),
+    ('Schwarzwaldmilch', 'Protein Milch', 'https://images.openfoodfacts.org/images/products/404/670/000/1806/front_en.56.400.jpg', 'off_api', 'front', true, 'Front — EAN 4046700001806', 'front_4046700001806'),
+    ('Bresso', 'Bresso', 'https://images.openfoodfacts.org/images/products/404/535/700/4383/front_de.54.400.jpg', 'off_api', 'front', true, 'Front — EAN 4045357004383', 'front_4045357004383'),
+    ('Milsani', 'Milch', 'https://images.openfoodfacts.org/images/products/406/146/286/4803/front_de.30.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061462864803', 'front_4061462864803'),
+    ('Bergader', 'Bavaria Blu', 'https://images.openfoodfacts.org/images/products/400/640/202/0413/front_de.60.400.jpg', 'off_api', 'front', true, 'Front — EAN 4006402020413', 'front_4006402020413'),
+    ('Aldi', 'Milch, haltbar, 1,5 %, Bio', 'https://images.openfoodfacts.org/images/products/405/648/901/3105/front_de.86.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489013105', 'front_4056489013105'),
+    ('Aldi', 'A/Joghurt mild 3,5% Fett', 'https://images.openfoodfacts.org/images/products/406/145/802/8813/front_de.96.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458028813', 'front_4061458028813'),
+    ('Patros', 'Patros Natur', 'https://images.openfoodfacts.org/images/products/400/267/115/1353/front_de.83.400.jpg', 'off_api', 'front', true, 'Front — EAN 4002671151353', 'front_4002671151353'),
+    ('Ehrmann', 'High-Protein-Pudding - Vanilla', 'https://images.openfoodfacts.org/images/products/400/297/124/3802/front_de.79.400.jpg', 'off_api', 'front', true, 'Front — EAN 4002971243802', 'front_4002971243802'),
+    ('Patros', 'Feta (Schaf- & Ziegenmilch)', 'https://images.openfoodfacts.org/images/products/400/246/813/4361/front_de.85.400.jpg', 'off_api', 'front', true, 'Front — EAN 4002468134361', 'front_4002468134361'),
+    ('Milsani', 'Frische Vollmilch 3,5%', 'https://images.openfoodfacts.org/images/products/406/146/286/5015/front_de.30.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061462865015', 'front_4061462865015'),
+    ('Milram', 'Benjamin', 'https://images.openfoodfacts.org/images/products/403/630/000/5304/front_de.50.400.jpg', 'off_api', 'front', true, 'Front — EAN 4036300005304', 'front_4036300005304'),
+    ('Milbona', 'Bio Fettarmer Joghurt mild', 'https://images.openfoodfacts.org/images/products/405/648/901/4003/front_de.62.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489014003', 'front_4056489014003'),
+    ('Bauer', 'Kirsche', 'https://images.openfoodfacts.org/images/products/400/233/411/3032/front_de.63.400.jpg', 'off_api', 'front', true, 'Front — EAN 4002334113032', 'front_4002334113032'),
+    ('Milbona', 'Skyr Vanilla', 'https://images.openfoodfacts.org/images/products/405/648/911/8190/front_en.80.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489118190', 'front_4056489118190'),
+    ('Weihenstephan', 'Joghurt Natur 3,5 % Fett', 'https://images.openfoodfacts.org/images/products/400/845/201/1007/front_de.173.400.jpg', 'off_api', 'front', true, 'Front — EAN 4008452011007', 'front_4008452011007'),
+    ('Cucina Nobile', 'Mozzarella', 'https://images.openfoodfacts.org/images/products/406/145/801/8531/front_de.88.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458018531', 'front_4061458018531'),
+    ('Bio', 'Bio-Feta', 'https://images.openfoodfacts.org/images/products/406/145/800/5548/front_de.99.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458005548', 'front_4061458005548'),
+    ('Ein gutes Stück Bayern', 'Haltbare Bio Vollmilch', 'https://images.openfoodfacts.org/images/products/405/648/937/9850/front_de.32.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489379850', 'front_4056489379850'),
+    ('Lyttos', 'Griechischer Joghurt', 'https://images.openfoodfacts.org/images/products/406/145/824/4404/front_de.21.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458244404', 'front_4061458244404'),
+    ('AF Deutschland', 'Fettarme Milch (laktosefrei; 1,5% Fett)', 'https://images.openfoodfacts.org/images/products/406/146/284/3723/front_de.27.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061462843723', 'front_4061462843723')
+) AS d(brand, product_name, url, source, image_type, is_primary, alt_text, off_image_id)
+JOIN products p ON p.country = 'DE' AND p.brand = d.brand AND p.product_name = d.product_name
+  AND p.category = 'Dairy' AND p.is_deprecated IS NOT TRUE
+ON CONFLICT (off_image_id) WHERE off_image_id IS NOT NULL DO UPDATE SET
+  url = EXCLUDED.url,
+  image_type = EXCLUDED.image_type,
+  is_primary = EXCLUDED.is_primary,
+  alt_text = EXCLUDED.alt_text;

--- a/db/pipelines/drinks-de/PIPELINE__drinks-de__01_insert_products.sql
+++ b/db/pipelines/drinks-de/PIPELINE__drinks-de__01_insert_products.sql
@@ -1,0 +1,85 @@
+-- PIPELINE (Drinks): insert products
+-- Source: Open Food Facts API (automated pipeline)
+-- Generated: 2026-02-25
+
+-- 0a. DEPRECATE old products in this category & release their EANs
+update products
+set is_deprecated = true, deprecated_reason = 'Replaced by pipeline refresh', ean = null
+where country = 'DE'
+  and category = 'Drinks'
+  and is_deprecated is not true;
+
+-- 0b. Release EANs across ALL categories to prevent unique constraint conflicts
+update products set ean = null
+where ean in ('4061464811218', '4061458061117', '4029764001807', '4066600603405', '4056489687641', '4056489989363', '4001513007704', '4061459133271', '4056489708995', '40554006', '4061458004121', '4056489708988', '4004790017565', '4066600204404', '4056489997511', '4004790037358', '4067796002089', '4001743754539', '4052700022932', '4056489689720', '4008287959192', '4061458028998', '5411188112709', '4056489983477', '4062139025299', '4008948194016', '4009491021354', '4067796000207', '90433627', '4056489749455', '42287995', '4280001939042', '4009300014492', '4048517746086', '4062139025251', '4061458252690', '4048517742040', '4062139025473', '42142195', '42448860', '3057640186158', '5000112546415', '7394376616501', '5449000017888', '90162565', '5060337500401', '5000112576009', '5411188134985', '42143819', '5449000134264', '5000112604450')
+  and ean is not null;
+
+-- 1. INSERT products
+insert into products (country, brand, product_type, category, product_name, prep_method, store_availability, controversies, ean)
+values
+  ('DE', 'My Vay', 'Grocery', 'Drinks', 'Bio-Haferdrink ungesüßt', 'not-applicable', 'Aldi', 'none', '4061464811218'),
+  ('DE', 'Rio d''Oro', 'Grocery', 'Drinks', 'Apfel-Direktsaft Naturtrüb', 'not-applicable', 'Aldi', 'none', '4061458061117'),
+  ('DE', 'Club Mate', 'Grocery', 'Drinks', 'Club-Mate Original', 'not-applicable', 'Carrefour', 'none', '4029764001807'),
+  ('DE', 'Paulaner', 'Grocery', 'Drinks', 'Paulaner Spezi', 'not-applicable', 'Kaufland', 'none', '4066600603405'),
+  ('DE', 'Lidl', 'Grocery', 'Drinks', 'Milch Mandel ohne Zucker', 'not-applicable', 'Lidl', 'none', '4056489687641'),
+  ('DE', 'Vemondo', 'Grocery', 'Drinks', 'Barista Oat Drink', 'not-applicable', 'Lidl', 'none', '4056489989363'),
+  ('DE', 'Gerolsteiner', 'Grocery', 'Drinks', 'Gerolsteiner Medium 1,5 Liter', 'not-applicable', 'Lidl', 'none', '4001513007704'),
+  ('DE', 'Aldi', 'Grocery', 'Drinks', 'Bio-Haferdrink Natur', 'not-applicable', 'Aldi', 'none', '4061459133271'),
+  ('DE', 'Lidl', 'Grocery', 'Drinks', 'No Milk Hafer 3,5% Fett', 'not-applicable', 'Lidl', 'none', '4056489708995'),
+  ('DE', 'Gut & Günstig', 'Grocery', 'Drinks', 'Mineralwasser', 'not-applicable', null, 'none', '40554006'),
+  ('DE', 'Asia Green Garden', 'Grocery', 'Drinks', 'Kokosnussmilch Klassik', 'not-applicable', 'Aldi', 'none', '4061458004121'),
+  ('DE', 'Vemondo', 'Grocery', 'Drinks', 'No Milk Hafer 1,8% Fett', 'not-applicable', 'Lidl', 'none', '4056489708988'),
+  ('DE', 'Berief', 'Grocery', 'Drinks', 'BiO HAFER NATUR', 'not-applicable', null, 'none', '4004790017565'),
+  ('DE', 'Paulaner', 'Grocery', 'Drinks', 'Spezi Zero', 'not-applicable', null, 'none', '4066600204404'),
+  ('DE', 'Vemondo', 'Grocery', 'Drinks', 'Bio Hafer', 'not-applicable', 'Lidl', 'none', '4056489997511'),
+  ('DE', 'Berief', 'Grocery', 'Drinks', 'Bio Hafer ohne Zucker', 'not-applicable', null, 'none', '4004790037358'),
+  ('DE', 'DmBio', 'Grocery', 'Drinks', 'Sojadrink natur', 'not-applicable', null, 'none', '4067796002089'),
+  ('DE', 'Bensdorp', 'Grocery', 'Drinks', 'Bensdorp Kakao', 'not-applicable', 'Lidl', 'none', '4001743754539'),
+  ('DE', 'Choco', 'Grocery', 'Drinks', 'Kakao Choco', 'not-applicable', null, 'none', '4052700022932'),
+  ('DE', 'Vemondo', 'Grocery', 'Drinks', 'High Protein Sojadrink', 'not-applicable', 'Lidl', 'none', '4056489689720'),
+  ('DE', 'Drinks & More GmbH & Co. KG', 'Grocery', 'Drinks', 'Knabe Malz', 'not-applicable', null, 'none', '4008287959192'),
+  ('DE', 'Rio d''Oro', 'Grocery', 'Drinks', 'Trauben-Direktsaft', 'not-applicable', 'Aldi', 'none', '4061458028998'),
+  ('DE', 'Alpro', 'Grocery', 'Drinks', 'Geröstete Mandel Ohne Zucker', 'not-applicable', 'Carrefour', 'none', '5411188112709'),
+  ('DE', 'Vemondo', 'Grocery', 'Drinks', 'Bio Hafer ohne Zucker', 'not-applicable', null, 'none', '4056489983477'),
+  ('DE', 'Pepsi', 'Grocery', 'Drinks', 'Pepsi Zero Zucker', 'not-applicable', null, 'none', '4062139025299'),
+  ('DE', 'Jever', 'Grocery', 'Drinks', 'Jever fun 4008948194016 Pilsener alkoholfrei', 'not-applicable', null, 'none', '4008948194016'),
+  ('DE', 'Valensia', 'Grocery', 'Drinks', 'Orange ohne Fruchtfleisch', 'not-applicable', null, 'none', '4009491021354'),
+  ('DE', 'DmBio', 'Grocery', 'Drinks', 'Oat Drink - Sugarfree', 'not-applicable', null, 'none', '4067796000207'),
+  ('DE', 'Red Bull', 'Grocery', 'Drinks', 'Kokos Blaubeere (Weiß)', 'not-applicable', 'Lidl', 'none', '90433627'),
+  ('DE', 'VEMondo', 'Grocery', 'Drinks', 'High protein soy with chocolate taste', 'not-applicable', null, 'none', '4056489749455'),
+  ('DE', 'Naturalis', 'Grocery', 'Drinks', 'Getränke - Mineralwasser - Classic', 'not-applicable', 'Netto', 'none', '42287995'),
+  ('DE', 'Vly', 'Grocery', 'Drinks', 'Erbsenproteindrink Ungesüsst aus Erbsenprotein', 'not-applicable', null, 'none', '4280001939042'),
+  ('DE', 'Teekanne', 'Grocery', 'Drinks', 'Teebeutel Italienische Limone', 'not-applicable', null, 'none', '4009300014492'),
+  ('DE', 'Hohes C', 'Grocery', 'Drinks', 'Saft Plus Eisen', 'not-applicable', null, 'none', '4048517746086'),
+  ('DE', 'Pepsi', 'Grocery', 'Drinks', 'Pepsi', 'not-applicable', null, 'none', '4062139025251'),
+  ('DE', 'Quellbrunn', 'Grocery', 'Drinks', 'Mineralwasser Naturell', 'not-applicable', null, 'none', '4061458252690'),
+  ('DE', 'Granini', 'Grocery', 'Drinks', 'Multivitaminsaft', 'not-applicable', null, 'none', '4048517742040'),
+  ('DE', 'Schwip schwap', 'Grocery', 'Drinks', 'Schwip Schwap Zero', 'not-applicable', null, 'none', '4062139025473'),
+  ('DE', 'Quellbrunn', 'Grocery', 'Drinks', 'Naturell Mierbachquelle ohne Kohlensäure', 'not-applicable', null, 'none', '42142195'),
+  ('DE', 'Müller', 'Grocery', 'Drinks', 'Müllermilch - Bananen-Geschmack', 'not-applicable', null, 'none', '42448860'),
+  ('DE', 'Volvic', 'Grocery', 'Drinks', 'Wasser Volvic naturelle', 'not-applicable', 'Lidl', 'none', '3057640186158'),
+  ('DE', 'Coca-Cola', 'Grocery', 'Drinks', 'Coca-Cola Original', 'not-applicable', 'Lidl', 'none', '5000112546415'),
+  ('DE', 'Oatly', 'Grocery', 'Drinks', 'Haferdrink Barista', 'not-applicable', 'Kaufland', 'none', '7394376616501'),
+  ('DE', 'Coca-Cola', 'Grocery', 'Drinks', 'Coca-Cola 1 Liter', 'not-applicable', null, 'none', '5449000017888'),
+  ('DE', 'Red Bull', 'Grocery', 'Drinks', 'Red Bull Energydrink Classic', 'not-applicable', 'Lidl', 'none', '90162565'),
+  ('DE', 'Monster Energy', 'Grocery', 'Drinks', 'Monster Energy Ultra', 'not-applicable', 'Lidl', 'none', '5060337500401'),
+  ('DE', 'Coca-Cola', 'Grocery', 'Drinks', 'Coca-Cola Zero', 'not-applicable', 'Lidl', 'none', '5000112576009'),
+  ('DE', 'Alpro', 'Grocery', 'Drinks', 'Alpro Not Milk', 'not-applicable', null, 'none', '5411188134985'),
+  ('DE', 'Saskia', 'Grocery', 'Drinks', 'Mineralwasser still 6 x 1,5 L', 'not-applicable', 'Lidl', 'none', '42143819'),
+  ('DE', 'Cola', 'Grocery', 'Drinks', 'Coca-Cola Zero', 'not-applicable', 'Kaufland', 'none', '5449000134264'),
+  ('DE', 'Coca-Cola', 'Grocery', 'Drinks', 'Cola Zero', 'not-applicable', 'Netto', 'none', '5000112604450')
+on conflict (country, brand, product_name) do update set
+  category = excluded.category,
+  ean = excluded.ean,
+  product_type = excluded.product_type,
+  store_availability = excluded.store_availability,
+  controversies = excluded.controversies,
+  prep_method = excluded.prep_method,
+  is_deprecated = false;
+
+-- 2. DEPRECATE removed products
+update products
+set is_deprecated = true, deprecated_reason = 'Removed from pipeline batch'
+where country = 'DE' and category = 'Drinks'
+  and is_deprecated is not true
+  and product_name not in ('Bio-Haferdrink ungesüßt', 'Apfel-Direktsaft Naturtrüb', 'Club-Mate Original', 'Paulaner Spezi', 'Milch Mandel ohne Zucker', 'Barista Oat Drink', 'Gerolsteiner Medium 1,5 Liter', 'Bio-Haferdrink Natur', 'No Milk Hafer 3,5% Fett', 'Mineralwasser', 'Kokosnussmilch Klassik', 'No Milk Hafer 1,8% Fett', 'BiO HAFER NATUR', 'Spezi Zero', 'Bio Hafer', 'Bio Hafer ohne Zucker', 'Sojadrink natur', 'Bensdorp Kakao', 'Kakao Choco', 'High Protein Sojadrink', 'Knabe Malz', 'Trauben-Direktsaft', 'Geröstete Mandel Ohne Zucker', 'Bio Hafer ohne Zucker', 'Pepsi Zero Zucker', 'Jever fun 4008948194016 Pilsener alkoholfrei', 'Orange ohne Fruchtfleisch', 'Oat Drink - Sugarfree', 'Kokos Blaubeere (Weiß)', 'High protein soy with chocolate taste', 'Getränke - Mineralwasser - Classic', 'Erbsenproteindrink Ungesüsst aus Erbsenprotein', 'Teebeutel Italienische Limone', 'Saft Plus Eisen', 'Pepsi', 'Mineralwasser Naturell', 'Multivitaminsaft', 'Schwip Schwap Zero', 'Naturell Mierbachquelle ohne Kohlensäure', 'Müllermilch - Bananen-Geschmack', 'Wasser Volvic naturelle', 'Coca-Cola Original', 'Haferdrink Barista', 'Coca-Cola 1 Liter', 'Red Bull Energydrink Classic', 'Monster Energy Ultra', 'Coca-Cola Zero', 'Alpro Not Milk', 'Mineralwasser still 6 x 1,5 L', 'Coca-Cola Zero', 'Cola Zero');

--- a/db/pipelines/drinks-de/PIPELINE__drinks-de__03_add_nutrition.sql
+++ b/db/pipelines/drinks-de/PIPELINE__drinks-de__03_add_nutrition.sql
@@ -1,0 +1,87 @@
+-- PIPELINE (Drinks): add nutrition facts
+-- Source: Open Food Facts verified per-100g data
+
+-- 1) Remove existing
+delete from nutrition_facts
+where product_id in (
+  select p.product_id
+  from products p
+  where p.country = 'DE' and p.category = 'Drinks'
+    and p.is_deprecated is not true
+);
+
+-- 2) Insert
+insert into nutrition_facts
+  (product_id, calories, total_fat_g, saturated_fat_g, trans_fat_g,
+   carbs_g, sugars_g, fibre_g, protein_g, salt_g)
+select
+  p.product_id,
+  d.calories, d.total_fat_g, d.saturated_fat_g, d.trans_fat_g,
+  d.carbs_g, d.sugars_g, d.fibre_g, d.protein_g, d.salt_g
+from (
+  values
+    ('My Vay', 'Bio-Haferdrink ungesüßt', 42.0, 1.4, 0.2, 0, 5.8, 0.0, 0.0, 0.8, 0.1),
+    ('Rio d''Oro', 'Apfel-Direktsaft Naturtrüb', 46.0, 0.5, 0.1, 0, 11.0, 10.0, 0, 0.5, 0.0),
+    ('Club Mate', 'Club-Mate Original', 20.0, 0.0, 0.0, 0, 5.0, 5.0, 0.0, 0.0, 0.0),
+    ('Paulaner', 'Paulaner Spezi', 37.0, 0.0, 0.0, 0, 9.2, 9.2, 0, 0.0, 0.0),
+    ('Lidl', 'Milch Mandel ohne Zucker', 15.0, 1.1, 0.1, 0, 0.5, 0.1, 0.0, 0.5, 0.2),
+    ('Vemondo', 'Barista Oat Drink', 58.0, 3.2, 0.3, 0, 5.7, 1.6, 1.0, 0.9, 0.1),
+    ('Gerolsteiner', 'Gerolsteiner Medium 1,5 Liter', 0.0, 0.0, 0.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Aldi', 'Bio-Haferdrink Natur', 40.0, 0.8, 0.1, 0, 7.3, 4.2, 0.5, 0.7, 0.1),
+    ('Lidl', 'No Milk Hafer 3,5% Fett', 53.0, 3.5, 0.3, 0, 4.1, 1.2, 1.1, 0.8, 0.1),
+    ('Gut & Günstig', 'Mineralwasser', 0.0, 0.0, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Asia Green Garden', 'Kokosnussmilch Klassik', 207.0, 21.0, 18.6, 0, 2.2, 2.1, 0, 1.8, 0),
+    ('Vemondo', 'No Milk Hafer 1,8% Fett', 38.0, 1.8, 0.2, 0, 4.1, 1.2, 1.1, 0.8, 0.1),
+    ('Berief', 'BiO HAFER NATUR', 40.0, 1.4, 0.2, 0, 6.0, 5.2, 0, 0.6, 0.1),
+    ('Paulaner', 'Spezi Zero', 1.0, 0.0, 0.0, 0, 0.5, 0.5, 0.0, 0.0, 0.0),
+    ('Vemondo', 'Bio Hafer', 37.0, 1.2, 0.2, 0, 5.6, 3.3, 1.0, 0.4, 0.1),
+    ('Berief', 'Bio Hafer ohne Zucker', 42.0, 1.8, 0.3, 0, 5.6, 0.0, 0, 0.8, 0.1),
+    ('DmBio', 'Sojadrink natur', 38.0, 1.9, 0.5, 0, 1.8, 0.7, 0.2, 3.2, 0.0),
+    ('Bensdorp', 'Bensdorp Kakao', 366.0, 21.0, 13.0, 0, 8.9, 0.6, 0.0, 20.0, 0.1),
+    ('Choco', 'Kakao Choco', 389.0, 3.0, 1.3, 0, 83.0, 80.0, 0.0, 3.9, 0.3),
+    ('Vemondo', 'High Protein Sojadrink', 50.0, 2.2, 0.3, 0, 2.5, 2.4, 0.0, 5.0, 0.2),
+    ('Drinks & More GmbH & Co. KG', 'Knabe Malz', 38.0, 0.0, 0, 0, 8.9, 7.1, 0, 0.0, 0.0),
+    ('Rio d''Oro', 'Trauben-Direktsaft', 67.0, 0.0, 0.0, 0, 16.0, 16.0, 0, 0.0, 0.0),
+    ('Alpro', 'Geröstete Mandel Ohne Zucker', 15.0, 1.1, 0.1, 0, 0.0, 0.0, 0.3, 0.5, 0.1),
+    ('Vemondo', 'Bio Hafer ohne Zucker', 33.0, 1.5, 0.2, 0, 3.7, 0.0, 1.0, 0.6, 0.1),
+    ('Pepsi', 'Pepsi Zero Zucker', 0.5, 0.0, 0.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Jever', 'Jever fun 4008948194016 Pilsener alkoholfrei', 15.0, 0.0, 0.0, 0, 0.5, 0.1, 0, 0.1, 0.0),
+    ('Valensia', 'Orange ohne Fruchtfleisch', 43.0, 0.2, 0.0, 0, 9.0, 9.0, 0.2, 0.7, 0.0),
+    ('DmBio', 'Oat Drink - Sugarfree', 42.0, 1.8, 0.3, 0, 5.6, 0.0, 1.1, 0.8, 0.1),
+    ('Red Bull', 'Kokos Blaubeere (Weiß)', 45.0, 0.0, 0, 0, 11.0, 11.0, 0, 0.0, 0.1),
+    ('VEMondo', 'High protein soy with chocolate taste', 64.0, 1.7, 0.3, 0, 7.2, 4.8, 0, 5.0, 0.2),
+    ('Naturalis', 'Getränke - Mineralwasser - Classic', 0.0, 0.0, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Vly', 'Erbsenproteindrink Ungesüsst aus Erbsenprotein', 37.0, 2.5, 0.3, 0, 0.2, 0.0, 2.1, 2.5, 0.1),
+    ('Teekanne', 'Teebeutel Italienische Limone', 2.0, 0.0, 0.0, 0, 0.4, 0.0, 0, 0.0, 0.0),
+    ('Hohes C', 'Saft Plus Eisen', 42.0, 0.0, 0.0, 0, 9.8, 9.1, 0, 0.0, 0.0),
+    ('Pepsi', 'Pepsi', 18.0, 0.0, 0.0, 0, 4.6, 4.6, 0.0, 0.0, 0.0),
+    ('Quellbrunn', 'Mineralwasser Naturell', 0.0, 0.0, 0.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Granini', 'Multivitaminsaft', 45.0, 0.0, 0.0, 0, 10.0, 9.8, 0, 0.0, 0.0),
+    ('Schwip schwap', 'Schwip Schwap Zero', 1.5, 0.0, 0, 0, 0.3, 0.3, 0, 0.0, 0.0),
+    ('Quellbrunn', 'Naturell Mierbachquelle ohne Kohlensäure', 0.0, 0.0, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Müller', 'Müllermilch - Bananen-Geschmack', 67.0, 1.4, 0.9, 0, 10.5, 10.0, 0, 3.2, 0.1),
+    ('Volvic', 'Wasser Volvic naturelle', 0.0, 0.0, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Coca-Cola', 'Coca-Cola Original', 42.0, 0.0, 0.0, 0, 10.6, 10.6, 0, 0.0, 0.0),
+    ('Oatly', 'Haferdrink Barista', 61.0, 3.0, 0.3, 0, 7.1, 3.4, 0.8, 1.1, 0.1),
+    ('Coca-Cola', 'Coca-Cola 1 Liter', 42.0, 0.0, 0.0, 0, 10.6, 10.6, 0.0, 0.0, 0.0),
+    ('Red Bull', 'Red Bull Energydrink Classic', 46.0, 0.0, 0.0, 0, 11.0, 11.0, 0.0, 0.0, 0.1),
+    ('Monster Energy', 'Monster Energy Ultra', 2.0, 0.0, 0.0, 0, 0.9, 0.0, 0.0, 0.0, 0.2),
+    ('Coca-Cola', 'Coca-Cola Zero', 0.2, 0.0, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Alpro', 'Alpro Not Milk', 59.0, 3.5, 0.4, 0, 5.7, 0.0, 1.0, 0.7, 0.1),
+    ('Saskia', 'Mineralwasser still 6 x 1,5 L', 0.0, 0.0, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Cola', 'Coca-Cola Zero', 0.2, 0.0, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Coca-Cola', 'Cola Zero', 0.2, 0.0, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0)
+) as d(brand, product_name, calories, total_fat_g, saturated_fat_g, trans_fat_g,
+       carbs_g, sugars_g, fibre_g, protein_g, salt_g)
+join products p on p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name
+  and p.category = 'Drinks' and p.is_deprecated is not true
+on conflict (product_id) do update set
+  calories = excluded.calories,
+  total_fat_g = excluded.total_fat_g,
+  saturated_fat_g = excluded.saturated_fat_g,
+  trans_fat_g = excluded.trans_fat_g,
+  carbs_g = excluded.carbs_g,
+  sugars_g = excluded.sugars_g,
+  fibre_g = excluded.fibre_g,
+  protein_g = excluded.protein_g,
+  salt_g = excluded.salt_g;

--- a/db/pipelines/drinks-de/PIPELINE__drinks-de__04_scoring.sql
+++ b/db/pipelines/drinks-de/PIPELINE__drinks-de__04_scoring.sql
@@ -1,0 +1,123 @@
+-- PIPELINE (Drinks): scoring
+-- Generated: 2026-02-25
+
+-- 2. Nutri-Score
+update products p set
+  nutri_score_label = d.ns
+from (
+  values
+    ('My Vay', 'Bio-Haferdrink ungesüßt', 'C'),
+    ('Rio d''Oro', 'Apfel-Direktsaft Naturtrüb', 'C'),
+    ('Club Mate', 'Club-Mate Original', 'C'),
+    ('Paulaner', 'Paulaner Spezi', 'E'),
+    ('Lidl', 'Milch Mandel ohne Zucker', 'B'),
+    ('Vemondo', 'Barista Oat Drink', 'C'),
+    ('Gerolsteiner', 'Gerolsteiner Medium 1,5 Liter', 'A'),
+    ('Aldi', 'Bio-Haferdrink Natur', 'C'),
+    ('Lidl', 'No Milk Hafer 3,5% Fett', 'C'),
+    ('Gut & Günstig', 'Mineralwasser', 'A'),
+    ('Asia Green Garden', 'Kokosnussmilch Klassik', 'UNKNOWN'),
+    ('Vemondo', 'No Milk Hafer 1,8% Fett', 'C'),
+    ('Berief', 'BiO HAFER NATUR', 'D'),
+    ('Paulaner', 'Spezi Zero', 'C'),
+    ('Vemondo', 'Bio Hafer', 'C'),
+    ('Berief', 'Bio Hafer ohne Zucker', 'C'),
+    ('DmBio', 'Sojadrink natur', 'B'),
+    ('Bensdorp', 'Bensdorp Kakao', 'UNKNOWN'),
+    ('Choco', 'Kakao Choco', 'UNKNOWN'),
+    ('Vemondo', 'High Protein Sojadrink', 'B'),
+    ('Drinks & More GmbH & Co. KG', 'Knabe Malz', 'D'),
+    ('Rio d''Oro', 'Trauben-Direktsaft', 'E'),
+    ('Alpro', 'Geröstete Mandel Ohne Zucker', 'B'),
+    ('Vemondo', 'Bio Hafer ohne Zucker', 'B'),
+    ('Pepsi', 'Pepsi Zero Zucker', 'C'),
+    ('Jever', 'Jever fun 4008948194016 Pilsener alkoholfrei', 'B'),
+    ('Valensia', 'Orange ohne Fruchtfleisch', 'E'),
+    ('DmBio', 'Oat Drink - Sugarfree', 'C'),
+    ('Red Bull', 'Kokos Blaubeere (Weiß)', 'E'),
+    ('VEMondo', 'High protein soy with chocolate taste', 'B'),
+    ('Naturalis', 'Getränke - Mineralwasser - Classic', 'A'),
+    ('Vly', 'Erbsenproteindrink Ungesüsst aus Erbsenprotein', 'B'),
+    ('Teekanne', 'Teebeutel Italienische Limone', 'UNKNOWN'),
+    ('Hohes C', 'Saft Plus Eisen', 'C'),
+    ('Pepsi', 'Pepsi', 'D'),
+    ('Quellbrunn', 'Mineralwasser Naturell', 'A'),
+    ('Granini', 'Multivitaminsaft', 'D'),
+    ('Schwip schwap', 'Schwip Schwap Zero', 'C'),
+    ('Quellbrunn', 'Naturell Mierbachquelle ohne Kohlensäure', 'A'),
+    ('Müller', 'Müllermilch - Bananen-Geschmack', 'D'),
+    ('Volvic', 'Wasser Volvic naturelle', 'A'),
+    ('Coca-Cola', 'Coca-Cola Original', 'E'),
+    ('Oatly', 'Haferdrink Barista', 'D'),
+    ('Coca-Cola', 'Coca-Cola 1 Liter', 'E'),
+    ('Red Bull', 'Red Bull Energydrink Classic', 'E'),
+    ('Monster Energy', 'Monster Energy Ultra', 'C'),
+    ('Coca-Cola', 'Coca-Cola Zero', 'C'),
+    ('Alpro', 'Alpro Not Milk', 'C'),
+    ('Saskia', 'Mineralwasser still 6 x 1,5 L', 'A'),
+    ('Cola', 'Coca-Cola Zero', 'C'),
+    ('Coca-Cola', 'Cola Zero', 'B')
+) as d(brand, product_name, ns)
+where p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name;
+
+-- 3. NOVA classification
+update products p set
+  nova_classification = d.nova
+from (
+  values
+    ('My Vay', 'Bio-Haferdrink ungesüßt', '3'),
+    ('Rio d''Oro', 'Apfel-Direktsaft Naturtrüb', '1'),
+    ('Club Mate', 'Club-Mate Original', '4'),
+    ('Paulaner', 'Paulaner Spezi', '4'),
+    ('Lidl', 'Milch Mandel ohne Zucker', '4'),
+    ('Vemondo', 'Barista Oat Drink', '4'),
+    ('Gerolsteiner', 'Gerolsteiner Medium 1,5 Liter', '1'),
+    ('Aldi', 'Bio-Haferdrink Natur', '3'),
+    ('Lidl', 'No Milk Hafer 3,5% Fett', '4'),
+    ('Gut & Günstig', 'Mineralwasser', '4'),
+    ('Asia Green Garden', 'Kokosnussmilch Klassik', '4'),
+    ('Vemondo', 'No Milk Hafer 1,8% Fett', '4'),
+    ('Berief', 'BiO HAFER NATUR', '3'),
+    ('Paulaner', 'Spezi Zero', '4'),
+    ('Vemondo', 'Bio Hafer', '4'),
+    ('Berief', 'Bio Hafer ohne Zucker', '3'),
+    ('DmBio', 'Sojadrink natur', '1'),
+    ('Bensdorp', 'Bensdorp Kakao', '1'),
+    ('Choco', 'Kakao Choco', '4'),
+    ('Vemondo', 'High Protein Sojadrink', '4'),
+    ('Drinks & More GmbH & Co. KG', 'Knabe Malz', '4'),
+    ('Rio d''Oro', 'Trauben-Direktsaft', '1'),
+    ('Alpro', 'Geröstete Mandel Ohne Zucker', '4'),
+    ('Vemondo', 'Bio Hafer ohne Zucker', '4'),
+    ('Pepsi', 'Pepsi Zero Zucker', '4'),
+    ('Jever', 'Jever fun 4008948194016 Pilsener alkoholfrei', '4'),
+    ('Valensia', 'Orange ohne Fruchtfleisch', '4'),
+    ('DmBio', 'Oat Drink - Sugarfree', '3'),
+    ('Red Bull', 'Kokos Blaubeere (Weiß)', '4'),
+    ('VEMondo', 'High protein soy with chocolate taste', '4'),
+    ('Naturalis', 'Getränke - Mineralwasser - Classic', '1'),
+    ('Vly', 'Erbsenproteindrink Ungesüsst aus Erbsenprotein', '4'),
+    ('Teekanne', 'Teebeutel Italienische Limone', '4'),
+    ('Hohes C', 'Saft Plus Eisen', '1'),
+    ('Pepsi', 'Pepsi', '4'),
+    ('Quellbrunn', 'Mineralwasser Naturell', '4'),
+    ('Granini', 'Multivitaminsaft', '3'),
+    ('Schwip schwap', 'Schwip Schwap Zero', '4'),
+    ('Quellbrunn', 'Naturell Mierbachquelle ohne Kohlensäure', '1'),
+    ('Müller', 'Müllermilch - Bananen-Geschmack', '4'),
+    ('Volvic', 'Wasser Volvic naturelle', '1'),
+    ('Coca-Cola', 'Coca-Cola Original', '4'),
+    ('Oatly', 'Haferdrink Barista', '3'),
+    ('Coca-Cola', 'Coca-Cola 1 Liter', '4'),
+    ('Red Bull', 'Red Bull Energydrink Classic', '4'),
+    ('Monster Energy', 'Monster Energy Ultra', '4'),
+    ('Coca-Cola', 'Coca-Cola Zero', '4'),
+    ('Alpro', 'Alpro Not Milk', '4'),
+    ('Saskia', 'Mineralwasser still 6 x 1,5 L', '1'),
+    ('Cola', 'Coca-Cola Zero', '4'),
+    ('Coca-Cola', 'Cola Zero', '4')
+) as d(brand, product_name, nova)
+where p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name;
+
+-- 0/1/4/5. Score category (concern defaults, unhealthiness, flags, confidence)
+CALL score_category('Drinks', 100, 'DE');

--- a/db/pipelines/drinks-de/PIPELINE__drinks-de__05_source_provenance.sql
+++ b/db/pipelines/drinks-de/PIPELINE__drinks-de__05_source_provenance.sql
@@ -1,0 +1,65 @@
+-- PIPELINE (Drinks): source provenance
+-- Generated: 2026-02-25
+
+-- 1. Update source info on products
+UPDATE products p SET
+  source_type = 'off_api',
+  source_url = d.source_url,
+  source_ean = d.source_ean
+FROM (
+  VALUES
+    ('My Vay', 'Bio-Haferdrink ungesüßt', 'https://world.openfoodfacts.org/product/4061464811218', '4061464811218'),
+    ('Rio d''Oro', 'Apfel-Direktsaft Naturtrüb', 'https://world.openfoodfacts.org/product/4061458061117', '4061458061117'),
+    ('Club Mate', 'Club-Mate Original', 'https://world.openfoodfacts.org/product/4029764001807', '4029764001807'),
+    ('Paulaner', 'Paulaner Spezi', 'https://world.openfoodfacts.org/product/4066600603405', '4066600603405'),
+    ('Lidl', 'Milch Mandel ohne Zucker', 'https://world.openfoodfacts.org/product/4056489687641', '4056489687641'),
+    ('Vemondo', 'Barista Oat Drink', 'https://world.openfoodfacts.org/product/4056489989363', '4056489989363'),
+    ('Gerolsteiner', 'Gerolsteiner Medium 1,5 Liter', 'https://world.openfoodfacts.org/product/4001513007704', '4001513007704'),
+    ('Aldi', 'Bio-Haferdrink Natur', 'https://world.openfoodfacts.org/product/4061459133271', '4061459133271'),
+    ('Lidl', 'No Milk Hafer 3,5% Fett', 'https://world.openfoodfacts.org/product/4056489708995', '4056489708995'),
+    ('Gut & Günstig', 'Mineralwasser', 'https://world.openfoodfacts.org/product/40554006', '40554006'),
+    ('Asia Green Garden', 'Kokosnussmilch Klassik', 'https://world.openfoodfacts.org/product/4061458004121', '4061458004121'),
+    ('Vemondo', 'No Milk Hafer 1,8% Fett', 'https://world.openfoodfacts.org/product/4056489708988', '4056489708988'),
+    ('Berief', 'BiO HAFER NATUR', 'https://world.openfoodfacts.org/product/4004790017565', '4004790017565'),
+    ('Paulaner', 'Spezi Zero', 'https://world.openfoodfacts.org/product/4066600204404', '4066600204404'),
+    ('Vemondo', 'Bio Hafer', 'https://world.openfoodfacts.org/product/4056489997511', '4056489997511'),
+    ('Berief', 'Bio Hafer ohne Zucker', 'https://world.openfoodfacts.org/product/4004790037358', '4004790037358'),
+    ('DmBio', 'Sojadrink natur', 'https://world.openfoodfacts.org/product/4067796002089', '4067796002089'),
+    ('Bensdorp', 'Bensdorp Kakao', 'https://world.openfoodfacts.org/product/4001743754539', '4001743754539'),
+    ('Choco', 'Kakao Choco', 'https://world.openfoodfacts.org/product/4052700022932', '4052700022932'),
+    ('Vemondo', 'High Protein Sojadrink', 'https://world.openfoodfacts.org/product/4056489689720', '4056489689720'),
+    ('Drinks & More GmbH & Co. KG', 'Knabe Malz', 'https://world.openfoodfacts.org/product/4008287959192', '4008287959192'),
+    ('Rio d''Oro', 'Trauben-Direktsaft', 'https://world.openfoodfacts.org/product/4061458028998', '4061458028998'),
+    ('Alpro', 'Geröstete Mandel Ohne Zucker', 'https://world.openfoodfacts.org/product/5411188112709', '5411188112709'),
+    ('Vemondo', 'Bio Hafer ohne Zucker', 'https://world.openfoodfacts.org/product/4056489983477', '4056489983477'),
+    ('Pepsi', 'Pepsi Zero Zucker', 'https://world.openfoodfacts.org/product/4062139025299', '4062139025299'),
+    ('Jever', 'Jever fun 4008948194016 Pilsener alkoholfrei', 'https://world.openfoodfacts.org/product/4008948194016', '4008948194016'),
+    ('Valensia', 'Orange ohne Fruchtfleisch', 'https://world.openfoodfacts.org/product/4009491021354', '4009491021354'),
+    ('DmBio', 'Oat Drink - Sugarfree', 'https://world.openfoodfacts.org/product/4067796000207', '4067796000207'),
+    ('Red Bull', 'Kokos Blaubeere (Weiß)', 'https://world.openfoodfacts.org/product/90433627', '90433627'),
+    ('VEMondo', 'High protein soy with chocolate taste', 'https://world.openfoodfacts.org/product/4056489749455', '4056489749455'),
+    ('Naturalis', 'Getränke - Mineralwasser - Classic', 'https://world.openfoodfacts.org/product/42287995', '42287995'),
+    ('Vly', 'Erbsenproteindrink Ungesüsst aus Erbsenprotein', 'https://world.openfoodfacts.org/product/4280001939042', '4280001939042'),
+    ('Teekanne', 'Teebeutel Italienische Limone', 'https://world.openfoodfacts.org/product/4009300014492', '4009300014492'),
+    ('Hohes C', 'Saft Plus Eisen', 'https://world.openfoodfacts.org/product/4048517746086', '4048517746086'),
+    ('Pepsi', 'Pepsi', 'https://world.openfoodfacts.org/product/4062139025251', '4062139025251'),
+    ('Quellbrunn', 'Mineralwasser Naturell', 'https://world.openfoodfacts.org/product/4061458252690', '4061458252690'),
+    ('Granini', 'Multivitaminsaft', 'https://world.openfoodfacts.org/product/4048517742040', '4048517742040'),
+    ('Schwip schwap', 'Schwip Schwap Zero', 'https://world.openfoodfacts.org/product/4062139025473', '4062139025473'),
+    ('Quellbrunn', 'Naturell Mierbachquelle ohne Kohlensäure', 'https://world.openfoodfacts.org/product/42142195', '42142195'),
+    ('Müller', 'Müllermilch - Bananen-Geschmack', 'https://world.openfoodfacts.org/product/42448860', '42448860'),
+    ('Volvic', 'Wasser Volvic naturelle', 'https://world.openfoodfacts.org/product/3057640186158', '3057640186158'),
+    ('Coca-Cola', 'Coca-Cola Original', 'https://world.openfoodfacts.org/product/5000112546415', '5000112546415'),
+    ('Oatly', 'Haferdrink Barista', 'https://world.openfoodfacts.org/product/7394376616501', '7394376616501'),
+    ('Coca-Cola', 'Coca-Cola 1 Liter', 'https://world.openfoodfacts.org/product/5449000017888', '5449000017888'),
+    ('Red Bull', 'Red Bull Energydrink Classic', 'https://world.openfoodfacts.org/product/90162565', '90162565'),
+    ('Monster Energy', 'Monster Energy Ultra', 'https://world.openfoodfacts.org/product/5060337500401', '5060337500401'),
+    ('Coca-Cola', 'Coca-Cola Zero', 'https://world.openfoodfacts.org/product/5000112576009', '5000112576009'),
+    ('Alpro', 'Alpro Not Milk', 'https://world.openfoodfacts.org/product/5411188134985', '5411188134985'),
+    ('Saskia', 'Mineralwasser still 6 x 1,5 L', 'https://world.openfoodfacts.org/product/42143819', '42143819'),
+    ('Cola', 'Coca-Cola Zero', 'https://world.openfoodfacts.org/product/5449000134264', '5449000134264'),
+    ('Coca-Cola', 'Cola Zero', 'https://world.openfoodfacts.org/product/5000112604450', '5000112604450')
+) AS d(brand, product_name, source_url, source_ean)
+WHERE p.country = 'DE' AND p.brand = d.brand
+  AND p.product_name = d.product_name
+  AND p.category = 'Drinks' AND p.is_deprecated IS NOT TRUE;

--- a/db/pipelines/drinks-de/PIPELINE__drinks-de__06_add_images.sql
+++ b/db/pipelines/drinks-de/PIPELINE__drinks-de__06_add_images.sql
@@ -1,0 +1,79 @@
+-- PIPELINE (Drinks): add product images
+-- Source: Open Food Facts API image URLs
+-- Generated: 2026-02-25
+
+-- 1. Remove existing OFF images for this category
+DELETE FROM product_images
+WHERE source = 'off_api'
+  AND product_id IN (
+    SELECT p.product_id FROM products p
+    WHERE p.country = 'DE' AND p.category = 'Drinks'
+      AND p.is_deprecated IS NOT TRUE
+  );
+
+-- 2. Insert images
+INSERT INTO product_images
+  (product_id, url, source, image_type, is_primary, alt_text, off_image_id)
+SELECT
+  p.product_id, d.url, d.source, d.image_type, d.is_primary, d.alt_text, d.off_image_id
+FROM (
+  VALUES
+    ('My Vay', 'Bio-Haferdrink ungesüßt', 'https://images.openfoodfacts.org/images/products/406/146/481/1218/front_de.70.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061464811218', 'front_4061464811218'),
+    ('Rio d''Oro', 'Apfel-Direktsaft Naturtrüb', 'https://images.openfoodfacts.org/images/products/406/145/806/1117/front_de.186.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458061117', 'front_4061458061117'),
+    ('Club Mate', 'Club-Mate Original', 'https://images.openfoodfacts.org/images/products/402/976/400/1807/front_en.227.400.jpg', 'off_api', 'front', true, 'Front — EAN 4029764001807', 'front_4029764001807'),
+    ('Paulaner', 'Paulaner Spezi', 'https://images.openfoodfacts.org/images/products/406/660/060/3405/front_de.143.400.jpg', 'off_api', 'front', true, 'Front — EAN 4066600603405', 'front_4066600603405'),
+    ('Lidl', 'Milch Mandel ohne Zucker', 'https://images.openfoodfacts.org/images/products/405/648/968/7641/front_en.106.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489687641', 'front_4056489687641'),
+    ('Vemondo', 'Barista Oat Drink', 'https://images.openfoodfacts.org/images/products/405/648/998/9363/front_de.26.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489989363', 'front_4056489989363'),
+    ('Gerolsteiner', 'Gerolsteiner Medium 1,5 Liter', 'https://images.openfoodfacts.org/images/products/400/151/300/7704/front_de.59.400.jpg', 'off_api', 'front', true, 'Front — EAN 4001513007704', 'front_4001513007704'),
+    ('Aldi', 'Bio-Haferdrink Natur', 'https://images.openfoodfacts.org/images/products/406/145/913/3271/front_de.71.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061459133271', 'front_4061459133271'),
+    ('Lidl', 'No Milk Hafer 3,5% Fett', 'https://images.openfoodfacts.org/images/products/405/648/970/8995/front_de.49.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489708995', 'front_4056489708995'),
+    ('Gut & Günstig', 'Mineralwasser', 'https://images.openfoodfacts.org/images/products/000/004/055/4006/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 40554006', 'front_40554006'),
+    ('Asia Green Garden', 'Kokosnussmilch Klassik', 'https://images.openfoodfacts.org/images/products/406/145/800/4121/front_de.161.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458004121', 'front_4061458004121'),
+    ('Vemondo', 'No Milk Hafer 1,8% Fett', 'https://images.openfoodfacts.org/images/products/405/648/970/8988/front_de.38.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489708988', 'front_4056489708988'),
+    ('Berief', 'BiO HAFER NATUR', 'https://images.openfoodfacts.org/images/products/400/479/001/7565/front_en.56.400.jpg', 'off_api', 'front', true, 'Front — EAN 4004790017565', 'front_4004790017565'),
+    ('Paulaner', 'Spezi Zero', 'https://images.openfoodfacts.org/images/products/406/660/020/4404/front_de.20.400.jpg', 'off_api', 'front', true, 'Front — EAN 4066600204404', 'front_4066600204404'),
+    ('Vemondo', 'Bio Hafer', 'https://images.openfoodfacts.org/images/products/405/648/999/7511/front_de.92.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489997511', 'front_4056489997511'),
+    ('Berief', 'Bio Hafer ohne Zucker', 'https://images.openfoodfacts.org/images/products/400/479/003/7358/front_de.23.400.jpg', 'off_api', 'front', true, 'Front — EAN 4004790037358', 'front_4004790037358'),
+    ('DmBio', 'Sojadrink natur', 'https://images.openfoodfacts.org/images/products/406/779/600/2089/front_de.32.400.jpg', 'off_api', 'front', true, 'Front — EAN 4067796002089', 'front_4067796002089'),
+    ('Bensdorp', 'Bensdorp Kakao', 'https://images.openfoodfacts.org/images/products/400/174/375/4539/front_en.59.400.jpg', 'off_api', 'front', true, 'Front — EAN 4001743754539', 'front_4001743754539'),
+    ('Choco', 'Kakao Choco', 'https://images.openfoodfacts.org/images/products/405/270/002/2932/front_de.5.400.jpg', 'off_api', 'front', true, 'Front — EAN 4052700022932', 'front_4052700022932'),
+    ('Vemondo', 'High Protein Sojadrink', 'https://images.openfoodfacts.org/images/products/405/648/968/9720/front_en.62.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489689720', 'front_4056489689720'),
+    ('Drinks & More GmbH & Co. KG', 'Knabe Malz', 'https://images.openfoodfacts.org/images/products/400/828/795/9192/front_de.21.400.jpg', 'off_api', 'front', true, 'Front — EAN 4008287959192', 'front_4008287959192'),
+    ('Rio d''Oro', 'Trauben-Direktsaft', 'https://images.openfoodfacts.org/images/products/406/145/802/8998/front_de.65.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458028998', 'front_4061458028998'),
+    ('Alpro', 'Geröstete Mandel Ohne Zucker', 'https://images.openfoodfacts.org/images/products/541/118/811/2709/front_en.927.400.jpg', 'off_api', 'front', true, 'Front — EAN 5411188112709', 'front_5411188112709'),
+    ('Vemondo', 'Bio Hafer ohne Zucker', 'https://images.openfoodfacts.org/images/products/405/648/998/3477/front_de.22.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489983477', 'front_4056489983477'),
+    ('Pepsi', 'Pepsi Zero Zucker', 'https://images.openfoodfacts.org/images/products/406/213/902/5299/front_de.18.400.jpg', 'off_api', 'front', true, 'Front — EAN 4062139025299', 'front_4062139025299'),
+    ('Jever', 'Jever fun 4008948194016 Pilsener alkoholfrei', 'https://images.openfoodfacts.org/images/products/400/894/819/4016/front_en.32.400.jpg', 'off_api', 'front', true, 'Front — EAN 4008948194016', 'front_4008948194016'),
+    ('Valensia', 'Orange ohne Fruchtfleisch', 'https://images.openfoodfacts.org/images/products/400/949/102/1354/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4009491021354', 'front_4009491021354'),
+    ('DmBio', 'Oat Drink - Sugarfree', 'https://images.openfoodfacts.org/images/products/406/779/600/0207/front_en.7.400.jpg', 'off_api', 'front', true, 'Front — EAN 4067796000207', 'front_4067796000207'),
+    ('Red Bull', 'Kokos Blaubeere (Weiß)', 'https://images.openfoodfacts.org/images/products/000/009/043/3627/front_de.72.400.jpg', 'off_api', 'front', true, 'Front — EAN 90433627', 'front_90433627'),
+    ('VEMondo', 'High protein soy with chocolate taste', 'https://images.openfoodfacts.org/images/products/405/648/974/9455/front_en.32.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489749455', 'front_4056489749455'),
+    ('Naturalis', 'Getränke - Mineralwasser - Classic', 'https://images.openfoodfacts.org/images/products/000/004/228/7995/front_de.62.400.jpg', 'off_api', 'front', true, 'Front — EAN 42287995', 'front_42287995'),
+    ('Vly', 'Erbsenproteindrink Ungesüsst aus Erbsenprotein', 'https://images.openfoodfacts.org/images/products/428/000/193/9042/front_de.84.400.jpg', 'off_api', 'front', true, 'Front — EAN 4280001939042', 'front_4280001939042'),
+    ('Teekanne', 'Teebeutel Italienische Limone', 'https://images.openfoodfacts.org/images/products/400/930/001/4492/front_de.59.400.jpg', 'off_api', 'front', true, 'Front — EAN 4009300014492', 'front_4009300014492'),
+    ('Hohes C', 'Saft Plus Eisen', 'https://images.openfoodfacts.org/images/products/404/851/774/6086/front_de.18.400.jpg', 'off_api', 'front', true, 'Front — EAN 4048517746086', 'front_4048517746086'),
+    ('Pepsi', 'Pepsi', 'https://images.openfoodfacts.org/images/products/406/213/902/5251/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4062139025251', 'front_4062139025251'),
+    ('Quellbrunn', 'Mineralwasser Naturell', 'https://images.openfoodfacts.org/images/products/406/145/825/2690/front_de.36.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458252690', 'front_4061458252690'),
+    ('Granini', 'Multivitaminsaft', 'https://images.openfoodfacts.org/images/products/404/851/774/2040/front_de.30.400.jpg', 'off_api', 'front', true, 'Front — EAN 4048517742040', 'front_4048517742040'),
+    ('Schwip schwap', 'Schwip Schwap Zero', 'https://images.openfoodfacts.org/images/products/406/213/902/5473/front_de.20.400.jpg', 'off_api', 'front', true, 'Front — EAN 4062139025473', 'front_4062139025473'),
+    ('Quellbrunn', 'Naturell Mierbachquelle ohne Kohlensäure', 'https://images.openfoodfacts.org/images/products/000/004/214/2195/front_de.54.400.jpg', 'off_api', 'front', true, 'Front — EAN 42142195', 'front_42142195'),
+    ('Müller', 'Müllermilch - Bananen-Geschmack', 'https://images.openfoodfacts.org/images/products/000/004/244/8860/front_de.31.400.jpg', 'off_api', 'front', true, 'Front — EAN 42448860', 'front_42448860'),
+    ('Volvic', 'Wasser Volvic naturelle', 'https://images.openfoodfacts.org/images/products/305/764/018/6158/front_de.79.400.jpg', 'off_api', 'front', true, 'Front — EAN 3057640186158', 'front_3057640186158'),
+    ('Coca-Cola', 'Coca-Cola Original', 'https://images.openfoodfacts.org/images/products/500/011/254/6415/front_de.137.400.jpg', 'off_api', 'front', true, 'Front — EAN 5000112546415', 'front_5000112546415'),
+    ('Oatly', 'Haferdrink Barista', 'https://images.openfoodfacts.org/images/products/739/437/661/6501/front_en.190.400.jpg', 'off_api', 'front', true, 'Front — EAN 7394376616501', 'front_7394376616501'),
+    ('Coca-Cola', 'Coca-Cola 1 Liter', 'https://images.openfoodfacts.org/images/products/544/900/001/7888/front_de.147.400.jpg', 'off_api', 'front', true, 'Front — EAN 5449000017888', 'front_5449000017888'),
+    ('Red Bull', 'Red Bull Energydrink Classic', 'https://images.openfoodfacts.org/images/products/000/009/016/2565/front_en.16.400.jpg', 'off_api', 'front', true, 'Front — EAN 90162565', 'front_90162565'),
+    ('Monster Energy', 'Monster Energy Ultra', 'https://images.openfoodfacts.org/images/products/506/033/750/0401/front_de.56.400.jpg', 'off_api', 'front', true, 'Front — EAN 5060337500401', 'front_5060337500401'),
+    ('Coca-Cola', 'Coca-Cola Zero', 'https://images.openfoodfacts.org/images/products/500/011/257/6009/front_de.108.400.jpg', 'off_api', 'front', true, 'Front — EAN 5000112576009', 'front_5000112576009'),
+    ('Alpro', 'Alpro Not Milk', 'https://images.openfoodfacts.org/images/products/541/118/813/4985/front_en.131.400.jpg', 'off_api', 'front', true, 'Front — EAN 5411188134985', 'front_5411188134985'),
+    ('Saskia', 'Mineralwasser still 6 x 1,5 L', 'https://images.openfoodfacts.org/images/products/000/004/214/3819/front_de.33.400.jpg', 'off_api', 'front', true, 'Front — EAN 42143819', 'front_42143819'),
+    ('Cola', 'Coca-Cola Zero', 'https://images.openfoodfacts.org/images/products/544/900/013/4264/front_en.65.400.jpg', 'off_api', 'front', true, 'Front — EAN 5449000134264', 'front_5449000134264'),
+    ('Coca-Cola', 'Cola Zero', 'https://images.openfoodfacts.org/images/products/500/011/260/4450/front_de.18.400.jpg', 'off_api', 'front', true, 'Front — EAN 5000112604450', 'front_5000112604450')
+) AS d(brand, product_name, url, source, image_type, is_primary, alt_text, off_image_id)
+JOIN products p ON p.country = 'DE' AND p.brand = d.brand AND p.product_name = d.product_name
+  AND p.category = 'Drinks' AND p.is_deprecated IS NOT TRUE
+ON CONFLICT (off_image_id) WHERE off_image_id IS NOT NULL DO UPDATE SET
+  url = EXCLUDED.url,
+  image_type = EXCLUDED.image_type,
+  is_primary = EXCLUDED.is_primary,
+  alt_text = EXCLUDED.alt_text;

--- a/db/pipelines/sweets-de/PIPELINE__sweets-de__01_insert_products.sql
+++ b/db/pipelines/sweets-de/PIPELINE__sweets-de__01_insert_products.sql
@@ -1,0 +1,85 @@
+-- PIPELINE (Sweets): insert products
+-- Source: Open Food Facts API (automated pipeline)
+-- Generated: 2026-02-25
+
+-- 0a. DEPRECATE old products in this category & release their EANs
+update products
+set is_deprecated = true, deprecated_reason = 'Replaced by pipeline refresh', ean = null
+where country = 'DE'
+  and category = 'Sweets'
+  and is_deprecated is not true;
+
+-- 0b. Release EANs across ALL categories to prevent unique constraint conflicts
+update products set ean = null
+where ean in ('40084060', '4000417693310', '40084107', '4056489471264', '4061458021630', '4000417693815', '4061462044809', '40896243', '4061458021593', '4000417602015', '4000417602510', '4061459208078', '4000417601810', '4000417602619', '4000539150869', '4000417670014', '4000607151200', '4061462452772', '4000417602114', '4006814001796', '4030387760866', '4061458021616', '4061458022002', '4061458160964', '4000417670915', '4000539003509', '40896250', '4000417629418', '4000417693211', '4000417670410', '4000539671203', '4000607151002', '4008400524023', '4000417602718', '4000417602213', '4000417621412', '4025700001450', '4000417601216', '4061458021753', '4061458021883', '4006040488897', '4000417622211', '4000417623713', '4000607730900', '4000417601513', '4008400511825', '4014400917956', '4061458021647', '4000417106100', '4000417670311', '4000417628510')
+  and ean is not null;
+
+-- 1. INSERT products
+insert into products (country, brand, product_type, category, product_name, prep_method, store_availability, controversies, ean)
+values
+  ('DE', 'Ferrero', 'Grocery', 'Sweets', 'Ferrero Yogurette 40084060 Gefüllte Vollmilchschokolade mit Magermilchjoghurt-Erdbeer-Creme', 'not-applicable', 'Lidl', 'none', '40084060'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Kakao-Klasse Die Kräftige 74%', 'not-applicable', null, 'none', '4000417693310'),
+  ('DE', 'Kinder', 'Grocery', 'Sweets', 'Überraschung', 'not-applicable', null, 'none', '40084107'),
+  ('DE', 'J. D. Gross', 'Grocery', 'Sweets', 'Edelbitter Mild 90%', 'not-applicable', 'Lidl', 'none', '4056489471264'),
+  ('DE', 'Moser Roth', 'Grocery', 'Sweets', 'Edelbitter-Schokolade 85 % Cacao', 'not-applicable', 'Aldi', 'none', '4061458021630'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Kakao Klasse die Starke - 81%', 'not-applicable', 'Aldi', 'none', '4000417693815'),
+  ('DE', 'Moser Roth', 'Grocery', 'Sweets', 'Edelbitter 90 % Cacao', 'not-applicable', 'Aldi', 'none', '4061462044809'),
+  ('DE', 'Lidl', 'Grocery', 'Sweets', 'Lidl Organic Dark Chocolate', 'not-applicable', 'Lidl', 'none', '40896243'),
+  ('DE', 'Aldi', 'Grocery', 'Sweets', 'Edelbitter-Schokolade 70% Cacao', 'not-applicable', 'Aldi', 'none', '4061458021593'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Schokolade Halbbitter', 'not-applicable', null, 'none', '4000417602015'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Marzipan', 'not-applicable', 'Lidl', 'none', '4000417602510'),
+  ('DE', 'Aldi', 'Grocery', 'Sweets', 'Edelbitter- Schokolade', 'not-applicable', 'Aldi', 'none', '4061459208078'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Alpenmilch', 'not-applicable', 'Netto', 'none', '4000417601810'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Ritter Sport Nugat', 'not-applicable', 'Netto', 'none', '4000417602619'),
+  ('DE', 'Lindt', 'Grocery', 'Sweets', 'Lindt Dubai Style Chocolade', 'not-applicable', null, 'none', '4000539150869'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Ritter Sport Voll-Nuss', 'not-applicable', null, 'none', '4000417670014'),
+  ('DE', 'Schogetten', 'Grocery', 'Sweets', 'Schogetten originals: Edel-Zartbitter', 'not-applicable', null, 'none', '4000607151200'),
+  ('DE', 'Choceur', 'Grocery', 'Sweets', 'Aldi-Gipfel', 'not-applicable', 'Aldi', 'none', '4061462452772'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Edel-Vollmilch', 'not-applicable', 'Kaufland', 'none', '4000417602114'),
+  ('DE', 'Müller & Müller GmbH', 'Grocery', 'Sweets', 'Blockschokolade', 'not-applicable', null, 'none', '4006814001796'),
+  ('DE', 'Sarotti', 'Grocery', 'Sweets', 'Mild 85%', 'not-applicable', null, 'none', '4030387760866'),
+  ('DE', 'Aldi', 'Grocery', 'Sweets', 'Nussknacker - Vollmilchschokolade', 'not-applicable', 'Aldi', 'none', '4061458021616'),
+  ('DE', 'Aldi', 'Grocery', 'Sweets', 'Nussknacker - Zartbitterschokolade', 'not-applicable', 'Aldi', 'none', '4061458022002'),
+  ('DE', 'Back Family', 'Grocery', 'Sweets', 'Schoko-Chunks - Zartbitter', 'not-applicable', 'Aldi', 'none', '4061458160964'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Pistachio', 'not-applicable', 'Tesco', 'none', '4000417670915'),
+  ('DE', 'Lindt', 'Grocery', 'Sweets', 'Excellence Mild 70%', 'not-applicable', null, 'none', '4000539003509'),
+  ('DE', 'Fairglobe', 'Grocery', 'Sweets', 'Bio Vollmilch-Schokolade', 'not-applicable', 'Lidl', 'none', '40896250'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Kakao-Mousse', 'not-applicable', null, 'none', '4000417629418'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Kakao Klasse 61 die feine aus Nicaragua', 'not-applicable', null, 'none', '4000417693211'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Ritter Sport Honig Salz Mandel', 'not-applicable', 'Netto', 'none', '4000417670410'),
+  ('DE', 'Lindt', 'Grocery', 'Sweets', 'Gold Bunny', 'not-applicable', 'Kaufland', 'none', '4000539671203'),
+  ('DE', 'Schogetten', 'Grocery', 'Sweets', 'Schogetten - Edel-Alpenvollmilchschokolade', 'not-applicable', null, 'none', '4000607151002'),
+  ('DE', 'Ferrero', 'Grocery', 'Sweets', 'Kinder Osterhase - Harry Hase', 'not-applicable', 'Netto', 'none', '4008400524023'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Joghurt', 'not-applicable', 'Netto', 'none', '4000417602718'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Trauben Nuss', 'not-applicable', 'Netto', 'none', '4000417602213'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Knusperkeks', 'not-applicable', null, 'none', '4000417621412'),
+  ('DE', 'Milka', 'Grocery', 'Sweets', 'Schokolade Joghurt', 'not-applicable', 'Żabka', 'none', '4025700001450'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Rum Trauben Nuss Schokolade', 'not-applicable', null, 'none', '4000417601216'),
+  ('DE', 'Aldi', 'Grocery', 'Sweets', 'Schokolade (Alpen-Sahne-)', 'not-applicable', 'Aldi', 'none', '4061458021753'),
+  ('DE', 'Aldi', 'Grocery', 'Sweets', 'Erdbeer-Joghurt', 'not-applicable', 'Aldi', 'none', '4061458021883'),
+  ('DE', 'Rapunzel', 'Grocery', 'Sweets', 'Nirwana Vegan', 'not-applicable', null, 'none', '4006040488897'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Haselnuss', 'not-applicable', null, 'none', '4000417622211'),
+  ('DE', 'Ritter SPORT', 'Grocery', 'Sweets', 'Ritter Sport Erdbeer', 'not-applicable', null, 'none', '4000417623713'),
+  ('DE', 'Schogetten', 'Grocery', 'Sweets', 'Schogetten Edel-Zartbitter-Haselnuss', 'not-applicable', 'Kaufland', 'none', '4000607730900'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Amicelli', 'not-applicable', null, 'none', '4000417601513'),
+  ('DE', 'Ferrero', 'Grocery', 'Sweets', 'Kinder Weihnachtsmann', 'not-applicable', null, 'none', '4008400511825'),
+  ('DE', 'Merci', 'Grocery', 'Sweets', 'Finest Selection Mandel Knusper Vielfalt', 'not-applicable', null, 'none', '4014400917956'),
+  ('DE', 'Aldi', 'Grocery', 'Sweets', 'Rahm Mandel', 'not-applicable', 'Aldi', 'none', '4061458021647'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Vegan Roasted Peanut', 'roasted', null, 'none', '4000417106100'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Nussklasse Ganze Mandel', 'not-applicable', null, 'none', '4000417670311'),
+  ('DE', 'Ritter Sport', 'Grocery', 'Sweets', 'Ritter Sport Lemon', 'not-applicable', null, 'none', '4000417628510')
+on conflict (country, brand, product_name) do update set
+  category = excluded.category,
+  ean = excluded.ean,
+  product_type = excluded.product_type,
+  store_availability = excluded.store_availability,
+  controversies = excluded.controversies,
+  prep_method = excluded.prep_method,
+  is_deprecated = false;
+
+-- 2. DEPRECATE removed products
+update products
+set is_deprecated = true, deprecated_reason = 'Removed from pipeline batch'
+where country = 'DE' and category = 'Sweets'
+  and is_deprecated is not true
+  and product_name not in ('Ferrero Yogurette 40084060 Gefüllte Vollmilchschokolade mit Magermilchjoghurt-Erdbeer-Creme', 'Kakao-Klasse Die Kräftige 74%', 'Überraschung', 'Edelbitter Mild 90%', 'Edelbitter-Schokolade 85 % Cacao', 'Kakao Klasse die Starke - 81%', 'Edelbitter 90 % Cacao', 'Lidl Organic Dark Chocolate', 'Edelbitter-Schokolade 70% Cacao', 'Schokolade Halbbitter', 'Marzipan', 'Edelbitter- Schokolade', 'Alpenmilch', 'Ritter Sport Nugat', 'Lindt Dubai Style Chocolade', 'Ritter Sport Voll-Nuss', 'Schogetten originals: Edel-Zartbitter', 'Aldi-Gipfel', 'Edel-Vollmilch', 'Blockschokolade', 'Mild 85%', 'Nussknacker - Vollmilchschokolade', 'Nussknacker - Zartbitterschokolade', 'Schoko-Chunks - Zartbitter', 'Pistachio', 'Excellence Mild 70%', 'Bio Vollmilch-Schokolade', 'Kakao-Mousse', 'Kakao Klasse 61 die feine aus Nicaragua', 'Ritter Sport Honig Salz Mandel', 'Gold Bunny', 'Schogetten - Edel-Alpenvollmilchschokolade', 'Kinder Osterhase - Harry Hase', 'Joghurt', 'Trauben Nuss', 'Knusperkeks', 'Schokolade Joghurt', 'Rum Trauben Nuss Schokolade', 'Schokolade (Alpen-Sahne-)', 'Erdbeer-Joghurt', 'Nirwana Vegan', 'Haselnuss', 'Ritter Sport Erdbeer', 'Schogetten Edel-Zartbitter-Haselnuss', 'Amicelli', 'Kinder Weihnachtsmann', 'Finest Selection Mandel Knusper Vielfalt', 'Rahm Mandel', 'Vegan Roasted Peanut', 'Nussklasse Ganze Mandel', 'Ritter Sport Lemon');

--- a/db/pipelines/sweets-de/PIPELINE__sweets-de__03_add_nutrition.sql
+++ b/db/pipelines/sweets-de/PIPELINE__sweets-de__03_add_nutrition.sql
@@ -1,0 +1,87 @@
+-- PIPELINE (Sweets): add nutrition facts
+-- Source: Open Food Facts verified per-100g data
+
+-- 1) Remove existing
+delete from nutrition_facts
+where product_id in (
+  select p.product_id
+  from products p
+  where p.country = 'DE' and p.category = 'Sweets'
+    and p.is_deprecated is not true
+);
+
+-- 2) Insert
+insert into nutrition_facts
+  (product_id, calories, total_fat_g, saturated_fat_g, trans_fat_g,
+   carbs_g, sugars_g, fibre_g, protein_g, salt_g)
+select
+  p.product_id,
+  d.calories, d.total_fat_g, d.saturated_fat_g, d.trans_fat_g,
+  d.carbs_g, d.sugars_g, d.fibre_g, d.protein_g, d.salt_g
+from (
+  values
+    ('Ferrero', 'Ferrero Yogurette 40084060 Gefüllte Vollmilchschokolade mit Magermilchjoghurt-Erdbeer-Creme', 576.0, 36.0, 20.8, 0, 56.8, 55.2, 0, 4.8, 0.0),
+    ('Ritter Sport', 'Kakao-Klasse Die Kräftige 74%', 627.0, 50.0, 32.0, 0, 27.0, 24.0, 0, 7.0, 0.0),
+    ('Kinder', 'Überraschung', 561.0, 34.9, 22.9, 0, 52.6, 52.3, 0, 8.4, 0.3),
+    ('J. D. Gross', 'Edelbitter Mild 90%', 608.0, 51.9, 31.4, 0, 16.2, 7.3, 14.6, 11.0, 0.0),
+    ('Moser Roth', 'Edelbitter-Schokolade 85 % Cacao', 604.0, 50.0, 31.0, 0, 20.0, 14.0, 14.0, 11.0, 0.3),
+    ('Ritter Sport', 'Kakao Klasse die Starke - 81%', 609.0, 52.0, 33.0, 0, 20.0, 16.0, 0, 9.4, 0.0),
+    ('Moser Roth', 'Edelbitter 90 % Cacao', 644.0, 56.8, 35.2, 0, 15.2, 8.8, 14.0, 11.2, 0.0),
+    ('Lidl', 'Lidl Organic Dark Chocolate', 600.0, 40.0, 26.7, 0, 46.7, 26.7, 10.0, 10.0, 0.0),
+    ('Aldi', 'Edelbitter-Schokolade 70% Cacao', 578.0, 42.0, 26.0, 0, 34.0, 28.0, 12.0, 9.5, 0.0),
+    ('Ritter Sport', 'Schokolade Halbbitter', 534.0, 33.0, 19.0, 0, 50.0, 48.0, 0, 6.0, 0.0),
+    ('Ritter Sport', 'Marzipan', 496.0, 27.0, 11.0, 0, 52.0, 51.0, 0, 7.0, 0.0),
+    ('Aldi', 'Edelbitter- Schokolade', 583.0, 43.0, 26.0, 0, 37.0, 29.0, 10.0, 6.7, 0.0),
+    ('Ritter Sport', 'Alpenmilch', 547.0, 32.0, 20.0, 0, 54.0, 53.0, 0, 8.2, 0.2),
+    ('Ritter Sport', 'Ritter Sport Nugat', 552.0, 33.0, 13.0, 0, 54.0, 51.0, 0, 7.3, 0.1),
+    ('Lindt', 'Lindt Dubai Style Chocolade', 563.0, 36.0, 19.0, 0, 50.0, 46.0, 0, 8.3, 0.3),
+    ('Ritter Sport', 'Ritter Sport Voll-Nuss', 569.0, 38.0, 13.0, 0, 45.0, 43.0, 0, 8.9, 0.1),
+    ('Schogetten', 'Schogetten originals: Edel-Zartbitter', 529.0, 31.0, 19.0, 0, 52.0, 47.0, 0, 6.8, 0.0),
+    ('Choceur', 'Aldi-Gipfel', 527.0, 27.9, 16.4, 0, 63.2, 62.5, 1.8, 4.9, 0.1),
+    ('Ritter Sport', 'Edel-Vollmilch', 571.0, 38.0, 23.0, 0, 48.0, 47.0, 0, 7.3, 0.2),
+    ('Müller & Müller GmbH', 'Blockschokolade', 531.0, 31.0, 20.0, 0, 53.0, 50.0, 0, 6.0, 0.0),
+    ('Sarotti', 'Mild 85%', 655.0, 60.0, 38.0, 0, 15.0, 11.0, 0, 7.5, 0.0),
+    ('Aldi', 'Nussknacker - Vollmilchschokolade', 591.0, 40.0, 16.0, 0, 45.0, 41.0, 0, 11.0, 0.2),
+    ('Aldi', 'Nussknacker - Zartbitterschokolade', 590.0, 41.0, 16.0, 0, 42.0, 36.0, 8.1, 8.9, 0.0),
+    ('Back Family', 'Schoko-Chunks - Zartbitter', 528.0, 31.3, 18.5, 0, 51.5, 47.1, 7.9, 6.2, 0.0),
+    ('Ritter Sport', 'Pistachio', 539.0, 32.3, 14.8, 0.0, 51.6, 51.6, 3.2, 6.5, 1.4),
+    ('Lindt', 'Excellence Mild 70%', 610.0, 48.0, 29.0, 0, 33.0, 29.0, 0, 6.9, 0.1),
+    ('Fairglobe', 'Bio Vollmilch-Schokolade', 564.0, 35.7, 21.5, 0, 52.7, 51.5, 0.1, 7.2, 0.2),
+    ('Ritter Sport', 'Kakao-Mousse', 577.0, 39.0, 23.0, 0, 47.0, 46.0, 0, 7.4, 0.3),
+    ('Ritter Sport', 'Kakao Klasse 61 die feine aus Nicaragua', 600.0, 45.0, 28.0, 0, 40.0, 37.0, 0.0, 5.6, 0.0),
+    ('Ritter Sport', 'Ritter Sport Honig Salz Mandel', 548.0, 34.0, 13.0, 0, 48.0, 47.0, 0.0, 9.1, 0.3),
+    ('Lindt', 'Gold Bunny', 544.0, 32.0, 19.0, 0, 56.0, 54.0, 0, 7.2, 0.3),
+    ('Schogetten', 'Schogetten - Edel-Alpenvollmilchschokolade', 551.0, 33.0, 20.0, 0, 57.0, 56.0, 0, 5.5, 0.1),
+    ('Ferrero', 'Kinder Osterhase - Harry Hase', 579.0, 36.2, 24.1, 0, 53.9, 53.6, 0, 8.8, 0.3),
+    ('Ritter Sport', 'Joghurt', 585.0, 40.0, 23.0, 0, 48.0, 48.0, 0, 6.7, 0.2),
+    ('Ritter Sport', 'Trauben Nuss', 516.0, 28.0, 14.0, 0, 58.0, 55.0, 0, 6.4, 0.1),
+    ('Ritter Sport', 'Knusperkeks', 544.0, 32.0, 19.0, 0, 57.0, 50.0, 0, 6.2, 0.3),
+    ('Milka', 'Schokolade Joghurt', 573.0, 37.0, 21.0, 0, 56.0, 55.0, 1.1, 4.4, 0.2),
+    ('Ritter Sport', 'Rum Trauben Nuss Schokolade', 522.0, 28.0, 15.0, 0, 56.0, 54.0, 0, 6.3, 0.1),
+    ('Aldi', 'Schokolade (Alpen-Sahne-)', 580.0, 41.0, 25.0, 0, 44.0, 41.0, 5.1, 8.2, 0.1),
+    ('Aldi', 'Erdbeer-Joghurt', 577.0, 38.0, 23.0, 0, 52.0, 51.0, 0, 6.3, 0.2),
+    ('Rapunzel', 'Nirwana Vegan', 573.0, 38.0, 16.0, 0, 52.0, 43.0, 3.9, 4.6, 0.2),
+    ('Ritter Sport', 'Haselnuss', 554.0, 34.0, 17.0, 0, 53.0, 50.0, 0, 7.3, 0.2),
+    ('Ritter SPORT', 'Ritter Sport Erdbeer', 572.0, 38.0, 22.0, 0, 49.0, 48.0, 0, 6.6, 0.2),
+    ('Schogetten', 'Schogetten Edel-Zartbitter-Haselnuss', 565.0, 38.0, 20.0, 0, 45.0, 41.0, 0, 7.1, 0.0),
+    ('Ritter Sport', 'Amicelli', 563.0, 35.0, 17.0, 0, 53.0, 50.0, 0, 6.5, 0.2),
+    ('Ferrero', 'Kinder Weihnachtsmann', 577.0, 36.2, 24.1, 0, 53.9, 53.6, 0, 8.8, 0.3),
+    ('Merci', 'Finest Selection Mandel Knusper Vielfalt', 571.0, 37.4, 19.0, 0, 47.2, 44.5, 0, 9.6, 0.2),
+    ('Aldi', 'Rahm Mandel', 581.0, 40.0, 17.0, 0, 39.0, 39.0, 5.3, 12.0, 0.2),
+    ('Ritter Sport', 'Vegan Roasted Peanut', 574.0, 40.0, 17.0, 0, 37.0, 35.0, 0.0, 14.0, 0.4),
+    ('Ritter Sport', 'Nussklasse Ganze Mandel', 559.0, 37.0, 14.0, 0, 45.0, 44.0, 0, 9.8, 0.1),
+    ('Ritter Sport', 'Ritter Sport Lemon', 592.0, 41.0, 24.0, 0, 49.0, 49.0, 0, 5.9, 0.2)
+) as d(brand, product_name, calories, total_fat_g, saturated_fat_g, trans_fat_g,
+       carbs_g, sugars_g, fibre_g, protein_g, salt_g)
+join products p on p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name
+  and p.category = 'Sweets' and p.is_deprecated is not true
+on conflict (product_id) do update set
+  calories = excluded.calories,
+  total_fat_g = excluded.total_fat_g,
+  saturated_fat_g = excluded.saturated_fat_g,
+  trans_fat_g = excluded.trans_fat_g,
+  carbs_g = excluded.carbs_g,
+  sugars_g = excluded.sugars_g,
+  fibre_g = excluded.fibre_g,
+  protein_g = excluded.protein_g,
+  salt_g = excluded.salt_g;

--- a/db/pipelines/sweets-de/PIPELINE__sweets-de__04_scoring.sql
+++ b/db/pipelines/sweets-de/PIPELINE__sweets-de__04_scoring.sql
@@ -1,0 +1,123 @@
+-- PIPELINE (Sweets): scoring
+-- Generated: 2026-02-25
+
+-- 2. Nutri-Score
+update products p set
+  nutri_score_label = d.ns
+from (
+  values
+    ('Ferrero', 'Ferrero Yogurette 40084060 Gefüllte Vollmilchschokolade mit Magermilchjoghurt-Erdbeer-Creme', 'E'),
+    ('Ritter Sport', 'Kakao-Klasse Die Kräftige 74%', 'E'),
+    ('Kinder', 'Überraschung', 'E'),
+    ('J. D. Gross', 'Edelbitter Mild 90%', 'D'),
+    ('Moser Roth', 'Edelbitter-Schokolade 85 % Cacao', 'D'),
+    ('Ritter Sport', 'Kakao Klasse die Starke - 81%', 'E'),
+    ('Moser Roth', 'Edelbitter 90 % Cacao', 'D'),
+    ('Lidl', 'Lidl Organic Dark Chocolate', 'E'),
+    ('Aldi', 'Edelbitter-Schokolade 70% Cacao', 'E'),
+    ('Ritter Sport', 'Schokolade Halbbitter', 'E'),
+    ('Ritter Sport', 'Marzipan', 'E'),
+    ('Aldi', 'Edelbitter- Schokolade', 'E'),
+    ('Ritter Sport', 'Alpenmilch', 'E'),
+    ('Ritter Sport', 'Ritter Sport Nugat', 'E'),
+    ('Lindt', 'Lindt Dubai Style Chocolade', 'E'),
+    ('Ritter Sport', 'Ritter Sport Voll-Nuss', 'E'),
+    ('Schogetten', 'Schogetten originals: Edel-Zartbitter', 'E'),
+    ('Choceur', 'Aldi-Gipfel', 'E'),
+    ('Ritter Sport', 'Edel-Vollmilch', 'E'),
+    ('Müller & Müller GmbH', 'Blockschokolade', 'E'),
+    ('Sarotti', 'Mild 85%', 'E'),
+    ('Aldi', 'Nussknacker - Vollmilchschokolade', 'E'),
+    ('Aldi', 'Nussknacker - Zartbitterschokolade', 'E'),
+    ('Back Family', 'Schoko-Chunks - Zartbitter', 'E'),
+    ('Ritter Sport', 'Pistachio', 'E'),
+    ('Lindt', 'Excellence Mild 70%', 'E'),
+    ('Fairglobe', 'Bio Vollmilch-Schokolade', 'E'),
+    ('Ritter Sport', 'Kakao-Mousse', 'E'),
+    ('Ritter Sport', 'Kakao Klasse 61 die feine aus Nicaragua', 'E'),
+    ('Ritter Sport', 'Ritter Sport Honig Salz Mandel', 'E'),
+    ('Lindt', 'Gold Bunny', 'E'),
+    ('Schogetten', 'Schogetten - Edel-Alpenvollmilchschokolade', 'E'),
+    ('Ferrero', 'Kinder Osterhase - Harry Hase', 'E'),
+    ('Ritter Sport', 'Joghurt', 'E'),
+    ('Ritter Sport', 'Trauben Nuss', 'E'),
+    ('Ritter Sport', 'Knusperkeks', 'E'),
+    ('Milka', 'Schokolade Joghurt', 'E'),
+    ('Ritter Sport', 'Rum Trauben Nuss Schokolade', 'E'),
+    ('Aldi', 'Schokolade (Alpen-Sahne-)', 'E'),
+    ('Aldi', 'Erdbeer-Joghurt', 'E'),
+    ('Rapunzel', 'Nirwana Vegan', 'E'),
+    ('Ritter Sport', 'Haselnuss', 'E'),
+    ('Ritter SPORT', 'Ritter Sport Erdbeer', 'E'),
+    ('Schogetten', 'Schogetten Edel-Zartbitter-Haselnuss', 'E'),
+    ('Ritter Sport', 'Amicelli', 'E'),
+    ('Ferrero', 'Kinder Weihnachtsmann', 'E'),
+    ('Merci', 'Finest Selection Mandel Knusper Vielfalt', 'E'),
+    ('Aldi', 'Rahm Mandel', 'E'),
+    ('Ritter Sport', 'Vegan Roasted Peanut', 'E'),
+    ('Ritter Sport', 'Nussklasse Ganze Mandel', 'E'),
+    ('Ritter Sport', 'Ritter Sport Lemon', 'E')
+) as d(brand, product_name, ns)
+where p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name;
+
+-- 3. NOVA classification
+update products p set
+  nova_classification = d.nova
+from (
+  values
+    ('Ferrero', 'Ferrero Yogurette 40084060 Gefüllte Vollmilchschokolade mit Magermilchjoghurt-Erdbeer-Creme', '4'),
+    ('Ritter Sport', 'Kakao-Klasse Die Kräftige 74%', '3'),
+    ('Kinder', 'Überraschung', '4'),
+    ('J. D. Gross', 'Edelbitter Mild 90%', '4'),
+    ('Moser Roth', 'Edelbitter-Schokolade 85 % Cacao', '4'),
+    ('Ritter Sport', 'Kakao Klasse die Starke - 81%', '4'),
+    ('Moser Roth', 'Edelbitter 90 % Cacao', '4'),
+    ('Lidl', 'Lidl Organic Dark Chocolate', '4'),
+    ('Aldi', 'Edelbitter-Schokolade 70% Cacao', '4'),
+    ('Ritter Sport', 'Schokolade Halbbitter', '4'),
+    ('Ritter Sport', 'Marzipan', '4'),
+    ('Aldi', 'Edelbitter- Schokolade', '3'),
+    ('Ritter Sport', 'Alpenmilch', '4'),
+    ('Ritter Sport', 'Ritter Sport Nugat', '4'),
+    ('Lindt', 'Lindt Dubai Style Chocolade', '4'),
+    ('Ritter Sport', 'Ritter Sport Voll-Nuss', '4'),
+    ('Schogetten', 'Schogetten originals: Edel-Zartbitter', '4'),
+    ('Choceur', 'Aldi-Gipfel', '4'),
+    ('Ritter Sport', 'Edel-Vollmilch', '4'),
+    ('Müller & Müller GmbH', 'Blockschokolade', '4'),
+    ('Sarotti', 'Mild 85%', '4'),
+    ('Aldi', 'Nussknacker - Vollmilchschokolade', '4'),
+    ('Aldi', 'Nussknacker - Zartbitterschokolade', '4'),
+    ('Back Family', 'Schoko-Chunks - Zartbitter', '4'),
+    ('Ritter Sport', 'Pistachio', '4'),
+    ('Lindt', 'Excellence Mild 70%', '4'),
+    ('Fairglobe', 'Bio Vollmilch-Schokolade', '4'),
+    ('Ritter Sport', 'Kakao-Mousse', '4'),
+    ('Ritter Sport', 'Kakao Klasse 61 die feine aus Nicaragua', '3'),
+    ('Ritter Sport', 'Ritter Sport Honig Salz Mandel', '4'),
+    ('Lindt', 'Gold Bunny', '4'),
+    ('Schogetten', 'Schogetten - Edel-Alpenvollmilchschokolade', '4'),
+    ('Ferrero', 'Kinder Osterhase - Harry Hase', '4'),
+    ('Ritter Sport', 'Joghurt', '4'),
+    ('Ritter Sport', 'Trauben Nuss', '4'),
+    ('Ritter Sport', 'Knusperkeks', '4'),
+    ('Milka', 'Schokolade Joghurt', '4'),
+    ('Ritter Sport', 'Rum Trauben Nuss Schokolade', '4'),
+    ('Aldi', 'Schokolade (Alpen-Sahne-)', '4'),
+    ('Aldi', 'Erdbeer-Joghurt', '4'),
+    ('Rapunzel', 'Nirwana Vegan', '4'),
+    ('Ritter Sport', 'Haselnuss', '4'),
+    ('Ritter SPORT', 'Ritter Sport Erdbeer', '4'),
+    ('Schogetten', 'Schogetten Edel-Zartbitter-Haselnuss', '4'),
+    ('Ritter Sport', 'Amicelli', '4'),
+    ('Ferrero', 'Kinder Weihnachtsmann', '4'),
+    ('Merci', 'Finest Selection Mandel Knusper Vielfalt', '4'),
+    ('Aldi', 'Rahm Mandel', '4'),
+    ('Ritter Sport', 'Vegan Roasted Peanut', '4'),
+    ('Ritter Sport', 'Nussklasse Ganze Mandel', '4'),
+    ('Ritter Sport', 'Ritter Sport Lemon', '4')
+) as d(brand, product_name, nova)
+where p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name;
+
+-- 0/1/4/5. Score category (concern defaults, unhealthiness, flags, confidence)
+CALL score_category('Sweets', 100, 'DE');

--- a/db/pipelines/sweets-de/PIPELINE__sweets-de__05_source_provenance.sql
+++ b/db/pipelines/sweets-de/PIPELINE__sweets-de__05_source_provenance.sql
@@ -1,0 +1,65 @@
+-- PIPELINE (Sweets): source provenance
+-- Generated: 2026-02-25
+
+-- 1. Update source info on products
+UPDATE products p SET
+  source_type = 'off_api',
+  source_url = d.source_url,
+  source_ean = d.source_ean
+FROM (
+  VALUES
+    ('Ferrero', 'Ferrero Yogurette 40084060 Gefüllte Vollmilchschokolade mit Magermilchjoghurt-Erdbeer-Creme', 'https://world.openfoodfacts.org/product/40084060', '40084060'),
+    ('Ritter Sport', 'Kakao-Klasse Die Kräftige 74%', 'https://world.openfoodfacts.org/product/4000417693310', '4000417693310'),
+    ('Kinder', 'Überraschung', 'https://world.openfoodfacts.org/product/40084107', '40084107'),
+    ('J. D. Gross', 'Edelbitter Mild 90%', 'https://world.openfoodfacts.org/product/4056489471264', '4056489471264'),
+    ('Moser Roth', 'Edelbitter-Schokolade 85 % Cacao', 'https://world.openfoodfacts.org/product/4061458021630', '4061458021630'),
+    ('Ritter Sport', 'Kakao Klasse die Starke - 81%', 'https://world.openfoodfacts.org/product/4000417693815', '4000417693815'),
+    ('Moser Roth', 'Edelbitter 90 % Cacao', 'https://world.openfoodfacts.org/product/4061462044809', '4061462044809'),
+    ('Lidl', 'Lidl Organic Dark Chocolate', 'https://world.openfoodfacts.org/product/40896243', '40896243'),
+    ('Aldi', 'Edelbitter-Schokolade 70% Cacao', 'https://world.openfoodfacts.org/product/4061458021593', '4061458021593'),
+    ('Ritter Sport', 'Schokolade Halbbitter', 'https://world.openfoodfacts.org/product/4000417602015', '4000417602015'),
+    ('Ritter Sport', 'Marzipan', 'https://world.openfoodfacts.org/product/4000417602510', '4000417602510'),
+    ('Aldi', 'Edelbitter- Schokolade', 'https://world.openfoodfacts.org/product/4061459208078', '4061459208078'),
+    ('Ritter Sport', 'Alpenmilch', 'https://world.openfoodfacts.org/product/4000417601810', '4000417601810'),
+    ('Ritter Sport', 'Ritter Sport Nugat', 'https://world.openfoodfacts.org/product/4000417602619', '4000417602619'),
+    ('Lindt', 'Lindt Dubai Style Chocolade', 'https://world.openfoodfacts.org/product/4000539150869', '4000539150869'),
+    ('Ritter Sport', 'Ritter Sport Voll-Nuss', 'https://world.openfoodfacts.org/product/4000417670014', '4000417670014'),
+    ('Schogetten', 'Schogetten originals: Edel-Zartbitter', 'https://world.openfoodfacts.org/product/4000607151200', '4000607151200'),
+    ('Choceur', 'Aldi-Gipfel', 'https://world.openfoodfacts.org/product/4061462452772', '4061462452772'),
+    ('Ritter Sport', 'Edel-Vollmilch', 'https://world.openfoodfacts.org/product/4000417602114', '4000417602114'),
+    ('Müller & Müller GmbH', 'Blockschokolade', 'https://world.openfoodfacts.org/product/4006814001796', '4006814001796'),
+    ('Sarotti', 'Mild 85%', 'https://world.openfoodfacts.org/product/4030387760866', '4030387760866'),
+    ('Aldi', 'Nussknacker - Vollmilchschokolade', 'https://world.openfoodfacts.org/product/4061458021616', '4061458021616'),
+    ('Aldi', 'Nussknacker - Zartbitterschokolade', 'https://world.openfoodfacts.org/product/4061458022002', '4061458022002'),
+    ('Back Family', 'Schoko-Chunks - Zartbitter', 'https://world.openfoodfacts.org/product/4061458160964', '4061458160964'),
+    ('Ritter Sport', 'Pistachio', 'https://world.openfoodfacts.org/product/4000417670915', '4000417670915'),
+    ('Lindt', 'Excellence Mild 70%', 'https://world.openfoodfacts.org/product/4000539003509', '4000539003509'),
+    ('Fairglobe', 'Bio Vollmilch-Schokolade', 'https://world.openfoodfacts.org/product/40896250', '40896250'),
+    ('Ritter Sport', 'Kakao-Mousse', 'https://world.openfoodfacts.org/product/4000417629418', '4000417629418'),
+    ('Ritter Sport', 'Kakao Klasse 61 die feine aus Nicaragua', 'https://world.openfoodfacts.org/product/4000417693211', '4000417693211'),
+    ('Ritter Sport', 'Ritter Sport Honig Salz Mandel', 'https://world.openfoodfacts.org/product/4000417670410', '4000417670410'),
+    ('Lindt', 'Gold Bunny', 'https://world.openfoodfacts.org/product/4000539671203', '4000539671203'),
+    ('Schogetten', 'Schogetten - Edel-Alpenvollmilchschokolade', 'https://world.openfoodfacts.org/product/4000607151002', '4000607151002'),
+    ('Ferrero', 'Kinder Osterhase - Harry Hase', 'https://world.openfoodfacts.org/product/4008400524023', '4008400524023'),
+    ('Ritter Sport', 'Joghurt', 'https://world.openfoodfacts.org/product/4000417602718', '4000417602718'),
+    ('Ritter Sport', 'Trauben Nuss', 'https://world.openfoodfacts.org/product/4000417602213', '4000417602213'),
+    ('Ritter Sport', 'Knusperkeks', 'https://world.openfoodfacts.org/product/4000417621412', '4000417621412'),
+    ('Milka', 'Schokolade Joghurt', 'https://world.openfoodfacts.org/product/4025700001450', '4025700001450'),
+    ('Ritter Sport', 'Rum Trauben Nuss Schokolade', 'https://world.openfoodfacts.org/product/4000417601216', '4000417601216'),
+    ('Aldi', 'Schokolade (Alpen-Sahne-)', 'https://world.openfoodfacts.org/product/4061458021753', '4061458021753'),
+    ('Aldi', 'Erdbeer-Joghurt', 'https://world.openfoodfacts.org/product/4061458021883', '4061458021883'),
+    ('Rapunzel', 'Nirwana Vegan', 'https://world.openfoodfacts.org/product/4006040488897', '4006040488897'),
+    ('Ritter Sport', 'Haselnuss', 'https://world.openfoodfacts.org/product/4000417622211', '4000417622211'),
+    ('Ritter SPORT', 'Ritter Sport Erdbeer', 'https://world.openfoodfacts.org/product/4000417623713', '4000417623713'),
+    ('Schogetten', 'Schogetten Edel-Zartbitter-Haselnuss', 'https://world.openfoodfacts.org/product/4000607730900', '4000607730900'),
+    ('Ritter Sport', 'Amicelli', 'https://world.openfoodfacts.org/product/4000417601513', '4000417601513'),
+    ('Ferrero', 'Kinder Weihnachtsmann', 'https://world.openfoodfacts.org/product/4008400511825', '4008400511825'),
+    ('Merci', 'Finest Selection Mandel Knusper Vielfalt', 'https://world.openfoodfacts.org/product/4014400917956', '4014400917956'),
+    ('Aldi', 'Rahm Mandel', 'https://world.openfoodfacts.org/product/4061458021647', '4061458021647'),
+    ('Ritter Sport', 'Vegan Roasted Peanut', 'https://world.openfoodfacts.org/product/4000417106100', '4000417106100'),
+    ('Ritter Sport', 'Nussklasse Ganze Mandel', 'https://world.openfoodfacts.org/product/4000417670311', '4000417670311'),
+    ('Ritter Sport', 'Ritter Sport Lemon', 'https://world.openfoodfacts.org/product/4000417628510', '4000417628510')
+) AS d(brand, product_name, source_url, source_ean)
+WHERE p.country = 'DE' AND p.brand = d.brand
+  AND p.product_name = d.product_name
+  AND p.category = 'Sweets' AND p.is_deprecated IS NOT TRUE;

--- a/db/pipelines/sweets-de/PIPELINE__sweets-de__06_add_images.sql
+++ b/db/pipelines/sweets-de/PIPELINE__sweets-de__06_add_images.sql
@@ -1,0 +1,79 @@
+-- PIPELINE (Sweets): add product images
+-- Source: Open Food Facts API image URLs
+-- Generated: 2026-02-25
+
+-- 1. Remove existing OFF images for this category
+DELETE FROM product_images
+WHERE source = 'off_api'
+  AND product_id IN (
+    SELECT p.product_id FROM products p
+    WHERE p.country = 'DE' AND p.category = 'Sweets'
+      AND p.is_deprecated IS NOT TRUE
+  );
+
+-- 2. Insert images
+INSERT INTO product_images
+  (product_id, url, source, image_type, is_primary, alt_text, off_image_id)
+SELECT
+  p.product_id, d.url, d.source, d.image_type, d.is_primary, d.alt_text, d.off_image_id
+FROM (
+  VALUES
+    ('Ferrero', 'Ferrero Yogurette 40084060 Gefüllte Vollmilchschokolade mit Magermilchjoghurt-Erdbeer-Creme', 'https://images.openfoodfacts.org/images/products/000/004/008/4060/front_en.59.400.jpg', 'off_api', 'front', true, 'Front — EAN 40084060', 'front_40084060'),
+    ('Ritter Sport', 'Kakao-Klasse Die Kräftige 74%', 'https://images.openfoodfacts.org/images/products/400/041/769/3310/front_de.21.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417693310', 'front_4000417693310'),
+    ('Kinder', 'Überraschung', 'https://images.openfoodfacts.org/images/products/000/004/008/4107/front_de.239.400.jpg', 'off_api', 'front', true, 'Front — EAN 40084107', 'front_40084107'),
+    ('J. D. Gross', 'Edelbitter Mild 90%', 'https://images.openfoodfacts.org/images/products/405/648/947/1264/front_en.122.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489471264', 'front_4056489471264'),
+    ('Moser Roth', 'Edelbitter-Schokolade 85 % Cacao', 'https://images.openfoodfacts.org/images/products/406/145/802/1630/front_de.102.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458021630', 'front_4061458021630'),
+    ('Ritter Sport', 'Kakao Klasse die Starke - 81%', 'https://images.openfoodfacts.org/images/products/400/041/769/3815/front_de.13.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417693815', 'front_4000417693815'),
+    ('Moser Roth', 'Edelbitter 90 % Cacao', 'https://images.openfoodfacts.org/images/products/406/146/204/4809/front_de.48.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061462044809', 'front_4061462044809'),
+    ('Lidl', 'Lidl Organic Dark Chocolate', 'https://images.openfoodfacts.org/images/products/000/004/089/6243/front_en.168.400.jpg', 'off_api', 'front', true, 'Front — EAN 40896243', 'front_40896243'),
+    ('Aldi', 'Edelbitter-Schokolade 70% Cacao', 'https://images.openfoodfacts.org/images/products/406/145/802/1593/front_de.76.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458021593', 'front_4061458021593'),
+    ('Ritter Sport', 'Schokolade Halbbitter', 'https://images.openfoodfacts.org/images/products/400/041/760/2015/front_de.9.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417602015', 'front_4000417602015'),
+    ('Ritter Sport', 'Marzipan', 'https://images.openfoodfacts.org/images/products/400/041/760/2510/front_en.63.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417602510', 'front_4000417602510'),
+    ('Aldi', 'Edelbitter- Schokolade', 'https://images.openfoodfacts.org/images/products/406/145/920/8078/front_en.32.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061459208078', 'front_4061459208078'),
+    ('Ritter Sport', 'Alpenmilch', 'https://images.openfoodfacts.org/images/products/400/041/760/1810/front_de.6.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417601810', 'front_4000417601810'),
+    ('Ritter Sport', 'Ritter Sport Nugat', 'https://images.openfoodfacts.org/images/products/400/041/760/2619/front_de.39.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417602619', 'front_4000417602619'),
+    ('Lindt', 'Lindt Dubai Style Chocolade', 'https://images.openfoodfacts.org/images/products/400/053/915/0869/front_de.29.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000539150869', 'front_4000539150869'),
+    ('Ritter Sport', 'Ritter Sport Voll-Nuss', 'https://images.openfoodfacts.org/images/products/400/041/767/0014/front_de.12.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417670014', 'front_4000417670014'),
+    ('Schogetten', 'Schogetten originals: Edel-Zartbitter', 'https://images.openfoodfacts.org/images/products/400/060/715/1200/front_de.52.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000607151200', 'front_4000607151200'),
+    ('Choceur', 'Aldi-Gipfel', 'https://images.openfoodfacts.org/images/products/406/146/245/2772/front_de.6.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061462452772', 'front_4061462452772'),
+    ('Ritter Sport', 'Edel-Vollmilch', 'https://images.openfoodfacts.org/images/products/400/041/760/2114/front_de.14.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417602114', 'front_4000417602114'),
+    ('Müller & Müller GmbH', 'Blockschokolade', 'https://images.openfoodfacts.org/images/products/400/681/400/1796/front_en.27.400.jpg', 'off_api', 'front', true, 'Front — EAN 4006814001796', 'front_4006814001796'),
+    ('Sarotti', 'Mild 85%', 'https://images.openfoodfacts.org/images/products/403/038/776/0866/front_de.5.400.jpg', 'off_api', 'front', true, 'Front — EAN 4030387760866', 'front_4030387760866'),
+    ('Aldi', 'Nussknacker - Vollmilchschokolade', 'https://images.openfoodfacts.org/images/products/406/145/802/1616/front_de.71.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458021616', 'front_4061458021616'),
+    ('Aldi', 'Nussknacker - Zartbitterschokolade', 'https://images.openfoodfacts.org/images/products/406/145/802/2002/front_de.43.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458022002', 'front_4061458022002'),
+    ('Back Family', 'Schoko-Chunks - Zartbitter', 'https://images.openfoodfacts.org/images/products/406/145/816/0964/front_de.42.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458160964', 'front_4061458160964'),
+    ('Ritter Sport', 'Pistachio', 'https://images.openfoodfacts.org/images/products/400/041/767/0915/front_en.76.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417670915', 'front_4000417670915'),
+    ('Lindt', 'Excellence Mild 70%', 'https://images.openfoodfacts.org/images/products/400/053/900/3509/front_de.41.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000539003509', 'front_4000539003509'),
+    ('Fairglobe', 'Bio Vollmilch-Schokolade', 'https://images.openfoodfacts.org/images/products/000/004/089/6250/front_de.55.400.jpg', 'off_api', 'front', true, 'Front — EAN 40896250', 'front_40896250'),
+    ('Ritter Sport', 'Kakao-Mousse', 'https://images.openfoodfacts.org/images/products/400/041/762/9418/front_de.11.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417629418', 'front_4000417629418'),
+    ('Ritter Sport', 'Kakao Klasse 61 die feine aus Nicaragua', 'https://images.openfoodfacts.org/images/products/400/041/769/3211/front_de.5.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417693211', 'front_4000417693211'),
+    ('Ritter Sport', 'Ritter Sport Honig Salz Mandel', 'https://images.openfoodfacts.org/images/products/400/041/767/0410/front_de.30.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417670410', 'front_4000417670410'),
+    ('Lindt', 'Gold Bunny', 'https://images.openfoodfacts.org/images/products/400/053/967/1203/front_en.143.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000539671203', 'front_4000539671203'),
+    ('Schogetten', 'Schogetten - Edel-Alpenvollmilchschokolade', 'https://images.openfoodfacts.org/images/products/400/060/715/1002/front_de.59.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000607151002', 'front_4000607151002'),
+    ('Ferrero', 'Kinder Osterhase - Harry Hase', 'https://images.openfoodfacts.org/images/products/400/840/052/4023/front_de.52.400.jpg', 'off_api', 'front', true, 'Front — EAN 4008400524023', 'front_4008400524023'),
+    ('Ritter Sport', 'Joghurt', 'https://images.openfoodfacts.org/images/products/400/041/760/2718/front_de.39.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417602718', 'front_4000417602718'),
+    ('Ritter Sport', 'Trauben Nuss', 'https://images.openfoodfacts.org/images/products/400/041/760/2213/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417602213', 'front_4000417602213'),
+    ('Ritter Sport', 'Knusperkeks', 'https://images.openfoodfacts.org/images/products/400/041/762/1412/front_en.27.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417621412', 'front_4000417621412'),
+    ('Milka', 'Schokolade Joghurt', 'https://images.openfoodfacts.org/images/products/402/570/000/1450/front_en.47.400.jpg', 'off_api', 'front', true, 'Front — EAN 4025700001450', 'front_4025700001450'),
+    ('Ritter Sport', 'Rum Trauben Nuss Schokolade', 'https://images.openfoodfacts.org/images/products/400/041/760/1216/front_de.37.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417601216', 'front_4000417601216'),
+    ('Aldi', 'Schokolade (Alpen-Sahne-)', 'https://images.openfoodfacts.org/images/products/406/145/802/1753/front_de.37.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458021753', 'front_4061458021753'),
+    ('Aldi', 'Erdbeer-Joghurt', 'https://images.openfoodfacts.org/images/products/406/145/802/1883/front_de.16.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458021883', 'front_4061458021883'),
+    ('Rapunzel', 'Nirwana Vegan', 'https://images.openfoodfacts.org/images/products/400/604/048/8897/front_de.106.400.jpg', 'off_api', 'front', true, 'Front — EAN 4006040488897', 'front_4006040488897'),
+    ('Ritter Sport', 'Haselnuss', 'https://images.openfoodfacts.org/images/products/400/041/762/2211/front_de.64.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417622211', 'front_4000417622211'),
+    ('Ritter SPORT', 'Ritter Sport Erdbeer', 'https://images.openfoodfacts.org/images/products/400/041/762/3713/front_de.29.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417623713', 'front_4000417623713'),
+    ('Schogetten', 'Schogetten Edel-Zartbitter-Haselnuss', 'https://images.openfoodfacts.org/images/products/400/060/773/0900/front_de.25.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000607730900', 'front_4000607730900'),
+    ('Ritter Sport', 'Amicelli', 'https://images.openfoodfacts.org/images/products/400/041/760/1513/front_de.5.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417601513', 'front_4000417601513'),
+    ('Ferrero', 'Kinder Weihnachtsmann', 'https://images.openfoodfacts.org/images/products/400/840/051/1825/front_de.32.400.jpg', 'off_api', 'front', true, 'Front — EAN 4008400511825', 'front_4008400511825'),
+    ('Merci', 'Finest Selection Mandel Knusper Vielfalt', 'https://images.openfoodfacts.org/images/products/401/440/091/7956/front_en.79.400.jpg', 'off_api', 'front', true, 'Front — EAN 4014400917956', 'front_4014400917956'),
+    ('Aldi', 'Rahm Mandel', 'https://images.openfoodfacts.org/images/products/406/145/802/1647/front_de.36.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458021647', 'front_4061458021647'),
+    ('Ritter Sport', 'Vegan Roasted Peanut', 'https://images.openfoodfacts.org/images/products/400/041/710/6100/front_en.58.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417106100', 'front_4000417106100'),
+    ('Ritter Sport', 'Nussklasse Ganze Mandel', 'https://images.openfoodfacts.org/images/products/400/041/767/0311/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417670311', 'front_4000417670311'),
+    ('Ritter Sport', 'Ritter Sport Lemon', 'https://images.openfoodfacts.org/images/products/400/041/762/8510/front_de.28.400.jpg', 'off_api', 'front', true, 'Front — EAN 4000417628510', 'front_4000417628510')
+) AS d(brand, product_name, url, source, image_type, is_primary, alt_text, off_image_id)
+JOIN products p ON p.country = 'DE' AND p.brand = d.brand AND p.product_name = d.product_name
+  AND p.category = 'Sweets' AND p.is_deprecated IS NOT TRUE
+ON CONFLICT (off_image_id) WHERE off_image_id IS NOT NULL DO UPDATE SET
+  url = EXCLUDED.url,
+  image_type = EXCLUDED.image_type,
+  is_primary = EXCLUDED.is_primary,
+  alt_text = EXCLUDED.alt_text;

--- a/db/qa/QA__multi_country_consistency.sql
+++ b/db/qa/QA__multi_country_consistency.sql
@@ -102,14 +102,14 @@ WHERE p.is_deprecated IS NOT TRUE
   );
 
 -- ═══════════════════════════════════════════════════════════════════════════════
--- 8. DE micro-pilot only in allowed category (Chips)
+-- 8. DE micro-pilot only in allowed categories
 -- ═══════════════════════════════════════════════════════════════════════════════
-SELECT '8. DE products only in Chips category' AS check_name,
+SELECT '8. DE products only in allowed categories' AS check_name,
        COUNT(*) AS violations
 FROM products p
 WHERE p.country = 'DE'
   AND p.is_deprecated IS NOT TRUE
-  AND p.category != 'Chips';
+  AND p.category NOT IN ('Chips', 'Bread', 'Dairy', 'Drinks', 'Sweets');
 
 -- ═══════════════════════════════════════════════════════════════════════════════
 -- 9. Data completeness parity: DE avg completeness within 30pts of PL

--- a/db/qa/QA__scoring_formula_tests.sql
+++ b/db/qa/QA__scoring_formula_tests.sql
@@ -214,6 +214,7 @@ SELECT p.product_id, p.brand, p.product_name,
        CONCAT('Expected 6-10, got ', p.unhealthiness_score) AS detail
 FROM products p
 WHERE p.product_name = 'Coca-Cola Zero'
+  AND p.country = 'PL'
   AND p.is_deprecated IS NOT TRUE
   AND p.unhealthiness_score::int NOT BETWEEN 6 AND 10;
 

--- a/pipeline/sql_generator.py
+++ b/pipeline/sql_generator.py
@@ -154,7 +154,7 @@ where ean in ({ean_literals})
 
 -- 0a. DEPRECATE old products in this category & release their EANs
 update products
-set is_deprecated = true, ean = null
+set is_deprecated = true, deprecated_reason = 'Replaced by pipeline refresh', ean = null
 where country = {_sql_text(country)}
   and category = {_sql_text(category)}
   and is_deprecated is not true;
@@ -470,7 +470,10 @@ def generate_pipeline(
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
 
-    slug = _slug(category)
+    # Use the directory name as the file slug so that files inside
+    # ``dairy-de/`` are named ``PIPELINE__dairy-de__*`` (matches
+    # check_pipeline_structure.py expectations).
+    slug = out.name
     today = datetime.date.today().isoformat()
 
     files: list[Path] = []


### PR DESCRIPTION
## Summary

Expands the Germany (DE) micro-pilot from 1 category (Chips, 51 products) to **5 categories with 252 active products**:

| Category | Active | Deprecated |
|----------|--------|------------|
| Bread    | 49     | 2          |
| Chips    | 51     | 0          |
| Dairy    | 50     | 1          |
| Drinks   | 51     | 0          |
| Sweets   | 51     | 0          |
| **Total**| **252**| **3**      |

3 DE products deprecated due to unreliable OFF API calorie data (>35% back-calculation deviation).

## Changes

### Pipeline (multi-country support)
- **`pipeline/off_client.py`**: Added `search_products()` generic function, `GERMAN_RETAILERS` set, `_COUNTRY_MARKET_DATA` dict, `market_score()`, `_normalise_name_casing()` for ALL CAPS → Title Case, pipe character stripping
- **`pipeline/run.py`**: Added `--country` CLI argument (PL default, DE supported), country-aware sorting and output directory naming
- **`pipeline/sql_generator.py`**: Slug derived from output directory name (not category), deprecation reason included
- **`pipeline/validator.py`**: Calorie back-calculation check (>35% deviation = warning)

### Generated Data (4 new DE categories × 5 files each = 20 new SQL files)
- `db/pipelines/bread-de/` — 51 products (49 active, 2 deprecated)
- `db/pipelines/dairy-de/` — 51 products (50 active, 1 deprecated)
- `db/pipelines/drinks-de/` — 51 products (all active)
- `db/pipelines/sweets-de/` — 51 products (all active)

### QA Fixes
- **`QA__multi_country_consistency.sql`**: Check 8 expanded to allow 5 DE categories
- **`QA__scoring_formula_tests.sql`**: Coca-Cola Zero regression test scoped to PL

### Documentation
- **`copilot-instructions.md`**: Updated scope, product counts, category tables, pipeline folders, CLI examples

## Verification

```
Pipeline structure check: 25 categories verified ✓
QA: 32/33 suites PASS (459/460 checks)
  - Suite 21 check 6: PRE-EXISTING failure (0 allergen data after DB reset — not caused by this PR)
EAN validation: All checksums valid ✓
```

**DB Inventory:** 1,281 active | 51 deprecated | 1,302 nutrition rows | 25 pipeline folders

## Pre-existing Issue (not in scope)

Suite 21 (Allergen Filtering) check 6 fails because `product_allergen_info` has 0 rows. This is a pre-existing issue caused by the enrichment migration (`20260210001400`) containing hardcoded product IDs that don't match after `supabase db reset`. Tracked separately.

Closes #148