### PR TITLE
feat(frontend): add brand identity design tokens and JSON export

### DIFF
--- a/docs/assets/design-tokens.json
+++ b/docs/assets/design-tokens.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$version": "1.0.0",
+  "$description": "Poland Food DB — Design tokens for brand identity, scoring, and UI surfaces. Source of truth: frontend/src/styles/globals.css + frontend/tailwind.config.ts",
+
+  "brand": {
+    "primary": {
+      "value": "#0d7377",
+      "usage": "Headers, CTAs, primary actions, navigation accents",
+      "wcag": { "onWhite": "5.6:1 (AA)", "onDark": "4.8:1 (AA)" }
+    },
+    "primaryDark": {
+      "value": "#095456",
+      "usage": "Dark mode primary, strong emphasis on light backgrounds",
+      "wcag": { "onWhite": "8.5:1 (AAA)" }
+    },
+    "secondary": {
+      "value": "#f8fafc",
+      "usage": "Clean background variant, secondary surfaces",
+      "wcag": { "note": "Background color — not used for text" }
+    },
+    "accent": {
+      "value": "#d4a844",
+      "usage": "Decorative badges, awards, premium highlights — NOT for text on white (2.2:1)",
+      "wcag": { "onDark": "7.8:1 (AAA)", "onWhite": "2.2:1 (FAIL — decorative only)" }
+    },
+    "action": {
+      "value": "#15803d",
+      "usage": "Existing action/CTA green (backward-compatible brand.DEFAULT)",
+      "wcag": { "onWhite": "5.0:1 (AA)" }
+    },
+    "actionHover": {
+      "value": "#166534",
+      "usage": "Hover state for action green",
+      "wcag": { "onWhite": "7.1:1 (AAA)" }
+    },
+    "actionSubtle": {
+      "value": "#dcfce7",
+      "usage": "Subtle background tint for action areas",
+      "wcag": { "note": "Background color — not used for text" }
+    },
+    "darkMode": {
+      "primary": { "value": "#2dd4bf", "usage": "Teal-400 for dark surfaces", "wcag": { "onDark": "8.6:1 (AAA)" } },
+      "accent": { "value": "#fbbf24", "usage": "Amber-400 for dark surfaces", "wcag": { "onDark": "12.3:1 (AAA)" } }
+    }
+  },
+
+  "scoring": {
+    "green": {
+      "value": "#22c55e",
+      "range": "1–20",
+      "label": "Low Risk",
+      "textValue": "#15803d",
+      "textWcag": "5.1:1 (AA)"
+    },
+    "yellow": {
+      "value": "#eab308",
+      "range": "21–40",
+      "label": "Moderate",
+      "textValue": "#854d0e",
+      "textWcag": "5.9:1 (AA)"
+    },
+    "orange": {
+      "value": "#f97316",
+      "range": "41–60",
+      "label": "Elevated",
+      "textValue": "#c2410c",
+      "textWcag": "5.2:1 (AA)"
+    },
+    "red": {
+      "value": "#ef4444",
+      "range": "61–80",
+      "label": "High Risk",
+      "textValue": "#b91c1c",
+      "textWcag": "5.9:1 (AA)"
+    },
+    "darkred": {
+      "value": "#991b1b",
+      "range": "81–100",
+      "label": "Very High Risk",
+      "textValue": "#991b1b",
+      "textWcag": "8.3:1 (AAA)"
+    }
+  },
+
+  "nutriScore": {
+    "A": { "value": "#038141", "label": "Best nutritional quality" },
+    "B": { "value": "#85bb2f", "label": "Good nutritional quality" },
+    "C": { "value": "#fecb02", "label": "Average nutritional quality" },
+    "D": { "value": "#ee8100", "label": "Poor nutritional quality" },
+    "E": { "value": "#e63e11", "label": "Worst nutritional quality" }
+  },
+
+  "nova": {
+    "1": { "value": "#22c55e", "label": "Unprocessed or minimally processed" },
+    "2": { "value": "#84cc16", "label": "Processed culinary ingredients" },
+    "3": { "value": "#f59e0b", "label": "Processed foods" },
+    "4": { "value": "#ef4444", "label": "Ultra-processed products" }
+  },
+
+  "semantic": {
+    "success": { "value": "#22c55e", "usage": "Positive outcomes, confirmations" },
+    "warning": { "value": "#f59e0b", "usage": "Caution states, approaching limits" },
+    "error": { "value": "#ef4444", "usage": "Errors, destructive actions, alerts" },
+    "info": { "value": "#3b82f6", "usage": "Informational messages, neutral highlights" }
+  },
+
+  "surfaces": {
+    "light": {
+      "default": { "value": "#ffffff" },
+      "subtle": { "value": "#f9fafb", "note": "gray-50" },
+      "muted": { "value": "#f3f4f6", "note": "gray-100" },
+      "overlay": { "value": "rgba(0, 0, 0, 0.5)" }
+    },
+    "dark": {
+      "default": { "value": "#111827", "note": "gray-900" },
+      "subtle": { "value": "#1f2937", "note": "gray-800" },
+      "muted": { "value": "#374151", "note": "gray-700" },
+      "overlay": { "value": "rgba(0, 0, 0, 0.7)" }
+    }
+  },
+
+  "neutral": {
+    "light": {
+      "50": "#f8fafc",
+      "200": "#e2e8f0",
+      "400": "#94a3b8",
+      "600": "#475569",
+      "900": "#0f172a"
+    },
+    "dark": {
+      "50": "#0f172a",
+      "200": "#334155",
+      "400": "#94a3b8",
+      "600": "#cbd5e1",
+      "900": "#f8fafc"
+    }
+  },
+
+  "text": {
+    "light": {
+      "primary": { "value": "#111827", "wcag": "17.4:1 on white" },
+      "secondary": { "value": "#4b5563", "wcag": "7.1:1 on white (AA)" },
+      "muted": { "value": "#6b7280", "wcag": "4.6:1 on white (AA)" },
+      "inverse": { "value": "#ffffff" }
+    },
+    "dark": {
+      "primary": { "value": "#f9fafb" },
+      "secondary": { "value": "#d1d5db" },
+      "muted": { "value": "#9ca3af" },
+      "inverse": { "value": "#111827" }
+    }
+  },
+
+  "confidence": {
+    "high": { "value": "#22c55e", "label": "High data confidence" },
+    "medium": { "value": "#f59e0b", "label": "Medium data confidence" },
+    "low": { "value": "#ef4444", "label": "Low data confidence" }
+  },
+
+  "allergen": {
+    "present": { "value": "#ef4444", "label": "Contains allergen" },
+    "traces": { "value": "#f59e0b", "label": "May contain traces" },
+    "free": { "value": "#22c55e", "label": "Free from allergen" }
+  },
+
+  "border": {
+    "default": { "value": "#e5e7eb", "note": "gray-200" },
+    "strong": { "value": "#d1d5db", "note": "gray-300" }
+  }
+}

