### PR TITLE
ci(main-gate): deduplicate Playwright runs — smoke-only on main-gate

### DIFF
--- a/.github/workflows/main-gate.yml
+++ b/.github/workflows/main-gate.yml
@@ -30,7 +30,7 @@ env:
   BASELINE_STATIC: 90
   BASELINE_UNIT: 180
   BASELINE_BUILD: 120
-  BASELINE_E2E: 600
+  BASELINE_E2E: 300
   BASELINE_SONAR: 300
 
 jobs:
@@ -216,15 +216,15 @@ jobs:
           retention-days: 30
 
   # ─────────────────────────────────────────────────────────────────────────
-  # Job 4: Playwright full E2E — runs after build
+  # Job 4: Playwright smoke E2E — runs after build (full E2E in nightly)
   # ─────────────────────────────────────────────────────────────────────────
   e2e:
-    name: Playwright E2E
+    name: Playwright Smoke E2E
     runs-on: ubuntu-latest
     needs: build
     permissions:
       contents: read
-    timeout-minutes: 20
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: frontend
@@ -265,9 +265,9 @@ jobs:
         run: npx playwright install-deps chromium
         timeout-minutes: 8
 
-      - name: Playwright full E2E
-        run: npx playwright test 2>&1 | tee ../playwright-stdout.log
-        timeout-minutes: 12
+      - name: Playwright smoke E2E
+        run: npx playwright test --project=smoke 2>&1 | tee ../playwright-stdout.log
+        timeout-minutes: 5
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL_STAGING || secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY_STAGING || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -753,7 +753,7 @@ E2E tests are the **only** exception — they run against a live dev server but 
 - CI workflows (tiered architecture):
   - **`pr-gate.yml`**: Static checks (typecheck + lint) → Unit tests + Build (parallel) → Playwright smoke E2E
   - **`pr-title-lint.yml`**: PR title conventional-commit validation (all PRs)
-  - **`main-gate.yml`**: Typecheck → Lint → Build → Unit tests with coverage → Full Playwright E2E → SonarCloud scan + BLOCKING Quality Gate → Sentry sourcemap upload
+  - **`main-gate.yml`**: Typecheck → Lint → Build → Unit tests with coverage → Playwright smoke E2E → SonarCloud scan + BLOCKING Quality Gate → Sentry sourcemap upload
   - **`nightly.yml`**: Full Playwright (all projects incl. visual regression) + Data Integrity Audit (parallel)
   - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (446 checks) → Sanity (17 checks) → Confidence threshold
   - **`deploy.yml`**: Manual trigger → Schema diff → Approval gate (production) → Pre-deploy backup → `supabase db push` → Post-deploy sanity


### PR DESCRIPTION
## Summary

Deduplicates Playwright E2E runs on `main-gate.yml` — switches from full E2E to smoke-only (`--project=smoke`), matching `pr-gate.yml` behavior. Full E2E remains in `nightly.yml` as the authoritative gate.

## Changes

- **`main-gate.yml`**: `npx playwright test` → `npx playwright test --project=smoke`
- Step timeout: 12min → 5min
- Job timeout: 20min → 15min
- `BASELINE_E2E`: 600s → 300s
- Job name: "Playwright E2E" → "Playwright Smoke E2E"
- **`copilot-instructions.md`**: Updated §8.10 CI workflow description

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Main-gate Playwright step | ~12 min (full) | ~5 min (smoke) |
| Full E2E coverage | Every merge + nightly | Nightly only |

No test coverage loss — nightly runs full E2E + visual regression.

Closes #347