### PR TITLE
perf(migration): merge overlapping score triggers & fix change log fields (#374)

### DIFF
--- a/db/qa/QA__scoring_engine.sql
+++ b/db/qa/QA__scoring_engine.sql
@@ -185,14 +185,13 @@ SELECT CASE
     THEN 'PASS' ELSE 'FAIL'
 END AS "T15_drift_detection_callable";
 
--- ─── T16: Score trigger fires and creates audit entry ────────────────────
--- Note: This test creates a temp entry and rolls it back if possible.
--- In CI, we verify the trigger function exists.
+-- ─── T16: Unified score trigger installed on products ────────────────────
+-- Merged trg_score_audit + record_score_change into single trigger (#374)
 
 SELECT CASE
     WHEN EXISTS (
         SELECT 1 FROM pg_trigger
-        WHERE tgname = 'trg_products_score_audit'
+        WHERE tgname = 'trg_products_score_unified'
           AND tgrelid = 'products'::regclass
     )
     THEN 'PASS' ELSE 'FAIL'

--- a/supabase/migrations/20260312000300_trigger_optimization.sql
+++ b/supabase/migrations/20260312000300_trigger_optimization.sql
@@ -1,0 +1,193 @@
+-- ============================================================================
+-- Migration:  20260312000300_trigger_optimization.sql
+-- Issue:      #374 — Merge & optimize products table triggers
+-- Purpose:    1. Merge 2 overlapping score triggers into 1 unified trigger
+--             2. Fix change log tracked fields (remove 13 non-existent columns)
+--             3. Search vector guard — already implemented at trigger level (no changes)
+-- Result:     Products triggers: 5 → 4 | Total DB triggers: 16 → 15
+--             Tracked fields: 25 → 13 (eliminates 13 silent exception catches per row)
+-- Rollback:   Run the function definitions from the original migrations:
+--             - 20260225000000_canonical_scoring_engine.sql (trg_score_audit)
+--             - 20260220000300_score_history_watchlist.sql  (record_score_change)
+--             - 20260227000000_data_provenance.sql          (trg_product_change_log)
+--             Then recreate the two dropped triggers:
+--             CREATE TRIGGER trg_products_score_audit AFTER UPDATE ON products
+--               FOR EACH ROW EXECUTE FUNCTION trg_score_audit();
+--             CREATE TRIGGER trg_products_score_history AFTER UPDATE OF unhealthiness_score
+--               ON products FOR EACH ROW EXECUTE FUNCTION record_score_change();
+--             DROP TRIGGER IF EXISTS trg_products_score_unified ON products;
+-- ============================================================================
+
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  PHASE 1: Merge overlapping score triggers (2 → 1)                      ║
+-- ║  trg_score_audit + record_score_change → trg_unified_score_change       ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+
+-- The merged function writes to BOTH score_audit_log and product_score_history
+-- in a single trigger invocation, eliminating one trigger execution per row.
+
+CREATE OR REPLACE FUNCTION public.trg_unified_score_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+BEGIN
+    IF OLD.unhealthiness_score IS DISTINCT FROM NEW.unhealthiness_score THEN
+        -- 1) Score audit log (field-level audit trail)
+        INSERT INTO score_audit_log
+            (product_id, field_name, old_value, new_value,
+             model_version, country, trigger_type)
+        VALUES (
+            NEW.product_id,
+            'unhealthiness_score',
+            OLD.unhealthiness_score::text,
+            NEW.unhealthiness_score::text,
+            COALESCE(NEW.score_model_version, 'v3.2'),
+            COALESCE(NEW.country, 'PL'),
+            COALESCE(current_setting('app.score_trigger', true), 'pipeline')
+        );
+
+        -- 2) Score history snapshot (only when new score is not null)
+        IF NEW.unhealthiness_score IS NOT NULL THEN
+            INSERT INTO product_score_history (
+                product_id, unhealthiness_score, nutri_score_label,
+                nova_group, data_completeness_pct, score_delta, trigger_source
+            ) VALUES (
+                NEW.product_id,
+                NEW.unhealthiness_score,
+                NEW.nutri_score_label,
+                NEW.nova_classification,
+                NEW.data_completeness_pct,
+                NEW.unhealthiness_score - COALESCE(OLD.unhealthiness_score, NEW.unhealthiness_score),
+                'pipeline'
+            )
+            ON CONFLICT (product_id, recorded_at) DO UPDATE SET
+                unhealthiness_score   = EXCLUDED.unhealthiness_score,
+                nutri_score_label     = EXCLUDED.nutri_score_label,
+                nova_group            = EXCLUDED.nova_group,
+                data_completeness_pct = EXCLUDED.data_completeness_pct,
+                score_delta           = EXCLUDED.score_delta;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$function$;
+
+-- Drop the two old triggers
+DROP TRIGGER IF EXISTS trg_products_score_audit   ON products;
+DROP TRIGGER IF EXISTS trg_products_score_history ON products;
+
+-- Create the unified trigger (fires on unhealthiness_score changes only)
+CREATE TRIGGER trg_products_score_unified
+    AFTER UPDATE OF unhealthiness_score ON products
+    FOR EACH ROW EXECUTE FUNCTION trg_unified_score_change();
+
+
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  PHASE 2: Fix change log tracked fields (25 → 13)                      ║
+-- ║  Remove 13 columns that don't exist on `products` table                 ║
+-- ║  Fix column name: ingredient_concern_level → ingredient_concern_score   ║
+-- ║  Add nova_classification (scoring-relevant, was missing)                ║
+-- ║  Eliminates EXCEPTION WHEN undefined_column handler overhead            ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+
+CREATE OR REPLACE FUNCTION public.trg_product_change_log()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+    v_field TEXT;
+    -- Only columns that actually exist on the products table (13 fields).
+    -- Removed 13 non-existent columns that were silently caught by exception
+    -- handler on every row update (calories_100g, fat_100g, saturated_fat_100g,
+    -- carbs_100g, sugars_100g, fiber_100g, protein_100g, salt_100g,
+    -- trans_fat_100g, ingredients_text, allergens, additives, image_url).
+    -- Fixed: ingredient_concern_level → ingredient_concern_score.
+    -- Added: nova_classification (scoring-relevant).
+    v_tracked_fields TEXT[] := ARRAY[
+        'product_name', 'product_name_en', 'brand', 'category',
+        'nutri_score_label', 'unhealthiness_score', 'nova_classification',
+        'prep_method', 'controversies', 'ingredient_concern_score',
+        'source_type', 'confidence', 'data_completeness_pct'
+    ];
+    v_old_val JSONB;
+    v_new_val JSONB;
+BEGIN
+    FOREACH v_field IN ARRAY v_tracked_fields
+    LOOP
+        EXECUTE format('SELECT to_jsonb($1.%I), to_jsonb($2.%I)', v_field, v_field)
+            INTO v_old_val, v_new_val USING OLD, NEW;
+
+        IF v_old_val IS DISTINCT FROM v_new_val THEN
+            INSERT INTO product_change_log (
+                product_id, field_name, old_value, new_value,
+                source_key, actor_type, actor_id, country
+            ) VALUES (
+                NEW.product_id, v_field, v_old_val, v_new_val,
+                NEW.source_type,
+                COALESCE(current_setting('app.actor_type', true), 'system'),
+                current_setting('app.actor_id', true),
+                COALESCE(NEW.country, 'PL')
+            );
+        END IF;
+    END LOOP;
+
+    RETURN NEW;
+END;
+$function$;
+
+-- Note: The products_30_change_audit trigger already exists and points to
+-- trg_product_change_log(). No trigger recreation needed — CREATE OR REPLACE
+-- automatically updates the function the trigger calls.
+
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  PHASE 3: Search vector guard — NO CHANGES NEEDED                      ║
+-- ║  Already implemented at trigger level:                                  ║
+-- ║  trg_products_search_vector_update fires only on                        ║
+-- ║  INSERT OR UPDATE OF product_name, product_name_en, brand, category,    ║
+-- ║  country — scoring-only updates skip it automatically.                  ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Verification                                                           ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+
+DO $$
+DECLARE
+    v_count INT;
+BEGIN
+    -- Verify unified trigger exists
+    SELECT COUNT(*) INTO v_count
+    FROM pg_trigger
+    WHERE tgname = 'trg_products_score_unified'
+      AND tgrelid = 'products'::regclass;
+    ASSERT v_count = 1, 'trg_products_score_unified trigger not found';
+
+    -- Verify old triggers are gone
+    SELECT COUNT(*) INTO v_count
+    FROM pg_trigger
+    WHERE tgname IN ('trg_products_score_audit', 'trg_products_score_history')
+      AND tgrelid = 'products'::regclass;
+    ASSERT v_count = 0, 'Old score triggers still exist: expected 0, got ' || v_count;
+
+    -- Verify change audit trigger still exists
+    SELECT COUNT(*) INTO v_count
+    FROM pg_trigger
+    WHERE tgname = 'products_30_change_audit'
+      AND tgrelid = 'products'::regclass;
+    ASSERT v_count = 1, 'products_30_change_audit trigger missing';
+
+    -- Verify total trigger count on products is 4 (was 5)
+    SELECT COUNT(*) INTO v_count
+    FROM pg_trigger
+    WHERE tgrelid = 'products'::regclass
+      AND NOT tgisinternal;
+    ASSERT v_count = 4, 'Expected 4 triggers on products, found ' || v_count;
+
+    RAISE NOTICE '✅ Trigger optimization verified: 5 → 4 triggers on products';
+    RAISE NOTICE '✅ Unified score trigger active, old score triggers removed';
+    RAISE NOTICE '✅ Change log function updated: 25 → 13 tracked fields';
+END $$;

