### PR TITLE
data(qa): add confidence distribution regression guard + CI diagnostic (#445)

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -210,6 +210,38 @@ jobs:
             ORDER BY p.product_name;
           "
 
+      - name: Confidence distribution diagnostic
+        if: always()
+        run: |
+          echo "=== Confidence band distribution ==="
+          psql -c "
+            SELECT confidence_band, COUNT(*) AS products,
+                   ROUND(100.0 * COUNT(*) / SUM(COUNT(*)) OVER (), 1) AS pct
+            FROM v_product_confidence
+            GROUP BY confidence_band
+            ORDER BY MIN(total_confidence) DESC;
+          "
+          echo ""
+          echo "=== Confidence component averages ==="
+          psql -c "
+            SELECT ROUND(AVG(nutrition_pts), 1)  AS avg_nutrition,
+                   ROUND(AVG(ingredient_pts), 1)  AS avg_ingredient,
+                   ROUND(AVG(source_pts), 1)       AS avg_source,
+                   ROUND(AVG(ean_pts), 1)          AS avg_ean,
+                   ROUND(AVG(allergen_pts), 1)     AS avg_allergen,
+                   ROUND(AVG(total_confidence), 1) AS avg_total
+            FROM v_product_confidence;
+          "
+          echo ""
+          echo "=== products.confidence text enum distribution ==="
+          psql -c "
+            SELECT confidence, COUNT(*) AS products
+            FROM products
+            WHERE is_deprecated IS NOT TRUE
+            GROUP BY confidence
+            ORDER BY confidence;
+          "
+
       - name: Run QA via RUN_QA.ps1
         id: qa
         shell: pwsh

--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -9,7 +9,7 @@
         3. QA__source_coverage.sql (8 source provenance checks — informational)
         4. validate_eans.py (EAN-8/EAN-13 checksum validation — blocking)
         5. QA__api_surfaces.sql (18 API contract validation checks — blocking)
-        6. QA__confidence_scoring.sql (13 confidence scoring checks — blocking)
+        6. QA__confidence_scoring.sql (14 confidence scoring checks — blocking)
         7. QA__data_quality.sql (25 data quality & plausibility checks — blocking)
         8. QA__referential_integrity.sql (18 referential integrity checks — blocking)
         9. QA__view_consistency.sql (13 view & function consistency checks — blocking)
@@ -137,7 +137,7 @@ $suiteCatalog = @(
     @{ Num = 3; Name = "Source Coverage"; Short = "Source"; Id = "source_coverage"; Checks = 8; Blocking = $false; Kind = "sql-special"; File = "QA__source_coverage.sql" },
     @{ Num = 4; Name = "EAN Checksum Validation"; Short = "EAN"; Id = "ean"; Checks = 1; Blocking = $true; Kind = "python"; File = "validate_eans.py" },
     @{ Num = 5; Name = "API Surface Validation"; Short = "API"; Id = "api"; Checks = 18; Blocking = $true; Kind = "sql"; File = "QA__api_surfaces.sql" },
-    @{ Num = 6; Name = "Confidence Scoring"; Short = "Confidence"; Id = "confidence"; Checks = 13; Blocking = $true; Kind = "sql"; File = "QA__confidence_scoring.sql" },
+    @{ Num = 6; Name = "Confidence Scoring"; Short = "Confidence"; Id = "confidence"; Checks = 14; Blocking = $true; Kind = "sql"; File = "QA__confidence_scoring.sql" },
     @{ Num = 7; Name = "Data Quality & Plausibility"; Short = "DataQuality"; Id = "data_quality"; Checks = 25; Blocking = $true; Kind = "sql"; File = "QA__data_quality.sql" },
     @{ Num = 8; Name = "Referential Integrity"; Short = "RefInteg"; Id = "referential"; Checks = 18; Blocking = $true; Kind = "sql"; File = "QA__referential_integrity.sql" },
     @{ Num = 9; Name = "View & Function Consistency"; Short = "Views"; Id = "views"; Checks = 13; Blocking = $true; Kind = "sql"; File = "QA__view_consistency.sql" },

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -8,7 +8,7 @@
 > **Servings:** removed as separate table — all nutrition data is per-100g on nutrition_facts
 > **Ingredient analytics:** 2,995 unique ingredients (all clean ASCII English), 1,269 allergen declarations, 1,361 trace declarations
 > **Ingredient concerns:** EFSA-based 4-tier additive classification (0=none, 1=low, 2=moderate, 3=high)
-> **QA:** 679 checks across 47 suites + 23 negative validation tests — all passing
+> **QA:** 680 checks across 47 suites + 23 negative validation tests — all passing
 
 ---
 
@@ -91,7 +91,7 @@ poland-food-db/
 │   │   ├── QA__scoring_formula_tests.sql  # 29 scoring validation checks
 │   │   ├── QA__api_surfaces.sql     # 18 API surface validation checks
 │   │   ├── QA__api_contract.sql     # 33 API contract checks
-│   │   ├── QA__confidence_scoring.sql  # 13 confidence scoring checks
+│   │   ├── QA__confidence_scoring.sql  # 14 confidence scoring checks
 │   │   ├── QA__confidence_reporting.sql # 7 confidence reporting checks
 │   │   ├── QA__data_quality.sql          # 25 data quality checks
 │   │   ├── QA__data_consistency.sql      # 22 data consistency checks
@@ -256,7 +256,7 @@ poland-food-db/
 │       ├── 006-append-only-migrations.md
 │       └── 007-english-canonical-ingredients.md
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
-├── RUN_QA.ps1                       # QA test runner (679 checks across 47 suites)
+├── RUN_QA.ps1                       # QA test runner (680 checks across 47 suites)
 ├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (23 injection tests)
 ├── RUN_SANITY.ps1                   # Sanity checks (16) — row counts, schema assertions
 ├── RUN_REMOTE.ps1                   # Remote deployment (requires confirmation)
@@ -624,7 +624,7 @@ A change is **not done** unless relevant tests were added/updated, every suite i
 | Component tests     | **Testing Library React** + Vitest                | `frontend/src/components/**/*.test.tsx`      | same as above                        |
 | E2E smoke           | **Playwright 1.58** (Chromium)                    | `frontend/e2e/smoke.spec.ts`                 | `cd frontend && npx playwright test` |
 | E2E auth            | Playwright (requires `SUPABASE_SERVICE_ROLE_KEY`) | `frontend/e2e/authenticated.spec.ts`         | same (CI auto-detects key)           |
-| DB QA (679 checks)  | Raw SQL (zero rows = pass)                        | `db/qa/QA__*.sql` (47 suites)                | `.\RUN_QA.ps1`                       |
+| DB QA (680 checks)  | Raw SQL (zero rows = pass)                        | `db/qa/QA__*.sql` (47 suites)                | `.\RUN_QA.ps1`                       |
 | Negative validation | SQL injection/constraint tests                    | `db/qa/TEST__negative_checks.sql`            | `.\RUN_NEGATIVE_TESTS.ps1`           |
 | DB sanity           | Row-count + schema assertions                     | via `RUN_SANITY.ps1`                         | `.\RUN_SANITY.ps1 -Env local`        |
 | Pipeline structure  | Python validator                                  | `check_pipeline_structure.py`                | `python check_pipeline_structure.py` |
@@ -762,7 +762,7 @@ E2E tests are the **only** exception — they run against a live dev server but 
   - **`pr-title-lint.yml`**: PR title conventional-commit validation (all PRs)
   - **`main-gate.yml`**: Typecheck → Lint → Build → Unit tests with coverage → Playwright smoke E2E → SonarCloud scan + BLOCKING Quality Gate → Sentry sourcemap upload
   - **`nightly.yml`**: Full Playwright (all projects incl. visual regression) + Data Integrity Audit (parallel)
-  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (679 checks) → Sanity (17 checks) → Confidence threshold
+  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (680 checks) → Sanity (17 checks) → Confidence threshold
   - **`deploy.yml`**: Manual trigger → Schema diff → Approval gate (production) → Pre-deploy backup → `supabase db push` → Post-deploy sanity
   - **`sync-cloud-db.yml`**: Auto-sync migrations to production on merge to `main`
 
@@ -796,7 +796,7 @@ If adding/changing DB schema or SQL functions:
 - For rollback procedures, see `DEPLOYMENT.md` → **Rollback Procedures** (5 scenarios + emergency checklist).
 - Add a QA check that verifies the migration outcome (row counts, constraint behavior).
 - Ensure idempotency (`IF NOT EXISTS`, `ON CONFLICT`, `DO UPDATE SET`).
-- Run `.\RUN_QA.ps1` to verify all 679 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 23 injection tests.
+- Run `.\RUN_QA.ps1` to verify all 680 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 23 injection tests.
 
 ### 8.14 Snapshots Are Not Enough
 
@@ -846,7 +846,7 @@ At the end of every PR-like change, include a **Verification** section:
 | EAN Validation            | `validate_eans.py`                  |      1 | Yes       |
 | API Surfaces              | `QA__api_surfaces.sql`              |     18 | Yes       |
 | API Contract              | `QA__api_contract.sql`              |     33 | Yes       |
-| Confidence Scoring        | `QA__confidence_scoring.sql`        |     13 | Yes       |
+| Confidence Scoring        | `QA__confidence_scoring.sql`        |     14 | Yes       |
 | Confidence Reporting      | `QA__confidence_reporting.sql`      |      7 | Yes       |
 | Data Quality              | `QA__data_quality.sql`              |     25 | Yes       |
 | Ref. Integrity            | `QA__referential_integrity.sql`     |     18 | Yes       |
@@ -889,7 +889,7 @@ At the end of every PR-like change, include a **Verification** section:
 | Function Security Audit   | `QA__function_security_audit.sql`   |      6 | Yes       |
 | **Negative Validation**   | `TEST__negative_checks.sql`         |     23 | Yes       |
 
-**Run:** `.\RUN_QA.ps1` — expects **679/679 checks passing** (+ EAN validation).
+**Run:** `.\RUN_QA.ps1` — expects **680/680 checks passing** (+ EAN validation).
 **Run:** `.\RUN_NEGATIVE_TESTS.ps1` — expects **23/23 caught**.
 
 ### 8.19 Key Regression Tests (Scoring Suite)
@@ -1378,7 +1378,7 @@ Before a feature is considered complete, verify against all CI gates:
 | Gate                | Command                               | Expected                        |
 | ------------------- | ------------------------------------- | ------------------------------- |
 | Pipeline structure  | `python check_pipeline_structure.py`  | 0 errors                        |
-| DB QA               | `.\RUN_QA.ps1`                        | All checks pass (currently 679) |
+| DB QA               | `.\RUN_QA.ps1`                        | All checks pass (currently 680) |
 | Negative tests      | `.\RUN_NEGATIVE_TESTS.ps1`            | All caught (currently 29)       |
 | pgTAP tests         | `supabase test db`                    | All pass                        |
 | TypeScript          | `cd frontend && npx tsc --noEmit`     | 0 errors                        |


### PR DESCRIPTION
## Summary

Adds a QA regression guard and CI diagnostic for confidence score distribution, closing #445.

### Root Cause

The confidence distribution was 0% high / 97.8% medium / 2.2% low because `ingredient_pts` (25) and `allergen_pts` (10) were both 0 for all products — `product_ingredient` had 0 rows and `product_allergen_info` had ~20 rows. Maximum achievable score was ~65/100, mathematically preventing any product from reaching the "high" band (80+).

**Fixed by PR #454** (enrichment replay), which populates ingredient + allergen data in CI. This PR adds regression guards to prevent the distribution from reverting.

### Changes

| File | Change |
|------|--------|
| `db/qa/QA__confidence_scoring.sql` | Add check 14: ≥100 products must be in "high" band (80+) |
| `.github/workflows/qa.yml` | Add "Confidence distribution diagnostic" step — outputs band distribution, component averages, and `products.confidence` text enum breakdown |
| `RUN_QA.ps1` | Update check count: 13 → 14 for Confidence Scoring suite |
| `copilot-instructions.md` | Update all QA check counts: 679 → 680 |

### Acceptance Criteria (#445)

- [x] QA check enforces ≥100 products in "high" confidence band
- [x] CI diagnostic shows band distribution, component averages, confidence enum
- [x] `QA__confidence_scoring.sql` check count updated (13 → 14)
- [x] `RUN_QA.ps1` and `copilot-instructions.md` totals consistent (680)

### Verification

CI will verify:
- The new check 14 passes (≥100 products in "high" band after enrichment)
- The diagnostic step outputs the actual distribution numbers
- All existing 679 checks continue to pass (680 total with new check)

Closes #445