### PR TITLE
refactor(scoring): remove legacy compute_unhealthiness_v31()

### DIFF
--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -245,7 +245,7 @@ poland-food-db/
 │   ├── UX_IMPACT_METRICS.md         # UX measurement standard, metric catalog, SQL templates
 │   ├── UX_UI_DESIGN.md              # UI/UX guidelines
 │   ├── VIEWING_AND_TESTING.md       # Queries, Studio UI, test runner
-│   ├── api-registry.yaml            # Structured registry of all 192 functions (YAML)
+│   ├── api-registry.yaml            # Structured registry of all 191 functions (YAML)
 │   └── decisions/                   # Architecture Decision Records (MADR 3.0)
 │       ├── 000-template.md          # ADR template
 │       ├── 001-postgresql-only-stack.md
@@ -556,7 +556,7 @@ a mix of `'baked'`, `'fried'`, and `'none'`.
 
 ## 7. Migrations
 
-**Location:** `supabase/migrations/` — managed by Supabase CLI. Currently **167 migrations**.
+**Location:** `supabase/migrations/` — managed by Supabase CLI. Currently **168 migrations**.
 
 **Rules:**
 

--- a/db/qa/QA__security_posture.sql
+++ b/db/qa/QA__security_posture.sql
@@ -141,7 +141,7 @@ FROM pg_proc p
 JOIN pg_namespace n ON p.pronamespace = n.oid
 WHERE n.nspname = 'public'
   AND p.proname IN (
-    'compute_unhealthiness_v31','compute_unhealthiness_v32',
+    'compute_unhealthiness_v32',
     'explain_score_v32','compute_data_confidence','compute_data_completeness',
     'assign_confidence','find_similar_products','find_better_alternatives',
     'refresh_all_materialized_views','mv_staleness_check',

--- a/docs/API_CONVENTIONS.md
+++ b/docs/API_CONVENTIONS.md
@@ -270,7 +270,6 @@ so renaming is unnecessary:
 
 | Function                        | Domain         | Notes                              |
 | ------------------------------- | -------------- | ---------------------------------- |
-| `compute_unhealthiness_v31`     | scoring        | Superseded by v32, kept for audit  |
 | `compute_unhealthiness_v32`     | scoring        | Active scoring function            |
 | `assign_confidence`             | confidence     | Called by `score_category()`       |
 | `find_better_alternatives`      | products       | Called by `api_better_alternatives` |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -192,14 +192,14 @@ Pairs investigated for overlap during the 2026-02-28 audit:
 
 ## Obsolete Reference Check
 
-Files checked for references to deprecated elements (`compute_unhealthiness_v31`, `scored_at`, `column_metadata`):
+Files checked for references to deprecated elements (`scored_at`, `column_metadata`). Note: `compute_unhealthiness_v31` was dropped in migration `20260314000100_remove_legacy_v31_scoring.sql`.
 
 | File                   | Hits | Assessment                                                                      |
 | ---------------------- | ---- | ------------------------------------------------------------------------------- |
 | FEATURE_SUNSETTING.md  | 2    | `column_metadata` referenced as **already-cleaned-up example** — intentional    |
 | SCORING_ENGINE.md      | 5    | References to v3.1 as **historical context** in version evolution — intentional |
 | SCORING_METHODOLOGY.md | 4    | References to v3.1 as **previous version** in changelog section — intentional   |
-| SECURITY_AUDIT.md      | 2    | References to scoring version history — intentional                             |
+| SECURITY_AUDIT.md      | 1    | v31 row removed (function dropped); remaining v3.2 reference — valid        |
 | UX_UI_DESIGN.md        | 1    | Minor v3.1 reference in historical context — intentional                        |
 
 **Result:** No stale or misleading obsolete references found. All hits are intentional historical context.

--- a/docs/SECURITY_AUDIT.md
+++ b/docs/SECURITY_AUDIT.md
@@ -145,7 +145,6 @@ All remaining `api_*` functions require `authenticated` role. Each function that
 
 | Function                         | Purpose                    | Callable by External Roles |
 | -------------------------------- | -------------------------- | -------------------------- |
-| `compute_unhealthiness_v31`      | Score computation          | ❌                          |
 | `compute_unhealthiness_v32`      | Score computation v3.2     | ❌                          |
 | `explain_score_v32`              | Score explanation          | ❌                          |
 | `compute_data_confidence`        | Data quality scoring       | ❌                          |

--- a/docs/api-registry.yaml
+++ b/docs/api-registry.yaml
@@ -1,6 +1,6 @@
 # API Registry — Poland Food DB
 #
-# Canonical registry of all 192 public-schema functions.
+# Canonical registry of all 191 public-schema functions.
 # Last updated: 2026-03-14
 # Naming convention: docs/API_CONVENTIONS.md
 # Contract details: docs/API_CONTRACTS.md
@@ -1909,26 +1909,6 @@ run_full_data_audit:
 # ═══════════════════════════════════════════════════════════════════
 # SCORING INTERNALS DOMAIN
 # ═══════════════════════════════════════════════════════════════════
-
-compute_unhealthiness_v31:
-  domain: scoring
-  visibility: internal
-  auth: n/a
-  params:
-    p_saturated_fat_g: { type: numeric, required: true }
-    p_sugars_g: { type: numeric, required: true }
-    p_salt_g: { type: numeric, required: true }
-    p_calories: { type: numeric, required: true }
-    p_trans_fat_g: { type: numeric, required: true }
-    p_additives_count: { type: numeric, required: true }
-    p_prep_method: { type: text, required: true }
-    p_controversies: { type: text, required: true }
-  returns: integer
-  p95_target: 1
-  deprecated: false
-  notes: >
-    Unhealthiness v3.1b scoring formula: 8 factors with weighted sum.
-    Differentiates smoked/steamed/grilled prep methods. IMMUTABLE.
 
 compute_unhealthiness_v32:
   domain: scoring

--- a/supabase/migrations/20260314000100_remove_legacy_v31_scoring.sql
+++ b/supabase/migrations/20260314000100_remove_legacy_v31_scoring.sql
@@ -1,0 +1,27 @@
+-- ============================================================================
+-- Migration: Remove legacy compute_unhealthiness_v31() scoring function
+-- Issue:     #447
+-- Purpose:   Drop dead code — v31 was superseded by v32 in migration
+--            20260210001900_ingredient_concern_scoring.sql. No active callers.
+-- Rollback:  Re-create from 20260210001000_prep_method_not_null_and_scoring_v31b.sql
+-- ============================================================================
+
+-- Revoke any leftover grants (idempotent — silent if already revoked)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public'
+      AND p.proname = 'compute_unhealthiness_v31'
+  ) THEN
+    REVOKE ALL ON FUNCTION public.compute_unhealthiness_v31(
+      numeric, numeric, numeric, numeric, numeric, numeric, text, text
+    ) FROM anon, authenticated;
+  END IF;
+END $$;
+
+-- Drop the function (idempotent)
+DROP FUNCTION IF EXISTS public.compute_unhealthiness_v31(
+  numeric, numeric, numeric, numeric, numeric, numeric, text, text
+);