--- a/frontend/docs/DESIGN_SYSTEM.md
+++ b/frontend/docs/DESIGN_SYSTEM.md
@@ -56,6 +56,27 @@ This document defines the design token vocabulary for the poland-food-db fronten
 
 > **Note**: The full `brand-50` through `brand-900` palette is preserved for backward compatibility.
 
+### Brand Identity (#406)
+
+| Token                       | Light     | Dark      | Tailwind Class          | WCAG on White |
+| --------------------------- | --------- | --------- | ----------------------- | ------------- |
+| `--color-brand-primary`     | `#0d7377` | `#2dd4bf` | `bg-brand-primary`      | 5.6:1 (AA)    |
+| `--color-brand-primary-dark`| `#095456` | `#0d7377` | `bg-brand-primary-dark` | 8.5:1 (AAA)   |
+| `--color-brand-secondary`   | `#f8fafc` | `#1e293b` | `bg-brand-secondary`    | Background    |
+| `--color-brand-accent`      | `#d4a844` | `#fbbf24` | `bg-brand-accent`       | 2.2:1 (decorative) |
+
+> **Warning**: `brand-accent` (gold) does NOT meet WCAG AA as text on white backgrounds. Use only for decorative elements, badges, or on dark surfaces where it achieves 7.8:1 contrast.
+
+### Neutral Scale (#406)
+
+| Token                | Light     | Dark      | Tailwind Class  |
+| -------------------- | --------- | --------- | --------------- |
+| `--color-neutral-50` | `#f8fafc` | `#0f172a` | `bg-neutral-50` |
+| `--color-neutral-200`| `#e2e8f0` | `#334155` | `bg-neutral-200`|
+| `--color-neutral-400`| `#94a3b8` | `#94a3b8` | `bg-neutral-400`|
+| `--color-neutral-600`| `#475569` | `#cbd5e1` | `bg-neutral-600`|
+| `--color-neutral-900`| `#0f172a` | `#f8fafc` | `bg-neutral-900`|
+
 ### Health Score Bands
 
 | Token                   | Light     | Dark      | Tailwind Class                           | Score Range |
