### PR TITLE
data(quality): fix bread salt error, reclassify 2 Baby products, add plausibility QA checks

### DIFF
--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -14,7 +14,7 @@
         8. QA__referential_integrity.sql (18 referential integrity checks — blocking)
         9. QA__view_consistency.sql (13 view & function consistency checks — blocking)
        10. QA__naming_conventions.sql (12 naming/formatting convention checks — blocking)
-       11. QA__nutrition_ranges.sql (16 nutrition range & plausibility checks — blocking)
+       11. QA__nutrition_ranges.sql (18 nutrition range & plausibility checks — blocking)
        12. QA__data_consistency.sql (20 data consistency & domain checks — blocking)
        13. QA__allergen_integrity.sql (14 allergen & trace integrity checks — blocking)
        14. QA__serving_source_validation.sql (16 serving & source checks — blocking)
@@ -129,7 +129,7 @@ $suiteCatalog = @(
     @{ Num = 8; Name = "Referential Integrity"; Short = "RefInteg"; Id = "referential"; Checks = 18; Blocking = $true; Kind = "sql"; File = "QA__referential_integrity.sql" },
     @{ Num = 9; Name = "View & Function Consistency"; Short = "Views"; Id = "views"; Checks = 13; Blocking = $true; Kind = "sql"; File = "QA__view_consistency.sql" },
     @{ Num = 10; Name = "Naming Conventions"; Short = "Naming"; Id = "naming"; Checks = 12; Blocking = $true; Kind = "sql"; File = "QA__naming_conventions.sql" },
-    @{ Num = 11; Name = "Nutrition Ranges & Plausibility"; Short = "NutriRange"; Id = "nutrition_ranges"; Checks = 16; Blocking = $true; Kind = "sql"; File = "QA__nutrition_ranges.sql" },
+    @{ Num = 11; Name = "Nutrition Ranges & Plausibility"; Short = "NutriRange"; Id = "nutrition_ranges"; Checks = 18; Blocking = $true; Kind = "sql"; File = "QA__nutrition_ranges.sql" },
     @{ Num = 12; Name = "Data Consistency"; Short = "DataConsist"; Id = "data_consistency"; Checks = 20; Blocking = $true; Kind = "sql"; File = "QA__data_consistency.sql" },
     @{ Num = 13; Name = "Allergen & Trace Integrity"; Short = "Allergen"; Id = "allergen_integrity"; Checks = 15; Blocking = $true; Kind = "sql"; File = "QA__allergen_integrity.sql" },
     @{ Num = 14; Name = "Serving & Source Validation"; Short = "ServSource"; Id = "serving_source"; Checks = 16; Blocking = $true; Kind = "sql"; File = "QA__serving_source_validation.sql" },

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -8,7 +8,7 @@
 > **Servings:** removed as separate table — all nutrition data is per-100g on nutrition_facts
 > **Ingredient analytics:** 2,995 unique ingredients (all clean ASCII English), 1,269 allergen declarations, 1,361 trace declarations
 > **Ingredient concerns:** EFSA-based 4-tier additive classification (0=none, 1=low, 2=moderate, 3=high)
-> **QA:** 473 checks across 34 suites + 23 negative validation tests — all passing
+> **QA:** 475 checks across 34 suites + 23 negative validation tests — all passing
 
 ---
 
@@ -256,7 +256,7 @@ poland-food-db/
 │       ├── 006-append-only-migrations.md
 │       └── 007-english-canonical-ingredients.md
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
-├── RUN_QA.ps1                       # QA test runner (473 checks across 34 suites)
+├── RUN_QA.ps1                       # QA test runner (475 checks across 34 suites)
 ├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (23 injection tests)
 ├── RUN_SANITY.ps1                   # Sanity checks (16) — row counts, schema assertions
 ├── RUN_REMOTE.ps1                   # Remote deployment (requires confirmation)
@@ -789,7 +789,7 @@ If adding/changing DB schema or SQL functions:
 - For rollback procedures, see `DEPLOYMENT.md` → **Rollback Procedures** (5 scenarios + emergency checklist).
 - Add a QA check that verifies the migration outcome (row counts, constraint behavior).
 - Ensure idempotency (`IF NOT EXISTS`, `ON CONFLICT`, `DO UPDATE SET`).
-- Run `.\RUN_QA.ps1` to verify all 473 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 23 injection tests.
+- Run `.\RUN_QA.ps1` to verify all 475 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 23 injection tests.
 
 ### 8.14 Snapshots Are Not Enough
 
@@ -845,7 +845,7 @@ At the end of every PR-like change, include a **Verification** section:
 | Ref. Integrity            | `QA__referential_integrity.sql`     |     18 | Yes       |
 | View Consistency          | `QA__view_consistency.sql`          |     13 | Yes       |
 | Naming Conventions        | `QA__naming_conventions.sql`        |     12 | Yes       |
-| Nutrition Ranges          | `QA__nutrition_ranges.sql`          |     16 | Yes       |
+| Nutrition Ranges          | `QA__nutrition_ranges.sql`          |     18 | Yes       |
 | Data Consistency          | `QA__data_consistency.sql`          |     20 | Yes       |
 | Allergen Integrity        | `QA__allergen_integrity.sql`        |     15 | Yes       |
 | Allergen Filtering        | `QA__allergen_filtering.sql`        |      6 | Yes       |
@@ -869,7 +869,7 @@ At the end of every PR-like change, include a **Verification** section:
 | Event Intelligence        | `QA__event_intelligence.sql`        |     18 | Yes       |
 | **Negative Validation**   | `TEST__negative_checks.sql`         |     23 | Yes       |
 
-**Run:** `.\RUN_QA.ps1` — expects **473/473 checks passing** (+ EAN validation).
+**Run:** `.\RUN_QA.ps1` — expects **475/475 checks passing** (+ EAN validation).
 **Run:** `.\RUN_NEGATIVE_TESTS.ps1` — expects **23/23 caught**.
 
 ### 8.19 Key Regression Tests (Scoring Suite)

--- a/supabase/migrations/20260307000300_fix_extreme_nutrition_values.sql
+++ b/supabase/migrations/20260307000300_fix_extreme_nutrition_values.sql
@@ -1,0 +1,72 @@
+-- =============================================================================
+-- Migration: Fix extreme nutrition values and category misclassifications
+-- Issue: #366
+-- Date: 2026-02-25
+--
+-- Changes:
+--   Step 1: Fix confirmed salt decimal error for bread product
+--   Step 2: Reclassify 2 misclassified Baby products
+--   Step 3: Re-score affected categories
+--   Step 4: Refresh materialized views
+--
+-- Rollback:
+--   UPDATE nutrition_facts SET salt_g = 13.0
+--     WHERE product_id = (SELECT product_id FROM products
+--       WHERE product_name = 'Chleb wieloziarnisty Złoty Łan'
+--       AND brand = 'Pano' AND country = 'PL');
+--   UPDATE products SET category = 'Baby'
+--     WHERE product_id IN (23, 44);  -- Przyprawa Maggi, Bezwodny tłuszcz mleczny
+--   CALL score_category('Bread');
+--   CALL score_category('Baby');
+--   CALL score_category('Condiments');
+--   CALL score_category('Dairy');
+-- =============================================================================
+
+-- ─── Step 1: Fix bread salt decimal error ────────────────────────────────────
+-- Product: "Chleb wieloziarnisty Złoty Łan" (Pano, EAN 5900340007347)
+-- Current: 13.0g salt/100g — impossible for bread (normal range: 0.8-1.5g/100g)
+-- Evidence: Sister product "Chleb wieloziarnisty złoty łan" (EAN 5901486007406)
+--   has 1.0g salt. OFF API also reports 13g (community data entry error in OFF).
+-- Fix: 1.3g (likely decimal shift 1.3 → 13.0)
+UPDATE nutrition_facts
+SET salt_g = 1.3
+WHERE product_id = (
+    SELECT product_id FROM products
+    WHERE product_name = 'Chleb wieloziarnisty Złoty Łan'
+      AND brand = 'Pano'
+      AND country = 'PL'
+)
+AND salt_g = 13.0;  -- Guard: only apply if still at error value
+
+-- ─── Step 2: Reclassify misclassified Baby products ─────────────────────────
+-- Product: "Przyprawa Maggi" (Nestlé) — OFF category: en:condiments
+-- This is a seasoning/condiment, not baby food.
+UPDATE products
+SET category = 'Condiments'
+WHERE product_name = 'Przyprawa Maggi'
+  AND brand = 'Nestlé'
+  AND country = 'PL'
+  AND category = 'Baby';  -- Guard: only apply if still in Baby
+
+-- Product: "Bezwodny tłuszcz mleczny, Masło klarowane" (Mlekovita)
+-- OFF category: pl:masła-klarowane (clarified butter)
+-- This is a dairy cooking fat, not baby food.
+UPDATE products
+SET category = 'Dairy'
+WHERE product_name = 'Bezwodny tłuszcz mleczny, Masło klarowane'
+  AND brand = 'Mlekovita'
+  AND country = 'PL'
+  AND category = 'Baby';  -- Guard: only apply if still in Baby
+
+-- ─── Step 3: Re-score affected categories ────────────────────────────────────
+-- Bread: salt correction changes unhealthiness_score
+-- Baby: 2 products removed → category stats change
+-- Condiments: 1 product added (Maggi)
+-- Dairy: 1 product added (Bezwodny tłuszcz)
+CALL score_category('Bread');
+CALL score_category('Baby');
+CALL score_category('Condiments');
+CALL score_category('Dairy');
+
+-- ─── Step 4: Refresh materialized views ──────────────────────────────────────
+SELECT refresh_all_materialized_views();


### PR DESCRIPTION
## Summary

Closes #366

Fixes 3 extreme nutrition / misclassification issues identified in issue #366:

### 1. Bread Salt Decimal Error
- **Product:** Chleb wieloziarnisty Złoty Łan (Pano, EAN `5900340007347`, product_id 112)
- **Problem:** salt_g = 13.0 — impossible for bread (normal: 0.8–1.5g)
- **Root cause:** OFF API itself reports `salt_100g: 13` — likely decimal shift at data-entry (1.3 → 13.0)
- **Evidence:** Sister product (product_id 111, EAN `5901486007406`) has 1.0g salt
- **Fix:** `salt_g` corrected from 13.0 → 1.3; score dropped from 40 → 31

### 2. Baby Category Misclassifications
- **Przyprawa Maggi** (product_id 23, Nestlé): Seasoning reclassified Baby → **Condiments** (OFF: `en:condiments`)
- **Bezwodny tłuszcz mleczny** (product_id 44, Mlekovita): Clarified butter reclassified Baby → **Dairy** (OFF: `pl:masła-klarowane`)

### 3. New QA Plausibility Checks
Added 2 checks to `QA__nutrition_ranges.sql` (16 → 18 checks):
- **Check 17:** Extreme salt (>10g/100g) outside expected categories (Sauces, Condiments, Seafood & Fish, Instant & Frozen)
- **Check 18:** Extreme calories (>700 kcal/100g) outside expected categories (Nuts/Seeds/Legumes, Plant-Based, Condiments, Dairy)

## Verification

| Gate | Result |
|------|--------|
| QA (34 suites) | **475/475 pass** |
| Negative tests | **23/23 caught** |
| EAN validation | **1253/1253 valid** |

## Files Changed

| File | Change |
|------|--------|
| `supabase/migrations/20260307000300_fix_extreme_nutrition_values.sql` | New migration (salt fix + reclassifications + re-score + MV refresh) |
| `db/qa/QA__nutrition_ranges.sql` | +2 plausibility checks (17, 18); header 16 → 18 |
| `RUN_QA.ps1` | Nutrition ranges check count 16 → 18 |
| `copilot-instructions.md` | QA totals 473 → 475 (5 references) |