### PR DESCRIPTION
## Summary

Drop dead code: `compute_unhealthiness_v31()` was superseded by `compute_unhealthiness_v32()` in migration `20260210001900_ingredient_concern_scoring.sql`. No active callers remain — verified by searching all pipelines, QA suites, views, and frontend code.

## Changes

| File | Change |
|------|--------|
| `supabase/migrations/20260314000100_remove_legacy_v31_scoring.sql` | New migration: REVOKE grants + DROP FUNCTION IF EXISTS |
| `db/qa/QA__security_posture.sql` | Remove v31 from check 10 (anon-blocked internal functions) |
| `docs/api-registry.yaml` | Remove v31 entry (192 → 191 functions) |
| `docs/API_CONVENTIONS.md` | Remove v31 row from legacy functions table |
| `docs/SECURITY_AUDIT.md` | Remove v31 row from internal functions table |
| `docs/INDEX.md` | Update obsolete reference check (note v31 dropped) |
| `copilot-instructions.md` | Update function count (192→191), migration count (167→168) |

## Verification

- [x] Pipeline structure: 25 categories verified ✅
- [x] TypeScript: compiles clean ✅
- [x] Vitest: 3,953 passed, 241 files ✅
- [x] Migration ordering: valid ✅
- [x] Repo hygiene: 6/6 passed ✅
- [x] No active v31 references in pipelines, QA, views, or frontend

## Migration Safety

- **Idempotent:** Uses `DROP FUNCTION IF EXISTS` + conditional REVOKE
- **Rollback:** Re-create from `20260210001000_prep_method_not_null_and_scoring_v31b.sql`
- **No data impact:** Function only, no table/column changes

Closes #447