### PR TITLE
score(confidence): activate confidence verification with regression guards

### DIFF
--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -9,7 +9,7 @@
         3. QA__source_coverage.sql (8 source provenance checks — informational)
         4. validate_eans.py (EAN-8/EAN-13 checksum validation — blocking)
         5. QA__api_surfaces.sql (18 API contract validation checks — blocking)
-        6. QA__confidence_scoring.sql (10 confidence scoring checks — blocking)
+        6. QA__confidence_scoring.sql (13 confidence scoring checks — blocking)
         7. QA__data_quality.sql (25 data quality & plausibility checks — blocking)
         8. QA__referential_integrity.sql (18 referential integrity checks — blocking)
         9. QA__view_consistency.sql (13 view & function consistency checks — blocking)
@@ -124,7 +124,7 @@ $suiteCatalog = @(
     @{ Num = 3; Name = "Source Coverage"; Short = "Source"; Id = "source_coverage"; Checks = 8; Blocking = $false; Kind = "sql-special"; File = "QA__source_coverage.sql" },
     @{ Num = 4; Name = "EAN Checksum Validation"; Short = "EAN"; Id = "ean"; Checks = 1; Blocking = $true; Kind = "python"; File = "validate_eans.py" },
     @{ Num = 5; Name = "API Surface Validation"; Short = "API"; Id = "api"; Checks = 18; Blocking = $true; Kind = "sql"; File = "QA__api_surfaces.sql" },
-    @{ Num = 6; Name = "Confidence Scoring"; Short = "Confidence"; Id = "confidence"; Checks = 10; Blocking = $true; Kind = "sql"; File = "QA__confidence_scoring.sql" },
+    @{ Num = 6; Name = "Confidence Scoring"; Short = "Confidence"; Id = "confidence"; Checks = 13; Blocking = $true; Kind = "sql"; File = "QA__confidence_scoring.sql" },
     @{ Num = 7; Name = "Data Quality & Plausibility"; Short = "DataQuality"; Id = "data_quality"; Checks = 25; Blocking = $true; Kind = "sql"; File = "QA__data_quality.sql" },
     @{ Num = 8; Name = "Referential Integrity"; Short = "RefInteg"; Id = "referential"; Checks = 18; Blocking = $true; Kind = "sql"; File = "QA__referential_integrity.sql" },
     @{ Num = 9; Name = "View & Function Consistency"; Short = "Views"; Id = "views"; Checks = 13; Blocking = $true; Kind = "sql"; File = "QA__view_consistency.sql" },

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -8,7 +8,7 @@
 > **Servings:** removed as separate table — all nutrition data is per-100g on nutrition_facts
 > **Ingredient analytics:** 2,995 unique ingredients (all clean ASCII English), 1,269 allergen declarations, 1,361 trace declarations
 > **Ingredient concerns:** EFSA-based 4-tier additive classification (0=none, 1=low, 2=moderate, 3=high)
-> **QA:** 470 checks across 34 suites + 23 negative validation tests — all passing
+> **QA:** 473 checks across 34 suites + 23 negative validation tests — all passing
 
 ---
 
@@ -91,7 +91,7 @@ poland-food-db/
 │   │   ├── QA__scoring_formula_tests.sql  # 27 scoring validation checks
 │   │   ├── QA__api_surfaces.sql     # 18 API surface validation checks
 │   │   ├── QA__api_contract.sql     # 33 API contract checks
-│   │   ├── QA__confidence_scoring.sql  # 10 confidence scoring checks
+│   │   ├── QA__confidence_scoring.sql  # 13 confidence scoring checks
 │   │   ├── QA__confidence_reporting.sql # 7 confidence reporting checks
 │   │   ├── QA__data_quality.sql          # 25 data quality checks
 │   │   ├── QA__data_consistency.sql      # 20 data consistency checks
@@ -256,7 +256,7 @@ poland-food-db/
 │       ├── 006-append-only-migrations.md
 │       └── 007-english-canonical-ingredients.md
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
-├── RUN_QA.ps1                       # QA test runner (470 checks across 34 suites)
+├── RUN_QA.ps1                       # QA test runner (473 checks across 34 suites)
 ├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (23 injection tests)
 ├── RUN_SANITY.ps1                   # Sanity checks (16) — row counts, schema assertions
 ├── RUN_REMOTE.ps1                   # Remote deployment (requires confirmation)
@@ -789,7 +789,7 @@ If adding/changing DB schema or SQL functions:
 - For rollback procedures, see `DEPLOYMENT.md` → **Rollback Procedures** (5 scenarios + emergency checklist).
 - Add a QA check that verifies the migration outcome (row counts, constraint behavior).
 - Ensure idempotency (`IF NOT EXISTS`, `ON CONFLICT`, `DO UPDATE SET`).
-- Run `.\RUN_QA.ps1` to verify all 470 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 23 injection tests.
+- Run `.\RUN_QA.ps1` to verify all 473 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 23 injection tests.
 
 ### 8.14 Snapshots Are Not Enough
 
@@ -839,7 +839,7 @@ At the end of every PR-like change, include a **Verification** section:
 | EAN Validation            | `validate_eans.py`                  |      1 | Yes       |
 | API Surfaces              | `QA__api_surfaces.sql`              |     18 | Yes       |
 | API Contract              | `QA__api_contract.sql`              |     33 | Yes       |
-| Confidence Scoring        | `QA__confidence_scoring.sql`        |     10 | Yes       |
+| Confidence Scoring        | `QA__confidence_scoring.sql`        |     13 | Yes       |
 | Confidence Reporting      | `QA__confidence_reporting.sql`      |      7 | Yes       |
 | Data Quality              | `QA__data_quality.sql`              |     25 | Yes       |
 | Ref. Integrity            | `QA__referential_integrity.sql`     |     18 | Yes       |
@@ -869,7 +869,7 @@ At the end of every PR-like change, include a **Verification** section:
 | Event Intelligence        | `QA__event_intelligence.sql`        |     18 | Yes       |
 | **Negative Validation**   | `TEST__negative_checks.sql`         |     23 | Yes       |
 
-**Run:** `.\RUN_QA.ps1` — expects **470/470 checks passing** (+ EAN validation).
+**Run:** `.\RUN_QA.ps1` — expects **473/473 checks passing** (+ EAN validation).
 **Run:** `.\RUN_NEGATIVE_TESTS.ps1` — expects **23/23 caught**.
 
 ### 8.19 Key Regression Tests (Scoring Suite)
@@ -1395,12 +1395,12 @@ Use `.github/ISSUE_TEMPLATE/feature.md` for all significant issues. **Every sect
 
 ### When to Run
 
-| Trigger                                 | Action                                |
-| --------------------------------------- | ------------------------------------- |
-| File/directory added, removed, renamed  | `pwsh scripts/repo_verify.ps1`        |
-| Doc added or removed in `docs/`         | Script verifies `docs/INDEX.md` parity |
-| New migration added                     | Script verifies timestamp ordering    |
-| Before any commit                       | `git status` + `git diff --cached --name-only` |
+| Trigger                                | Action                                         |
+| -------------------------------------- | ---------------------------------------------- |
+| File/directory added, removed, renamed | `pwsh scripts/repo_verify.ps1`                 |
+| Doc added or removed in `docs/`        | Script verifies `docs/INDEX.md` parity         |
+| New migration added                    | Script verifies timestamp ordering             |
+| Before any commit                      | `git status` + `git diff --cached --name-only` |
 
 ### What the Script Checks
 

--- a/db/ci_post_enrichment.sql
+++ b/db/ci_post_enrichment.sql
@@ -82,3 +82,11 @@ CALL score_category('Drinks',   p_country := 'DE');
 CALL score_category('Sweets',   p_country := 'DE');
 
 COMMIT;
+
+-- ═══════════════════════════════════════════════════════════════
+-- Step 4: Refresh materialized views
+-- ═══════════════════════════════════════════════════════════════
+-- Must run AFTER COMMIT because some MVs use CONCURRENTLY refresh.
+-- Ensures v_product_confidence, mv_product_similarity, and
+-- mv_ingredient_frequency reflect the updated scores.
+SELECT refresh_all_materialized_views();


### PR DESCRIPTION
## Summary

Closes #344

Activates the confidence verification system after ingredient & allergen enrichment (#343). The confidence distribution is now multi-modal — no threshold tuning needed.

## Changes

### Pipeline
- **`db/ci_post_enrichment.sql`** — Added Step 4: `refresh_all_materialized_views()` after scoring COMMIT, ensuring `v_product_confidence`, `mv_product_similarity`, and `mv_ingredient_frequency` reflect updated scores

### QA Regression Guards
- **`db/qa/QA__confidence_scoring.sql`** — Added 3 new checks (10 → 13 total):
  - Check 11: Confidence is not mono-modal (at least 2 distinct confidence levels)
  - Check 12: Verified products exist (regression guard against all-estimated)
  - Check 13: MV confidence bands are multi-modal (at least 2 distinct bands)

### Metadata
- **`RUN_QA.ps1`** — Updated confidence suite check count (10 → 13)
- **`copilot-instructions.md`** — Updated QA totals (470 → 473)

## Confidence Distribution (Post-Enrichment Baseline)

| Country | Verified | Estimated | Low | Avg Completeness |
|---------|----------|-----------|-----|------------------|
| PL | 862 (83.8%) | 167 (16.2%) | 0 | 97.0% |
| DE | 51 (20.2%) | 201 (79.8%) | 0 | 89.5% |
| **Total** | **913 (71.3%)** | **368 (28.7%)** | **0** | **95.5%** |

**MV bands:** 910 high, 343 medium, 28 low (3-band distribution)

Issue expected 400+ verified — achieved 913 (128% above target).

## Threshold Tuning

**Not needed.** Distribution exceeds expectations:
- Verified products: 913 (target was 400+)
- Multi-modal: ✅ (2 confidence levels, 3 MV bands)
- No product has completeness < 73%

## Verification

| Gate | Result |
|------|--------|
| QA (34 suites) | ✅ 473/473 checks passing |
| Negative tests | ✅ 23/23 caught |
| Sanity checks | ✅ 17/17 passing |
| TypeScript | ✅ `tsc --noEmit` clean |
| Vitest | ✅ 3,933/3,933 passing |

## Files Changed

**4 files changed, +52 / -15 lines:**
- 1 modified pipeline script (`ci_post_enrichment.sql`)
- 1 modified QA suite (`QA__confidence_scoring.sql`)
- 1 modified runner script (`RUN_QA.ps1`)
- 1 updated docs (`copilot-instructions.md`)