### PR TITLE
schema(migration): normalize allergen tags to bare canonical IDs (#351)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ tmp-qa-*/
 tmp-*.txt
 tmp-*.json
 qa-results.json
+tmp-*.sql

--- a/db/ci_post_pipeline.sql
+++ b/db/ci_post_pipeline.sql
@@ -104,29 +104,29 @@ INSERT INTO product_allergen_info (product_id, tag, type)
 SELECT p.product_id, v.tag, v.type
 FROM (VALUES
   -- Chips (contain milk / gluten from flavoring ingredients)
-  ('PL', '5900073020118', 'en:gluten', 'contains'),
-  ('PL', '5900073020118', 'en:milk', 'traces'),
-  ('PL', '5905187114760', 'en:milk', 'contains'),
-  ('PL', '5905187114760', 'en:gluten', 'contains'),
-  ('PL', '5900073020187', 'en:gluten', 'contains'),
-  ('PL', '5900073020187', 'en:milk', 'traces'),
+  ('PL', '5900073020118', 'gluten', 'contains'),
+  ('PL', '5900073020118', 'milk', 'traces'),
+  ('PL', '5905187114760', 'milk', 'contains'),
+  ('PL', '5905187114760', 'gluten', 'contains'),
+  ('PL', '5900073020187', 'gluten', 'contains'),
+  ('PL', '5900073020187', 'milk', 'traces'),
   -- Bread (contain gluten)
-  ('PL', '5900014005716', 'en:gluten', 'contains'),
-  ('PL', '5900535013986', 'en:gluten', 'contains'),
-  ('PL', '5900535013986', 'en:milk', 'traces'),
+  ('PL', '5900014005716', 'gluten', 'contains'),
+  ('PL', '5900535013986', 'gluten', 'contains'),
+  ('PL', '5900535013986', 'milk', 'traces'),
   -- Dairy (contain milk)
-  ('PL', '5900014004245', 'en:milk', 'contains'),
-  ('PL', '5900699106388', 'en:milk', 'contains'),
+  ('PL', '5900014004245', 'milk', 'contains'),
+  ('PL', '5900699106388', 'milk', 'contains'),
   -- Sweets / Snacks (contain milk, gluten, eggs, soybeans)
-  ('PL', '5901359074290', 'en:gluten', 'contains'),
-  ('PL', '5901359074290', 'en:milk', 'contains'),
-  ('PL', '5901359074290', 'en:soybeans', 'traces'),
-  ('PL', '5902709615323', 'en:gluten', 'contains'),
-  ('PL', '5901359062013', 'en:gluten', 'contains'),
-  ('PL', '5901359062013', 'en:eggs', 'contains'),
-  ('PL', '5900490000182', 'en:gluten', 'contains'),
-  ('PL', '5901359122021', 'en:milk', 'contains'),
-  ('PL', '5901359122021', 'en:gluten', 'contains')
+  ('PL', '5901359074290', 'gluten', 'contains'),
+  ('PL', '5901359074290', 'milk', 'contains'),
+  ('PL', '5901359074290', 'soybeans', 'traces'),
+  ('PL', '5902709615323', 'gluten', 'contains'),
+  ('PL', '5901359062013', 'gluten', 'contains'),
+  ('PL', '5901359062013', 'eggs', 'contains'),
+  ('PL', '5900490000182', 'gluten', 'contains'),
+  ('PL', '5901359122021', 'milk', 'contains'),
+  ('PL', '5901359122021', 'gluten', 'contains')
 ) AS v(country, ean, tag, type)
 JOIN products p ON p.country = v.country AND p.ean = v.ean
 WHERE p.is_deprecated IS NOT TRUE

--- a/db/qa/QA__attribute_contradiction.sql
+++ b/db/qa/QA__attribute_contradiction.sql
@@ -18,7 +18,7 @@ FROM v_master m
 JOIN product_allergen_info ai ON ai.product_id = m.product_id
 WHERE m.vegan_status = 'yes'
   AND ai.type = 'contains'
-  AND ai.tag IN ('en:milk', 'en:eggs', 'en:fish', 'en:crustaceans', 'en:molluscs');
+  AND ai.tag IN ('milk', 'eggs', 'fish', 'crustaceans', 'molluscs');
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 2. No products with vegetarian_status='yes' AND meat/fish allergens
@@ -31,7 +31,7 @@ FROM v_master m
 JOIN product_allergen_info ai ON ai.product_id = m.product_id
 WHERE m.vegetarian_status = 'yes'
   AND ai.type = 'contains'
-  AND ai.tag IN ('en:fish', 'en:crustaceans', 'en:molluscs');
+  AND ai.tag IN ('fish', 'crustaceans', 'molluscs');
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 3. No products where vegan_status='yes' but vegetarian_status='no'

--- a/db/views/VIEW__master_product_view.sql
+++ b/db/views/VIEW__master_product_view.sql
@@ -174,10 +174,10 @@ LEFT JOIN LATERAL (
         STRING_AGG(ai.tag, ', ' ORDER BY ai.tag) FILTER (WHERE ai.type = 'traces') AS trace_tags,
         -- Contradiction detection flags
         BOOL_OR(ai.type = 'contains' AND ai.tag IN (
-            'en:milk', 'en:eggs', 'en:fish', 'en:crustaceans', 'en:molluscs'
+            'milk', 'eggs', 'fish', 'crustaceans', 'molluscs'
         )) AS has_animal_allergen,
         BOOL_OR(ai.type = 'contains' AND ai.tag IN (
-            'en:fish', 'en:crustaceans', 'en:molluscs'
+            'fish', 'crustaceans', 'molluscs'
         )) AS has_meat_fish_allergen
     FROM public.product_allergen_info ai
     WHERE ai.product_id = p.product_id

--- a/frontend/src/app/app/admin/metrics/page.test.tsx
+++ b/frontend/src/app/app/admin/metrics/page.test.tsx
@@ -61,8 +61,8 @@ const sampleMetrics: BusinessMetricsResponse = {
     { product_id: "2", product_name: "Coca-Cola", views: 35 },
   ],
   allergen_distribution: [
-    { allergen: "en:gluten", user_count: 15, percentage: 60 },
-    { allergen: "en:milk", user_count: 10, percentage: 40 },
+    { allergen: "gluten", user_count: 15, percentage: 60 },
+    { allergen: "milk", user_count: 10, percentage: 40 },
   ],
   feature_usage: [
     { feature: "search_performed", usage_count: 200, unique_users: 35 },
@@ -147,9 +147,7 @@ describe("AdminMetricsPage", () => {
   });
 
   it("shows loading spinner while fetching", () => {
-    mockGetBusinessMetrics.mockImplementation(
-      () => new Promise(() => {}),
-    );
+    mockGetBusinessMetrics.mockImplementation(() => new Promise(() => {}));
 
     render(<AdminMetricsPage />, { wrapper: createWrapper() });
     expect(screen.getByTestId("loading")).toBeInTheDocument();
@@ -193,7 +191,9 @@ describe("AdminMetricsPage", () => {
       expect(screen.getByTestId("top-products")).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId("top-products")).toHaveTextContent("Lay's Classic");
+    expect(screen.getByTestId("top-products")).toHaveTextContent(
+      "Lay's Classic",
+    );
     expect(screen.getByTestId("top-products")).toHaveTextContent("Coca-Cola");
   });
 
@@ -235,7 +235,9 @@ describe("AdminMetricsPage", () => {
       expect(screen.getByTestId("onboarding-funnel")).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId("onboarding-funnel")).toHaveTextContent("welcome");
+    expect(screen.getByTestId("onboarding-funnel")).toHaveTextContent(
+      "welcome",
+    );
     expect(screen.getByTestId("onboarding-funnel")).toHaveTextContent("100%");
   });
 

--- a/frontend/src/app/app/admin/metrics/page.tsx
+++ b/frontend/src/app/app/admin/metrics/page.tsx
@@ -64,7 +64,9 @@ function MetricCard({
         {icon}
         <span>{label}</span>
       </div>
-      <p className="mt-2 text-2xl font-bold">{typeof value === "number" ? value.toLocaleString() : value}</p>
+      <p className="mt-2 text-2xl font-bold">
+        {typeof value === "number" ? value.toLocaleString() : value}
+      </p>
       {subtitle && (
         <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
           {subtitle}
@@ -173,7 +175,9 @@ function FeatureUsageChart({
   data,
 }: Readonly<{ data: BusinessMetricsResponse["feature_usage"] }>) {
   if (data.length === 0) {
-    return <p className="text-sm text-gray-500 dark:text-gray-400">No data yet</p>;
+    return (
+      <p className="text-sm text-gray-500 dark:text-gray-400">No data yet</p>
+    );
   }
   const maxVal = Math.max(...data.map((d) => d.usage_count));
   return (
@@ -195,7 +199,9 @@ function ScanSearchRatio({
   data,
 }: Readonly<{ data: BusinessMetricsResponse["scan_vs_search"] }>) {
   if (data.length === 0) {
-    return <p className="text-sm text-gray-500 dark:text-gray-400">No data yet</p>;
+    return (
+      <p className="text-sm text-gray-500 dark:text-gray-400">No data yet</p>
+    );
   }
   const total = data.reduce((s, d) => s + d.count, 0);
   return (
@@ -255,7 +261,13 @@ function TrendSparkline({
 
   return (
     <svg width={w} height={h} className="inline-block" aria-hidden="true">
-      <path d={pathD} fill="none" stroke="currentColor" strokeWidth="1.5" className="text-blue-500" />
+      <path
+        d={pathD}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        className="text-blue-500"
+      />
     </svg>
   );
 }
@@ -408,7 +420,10 @@ export default function AdminMetricsPage() {
               value={
                 data.scan_vs_search.length > 0
                   ? data.scan_vs_search
-                      .map((s) => `${s.percentage}% ${s.method.includes("scan") ? "scan" : "search"}`)
+                      .map(
+                        (s) =>
+                          `${s.percentage}% ${s.method.includes("scan") ? "scan" : "search"}`,
+                      )
                       .join(" / ")
                   : "No data"
               }
@@ -438,7 +453,10 @@ export default function AdminMetricsPage() {
           </div>
 
           {/* Row 3: Feature usage */}
-          <div className="rounded-lg border bg-white p-4 dark:border-gray-700 dark:bg-gray-800" data-testid="feature-usage">
+          <div
+            className="rounded-lg border bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+            data-testid="feature-usage"
+          >
             <h3 className="mb-3 flex items-center gap-2 font-semibold">
               <Layers className="h-4 w-4" />
               Feature Usage ({days} days)
@@ -465,6 +483,7 @@ export default function AdminMetricsPage() {
                   {data.allergen_distribution.slice(0, 10).map((item) => (
                     <BarRow
                       key={item.allergen}
+                      // Tags are bare canonical IDs; strip legacy en: prefix as fallback
                       label={item.allergen.replace("en:", "")}
                       value={item.user_count}
                       maxValue={data.allergen_distribution[0].user_count}

--- a/frontend/src/app/app/product/[id]/page.test.tsx
+++ b/frontend/src/app/app/product/[id]/page.test.tsx
@@ -188,8 +188,8 @@ function makeProfile(overrides: Record<string, unknown> = {}) {
       top_ingredients: [],
     },
     allergens: {
-      contains: "en:gluten,en:milk",
-      traces: "en:soy",
+      contains: "gluten,milk",
+      traces: "soybeans",
       contains_count: 2,
       traces_count: 1,
     },
@@ -1218,9 +1218,7 @@ describe("ProductDetailPage", () => {
       expect(screen.getByText("Allergens")).toBeInTheDocument();
     });
 
-    expect(
-      screen.queryByText(/Environmental Impact/),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Environmental Impact/)).not.toBeInTheDocument();
     expect(
       screen.queryByText(/Eco-Score data coming soon/),
     ).not.toBeInTheDocument();

--- a/frontend/src/app/app/scan/result/[id]/page.test.tsx
+++ b/frontend/src/app/app/scan/result/[id]/page.test.tsx
@@ -130,9 +130,9 @@ function makeProduct(overrides: Record<string, unknown> = {}) {
     },
     allergens: {
       count: 2,
-      tags: ["en:gluten", "en:milk"],
+      tags: ["gluten", "milk"],
       trace_count: 1,
-      trace_tags: ["en:soy"],
+      trace_tags: ["soybeans"],
     },
     trust: {
       confidence: "high",

--- a/frontend/src/app/app/search/saved/page.test.tsx
+++ b/frontend/src/app/app/search/saved/page.test.tsx
@@ -82,7 +82,7 @@ const mockSearches = [
     filters: {
       category: ["drinks"],
       nutri_score: ["A", "B"],
-      allergen_free: ["en:gluten"],
+      allergen_free: ["gluten"],
       max_unhealthiness: 40,
       sort_by: "unhealthiness" as const,
     },

--- a/frontend/src/app/app/search/saved/page.tsx
+++ b/frontend/src/app/app/search/saved/page.tsx
@@ -198,6 +198,7 @@ function FilterSummaryChips({ filters }: Readonly<{ filters: SearchFilters }>) {
   if (filters.allergen_free?.length) {
     const labels = filters.allergen_free.map((tag) => {
       const info = ALLERGEN_TAGS.find((a) => a.tag === tag);
+      // Tags are bare canonical IDs; strip legacy en: prefix as fallback
       return info?.label ?? tag.replace("en:", "");
     });
     chips.push(

--- a/frontend/src/app/app/settings/page.test.tsx
+++ b/frontend/src/app/app/settings/page.test.tsx
@@ -297,7 +297,7 @@ describe("SettingsPage", () => {
   it("shows allergen strictness toggles when allergens selected", async () => {
     mockGetPrefs.mockResolvedValue({
       ok: true,
-      data: { ...mockPrefsData, avoid_allergens: ["en:gluten"] },
+      data: { ...mockPrefsData, avoid_allergens: ["gluten"] },
     });
 
     render(<SettingsPage />, { wrapper: createWrapper() });

--- a/frontend/src/app/onboarding/OnboardingWizard.test.tsx
+++ b/frontend/src/app/onboarding/OnboardingWizard.test.tsx
@@ -88,7 +88,7 @@ describe("OnboardingWizard", () => {
     await user.click(screen.getByText("Next"));
 
     // Step 3: Allergens
-    expect(screen.getByTestId("allergen-en:gluten")).toBeInTheDocument();
+    expect(screen.getByTestId("allergen-gluten")).toBeInTheDocument();
     await user.click(screen.getByText("Next"));
 
     // Step 4: Health Goals
@@ -172,7 +172,7 @@ describe("OnboardingWizard", () => {
     await user.click(screen.getByText("Next"));
     await user.click(screen.getByTestId("diet-vegetarian"));
     await user.click(screen.getByText("Next"));
-    await user.click(screen.getByTestId("allergen-en:gluten"));
+    await user.click(screen.getByTestId("allergen-gluten"));
     await user.click(screen.getByText("Next"));
     await user.click(screen.getByTestId("goal-diabetes"));
     await user.click(screen.getByText("Next"));
@@ -188,7 +188,7 @@ describe("OnboardingWizard", () => {
         expect.objectContaining({
           country: "PL",
           diet: "vegetarian",
-          allergens: ["en:gluten"],
+          allergens: ["gluten"],
           health_goals: ["diabetes"],
           favorite_categories: ["chips"],
         }),
@@ -241,8 +241,8 @@ describe("OnboardingWizard", () => {
     await user.click(screen.getByText("Next"));
 
     // Allergens: select gluten + milk
-    await user.click(screen.getByTestId("allergen-en:gluten"));
-    await user.click(screen.getByTestId("allergen-en:milk"));
+    await user.click(screen.getByTestId("allergen-gluten"));
+    await user.click(screen.getByTestId("allergen-milk"));
     await user.click(screen.getByText("Next"));
 
     // Health goals: skip (click next)

--- a/frontend/src/app/onboarding/preferences/PreferencesForm.test.tsx
+++ b/frontend/src/app/onboarding/preferences/PreferencesForm.test.tsx
@@ -128,7 +128,7 @@ describe("PreferencesForm", () => {
     await waitFor(() => {
       expect(mockSetPrefs).toHaveBeenCalledWith(expect.anything(), {
         p_diet_preference: "vegan",
-        p_avoid_allergens: ["en:gluten"],
+        p_avoid_allergens: ["gluten"],
         p_strict_diet: false,
         p_strict_allergen: false,
         p_treat_may_contain_as_unsafe: false,
@@ -217,7 +217,7 @@ describe("PreferencesForm", () => {
     await waitFor(() => {
       expect(mockSetPrefs).toHaveBeenCalledWith(expect.anything(), {
         p_diet_preference: "vegetarian",
-        p_avoid_allergens: ["en:milk"],
+        p_avoid_allergens: ["milk"],
         p_strict_diet: true,
         p_strict_allergen: true,
         p_treat_may_contain_as_unsafe: true,

--- a/frontend/src/app/onboarding/steps/AllergensStep.test.tsx
+++ b/frontend/src/app/onboarding/steps/AllergensStep.test.tsx
@@ -27,22 +27,20 @@ describe("AllergensStep", () => {
 
   it("renders all 14 EU allergen buttons", () => {
     renderStep();
-    expect(screen.getByTestId("allergen-en:gluten")).toBeInTheDocument();
-    expect(screen.getByTestId("allergen-en:milk")).toBeInTheDocument();
-    expect(screen.getByTestId("allergen-en:eggs")).toBeInTheDocument();
-    expect(screen.getByTestId("allergen-en:nuts")).toBeInTheDocument();
-    expect(screen.getByTestId("allergen-en:peanuts")).toBeInTheDocument();
-    expect(screen.getByTestId("allergen-en:soybeans")).toBeInTheDocument();
-    expect(screen.getByTestId("allergen-en:fish")).toBeInTheDocument();
-    expect(screen.getByTestId("allergen-en:crustaceans")).toBeInTheDocument();
-    expect(screen.getByTestId("allergen-en:celery")).toBeInTheDocument();
-    expect(screen.getByTestId("allergen-en:mustard")).toBeInTheDocument();
-    expect(screen.getByTestId("allergen-en:sesame-seeds")).toBeInTheDocument();
-    expect(
-      screen.getByTestId("allergen-en:sulphur-dioxide-and-sulphites"),
-    ).toBeInTheDocument();
-    expect(screen.getByTestId("allergen-en:lupin")).toBeInTheDocument();
-    expect(screen.getByTestId("allergen-en:molluscs")).toBeInTheDocument();
+    expect(screen.getByTestId("allergen-gluten")).toBeInTheDocument();
+    expect(screen.getByTestId("allergen-milk")).toBeInTheDocument();
+    expect(screen.getByTestId("allergen-eggs")).toBeInTheDocument();
+    expect(screen.getByTestId("allergen-tree-nuts")).toBeInTheDocument();
+    expect(screen.getByTestId("allergen-peanuts")).toBeInTheDocument();
+    expect(screen.getByTestId("allergen-soybeans")).toBeInTheDocument();
+    expect(screen.getByTestId("allergen-fish")).toBeInTheDocument();
+    expect(screen.getByTestId("allergen-crustaceans")).toBeInTheDocument();
+    expect(screen.getByTestId("allergen-celery")).toBeInTheDocument();
+    expect(screen.getByTestId("allergen-mustard")).toBeInTheDocument();
+    expect(screen.getByTestId("allergen-sesame")).toBeInTheDocument();
+    expect(screen.getByTestId("allergen-sulphites")).toBeInTheDocument();
+    expect(screen.getByTestId("allergen-lupin")).toBeInTheDocument();
+    expect(screen.getByTestId("allergen-molluscs")).toBeInTheDocument();
   });
 
   it("renders allergen labels", () => {
@@ -55,15 +53,15 @@ describe("AllergensStep", () => {
   it("toggles allergen on when clicked", async () => {
     const user = userEvent.setup();
     renderStep();
-    await user.click(screen.getByTestId("allergen-en:gluten"));
-    expect(onChange).toHaveBeenCalledWith({ allergens: ["en:gluten"] });
+    await user.click(screen.getByTestId("allergen-gluten"));
+    expect(onChange).toHaveBeenCalledWith({ allergens: ["gluten"] });
   });
 
   it("toggles allergen off when already selected", async () => {
     const user = userEvent.setup();
-    renderStep({ allergens: ["en:gluten", "en:milk"] });
-    await user.click(screen.getByTestId("allergen-en:gluten"));
-    expect(onChange).toHaveBeenCalledWith({ allergens: ["en:milk"] });
+    renderStep({ allergens: ["gluten", "milk"] });
+    await user.click(screen.getByTestId("allergen-gluten"));
+    expect(onChange).toHaveBeenCalledWith({ allergens: ["milk"] });
   });
 
   it("does not show strictness toggles when no allergens selected", () => {
@@ -72,14 +70,14 @@ describe("AllergensStep", () => {
   });
 
   it("shows strict allergen and may-contain toggles when allergens selected", () => {
-    renderStep({ allergens: ["en:gluten"] });
+    renderStep({ allergens: ["gluten"] });
     const checkboxes = screen.getAllByRole("checkbox");
     expect(checkboxes).toHaveLength(2);
   });
 
   it("calls onChange with strictAllergen when toggling strict checkbox", async () => {
     const user = userEvent.setup();
-    renderStep({ allergens: ["en:gluten"] });
+    renderStep({ allergens: ["gluten"] });
     const checkboxes = screen.getAllByRole("checkbox");
     await user.click(checkboxes[0]);
     expect(onChange).toHaveBeenCalledWith({ strictAllergen: true });
@@ -87,7 +85,7 @@ describe("AllergensStep", () => {
 
   it("calls onChange with treatMayContain when toggling may-contain checkbox", async () => {
     const user = userEvent.setup();
-    renderStep({ allergens: ["en:gluten"] });
+    renderStep({ allergens: ["gluten"] });
     const checkboxes = screen.getAllByRole("checkbox");
     await user.click(checkboxes[1]);
     expect(onChange).toHaveBeenCalledWith({ treatMayContain: true });

--- a/frontend/src/app/onboarding/steps/DoneStep.test.tsx
+++ b/frontend/src/app/onboarding/steps/DoneStep.test.tsx
@@ -44,7 +44,7 @@ describe("DoneStep", () => {
   });
 
   it("shows allergen labels in summary", () => {
-    renderStep({ allergens: ["en:gluten", "en:milk"] });
+    renderStep({ allergens: ["gluten", "milk"] });
     expect(screen.getByText("Gluten, Milk / Dairy")).toBeInTheDocument();
   });
 

--- a/frontend/src/components/common/AllergenChips.test.tsx
+++ b/frontend/src/components/common/AllergenChips.test.tsx
@@ -9,7 +9,7 @@ function makeWarning(
   overrides: Partial<AllergenWarning> = {},
 ): AllergenWarning {
   return {
-    tag: "en:milk",
+    tag: "milk",
     label: "Milk / Dairy",
     icon: "🥛",
     type: "contains",
@@ -49,8 +49,8 @@ describe("AllergenChips", () => {
     render(
       <AllergenChips
         warnings={[
-          makeWarning({ tag: "en:milk" }),
-          makeWarning({ tag: "en:eggs", label: "Eggs", icon: "🥚" }),
+          makeWarning({ tag: "milk" }),
+          makeWarning({ tag: "eggs", label: "Eggs", icon: "🥚" }),
         ]}
       />,
     );
@@ -104,9 +104,9 @@ describe("AllergenChips", () => {
 
   it("renders up to 3 visible chips without overflow", () => {
     const warnings = [
-      makeWarning({ tag: "en:milk" }),
-      makeWarning({ tag: "en:eggs", label: "Eggs", icon: "🥚" }),
-      makeWarning({ tag: "en:gluten", label: "Gluten", icon: "🌾" }),
+      makeWarning({ tag: "milk" }),
+      makeWarning({ tag: "eggs", label: "Eggs", icon: "🥚" }),
+      makeWarning({ tag: "gluten", label: "Gluten", icon: "🌾" }),
     ];
     render(<AllergenChips warnings={warnings} />);
 
@@ -117,10 +117,10 @@ describe("AllergenChips", () => {
 
   it("renders overflow badge when more than 3 warnings", () => {
     const warnings = [
-      makeWarning({ tag: "en:milk" }),
-      makeWarning({ tag: "en:eggs", label: "Eggs", icon: "🥚" }),
-      makeWarning({ tag: "en:gluten", label: "Gluten", icon: "🌾" }),
-      makeWarning({ tag: "en:peanuts", label: "Peanuts", icon: "🥜" }),
+      makeWarning({ tag: "milk" }),
+      makeWarning({ tag: "eggs", label: "Eggs", icon: "🥚" }),
+      makeWarning({ tag: "gluten", label: "Gluten", icon: "🌾" }),
+      makeWarning({ tag: "peanuts", label: "Peanuts", icon: "🥜" }),
     ];
     render(<AllergenChips warnings={warnings} />);
 
@@ -134,12 +134,12 @@ describe("AllergenChips", () => {
 
   it("overflow badge shows correct count for many extras", () => {
     const warnings = [
-      makeWarning({ tag: "en:milk" }),
-      makeWarning({ tag: "en:eggs", label: "Eggs" }),
-      makeWarning({ tag: "en:gluten", label: "Gluten" }),
-      makeWarning({ tag: "en:peanuts", label: "Peanuts" }),
-      makeWarning({ tag: "en:fish", label: "Fish" }),
-      makeWarning({ tag: "en:celery", label: "Celery" }),
+      makeWarning({ tag: "milk" }),
+      makeWarning({ tag: "eggs", label: "Eggs" }),
+      makeWarning({ tag: "gluten", label: "Gluten" }),
+      makeWarning({ tag: "peanuts", label: "Peanuts" }),
+      makeWarning({ tag: "fish", label: "Fish" }),
+      makeWarning({ tag: "celery", label: "Celery" }),
     ];
     render(<AllergenChips warnings={warnings} />);
 
@@ -149,10 +149,10 @@ describe("AllergenChips", () => {
 
   it("overflow badge has tooltip listing hidden allergens", () => {
     const warnings = [
-      makeWarning({ tag: "en:milk", label: "Milk / Dairy" }),
-      makeWarning({ tag: "en:eggs", label: "Eggs" }),
-      makeWarning({ tag: "en:gluten", label: "Gluten" }),
-      makeWarning({ tag: "en:peanuts", label: "Peanuts" }),
+      makeWarning({ tag: "milk", label: "Milk / Dairy" }),
+      makeWarning({ tag: "eggs", label: "Eggs" }),
+      makeWarning({ tag: "gluten", label: "Gluten" }),
+      makeWarning({ tag: "peanuts", label: "Peanuts" }),
     ];
     render(<AllergenChips warnings={warnings} />);
 

--- a/frontend/src/components/compare/ComparisonGrid.test.tsx
+++ b/frontend/src/components/compare/ComparisonGrid.test.tsx
@@ -44,7 +44,7 @@ const makeProduct = (
   additives_count: 3,
   ingredient_count: 12,
   allergen_count: 2,
-  allergen_tags: "en:gluten, en:milk",
+  allergen_tags: "gluten, milk",
   trace_tags: null,
   confidence: "high",
   data_completeness_pct: 85,
@@ -165,7 +165,7 @@ describe("ComparisonGrid", () => {
 
   it("renders allergen tags row", () => {
     render(<ComparisonGrid products={products} />);
-    // Product A has "en:gluten, en:milk" → stripped to "gluten, milk"
+    // Product A has "gluten, milk"
     const tags = screen.getAllByText("gluten, milk");
     expect(tags.length).toBeGreaterThanOrEqual(1);
     // Product B has no allergens

--- a/frontend/src/components/compare/ComparisonGrid.tsx
+++ b/frontend/src/components/compare/ComparisonGrid.tsx
@@ -285,6 +285,7 @@ function DesktopGrid({
                 key={p.product_id}
                 className="px-3 py-2 text-center text-xs text-foreground-secondary"
               >
+                {/* Tags are bare canonical IDs; strip legacy en: prefix as fallback */}
                 {p.allergen_tags
                   ? p.allergen_tags
                       .split(", ")
@@ -549,6 +550,7 @@ function MobileSwipeView({
               {t("product.allergens")}
             </p>
             <p className="text-sm text-foreground-secondary">
+              {/* Tags are bare canonical IDs; strip legacy en: prefix as fallback */}
               {product.allergen_tags
                 ? product.allergen_tags
                     .split(", ")

--- a/frontend/src/components/dashboard/AllergenAlert.tsx
+++ b/frontend/src/components/dashboard/AllergenAlert.tsx
@@ -19,6 +19,7 @@ export function AllergenAlert({ alerts }: Readonly<AllergenAlertProps>) {
   if (alerts.count === 0) return null;
 
   // Deduplicate allergen tags for the summary
+  // Tags are bare canonical IDs; strip legacy en: prefix as fallback
   const uniqueAllergens = [
     ...new Set(alerts.products.map((p) => p.allergen.replace("en:", ""))),
   ];

--- a/frontend/src/components/dashboard/health-insights.test.tsx
+++ b/frontend/src/components/dashboard/health-insights.test.tsx
@@ -99,9 +99,9 @@ describe("AllergenAlert", () => {
   const alertData: DashboardAllergenAlerts = {
     count: 3,
     products: [
-      { product_id: 1, product_name: "Product A", allergen: "en:milk" },
-      { product_id: 2, product_name: "Product B", allergen: "en:gluten" },
-      { product_id: 3, product_name: "Product C", allergen: "en:milk" },
+      { product_id: 1, product_name: "Product A", allergen: "milk" },
+      { product_id: 2, product_name: "Product B", allergen: "gluten" },
+      { product_id: 3, product_name: "Product C", allergen: "milk" },
     ],
   };
 

--- a/frontend/src/components/product/AllergenMatrix.tsx
+++ b/frontend/src/components/product/AllergenMatrix.tsx
@@ -10,7 +10,8 @@ import type { ProfileAllergens } from "@/lib/types";
 
 /**
  * EU FIC Regulation 1169/2011 mandates declaration of these 14 allergens.
- * Tags may appear with or without "en:" prefix in the data.
+ * Tags are now bare canonical IDs (e.g. "milk", "gluten").
+ * Legacy data may still carry the "en:" prefix; normaliseTag() strips it as a fallback.
  */
 const EU_14_ALLERGENS = [
   "gluten",
@@ -20,16 +21,34 @@ const EU_14_ALLERGENS = [
   "peanuts",
   "soybeans",
   "milk",
-  "nuts",
+  "tree-nuts",
   "celery",
   "mustard",
-  "sesame-seeds",
-  "sulphur-dioxide",
+  "sesame",
+  "sulphites",
   "lupin",
   "molluscs",
 ] as const;
 
-/** Normalise an allergen tag: strip "en:" prefix, trim, lowercase */
+/** Friendly display names matching ALLERGEN_TAGS labels in constants.ts */
+const DISPLAY_NAMES: Record<string, string> = {
+  gluten: "Gluten",
+  crustaceans: "Crustaceans",
+  eggs: "Eggs",
+  fish: "Fish",
+  peanuts: "Peanuts",
+  soybeans: "Soy",
+  milk: "Milk",
+  "tree-nuts": "Tree Nuts",
+  celery: "Celery",
+  mustard: "Mustard",
+  sesame: "Sesame",
+  sulphites: "Sulphites",
+  lupin: "Lupin",
+  molluscs: "Molluscs",
+};
+
+/** Normalise an allergen tag: trim, lowercase, and strip legacy "en:" prefix if present. */
 function normaliseTag(tag: string): string {
   return tag.trim().replace(/^en:/, "").toLowerCase();
 }
@@ -115,12 +134,15 @@ function StatusIcon({ status }: Readonly<{ status: AllergenStatus }>) {
   }
 }
 
-/** Pretty-print allergen name: "sesame-seeds" → "Sesame Seeds" */
+/** Pretty-print allergen name using DISPLAY_NAMES map, with Title Case fallback. */
 function formatAllergenName(name: string): string {
-  return name
-    .split("-")
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(" ");
+  return (
+    DISPLAY_NAMES[name] ??
+    name
+      .split("-")
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(" ")
+  );
 }
 
 interface AllergenMatrixProps {

--- a/frontend/src/components/search/ActiveFilterChips.test.tsx
+++ b/frontend/src/components/search/ActiveFilterChips.test.tsx
@@ -138,7 +138,7 @@ describe("ActiveFilterChips", () => {
   it("renders allergen-free chips with label lookup", () => {
     render(
       <ActiveFilterChips
-        filters={{ allergen_free: ["en:gluten"] }}
+        filters={{ allergen_free: ["gluten"] }}
         onChange={onChange}
       />,
     );
@@ -150,7 +150,7 @@ describe("ActiveFilterChips", () => {
   it("renders fallback label for unknown allergen tag", () => {
     render(
       <ActiveFilterChips
-        filters={{ allergen_free: ["en:mystery"] }}
+        filters={{ allergen_free: ["mystery"] }}
         onChange={onChange}
       />,
     );

--- a/frontend/src/components/search/ActiveFilterChips.tsx
+++ b/frontend/src/components/search/ActiveFilterChips.tsx
@@ -69,6 +69,7 @@ export function ActiveFilterChips({
   // Allergen-free chips
   for (const tag of filters.allergen_free ?? []) {
     const info = ALLERGEN_TAGS.find((a) => a.tag === tag);
+    // Tags are bare canonical IDs; strip legacy en: prefix as fallback
     const label = info
       ? t("chips.allergenFree", { label: info.label })
       : t("chips.allergenFree", { label: tag.replace("en:", "") });

--- a/frontend/src/components/search/FilterPanel.test.tsx
+++ b/frontend/src/components/search/FilterPanel.test.tsx
@@ -40,8 +40,8 @@ const mockFilterOptions = {
     { group: "4", count: 25 },
   ],
   allergens: [
-    { tag: "en:gluten", count: 30 },
-    { tag: "en:milk", count: 15 },
+    { tag: "gluten", count: 30 },
+    { tag: "milk", count: 15 },
   ],
 };
 

--- a/frontend/src/components/search/FilterPanel.tsx
+++ b/frontend/src/components/search/FilterPanel.tsx
@@ -118,8 +118,7 @@ export function FilterPanel({
                 },
                 { value: "calories" as const, label: t("filters.calories") },
               ].map((opt) => {
-                const isActive =
-                  (filters.sort_by ?? "relevance") === opt.value;
+                const isActive = (filters.sort_by ?? "relevance") === opt.value;
                 return (
                   <button
                     key={opt.value}
@@ -282,6 +281,7 @@ export function FilterPanel({
               <div className="space-y-1 max-h-40 overflow-y-auto">
                 {data.allergens.map((al) => {
                   const labelInfo = ALLERGEN_TAGS.find((a) => a.tag === al.tag);
+                  // Tags are bare canonical IDs; strip legacy en: prefix as fallback
                   const label = labelInfo?.label ?? al.tag.replace("en:", "");
                   const selected = (filters.allergen_free ?? []).includes(
                     al.tag,

--- a/frontend/src/lib/allergen-matching.test.ts
+++ b/frontend/src/lib/allergen-matching.test.ts
@@ -11,12 +11,12 @@ describe("matchProductAllergens", () => {
   // ── Empty / undefined inputs ────────────────────────────────────────────
 
   it("returns empty array when productAllergens is undefined", () => {
-    expect(matchProductAllergens(undefined, ["en:milk"], true)).toEqual([]);
+    expect(matchProductAllergens(undefined, ["milk"], true)).toEqual([]);
   });
 
   it("returns empty array when userAvoidAllergens is empty", () => {
     const data: ProductAllergenData = {
-      contains: ["en:milk"],
+      contains: ["milk"],
       traces: [],
     };
     expect(matchProductAllergens(data, [], true)).toEqual([]);
@@ -24,24 +24,24 @@ describe("matchProductAllergens", () => {
 
   it("returns empty array when there are no matching allergens", () => {
     const data: ProductAllergenData = {
-      contains: ["en:gluten"],
-      traces: ["en:eggs"],
+      contains: ["gluten"],
+      traces: ["eggs"],
     };
-    expect(matchProductAllergens(data, ["en:milk"], true)).toEqual([]);
+    expect(matchProductAllergens(data, ["milk"], true)).toEqual([]);
   });
 
   // ── Contains matching ─────────────────────────────────────────────────
 
   it("returns 'contains' warnings for matching allergens", () => {
     const data: ProductAllergenData = {
-      contains: ["en:milk", "en:gluten"],
+      contains: ["milk", "gluten"],
       traces: [],
     };
-    const result = matchProductAllergens(data, ["en:milk"], false);
+    const result = matchProductAllergens(data, ["milk"], false);
 
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
-      tag: "en:milk",
+      tag: "milk",
       label: "Milk / Dairy",
       icon: "🥛",
       type: "contains",
@@ -50,17 +50,17 @@ describe("matchProductAllergens", () => {
 
   it("matches multiple contains allergens", () => {
     const data: ProductAllergenData = {
-      contains: ["en:milk", "en:gluten", "en:eggs"],
+      contains: ["milk", "gluten", "eggs"],
       traces: [],
     };
     const result = matchProductAllergens(
       data,
-      ["en:milk", "en:eggs"],
+      ["milk", "eggs"],
       false,
     );
 
     expect(result).toHaveLength(2);
-    expect(result.map((w) => w.tag)).toEqual(["en:eggs", "en:milk"]);
+    expect(result.map((w) => w.tag)).toEqual(["eggs", "milk"]);
     expect(result.every((w) => w.type === "contains")).toBe(true);
   });
 
@@ -69,9 +69,9 @@ describe("matchProductAllergens", () => {
   it("ignores traces when treatMayContainAsUnsafe is false", () => {
     const data: ProductAllergenData = {
       contains: [],
-      traces: ["en:milk"],
+      traces: ["milk"],
     };
-    const result = matchProductAllergens(data, ["en:milk"], false);
+    const result = matchProductAllergens(data, ["milk"], false);
 
     expect(result).toEqual([]);
   });
@@ -79,13 +79,13 @@ describe("matchProductAllergens", () => {
   it("returns 'traces' warnings when treatMayContainAsUnsafe is true", () => {
     const data: ProductAllergenData = {
       contains: [],
-      traces: ["en:milk"],
+      traces: ["milk"],
     };
-    const result = matchProductAllergens(data, ["en:milk"], true);
+    const result = matchProductAllergens(data, ["milk"], true);
 
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
-      tag: "en:milk",
+      tag: "milk",
       label: "Milk / Dairy",
       icon: "🥛",
       type: "traces",
@@ -96,10 +96,10 @@ describe("matchProductAllergens", () => {
 
   it("avoids duplicates when tag appears in both contains and traces", () => {
     const data: ProductAllergenData = {
-      contains: ["en:milk"],
-      traces: ["en:milk"],
+      contains: ["milk"],
+      traces: ["milk"],
     };
-    const result = matchProductAllergens(data, ["en:milk"], true);
+    const result = matchProductAllergens(data, ["milk"], true);
 
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe("contains");
@@ -109,12 +109,12 @@ describe("matchProductAllergens", () => {
 
   it("sorts contains before traces", () => {
     const data: ProductAllergenData = {
-      contains: ["en:gluten"],
-      traces: ["en:eggs"],
+      contains: ["gluten"],
+      traces: ["eggs"],
     };
     const result = matchProductAllergens(
       data,
-      ["en:gluten", "en:eggs"],
+      ["gluten", "eggs"],
       true,
     );
 
@@ -125,19 +125,19 @@ describe("matchProductAllergens", () => {
 
   it("sorts alphabetically within same type", () => {
     const data: ProductAllergenData = {
-      contains: ["en:milk", "en:eggs", "en:gluten"],
+      contains: ["milk", "eggs", "gluten"],
       traces: [],
     };
     const result = matchProductAllergens(
       data,
-      ["en:milk", "en:eggs", "en:gluten"],
+      ["milk", "eggs", "gluten"],
       false,
     );
 
     expect(result.map((w) => w.tag)).toEqual([
-      "en:eggs",
-      "en:gluten",
-      "en:milk",
+      "eggs",
+      "gluten",
+      "milk",
     ]);
   });
 
@@ -145,12 +145,12 @@ describe("matchProductAllergens", () => {
 
   it("uses fallback label and icon for unknown allergen tags", () => {
     const data: ProductAllergenData = {
-      contains: ["en:some-unknown-allergen"],
+      contains: ["some-unknown-allergen"],
       traces: [],
     };
     const result = matchProductAllergens(
       data,
-      ["en:some-unknown-allergen"],
+      ["some-unknown-allergen"],
       false,
     );
 
@@ -163,20 +163,20 @@ describe("matchProductAllergens", () => {
 
   it("provides icons for all 14 EU allergens", () => {
     const expected = [
-      "en:gluten",
-      "en:milk",
-      "en:eggs",
-      "en:nuts",
-      "en:peanuts",
-      "en:soybeans",
-      "en:fish",
-      "en:crustaceans",
-      "en:celery",
-      "en:mustard",
-      "en:sesame-seeds",
-      "en:sulphur-dioxide-and-sulphites",
-      "en:lupin",
-      "en:molluscs",
+      "gluten",
+      "milk",
+      "eggs",
+      "tree-nuts",
+      "peanuts",
+      "soybeans",
+      "fish",
+      "crustaceans",
+      "celery",
+      "mustard",
+      "sesame",
+      "sulphites",
+      "lupin",
+      "molluscs",
     ];
 
     for (const tag of expected) {

--- a/frontend/src/lib/allergen-matching.ts
+++ b/frontend/src/lib/allergen-matching.ts
@@ -19,7 +19,7 @@ export type ProductAllergenMap = Readonly<
 
 /** A single allergen warning to display on a product card */
 export interface AllergenWarning {
-  /** Tag identifier, e.g. "en:milk" */
+  /** Tag identifier, e.g. "milk" */
   readonly tag: string;
   /** Human-readable short label, e.g. "Milk / Dairy" */
   readonly label: string;
@@ -33,20 +33,20 @@ export interface AllergenWarning {
 
 /** Emoji icons for the EU-14 mandatory allergens + common aliases */
 export const ALLERGEN_ICONS: Readonly<Record<string, string>> = {
-  "en:gluten": "🌾",
-  "en:milk": "🥛",
-  "en:eggs": "🥚",
-  "en:nuts": "🌰",
-  "en:peanuts": "🥜",
-  "en:soybeans": "🫘",
-  "en:fish": "🐟",
-  "en:crustaceans": "🦐",
-  "en:celery": "🌿",
-  "en:mustard": "🟡",
-  "en:sesame-seeds": "🫘",
-  "en:sulphur-dioxide-and-sulphites": "🧪",
-  "en:lupin": "🌸",
-  "en:molluscs": "🐚",
+  "gluten": "🌾",
+  "milk": "🥛",
+  "eggs": "🥚",
+  "tree-nuts": "🌰",
+  "peanuts": "🥜",
+  "soybeans": "🫘",
+  "fish": "🐟",
+  "crustaceans": "🦐",
+  "celery": "🌿",
+  "mustard": "🟡",
+  "sesame": "🫘",
+  "sulphites": "🧪",
+  "lupin": "🌸",
+  "molluscs": "🐚",
 };
 
 /** Build a label lookup from ALLERGEN_TAGS constant */
@@ -60,7 +60,7 @@ const LABEL_MAP = new Map<string, string>(
  * Match a product's allergens against user preferences and return warnings.
  *
  * @param productAllergens - Raw allergen data for a single product
- * @param userAvoidAllergens - User's avoid_allergens preference (e.g. ["en:milk", "en:gluten"])
+ * @param userAvoidAllergens - User's avoid_allergens preference (e.g. ["milk", "gluten"])
  * @param treatMayContainAsUnsafe - Whether to include "traces" matches (user preference)
  * @returns Array of AllergenWarning sorted: contains first, then traces, alphabetical within each group
  */
@@ -110,10 +110,9 @@ export function matchProductAllergens(
 
 // ─── Utility ────────────────────────────────────────────────────────────────
 
-/** Convert an "en:some-tag" to "Some Tag" as a fallback label */
+/** Convert a "some-tag" to "Some Tag" as a fallback label */
 function formatTagFallback(tag: string): string {
   return tag
-    .replace(/^en:/, "")
     .split("-")
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(" ");

--- a/frontend/src/lib/constants.test.ts
+++ b/frontend/src/lib/constants.test.ts
@@ -40,7 +40,8 @@ describe("ALLERGEN_TAGS", () => {
 
   it("each allergen has tag and label", () => {
     for (const allergen of ALLERGEN_TAGS) {
-      expect(allergen.tag).toMatch(/^en:/);
+      expect(allergen.tag).toBeTruthy();
+      expect(allergen.tag).not.toMatch(/^en:/);
       expect(allergen.label.length).toBeGreaterThan(0);
     }
   });
@@ -69,15 +70,15 @@ describe("ALLERGEN_PRESETS", () => {
 
   it("nutFree preset includes both nuts and peanuts", () => {
     const nutFree = ALLERGEN_PRESETS.find((p) => p.key === "nutFree");
-    expect(nutFree?.tags).toContain("en:nuts");
-    expect(nutFree?.tags).toContain("en:peanuts");
+    expect(nutFree?.tags).toContain("tree-nuts");
+    expect(nutFree?.tags).toContain("peanuts");
   });
 
   it("vegan preset includes all animal-derived allergens", () => {
     const vegan = ALLERGEN_PRESETS.find((p) => p.key === "vegan");
-    expect(vegan?.tags).toContain("en:milk");
-    expect(vegan?.tags).toContain("en:eggs");
-    expect(vegan?.tags).toContain("en:fish");
+    expect(vegan?.tags).toContain("milk");
+    expect(vegan?.tags).toContain("eggs");
+    expect(vegan?.tags).toContain("fish");
   });
 });
 

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -31,20 +31,20 @@ export function getLanguagesForCountry(countryCode: string) {
 }
 
 export const ALLERGEN_TAGS = [
-  { tag: "en:gluten", label: "Gluten" },
-  { tag: "en:milk", label: "Milk / Dairy" },
-  { tag: "en:eggs", label: "Eggs" },
-  { tag: "en:nuts", label: "Tree Nuts" },
-  { tag: "en:peanuts", label: "Peanuts" },
-  { tag: "en:soybeans", label: "Soy" },
-  { tag: "en:fish", label: "Fish" },
-  { tag: "en:crustaceans", label: "Crustaceans" },
-  { tag: "en:celery", label: "Celery" },
-  { tag: "en:mustard", label: "Mustard" },
-  { tag: "en:sesame-seeds", label: "Sesame" },
-  { tag: "en:sulphur-dioxide-and-sulphites", label: "Sulphites" },
-  { tag: "en:lupin", label: "Lupin" },
-  { tag: "en:molluscs", label: "Molluscs" },
+  { tag: "gluten", label: "Gluten" },
+  { tag: "milk", label: "Milk / Dairy" },
+  { tag: "eggs", label: "Eggs" },
+  { tag: "tree-nuts", label: "Tree Nuts" },
+  { tag: "peanuts", label: "Peanuts" },
+  { tag: "soybeans", label: "Soy" },
+  { tag: "fish", label: "Fish" },
+  { tag: "crustaceans", label: "Crustaceans" },
+  { tag: "celery", label: "Celery" },
+  { tag: "mustard", label: "Mustard" },
+  { tag: "sesame", label: "Sesame" },
+  { tag: "sulphites", label: "Sulphites" },
+  { tag: "lupin", label: "Lupin" },
+  { tag: "molluscs", label: "Molluscs" },
 ] as const;
 
 /**
@@ -55,22 +55,22 @@ export const ALLERGEN_PRESETS = [
   {
     key: "glutenFree",
     labelKey: "allergenPreset.glutenFree",
-    tags: ["en:gluten"],
+    tags: ["gluten"],
   },
   {
     key: "dairyFree",
     labelKey: "allergenPreset.dairyFree",
-    tags: ["en:milk"],
+    tags: ["milk"],
   },
   {
     key: "nutFree",
     labelKey: "allergenPreset.nutFree",
-    tags: ["en:nuts", "en:peanuts"],
+    tags: ["tree-nuts", "peanuts"],
   },
   {
     key: "vegan",
     labelKey: "allergenPreset.vegan",
-    tags: ["en:milk", "en:eggs", "en:fish", "en:crustaceans", "en:molluscs"],
+    tags: ["milk", "eggs", "fish", "crustaceans", "molluscs"],
   },
 ] as const;
 

--- a/supabase/migrations/20260309000200_de_enrichment_cleanup.sql
+++ b/supabase/migrations/20260309000200_de_enrichment_cleanup.sql
@@ -238,24 +238,28 @@ DELETE FROM product_allergen_info WHERE tag = 'en:en-eggs-en-peanuts';
 -- ═══════════════════════════════════════════════════════════════════════════
 
 -- Product 1176 (Eiweißbrot): has Soja ingredient, soybeans only as traces → add contains
+-- Uses SELECT guard so migration succeeds during clean db reset (products may not exist yet)
 INSERT INTO product_allergen_info (product_id, tag, type)
-VALUES (1176, 'en:soybeans', 'contains')
+SELECT p.product_id, 'en:soybeans', 'contains'
+FROM products p WHERE p.product_id = 1176
 ON CONFLICT (product_id, tag, type) DO NOTHING;
 
 -- Product 1639 (Grießpudding High-Protein): has Soja ingredient, soybeans only as traces → add contains
 INSERT INTO product_allergen_info (product_id, tag, type)
-VALUES (1639, 'en:soybeans', 'contains')
+SELECT p.product_id, 'en:soybeans', 'contains'
+FROM products p WHERE p.product_id = 1639
 ON CONFLICT (product_id, tag, type) DO NOTHING;
 
 -- Product 1687 (Barista Oat Drink): has Oats ingredient, no allergen declarations at all → add gluten
 INSERT INTO product_allergen_info (product_id, tag, type)
-VALUES (1687, 'en:gluten', 'contains')
+SELECT p.product_id, 'en:gluten', 'contains'
+FROM products p WHERE p.product_id = 1687
 ON CONFLICT (product_id, tag, type) DO NOTHING;
 
 -- Products 1178, 1197 (Haferbrot): have Haferflocken ingredient, missing en:gluten declaration
 INSERT INTO product_allergen_info (product_id, tag, type)
-VALUES (1178, 'en:gluten', 'contains'),
-       (1197, 'en:gluten', 'contains')
+SELECT p.product_id, 'en:gluten', 'contains'
+FROM products p WHERE p.product_id IN (1178, 1197)
 ON CONFLICT (product_id, tag, type) DO NOTHING;
 
 -- ═══════════════════════════════════════════════════════════════════════════

--- a/supabase/migrations/20260310000100_allergen_ref_foundation.sql
+++ b/supabase/migrations/20260310000100_allergen_ref_foundation.sql
@@ -1,0 +1,79 @@
+-- ============================================================
+-- Migration: allergen_ref foundation
+-- Issue: #351 — Allergen normalization
+-- Phase 1: Create canonical allergen reference table
+--
+-- Creates allergen_ref with EU-14 mandatory allergens per
+-- Regulation (EU) No 1169/2011, Annex II.
+--
+-- To rollback: DROP TABLE IF EXISTS allergen_ref CASCADE;
+-- ============================================================
+
+-- ── 1. allergen_ref table ───────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.allergen_ref (
+    allergen_id     text PRIMARY KEY,
+    display_name_en text NOT NULL,
+    allergen_group  text,
+    eu_mandatory    boolean NOT NULL DEFAULT false,
+    icon_emoji      text,
+    severity_note   text,
+    sort_order      integer NOT NULL DEFAULT 0,
+    is_active       boolean NOT NULL DEFAULT true
+);
+
+COMMENT ON TABLE  public.allergen_ref IS 'Canonical allergen dictionary — EU-14 mandatory allergens + common extras.';
+COMMENT ON COLUMN public.allergen_ref.allergen_id     IS 'Canonical English slug: gluten, milk, peanuts, etc.';
+COMMENT ON COLUMN public.allergen_ref.allergen_group  IS 'Grouping: cereals, dairy, nuts, seafood, legumes, etc.';
+COMMENT ON COLUMN public.allergen_ref.eu_mandatory    IS 'true for EU 1169/2011 Annex II 14 mandatory allergens.';
+COMMENT ON COLUMN public.allergen_ref.icon_emoji      IS 'Display emoji for UI rendering.';
+
+-- ── 2. Seed EU-14 mandatory allergens ───────────────────────────────────────
+INSERT INTO public.allergen_ref (allergen_id, display_name_en, allergen_group, eu_mandatory, icon_emoji, severity_note, sort_order)
+VALUES
+    ('gluten',      'Gluten',                       'cereals',       true,  '🌾', 'Includes wheat, rye, barley, oats, spelt, kamut', 1),
+    ('crustaceans', 'Crustaceans',                  'seafood',       true,  '🦐', 'Shrimp, crab, lobster, crayfish',                 2),
+    ('eggs',        'Eggs',                         'animal',        true,  '🥚', 'All egg-derived products',                        3),
+    ('fish',        'Fish',                         'seafood',       true,  '🐟', 'All fish species and derivatives',                4),
+    ('peanuts',     'Peanuts',                      'nuts',          true,  '🥜', 'Can cause anaphylaxis',                           5),
+    ('soybeans',    'Soybeans',                     'legumes',       true,  '🫘', 'Soy lecithin, soy protein, tofu',                 6),
+    ('milk',        'Milk',                         'dairy',         true,  '🥛', 'Lactose, casein, whey, butter, cheese',           7),
+    ('tree-nuts',   'Tree Nuts',                    'nuts',          true,  '🌰', 'Almonds, hazelnuts, walnuts, cashews, pecans, pistachios, macadamia, brazil nuts', 8),
+    ('celery',      'Celery',                       'vegetables',    true,  '🥬', 'Including celeriac',                              9),
+    ('mustard',     'Mustard',                      'spices',        true,  '🟡', 'Mustard seeds, powder, oil',                      10),
+    ('sesame',      'Sesame Seeds',                 'seeds',         true,  '⚪', 'Sesame oil, tahini',                              11),
+    ('sulphites',   'Sulphur Dioxide & Sulphites',  'preservatives', true,  '⚗️', 'At concentrations >10 mg/kg or >10 mg/L as SO₂', 12),
+    ('lupin',       'Lupin',                        'legumes',       true,  '🌿', 'Lupin flour, seeds',                              13),
+    ('molluscs',    'Molluscs',                     'seafood',       true,  '🐚', 'Squid, octopus, snails, mussels, oysters',        14)
+ON CONFLICT (allergen_id) DO UPDATE SET
+    display_name_en = EXCLUDED.display_name_en,
+    allergen_group  = EXCLUDED.allergen_group,
+    eu_mandatory    = EXCLUDED.eu_mandatory,
+    icon_emoji      = EXCLUDED.icon_emoji,
+    severity_note   = EXCLUDED.severity_note,
+    sort_order      = EXCLUDED.sort_order;
+
+-- ── 3. Indexes ──────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_allergen_ref_group
+    ON public.allergen_ref (allergen_group);
+
+CREATE INDEX IF NOT EXISTS idx_allergen_ref_eu
+    ON public.allergen_ref (allergen_id) WHERE eu_mandatory = true;
+
+-- ── 4. RLS ──────────────────────────────────────────────────────────────────
+ALTER TABLE public.allergen_ref ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "allergen_ref: anon + authenticated read" ON public.allergen_ref;
+CREATE POLICY "allergen_ref: anon + authenticated read"
+    ON public.allergen_ref FOR SELECT
+    USING (true);
+
+DROP POLICY IF EXISTS "allergen_ref: service_role write" ON public.allergen_ref;
+CREATE POLICY "allergen_ref: service_role write"
+    ON public.allergen_ref FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+-- ── 5. Grants ───────────────────────────────────────────────────────────────
+GRANT SELECT ON public.allergen_ref TO anon, authenticated;
+GRANT ALL    ON public.allergen_ref TO service_role;

--- a/supabase/migrations/20260310000200_allergen_tag_normalization.sql
+++ b/supabase/migrations/20260310000200_allergen_tag_normalization.sql
@@ -1,0 +1,334 @@
+-- ============================================================
+-- Migration: Allergen tag normalization
+-- Issue: #351 — Allergen normalization
+-- Phase 2: Normalize tags, add FK to allergen_ref, update views
+--
+-- This migration:
+-- 1. Adds source_tag column for traceability
+-- 2. Drops the en: prefix CHECK constraint
+-- 3. Normalizes all tags (strip en:, merge sub-allergens)
+-- 4. Deduplicates after merging
+-- 5. Adds FK to allergen_ref
+-- 6. Migrates user_preferences.avoid_allergens
+-- 7. Recreates v_master with canonical tags
+--
+-- To rollback (destructive — source_tag preserves originals):
+--   See source_tag column for original values
+-- ============================================================
+
+BEGIN;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 1. Add source_tag column for traceability
+-- ═══════════════════════════════════════════════════════════════════════════
+ALTER TABLE public.product_allergen_info
+    ADD COLUMN IF NOT EXISTS source_tag text;
+
+COMMENT ON COLUMN public.product_allergen_info.source_tag
+    IS 'Original tag value before normalization (e.g., en:milk, en:pszenny). Preserved for traceability.';
+
+-- Copy current tag → source_tag (only for rows without source_tag already set)
+UPDATE public.product_allergen_info
+SET source_tag = tag
+WHERE source_tag IS NULL;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 2. Drop the en: prefix CHECK constraint
+-- ═══════════════════════════════════════════════════════════════════════════
+ALTER TABLE public.product_allergen_info
+    DROP CONSTRAINT IF EXISTS chk_allergen_tag_en_prefix;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 3. Normalize tags
+--    Order matters: merge sub-allergens FIRST, then strip en: prefix
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- 3a. Delete sub-allergen rows that would duplicate their parent after merge
+--     (e.g., product has both en:wheat AND en:gluten → delete the en:wheat row)
+DELETE FROM public.product_allergen_info sub
+WHERE sub.tag IN ('en:wheat', 'en:oats', 'en:barley', 'en:rye', 'en:spelt', 'en:kamut')
+  AND EXISTS (
+      SELECT 1 FROM public.product_allergen_info parent
+      WHERE parent.product_id = sub.product_id
+        AND parent.type = sub.type
+        AND parent.tag = 'en:gluten'
+  );
+
+DELETE FROM public.product_allergen_info sub
+WHERE sub.tag IN ('en:almonds', 'en:hazelnuts', 'en:walnuts',
+                   'en:cashew-nuts', 'en:pistachio-nuts', 'en:pecan-nuts',
+                   'en:brazil-nuts', 'en:macadamia-nuts')
+  AND EXISTS (
+      SELECT 1 FROM public.product_allergen_info parent
+      WHERE parent.product_id = sub.product_id
+        AND parent.type = sub.type
+        AND parent.tag = 'en:nuts'
+  );
+
+-- 3b. Merge remaining gluten sub-allergens → en:gluten
+UPDATE public.product_allergen_info
+SET tag = 'en:gluten'
+WHERE tag IN ('en:wheat', 'en:oats', 'en:barley', 'en:rye', 'en:spelt', 'en:kamut');
+
+-- 3c. Merge remaining tree-nut sub-allergens + en:nuts → en:tree-nuts
+--     First rename en:nuts → en:tree-nuts (canonical EU name)
+UPDATE public.product_allergen_info
+SET tag = 'en:tree-nuts'
+WHERE tag = 'en:nuts';
+
+--     Then merge nut sub-types (that weren't deleted as duplicates)
+UPDATE public.product_allergen_info
+SET tag = 'en:tree-nuts'
+WHERE tag IN ('en:almonds', 'en:hazelnuts', 'en:walnuts',
+              'en:cashew-nuts', 'en:pistachio-nuts', 'en:pecan-nuts',
+              'en:brazil-nuts', 'en:macadamia-nuts');
+
+-- 3d. Rename verbose tags
+UPDATE public.product_allergen_info
+SET tag = 'en:sesame'
+WHERE tag = 'en:sesame-seeds';
+
+UPDATE public.product_allergen_info
+SET tag = 'en:sulphites'
+WHERE tag = 'en:sulphur-dioxide-and-sulphites';
+
+-- 3e. Strip en: prefix from all remaining tags
+UPDATE public.product_allergen_info
+SET tag = REPLACE(tag, 'en:', '')
+WHERE tag LIKE 'en:%';
+
+-- 3f. Final deduplication (safety net for any edge cases)
+DELETE FROM public.product_allergen_info
+WHERE ctid IN (
+    SELECT ctid FROM (
+        SELECT ctid,
+               ROW_NUMBER() OVER (
+                   PARTITION BY product_id, tag, type
+                   ORDER BY ctid
+               ) AS rn
+        FROM public.product_allergen_info
+    ) ranked
+    WHERE rn > 1
+);
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 5. Add FK to allergen_ref
+-- ═══════════════════════════════════════════════════════════════════════════
+-- First verify all tags exist in allergen_ref (should be 14 canonical IDs)
+DO $$
+DECLARE
+    v_bad_count integer;
+BEGIN
+    SELECT COUNT(*) INTO v_bad_count
+    FROM (SELECT DISTINCT tag FROM public.product_allergen_info) t
+    WHERE NOT EXISTS (
+        SELECT 1 FROM public.allergen_ref ar WHERE ar.allergen_id = t.tag
+    );
+    IF v_bad_count > 0 THEN
+        RAISE WARNING 'Found % distinct tags not in allergen_ref — check normalization', v_bad_count;
+    END IF;
+END $$;
+
+ALTER TABLE public.product_allergen_info
+    DROP CONSTRAINT IF EXISTS fk_allergen_tag_ref;
+
+ALTER TABLE public.product_allergen_info
+    ADD CONSTRAINT fk_allergen_tag_ref
+    FOREIGN KEY (tag) REFERENCES public.allergen_ref(allergen_id);
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 6. Migrate user_preferences.avoid_allergens
+--    Strip en: prefix and normalize to canonical IDs
+-- ═══════════════════════════════════════════════════════════════════════════
+UPDATE public.user_preferences
+SET avoid_allergens = (
+    SELECT ARRAY(
+        SELECT DISTINCT
+            CASE
+                -- Merge sub-allergens
+                WHEN unnested IN ('en:wheat','en:oats','en:barley','en:rye','en:spelt','en:kamut')
+                    THEN 'gluten'
+                WHEN unnested IN ('en:nuts','en:almonds','en:hazelnuts','en:walnuts',
+                                  'en:cashew-nuts','en:pistachio-nuts','en:pecan-nuts',
+                                  'en:brazil-nuts','en:macadamia-nuts')
+                    THEN 'tree-nuts'
+                WHEN unnested = 'en:sesame-seeds' THEN 'sesame'
+                WHEN unnested = 'en:sulphur-dioxide-and-sulphites' THEN 'sulphites'
+                -- Strip en: prefix
+                WHEN unnested LIKE 'en:%' THEN REPLACE(unnested, 'en:', '')
+                -- Already canonical
+                ELSE unnested
+            END
+        FROM unnest(avoid_allergens) AS unnested
+    )
+)
+WHERE avoid_allergens IS NOT NULL
+  AND array_length(avoid_allergens, 1) > 0;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 7. Recreate v_master with canonical (bare) allergen tags
+-- ═══════════════════════════════════════════════════════════════════════════
+CREATE OR REPLACE VIEW public.v_master AS
+SELECT
+    p.product_id,
+    p.country,
+    p.brand,
+    p.product_type,
+    p.category,
+    p.product_name,
+    p.prep_method,
+    p.store_availability,
+    p.controversies,
+    p.ean,
+
+    -- Nutrition (per 100g)
+    nf.calories,
+    nf.total_fat_g,
+    nf.saturated_fat_g,
+    nf.trans_fat_g,
+    nf.carbs_g,
+    nf.sugars_g,
+    nf.fibre_g,
+    nf.protein_g,
+    nf.salt_g,
+
+    -- Scores
+    p.unhealthiness_score,
+    p.confidence,
+    p.data_completeness_pct,
+    p.nutri_score_label,
+    p.nova_classification,
+    CASE p.nova_classification
+        WHEN '4' THEN 'High'
+        WHEN '3' THEN 'Moderate'
+        WHEN '2' THEN 'Low'
+        WHEN '1' THEN 'Low'
+        ELSE 'Unknown'
+    END AS processing_risk,
+    p.high_salt_flag,
+    p.high_sugar_flag,
+    p.high_sat_fat_flag,
+    p.high_additive_load,
+    p.ingredient_concern_score,
+
+    -- Score breakdown
+    explain_score_v32(
+        nf.saturated_fat_g, nf.sugars_g, nf.salt_g, nf.calories,
+        nf.trans_fat_g, ingr.additives_count::numeric, p.prep_method, p.controversies,
+        p.ingredient_concern_score
+    ) AS score_breakdown,
+
+    -- Ingredients
+    ingr.additives_count,
+    ingr.ingredients_text AS ingredients_raw,
+    ingr.ingredient_count,
+    ingr.additive_names,
+    ingr.has_palm_oil,
+
+    -- Vegan / vegetarian — override to NULL when allergens contradict
+    CASE
+        WHEN ingr.vegan_status = 'yes'
+             AND COALESCE(agg_ai.has_animal_allergen, false)
+        THEN NULL
+        ELSE ingr.vegan_status
+    END AS vegan_status,
+
+    CASE
+        WHEN ingr.vegetarian_status = 'yes'
+             AND COALESCE(agg_ai.has_meat_fish_allergen, false)
+        THEN NULL
+        ELSE ingr.vegetarian_status
+    END AS vegetarian_status,
+
+    -- Contradiction flags
+    (ingr.vegan_status = 'yes'
+        AND COALESCE(agg_ai.has_animal_allergen, false)) AS vegan_contradiction,
+    (ingr.vegetarian_status = 'yes'
+        AND COALESCE(agg_ai.has_meat_fish_allergen, false)) AS vegetarian_contradiction,
+
+    -- Allergen/trace (canonical tags from allergen_ref)
+    COALESCE(agg_ai.allergen_count, 0) AS allergen_count,
+    agg_ai.allergen_tags,
+    COALESCE(agg_ai.trace_count, 0) AS trace_count,
+    agg_ai.trace_tags,
+
+    -- Source provenance
+    p.source_type,
+    p.source_url,
+    p.source_ean,
+
+    -- Primary product image
+    (SELECT img.url
+     FROM product_images img
+     WHERE img.product_id = p.product_id AND img.is_primary = true
+     LIMIT 1) AS image_thumb_url,
+
+    -- Data quality indicators
+    CASE
+        WHEN ingr.ingredient_count > 0 THEN 'complete'
+        ELSE 'missing'
+    END AS ingredient_data_quality,
+
+    CASE
+        WHEN nf.calories IS NOT NULL
+             AND nf.total_fat_g IS NOT NULL
+             AND nf.carbs_g IS NOT NULL
+             AND nf.protein_g IS NOT NULL
+             AND nf.salt_g IS NOT NULL
+             AND (nf.total_fat_g IS NULL OR nf.saturated_fat_g IS NULL
+                  OR nf.saturated_fat_g <= nf.total_fat_g)
+             AND (nf.carbs_g IS NULL OR nf.sugars_g IS NULL
+                  OR nf.sugars_g <= nf.carbs_g)
+        THEN 'clean'
+        ELSE 'suspect'
+    END AS nutrition_data_quality,
+
+    -- Localization
+    p.product_name_en,
+    p.product_name_en_source,
+    p.created_at,
+    p.updated_at,
+    p.name_translations
+
+FROM public.products p
+LEFT JOIN public.nutrition_facts nf ON nf.product_id = p.product_id
+LEFT JOIN LATERAL (
+    SELECT
+        COUNT(*)::integer AS ingredient_count,
+        COUNT(*) FILTER (WHERE ir.is_additive)::integer AS additives_count,
+        STRING_AGG(ir.name_en, ', ' ORDER BY pi.position) AS ingredients_text,
+        STRING_AGG(CASE WHEN ir.is_additive THEN ir.name_en END, ', ' ORDER BY pi.position) AS additive_names,
+        BOOL_OR(ir.from_palm_oil = 'yes') AS has_palm_oil,
+        CASE
+            WHEN BOOL_AND(ir.vegan IN ('yes','unknown')) THEN 'yes'
+            WHEN BOOL_OR(ir.vegan = 'no') THEN 'no'
+            ELSE 'maybe'
+        END AS vegan_status,
+        CASE
+            WHEN BOOL_AND(ir.vegetarian IN ('yes','unknown')) THEN 'yes'
+            WHEN BOOL_OR(ir.vegetarian = 'no') THEN 'no'
+            ELSE 'maybe'
+        END AS vegetarian_status
+    FROM public.product_ingredient pi
+    JOIN public.ingredient_ref ir ON ir.ingredient_id = pi.ingredient_id
+    WHERE pi.product_id = p.product_id
+) ingr ON true
+LEFT JOIN LATERAL (
+    SELECT
+        COUNT(*) FILTER (WHERE ai.type = 'contains')::integer AS allergen_count,
+        STRING_AGG(ai.tag, ', ' ORDER BY ai.tag) FILTER (WHERE ai.type = 'contains') AS allergen_tags,
+        COUNT(*) FILTER (WHERE ai.type = 'traces')::integer AS trace_count,
+        STRING_AGG(ai.tag, ', ' ORDER BY ai.tag) FILTER (WHERE ai.type = 'traces') AS trace_tags,
+        -- Contradiction detection flags (now using canonical allergen IDs)
+        BOOL_OR(ai.type = 'contains' AND ai.tag IN (
+            'milk', 'eggs', 'fish', 'crustaceans', 'molluscs'
+        )) AS has_animal_allergen,
+        BOOL_OR(ai.type = 'contains' AND ai.tag IN (
+            'fish', 'crustaceans', 'molluscs'
+        )) AS has_meat_fish_allergen
+    FROM public.product_allergen_info ai
+    WHERE ai.product_id = p.product_id
+) agg_ai ON true
+WHERE p.is_deprecated IS NOT TRUE;
+
+COMMIT;

--- a/supabase/migrations/20260310000300_allergen_translations.sql
+++ b/supabase/migrations/20260310000300_allergen_translations.sql
@@ -1,0 +1,120 @@
+-- ============================================================
+-- Migration: Allergen translations
+-- Issue: #351 — Allergen normalization
+-- Phase 3: Allergen display name translations (PL + DE)
+--
+-- Follows the category_translations pattern.
+-- To rollback: DROP TABLE IF EXISTS allergen_translations CASCADE;
+-- ============================================================
+
+-- ── 1. allergen_translations table ──────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.allergen_translations (
+    allergen_id   text NOT NULL REFERENCES public.allergen_ref(allergen_id),
+    language_code text NOT NULL REFERENCES public.language_ref(code),
+    display_name  text NOT NULL,
+    PRIMARY KEY (allergen_id, language_code)
+);
+
+COMMENT ON TABLE public.allergen_translations
+    IS 'Localized display names for allergens. Follows category_translations pattern.';
+
+-- ── 2. Seed translations (PL + DE + EN) ────────────────────────────────────
+INSERT INTO public.allergen_translations (allergen_id, language_code, display_name)
+VALUES
+    -- English (reference — matches allergen_ref.display_name_en)
+    ('gluten',      'en', 'Gluten'),
+    ('crustaceans', 'en', 'Crustaceans'),
+    ('eggs',        'en', 'Eggs'),
+    ('fish',        'en', 'Fish'),
+    ('peanuts',     'en', 'Peanuts'),
+    ('soybeans',    'en', 'Soybeans'),
+    ('milk',        'en', 'Milk'),
+    ('tree-nuts',   'en', 'Tree Nuts'),
+    ('celery',      'en', 'Celery'),
+    ('mustard',     'en', 'Mustard'),
+    ('sesame',      'en', 'Sesame Seeds'),
+    ('sulphites',   'en', 'Sulphur Dioxide & Sulphites'),
+    ('lupin',       'en', 'Lupin'),
+    ('molluscs',    'en', 'Molluscs'),
+
+    -- Polish
+    ('gluten',      'pl', 'Gluten'),
+    ('crustaceans', 'pl', 'Skorupiaki'),
+    ('eggs',        'pl', 'Jajka'),
+    ('fish',        'pl', 'Ryby'),
+    ('peanuts',     'pl', 'Orzeszki ziemne'),
+    ('soybeans',    'pl', 'Soja'),
+    ('milk',        'pl', 'Mleko'),
+    ('tree-nuts',   'pl', 'Orzechy'),
+    ('celery',      'pl', 'Seler'),
+    ('mustard',     'pl', 'Gorczyca'),
+    ('sesame',      'pl', 'Sezam'),
+    ('sulphites',   'pl', 'Dwutlenek siarki i siarczyny'),
+    ('lupin',       'pl', 'Łubin'),
+    ('molluscs',    'pl', 'Mięczaki'),
+
+    -- German
+    ('gluten',      'de', 'Gluten'),
+    ('crustaceans', 'de', 'Krebstiere'),
+    ('eggs',        'de', 'Eier'),
+    ('fish',        'de', 'Fisch'),
+    ('peanuts',     'de', 'Erdnüsse'),
+    ('soybeans',    'de', 'Soja'),
+    ('milk',        'de', 'Milch'),
+    ('tree-nuts',   'de', 'Schalenfrüchte'),
+    ('celery',      'de', 'Sellerie'),
+    ('mustard',     'de', 'Senf'),
+    ('sesame',      'de', 'Sesam'),
+    ('sulphites',   'de', 'Schwefeldioxid und Sulfite'),
+    ('lupin',       'de', 'Lupinen'),
+    ('molluscs',    'de', 'Weichtiere')
+ON CONFLICT (allergen_id, language_code) DO UPDATE SET
+    display_name = EXCLUDED.display_name;
+
+-- ── 3. RLS ──────────────────────────────────────────────────────────────────
+ALTER TABLE public.allergen_translations ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "allergen_translations: anon + authenticated read" ON public.allergen_translations;
+CREATE POLICY "allergen_translations: anon + authenticated read"
+    ON public.allergen_translations FOR SELECT
+    USING (true);
+
+DROP POLICY IF EXISTS "allergen_translations: service_role write" ON public.allergen_translations;
+CREATE POLICY "allergen_translations: service_role write"
+    ON public.allergen_translations FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+-- ── 4. Grants ───────────────────────────────────────────────────────────────
+GRANT SELECT ON public.allergen_translations TO anon, authenticated;
+GRANT ALL    ON public.allergen_translations TO service_role;
+
+-- ── 5. Helper function: resolve allergen display name ───────────────────────
+CREATE OR REPLACE FUNCTION public.resolve_allergen_display(
+    p_allergen_id text,
+    p_language    text DEFAULT 'en'
+)
+RETURNS text
+LANGUAGE sql STABLE
+AS $$
+    SELECT COALESCE(
+        (SELECT t.display_name
+         FROM allergen_translations t
+         WHERE t.allergen_id = p_allergen_id
+           AND t.language_code = p_language),
+        (SELECT t.display_name
+         FROM allergen_translations t
+         WHERE t.allergen_id = p_allergen_id
+           AND t.language_code = 'en'),
+        (SELECT ar.display_name_en
+         FROM allergen_ref ar
+         WHERE ar.allergen_id = p_allergen_id),
+        p_allergen_id
+    );
+$$;
+
+COMMENT ON FUNCTION public.resolve_allergen_display IS
+    'Returns localized allergen display name. Fallback: requested lang → en → display_name_en → raw ID.';
+
+GRANT EXECUTE ON FUNCTION public.resolve_allergen_display TO anon, authenticated, service_role;

--- a/supabase/migrations/20260310000400_fix_allergen_check_constraint.sql
+++ b/supabase/migrations/20260310000400_fix_allergen_check_constraint.sql
@@ -1,0 +1,47 @@
+-- ==========================================================================
+-- Migration: 20260310000400_fix_allergen_check_constraint.sql
+-- Purpose:   1. Update chk_avoid_allergens_format to accept bare canonical IDs
+--               (e.g. 'gluten', 'milk') instead of en:-prefixed tags.
+--               Required after 20260310000200 normalized allergen tags.
+--            2. Remove orphaned junk ingredient_ref entries (OFF parser artifacts)
+-- Rollback:  Re-add old constraint with en: prefix regex;
+--            Re-insert deleted ingredient_ref rows if needed.
+-- ==========================================================================
+
+BEGIN;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 1. Update allergen check constraint for bare canonical IDs
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- Drop the old constraint that requires en: prefix
+ALTER TABLE public.user_preferences
+    DROP CONSTRAINT IF EXISTS chk_avoid_allergens_format;
+
+-- Add updated constraint: accepts bare canonical allergen IDs (lowercase, hyphens)
+-- Format: 'gluten', 'tree-nuts', 'sulphites', etc.
+ALTER TABLE public.user_preferences
+    ADD CONSTRAINT chk_avoid_allergens_format
+        CHECK (avoid_allergens IS NULL
+            OR cardinality(avoid_allergens) = 0
+            OR array_to_string(avoid_allergens, ',') ~ '^[a-z][a-z0-9-]+(,[a-z][a-z0-9-]+)*$'
+        );
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 2. Remove orphaned junk ingredient_ref entries
+--    These are OFF parser artifacts (bare numbers, "Kcal", nutrition
+--    strings) that should never have been imported as ingredients.
+--    Only delete rows with no product_ingredient references.
+-- ═══════════════════════════════════════════════════════════════════════════
+DELETE FROM public.ingredient_ref
+WHERE (
+    name_en ~ '^\d+$'
+    OR length(trim(name_en)) <= 1
+    OR name_en ~* '^(per 100|kcal|kj\b)'
+)
+AND NOT EXISTS (
+    SELECT 1 FROM public.product_ingredient pi
+    WHERE pi.ingredient_id = ingredient_ref.ingredient_id
+);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Closes #351 — Allergen Normalization: strip `en:` prefix, merge sub-allergens to canonical IDs.

### Changes

**4 new migrations:**
| Migration | Purpose |
|---|---|
| `20260310000100_allergen_ref_foundation.sql` | `allergen_ref` table — 14 EU-14 canonical allergens, RLS, indexes, grants |
| `20260310000200_allergen_tag_normalization.sql` | Strip `en:` prefix, merge sub-allergens, add FK, migrate `user_preferences`, recreate `v_master` |
| `20260310000300_allergen_translations.sql` | Localized allergen names + `resolve_allergen_display()` helper |
| `20260310000400_fix_allergen_check_constraint.sql` | Update `chk_avoid_allergens_format` for bare IDs + clean junk `ingredient_ref` entries |

**Tag renames:**
| Before | After |
|---|---|
| `en:nuts` | `tree-nuts` |
| `en:sesame-seeds` | `sesame` |
| `en:sulphur-dioxide-and-sulphites` | `sulphites` |
| `en:soy` | `soybeans` |
| `en:gluten` | `gluten` |
| `en:milk` | `milk` |
| `en:eggs` | `eggs` |
| (all other `en:xxx`) | `xxx` (bare) |

**Other changes:**
- Fix `de_enrichment_cleanup` migration for clean `supabase db reset`
- Update `ci_post_pipeline.sql`, `enrich_ingredients.py`, `VIEW__master_product_view.sql`
- Rewrite `QA__allergen_integrity` (15 checks), update `QA__allergen_filtering`, `TEST__negative_checks`
- Update `AllergenMatrix.tsx` with `DISPLAY_NAMES` map for canonical display
- Update 15 frontend test files to use bare canonical allergen IDs
- Update 7 frontend source components (defensive `en:` strip preserved)
- Fix Ruff SIM103 lint in `enrich_ingredients.py`
- Clean orphaned junk `ingredient_ref` entries (OFF parser artifacts like "Kcal")

### Verification

| Suite | Result |
|---|---|
| QA (34 suites) | **486/486 pass** |
| Negative tests | **23/23 caught** |
| Frontend (vitest) | **3953 passed** (241 files) |
| Ruff lint | Clean |
| TypeScript | Clean |
