### PR TITLE
chore(cleanup): clean up tmp-* dirs and add qa-baseline.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,4 +85,5 @@ tmp-qa-*/
 tmp-*.txt
 tmp-*.json
 qa-results.json
+qa-baseline.json
 tmp-*.sql


### PR DESCRIPTION
# Clean up tmp-* directories and QA artifacts — Issue #446

Closes #446

## Problem

8 `tmp-*` directories and QA artifact files (`qa-results.json`, `qa-baseline.json`) accumulated in workspace root, violating `docs/REPO_GOVERNANCE.md` root cleanliness rules.

## Changes

### `.gitignore`
- Added `qa-baseline.json` pattern (was missing — `qa-results.json` was already covered)

### Local cleanup (not tracked, so no git diff)
- Deleted 8 directories: `tmp-ci-2/`, `tmp-ci-main/`, `tmp-ci-qa/`, `tmp-qa/`, `tmp-qa-391/`, `tmp-qa-artifact/`, `tmp-qa-check/`, `tmp-qa-ci/`
- Deleted files: `qa-results.json`, `qa-baseline.json`, `tmp-enrichment-log.txt`, `tmp-enrichment-run.log`, `tmp-git-status.txt`

## Verification

- All items were already untracked (`.gitignore` had `tmp-*/` patterns)
- `scripts/repo_verify.ps1`: 5/6 checks pass; root cleanliness shows clean in CI (one local locked file `tmp-db-reset.log` is process-specific)
- No CI workflow depends on these directories persisting