@@ -597,9 +618,10 @@ Use the token mapping from this document when migrating these files.
 
 ## Files
 
-| File                     | Purpose                                                                                         |
-| ------------------------ | ----------------------------------------------------------------------------------------------- |
-| `src/styles/globals.css` | CSS custom property definitions (`:root`, `[data-theme="dark"]`, `@media prefers-color-scheme`) |
-| `tailwind.config.ts`     | Tailwind theme extension mapping CSS vars to utility classes                                    |
-| `src/lib/constants.ts`   | Score band, Nutri-Score, warning severity, concern tier color maps                              |
-| `docs/DESIGN_SYSTEM.md`  | This document                                                                                   |
+| File                              | Purpose                                                                                         |
+| --------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `src/styles/globals.css`          | CSS custom property definitions (`:root`, `[data-theme="dark"]`, `@media prefers-color-scheme`) |
+| `tailwind.config.ts`              | Tailwind theme extension mapping CSS vars to utility classes                                    |
+| `src/lib/constants.ts`            | Score band, Nutri-Score, warning severity, concern tier color maps                              |
+| `docs/assets/design-tokens.json`  | Structured JSON export for design tools and documentation (#406)                                |
+| `docs/DESIGN_SYSTEM.md`           | This document                                                                                   |

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -25,6 +25,19 @@
     --color-brand-hover: #166534; /* green-800 */
     --color-brand-subtle: #dcfce7; /* brand-100 */
 
+    /* ── Brand Identity (#406) ── */
+    --color-brand-primary: #0d7377; /* Deep emerald teal — 5.6:1 on white (WCAG AA) */
+    --color-brand-primary-dark: #095456; /* Darker variant — 8.5:1 on white (WCAG AAA) */
+    --color-brand-secondary: #f8fafc; /* Clean white/slate — background variant */
+    --color-brand-accent: #d4a844; /* Warm gold — 7.8:1 on dark bg; decorative only on white (2.2:1) */
+
+    /* ── Neutral Scale ── */
+    --color-neutral-50: #f8fafc;
+    --color-neutral-200: #e2e8f0;
+    --color-neutral-400: #94a3b8;
+    --color-neutral-600: #475569;
+    --color-neutral-900: #0f172a;
+
     /* ── Health Score Bands ── */
     --color-score-green: #22c55e; /* 1–20 */
     --color-score-yellow: #eab308; /* 21–40 */
@@ -157,6 +170,19 @@
     --color-brand-hover: #22c55e; /* green-500 */
     --color-brand-subtle: #14532d; /* green-900 */
 
+    /* ── Brand Identity (dark mode) ── */
+    --color-brand-primary: #2dd4bf; /* Teal-400 — 8.6:1 on dark surface */
+    --color-brand-primary-dark: #0d7377; /* Uses light-mode primary as dark-mode variant */
+    --color-brand-secondary: #1e293b; /* Slate-800 — dark surface variant */
+    --color-brand-accent: #fbbf24; /* Amber-400 — 12.3:1 on dark surface */
+
+    /* ── Neutral Scale (dark mode — inverted) ── */
+    --color-neutral-50: #0f172a;
+    --color-neutral-200: #334155;
+    --color-neutral-400: #94a3b8;
+    --color-neutral-600: #cbd5e1;
+    --color-neutral-900: #f8fafc;
+
     /* Score bands — same hues, adjusted lightness for dark backgrounds */
     --color-score-green: #4ade80;
     --color-score-yellow: #facc15;
@@ -229,6 +255,18 @@
       --color-brand: #4ade80;
       --color-brand-hover: #22c55e;
       --color-brand-subtle: #14532d;
+
+      /* ── Brand Identity (dark mode — system preference fallback) ── */
+      --color-brand-primary: #2dd4bf;
+      --color-brand-primary-dark: #0d7377;
+      --color-brand-secondary: #1e293b;
+      --color-brand-accent: #fbbf24;
+
+      --color-neutral-50: #0f172a;
+      --color-neutral-200: #334155;
+      --color-neutral-400: #94a3b8;
+      --color-neutral-600: #cbd5e1;
+      --color-neutral-900: #f8fafc;
 
       --color-score-green: #4ade80;
       --color-score-yellow: #facc15;

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -19,6 +19,11 @@ const config: Config = {
           DEFAULT: "var(--color-brand)",
           hover: "var(--color-brand-hover)",
           subtle: "var(--color-brand-subtle)",
+          // Brand Identity (#406) — additive, does not replace existing keys
+          primary: "var(--color-brand-primary)",
+          "primary-dark": "var(--color-brand-primary-dark)",
+          secondary: "var(--color-brand-secondary)",
+          accent: "var(--color-brand-accent)",
           50: "#f0fdf4",
           100: "#dcfce7",
           200: "#bbf7d0",
@@ -54,6 +59,15 @@ const config: Config = {
           secondary: "var(--color-text-secondary)",
           muted: "var(--color-text-muted)",
           inverse: "var(--color-text-inverse)",
+        },
+
+        // ── Neutral Scale (#406) ──
+        neutral: {
+          50: "var(--color-neutral-50)",
+          200: "var(--color-neutral-200)",
+          400: "var(--color-neutral-400)",
+          600: "var(--color-neutral-600)",
+          900: "var(--color-neutral-900)",
         },
 
         // ── Health Score Bands ──


### PR DESCRIPTION
## Summary

Closes #406 — Part of Epic #397 (Brand Identity Foundation)

Adds brand identity design tokens (CSS custom properties + Tailwind + JSON export) as the foundational layer for the brand identity system.

---

## Changes

### 1. CSS Custom Properties (`globals.css`)
**New brand identity tokens (`:root`, `[data-theme="dark"]`, `@media prefers-color-scheme`):**

| Token | Light | Dark | WCAG on white |
|-------|-------|------|---------------|
| `--color-brand-primary` | `#0d7377` (deep teal) | `#2dd4bf` (teal-400) | 5.6:1 — AA ✓ |
| `--color-brand-primary-dark` | `#095456` | `#0d7377` | 8.5:1 — AAA ✓ |
| `--color-brand-secondary` | `#f8fafc` (clean white) | `#1e293b` (slate-800) | Background only |
| `--color-brand-accent` | `#d4a844` (warm gold) | `#fbbf24` (amber-400) | 2.2:1 — decorative only |

**New neutral scale:**

| Token | Light | Dark |
|-------|-------|------|
| `--color-neutral-50` | `#f8fafc` | `#0f172a` |
| `--color-neutral-200` | `#e2e8f0` | `#334155` |
| `--color-neutral-400` | `#94a3b8` | `#94a3b8` |
| `--color-neutral-600` | `#475569` | `#cbd5e1` |
| `--color-neutral-900` | `#0f172a` | `#f8fafc` |

### 2. Tailwind Config Extension (`tailwind.config.ts`)
- `brand.primary`, `brand.primary-dark`, `brand.secondary`, `brand.accent` → CSS variable references
- `neutral.50/200/400/600/900` → CSS variable references

All existing brand keys (`DEFAULT`, `hover`, `subtle`, `50`–`900`) preserved — **zero visual regression**.

### 3. JSON Token Export (`docs/assets/design-tokens.json`)
Structured export with:
- Brand tokens (light + dark mode, WCAG ratios, usage guidelines)
- Scoring bands (value, range, label, WCAG-safe text colors)
- Semantic, surface, neutral, Nutri-Score, NOVA, confidence, allergen sections
- WCAG AA/AAA contrast documentation per token

### 4. Documentation (`DESIGN_SYSTEM.md`)
- Brand Identity and Neutral Scale token tables added
- WCAG contrast ratios documented per token
- Gold accent warning (decorative only on light)
- JSON export added to Files reference

## Backward Compatibility

**Fully backward-compatible.** All existing classes preserved:
- `bg-brand`, `text-brand`, `bg-brand-hover`, `bg-brand-subtle` → unchanged
- `bg-score-green`, `text-score-green-text`, etc. → unchanged
- All existing CSS custom properties → unchanged

## Verification

| Check | Result |
|---|---|
| `npx tsc --noEmit` | 0 errors ✓ |
| `npx vitest run` | 241 passed, 3953 tests ✓ |
| JSON valid | ✓ |
| No visual regression | Additive only ✓ |

## File Impact

**4 files changed, +251 / -6 lines:**
- 1 new file: `docs/assets/design-tokens.json` (171 lines)
- 1 modified CSS: `frontend/src/styles/globals.css` (+38 lines)
- 1 modified TS: `frontend/tailwind.config.ts` (+14 lines)
- 1 modified doc: `frontend/docs/DESIGN_SYSTEM.md` (+28 / -6 lines)