--- a/supabase/tests/schema_contracts.test.sql
+++ b/supabase/tests/schema_contracts.test.sql
@@ -7,7 +7,7 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 
 BEGIN;
-SELECT plan(167);
+SELECT plan(172);
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 1. Core data tables exist
@@ -240,6 +240,13 @@ SELECT has_function('public', 'api_list_stores',                  'function api_
 -- v_master store columns
 SELECT has_column('public', 'v_master', 'store_count',            'v_master.store_count exists');
 SELECT has_column('public', 'v_master', 'store_names',            'v_master.store_names exists');
+
+-- ─── Trigger Optimization (#374) ──────────────────────────────────────────────
+SELECT has_trigger('products', 'trg_products_score_unified',      'unified score trigger exists on products');
+SELECT has_trigger('products', 'products_30_change_audit',        'change audit trigger exists on products');
+SELECT has_trigger('products', 'trg_products_search_vector_update', 'search vector trigger exists on products');
+SELECT has_trigger('products', 'trg_products_updated_at',         'updated_at trigger exists on products');
+SELECT has_function('public', 'trg_unified_score_change',         'function trg_unified_score_change exists');
 
 -- Żabka deactivated
 SELECT ok(


### PR DESCRIPTION
## Summary

Closes #374 — Merge & optimize products table triggers for pipeline performance.

### Changes

**Phase 1: Merge overlapping score triggers (2 → 1)**
- Combined `trg_score_audit` + `record_score_change` into single `trg_unified_score_change()` function
- Dropped triggers `trg_products_score_audit` and `trg_products_score_history`
- Created unified trigger `trg_products_score_unified` (fires `AFTER UPDATE OF unhealthiness_score`)
- Both `score_audit_log` and `product_score_history` populated from single trigger invocation

**Phase 2: Fix change log tracked fields (25 → 13)**
- Removed 13 non-existent columns that were silently caught by `EXCEPTION WHEN undefined_column` handler on every row update (`calories_100g`, `fat_100g`, `saturated_fat_100g`, `carbs_100g`, `sugars_100g`, `fiber_100g`, `protein_100g`, `salt_100g`, `trans_fat_100g`, `ingredients_text`, `allergens`, `additives`, `image_url`)
- Fixed column name: `ingredient_concern_level` → `ingredient_concern_score`
- Added `nova_classification` (scoring-relevant, was missing)
- Eliminated dynamic SQL exception handler overhead (13 silent catches per row per update)

**Phase 3: Search vector guard — NO CHANGES NEEDED**
- Already implemented at trigger level: `UPDATE OF product_name, product_name_en, brand, category, country`
- Scoring-only updates already skip search vector recomputation

### Impact
- Products table triggers: **5 → 4** (net reduction of 1 trigger invocation per score update)
- Total DB triggers: **16 → 15**
- Dynamic SQL calls per product update: reduced from 25 to 13 (48% fewer)
- Eliminated 13 silent exception catches per product update in change log trigger

### Testing
- 5 new pgTAP contract tests (plan 167 → 172): 4 `has_trigger` + 1 `has_function`
- Updated QA T16 in `QA__scoring_engine.sql` for renamed trigger
- Migration includes inline verification assertions

### Files Changed
| File | Change |
|------|--------|
| `supabase/migrations/20260312000300_trigger_optimization.sql` | New migration (3 phases) |
| `db/qa/QA__scoring_engine.sql` | T16: updated trigger name |
| `supabase/tests/schema_contracts.test.sql` | +5 trigger/function assertions |

### Verification
```
QA:              501/501 ALL PASSED
Negative tests:  23/23 caught
Pipeline:        25 categories verified
Trigger count:   5 → 4 on products (verified)
Audit tables:    Both populated from unified trigger (verified)
```