### PR TITLE
docs(qa): sync copilot-instructions.md with reality — 15+ outdated counts fixed

### DIFF
--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -5,7 +5,7 @@
 .DESCRIPTION
     Executes:
         1. QA__null_checks.sql (29 data integrity checks)
-        2. QA__scoring_formula_tests.sql (29 algorithm validation checks)
+        2. QA__scoring_formula_tests.sql (31 algorithm validation checks)
         3. QA__source_coverage.sql (8 source provenance checks — informational)
         4. validate_eans.py (EAN-8/EAN-13 checksum validation — blocking)
         5. QA__api_surfaces.sql (18 API contract validation checks — blocking)
@@ -133,7 +133,7 @@ $QA_DIR = Join-Path (Join-Path $SCRIPT_ROOT "db") "qa"
 # Single source of truth for suite metadata (names, counts, blocking behavior)
 $suiteCatalog = @(
     @{ Num = 1; Name = "Data Integrity"; Short = "Integrity"; Id = "integrity"; Checks = 29; Blocking = $true; Kind = "sql-special"; File = "QA__null_checks.sql" },
-    @{ Num = 2; Name = "Scoring Formula"; Short = "Scoring"; Id = "scoring"; Checks = 29; Blocking = $true; Kind = "sql-special"; File = "QA__scoring_formula_tests.sql" },
+    @{ Num = 2; Name = "Scoring Formula"; Short = "Scoring"; Id = "scoring"; Checks = 31; Blocking = $true; Kind = "sql-special"; File = "QA__scoring_formula_tests.sql" },
     @{ Num = 3; Name = "Source Coverage"; Short = "Source"; Id = "source_coverage"; Checks = 8; Blocking = $false; Kind = "sql-special"; File = "QA__source_coverage.sql" },
     @{ Num = 4; Name = "EAN Checksum Validation"; Short = "EAN"; Id = "ean"; Checks = 1; Blocking = $true; Kind = "python"; File = "validate_eans.py" },
     @{ Num = 5; Name = "API Surface Validation"; Short = "API"; Id = "api"; Checks = 18; Blocking = $true; Kind = "sql"; File = "QA__api_surfaces.sql" },


### PR DESCRIPTION
# docs(qa): sync copilot-instructions.md with reality

Closes #440

## Problem

`copilot-instructions.md` had 15+ outdated data points causing incorrect assumptions by AI assistants and developers.

## Changes

### QA Check Count: 680 → 690 (+10)

The total was wrong due to 3 stale suite counts:

| Suite | Was | Actual | Delta | Source |
|---|---|---|---|---|
| Scoring Formula | 29 | 31 | +2 | File header says 31, catalog said 29 |
| Security Posture | 22 | 29 | +7 | 7 checks added in prior migration |
| Index & Temporal | 15 | 19 | +4 | 4 checks added in prior migration |

Updated in **7 occurrences** across copilot-instructions.md (header, §3, §8.1, §8.10, §8.13, §8.18, §15.17).

### Migration Count: 140 → 167

27 migrations were added since the last update.

### CI Workflows: 15 → 19

Added 4 missing workflow entries to §3 project layout:
- `python-lint.yml` — Python linting (Ruff)
- `repo-verify.yml` — Repo hygiene verification
- `validate-alerts.yml` — Alert configuration validation
- `dr-drill.yml` — Disaster recovery drill

### qa.yml Description Fix

The `qa.yml` comment in §3 said \"QA (460)\" — updated to \"QA (690)\".

### RUN_QA.ps1

Updated scoring formula catalog entry: `Checks = 29` → `Checks = 31` (matching file header).

## Out of Scope (noted for future)

These items need DB queries to verify and are tracked separately:
- Active product count (~1,281)
- Deprecated product count (51)
- Ingredient analytics counts (2,995 / 1,269 / 1,361)

## File Impact

**2 files changed, +19 / -15 lines**
- `copilot-instructions.md` — 13 replacements across 7 sections
- `RUN_QA.ps1` — scoring formula catalog + header comment"