### PR TITLE
feat(frontend): enhance Nutri-Score, NOVA, and Confidence badge components

### DIFF
--- a/frontend/src/components/common/ConfidenceBadge.test.tsx
+++ b/frontend/src/components/common/ConfidenceBadge.test.tsx
@@ -5,62 +5,170 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { ConfidenceBadge } from "./ConfidenceBadge";
 
 describe("ConfidenceBadge", () => {
-  it.each(["high", "medium", "low"] as const)("renders %s level", (level) => {
-    render(<ConfidenceBadge level={level} />);
-    const label = level.charAt(0).toUpperCase() + level.slice(1);
-    expect(screen.getByText(label)).toBeTruthy();
+  // ─── Valid levels ───────────────────────────────────────────────────────
+
+  describe("valid levels", () => {
+    it("renders Verified for high level", () => {
+      render(<ConfidenceBadge level="high" />);
+      expect(screen.getByText("Verified")).toBeTruthy();
+    });
+
+    it("renders Estimated for medium level", () => {
+      render(<ConfidenceBadge level="medium" />);
+      expect(screen.getByText("Estimated")).toBeTruthy();
+    });
+
+    it("renders Low for low level", () => {
+      render(<ConfidenceBadge level="low" />);
+      expect(screen.getByText("Low")).toBeTruthy();
+    });
+
+    it("maps high to confidence-high color", () => {
+      render(<ConfidenceBadge level="high" />);
+      const badge = screen.getByText("Verified").closest("span")!;
+      expect(badge.className).toContain("text-confidence-high");
+      expect(badge.className).toContain("bg-confidence-high/10");
+    });
+
+    it("maps low to confidence-low color", () => {
+      render(<ConfidenceBadge level="low" />);
+      expect(screen.getByText("Low").closest("span")!.className).toContain(
+        "text-confidence-low",
+      );
+    });
   });
 
-  it("maps high to confidence-high color", () => {
-    render(<ConfidenceBadge level="high" />);
-    const badge = screen.getByText("High");
-    expect(badge.className).toContain("text-confidence-high");
-    expect(badge.className).toContain("bg-confidence-high/10");
+  // ─── DB value aliases ───────────────────────────────────────────────────
+
+  describe("DB value aliases", () => {
+    it("maps 'verified' (DB value) to high/Verified", () => {
+      render(<ConfidenceBadge level="verified" />);
+      expect(screen.getByText("Verified")).toBeTruthy();
+    });
+
+    it("maps 'estimated' (DB value) to medium/Estimated", () => {
+      render(<ConfidenceBadge level="estimated" />);
+      expect(screen.getByText("Estimated")).toBeTruthy();
+    });
+
+    it("maps 'low' from DB directly", () => {
+      render(<ConfidenceBadge level="low" />);
+      expect(screen.getByText("Low")).toBeTruthy();
+    });
   });
 
-  it("maps low to confidence-low color", () => {
-    render(<ConfidenceBadge level="low" />);
-    expect(screen.getByText("Low").className).toContain("text-confidence-low");
+  // ─── Shield icons ──────────────────────────────────────────────────────
+
+  describe("shield icons", () => {
+    it("renders shield SVG icon for all levels", () => {
+      const { container } = render(<ConfidenceBadge level="high" />);
+      const shields = container.querySelectorAll('[data-testid="shield-icon"]');
+      expect(shields.length).toBe(1);
+    });
+
+    it("renders ✓ symbol inside shield for high", () => {
+      render(<ConfidenceBadge level="high" />);
+      const shield = screen.getByTestId("shield-icon");
+      const text = shield.querySelector("text");
+      expect(text?.textContent).toBe("✓");
+    });
+
+    it("renders ~ symbol inside shield for medium", () => {
+      render(<ConfidenceBadge level="medium" />);
+      const shield = screen.getByTestId("shield-icon");
+      const text = shield.querySelector("text");
+      expect(text?.textContent).toBe("~");
+    });
+
+    it("renders ! symbol inside shield for low", () => {
+      render(<ConfidenceBadge level="low" />);
+      const shield = screen.getByTestId("shield-icon");
+      const text = shield.querySelector("text");
+      expect(text?.textContent).toBe("!");
+    });
+
+    it("renders ? symbol inside shield for null", () => {
+      render(<ConfidenceBadge level={null} />);
+      const shield = screen.getByTestId("shield-icon");
+      const text = shield.querySelector("text");
+      expect(text?.textContent).toBe("?");
+    });
+
+    it("shield is aria-hidden", () => {
+      render(<ConfidenceBadge level="high" />);
+      const shield = screen.getByTestId("shield-icon");
+      expect(shield.getAttribute("aria-hidden")).toBe("true");
+    });
   });
 
-  it("renders Unknown for null level", () => {
-    render(<ConfidenceBadge level={null} />);
-    expect(screen.getByText("Unknown")).toBeTruthy();
-    expect(screen.getByText("Unknown").className).toContain(
-      "text-foreground-muted",
-    );
+  // ─── showLabel ──────────────────────────────────────────────────────────
+
+  describe("showLabel prop", () => {
+    it("shows label by default", () => {
+      render(<ConfidenceBadge level="high" />);
+      expect(screen.getByText("Verified")).toBeTruthy();
+    });
+
+    it("hides label when showLabel is false", () => {
+      render(<ConfidenceBadge level="high" showLabel={false} />);
+      expect(screen.queryByText("Verified")).toBeNull();
+    });
   });
 
-  it("shows percentage when provided", () => {
-    render(<ConfidenceBadge level="high" percentage={85} />);
-    expect(screen.getByText("85%")).toBeTruthy();
+  // ─── Null handling ──────────────────────────────────────────────────────
+
+  describe("null handling", () => {
+    it("renders Unknown for null level", () => {
+      render(<ConfidenceBadge level={null} />);
+      expect(screen.getByText("Unknown")).toBeTruthy();
+      expect(screen.getByText("Unknown").closest("span")!.className).toContain(
+        "text-foreground-muted",
+      );
+    });
   });
 
-  it("hides percentage for invalid values", () => {
-    render(<ConfidenceBadge level="high" percentage={-1} />);
-    expect(screen.queryByText("-1%")).toBeNull();
+  // ─── Percentage ─────────────────────────────────────────────────────────
+
+  describe("percentage", () => {
+    it("shows percentage when provided", () => {
+      render(<ConfidenceBadge level="high" percentage={85} />);
+      expect(screen.getByText("85%")).toBeTruthy();
+    });
+
+    it("hides percentage for invalid values", () => {
+      render(<ConfidenceBadge level="high" percentage={-1} />);
+      expect(screen.queryByText("-1%")).toBeNull();
+    });
   });
 
-  it("has accessible aria-label", () => {
-    render(<ConfidenceBadge level="medium" percentage={60} />);
-    expect(screen.getByLabelText("Confidence: Medium (60%)")).toBeTruthy();
+  // ─── Accessibility ──────────────────────────────────────────────────────
+
+  describe("accessibility", () => {
+    it("has accessible aria-label with percentage", () => {
+      render(<ConfidenceBadge level="medium" percentage={60} />);
+      expect(screen.getByLabelText("Confidence: Estimated (60%)")).toBeTruthy();
+    });
+
+    it("has accessible aria-label without percentage", () => {
+      render(<ConfidenceBadge level="high" />);
+      expect(screen.getByLabelText("Confidence: Verified")).toBeTruthy();
+    });
   });
 
-  it("has accessible aria-label without percentage", () => {
-    render(<ConfidenceBadge level="high" />);
-    expect(screen.getByLabelText("Confidence: High")).toBeTruthy();
-  });
+  // ─── Tooltip ────────────────────────────────────────────────────────────
 
-  it("shows tooltip on hover when showTooltip is true", async () => {
-    const user = userEvent.setup();
-    render(
-      <TooltipPrimitive.Provider delayDuration={0}>
-        <ConfidenceBadge level="high" showTooltip />
-      </TooltipPrimitive.Provider>,
-    );
+  describe("tooltip", () => {
+    it("shows tooltip on hover when showTooltip is true", async () => {
+      const user = userEvent.setup();
+      render(
+        <TooltipPrimitive.Provider delayDuration={0}>
+          <ConfidenceBadge level="high" showTooltip />
+        </TooltipPrimitive.Provider>,
+      );
 
-    await user.hover(screen.getByText("High"));
-    const tooltip = await screen.findByRole("tooltip");
-    expect(tooltip.textContent).toContain("High confidence");
+      await user.hover(screen.getByText("Verified"));
+      const tooltip = await screen.findByRole("tooltip");
+      expect(tooltip.textContent).toContain("High confidence");
+    });
   });
 });

--- a/frontend/src/components/common/ConfidenceBadge.tsx
+++ b/frontend/src/components/common/ConfidenceBadge.tsx
@@ -1,7 +1,14 @@
 /**
- * ConfidenceBadge — data confidence indicator for user trust.
+ * ConfidenceBadge — data confidence indicator with shield icon.
+ *
+ * Levels:
+ *   high / verified  → shield ✓ (green)
+ *   medium / estimated → shield ~ (amber)
+ *   low              → shield ! (red)
  *
  * Uses `--color-confidence-high/medium/low` design tokens.
+ * Accepts both DB band values (high/medium/low) and assign_confidence()
+ * values (verified/estimated/low) via normalization.
  */
 
 import React from "react";
@@ -13,10 +20,12 @@ export type ConfidenceLevel = "high" | "medium" | "low";
 export type ConfidenceBadgeSize = "sm" | "md";
 
 export interface ConfidenceBadgeProps {
-  /** Confidence level. */
-  readonly level: ConfidenceLevel | null | undefined;
+  /** Confidence level. Accepts 'high'/'medium'/'low' or 'verified'/'estimated'. */
+  readonly level: string | null | undefined;
   /** Optional percentage to display alongside the level. */
   readonly percentage?: number;
+  /** Show the text label. @default true */
+  readonly showLabel?: boolean;
   /** Size preset. @default "sm" */
   readonly size?: ConfidenceBadgeSize;
   /** Show explanatory tooltip on hover. @default false */
@@ -31,23 +40,37 @@ interface ConfidenceConfig {
   label: string;
   bg: string;
   text: string;
+  /** Shield symbol: ✓, ~, ! */
+  symbol: string;
 }
+
+/** Normalize DB assign_confidence() values to band keys. */
+const LEVEL_ALIASES: Record<string, ConfidenceLevel> = {
+  high: "high",
+  verified: "high",
+  medium: "medium",
+  estimated: "medium",
+  low: "low",
+};
 
 const LEVEL_CONFIGS: Record<ConfidenceLevel, ConfidenceConfig> = {
   high: {
-    label: "High",
+    label: "Verified",
     bg: "bg-confidence-high/10",
     text: "text-confidence-high",
+    symbol: "✓",
   },
   medium: {
-    label: "Medium",
+    label: "Estimated",
     bg: "bg-confidence-medium/10",
     text: "text-confidence-medium",
+    symbol: "~",
   },
   low: {
     label: "Low",
     bg: "bg-confidence-low/10",
     text: "text-confidence-low",
+    symbol: "!",
   },
 };
 
@@ -55,6 +78,7 @@ const FALLBACK: ConfidenceConfig = {
   label: "Unknown",
   bg: "bg-surface-muted",
   text: "text-foreground-muted",
+  symbol: "?",
 };
 
 const SIZE_CLASSES: Record<ConfidenceBadgeSize, string> = {
@@ -62,19 +86,73 @@ const SIZE_CLASSES: Record<ConfidenceBadgeSize, string> = {
   md: "px-2.5 py-1 text-sm",
 };
 
+const SHIELD_SIZE: Record<ConfidenceBadgeSize, number> = {
+  sm: 14,
+  md: 18,
+};
+
+// ─── Shield SVG ─────────────────────────────────────────────────────────────
+
+function ShieldIcon({
+  symbol,
+  size,
+  className,
+}: {
+  symbol: string;
+  size: number;
+  className: string;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 16 18"
+      fill="none"
+      className={`inline-block flex-shrink-0 ${className}`}
+      aria-hidden="true"
+      data-testid="shield-icon"
+    >
+      {/* Shield outline */}
+      <path
+        d="M8 1L2 4v4c0 4.5 2.6 7.3 6 9 3.4-1.7 6-4.5 6-9V4L8 1z"
+        fill="currentColor"
+        opacity={0.15}
+        stroke="currentColor"
+        strokeWidth={1.2}
+        strokeLinejoin="round"
+      />
+      {/* Symbol inside shield */}
+      <text
+        x="8"
+        y="10.5"
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill="currentColor"
+        style={{ fontSize: "8px", fontWeight: 700 }}
+      >
+        {symbol}
+      </text>
+    </svg>
+  );
+}
+
 // ─── Component ──────────────────────────────────────────────────────────────
 
 export const ConfidenceBadge = React.memo(function ConfidenceBadge({
   level,
   percentage,
+  showLabel = true,
   size = "sm",
   showTooltip = false,
   className = "",
 }: Readonly<ConfidenceBadgeProps>) {
-  const config = level ? (LEVEL_CONFIGS[level] ?? FALLBACK) : FALLBACK;
+  const normalized = level ? LEVEL_ALIASES[level.toLowerCase()] : undefined;
+  const config = normalized ? LEVEL_CONFIGS[normalized] : FALLBACK;
   const showPercentage =
     percentage != null && percentage >= 0 && percentage <= 100;
-  const tooltipKey = level ? `tooltip.confidence.${level}` : undefined;
+  const tooltipKey = normalized
+    ? `tooltip.confidence.${normalized}`
+    : undefined;
 
   const badge = (
     <span
@@ -94,7 +172,12 @@ export const ConfidenceBadge = React.memo(function ConfidenceBadge({
         .filter(Boolean)
         .join(" ")}
     >
-      {config.label}
+      <ShieldIcon
+        symbol={config.symbol}
+        size={SHIELD_SIZE[size]}
+        className={config.text}
+      />
+      {showLabel && config.label}
       {showPercentage && <span className="opacity-75">{percentage}%</span>}
     </span>
   );

--- a/frontend/src/components/common/NovaBadge.test.tsx
+++ b/frontend/src/components/common/NovaBadge.test.tsx
@@ -5,67 +5,143 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { NovaBadge } from "./NovaBadge";
 
 describe("NovaBadge", () => {
-  it.each([1, 2, 3, 4] as const)("renders group %i", (group) => {
-    render(<NovaBadge group={group} />);
-    expect(screen.getByText(String(group))).toBeTruthy();
+  // ─── sm/md: pill badge ──────────────────────────────────────────────────
+
+  describe("pill badge (sm/md)", () => {
+    it.each([1, 2, 3, 4] as const)("renders group %i", (group) => {
+      render(<NovaBadge group={group} />);
+      expect(screen.getByText(String(group))).toBeTruthy();
+    });
+
+    it("maps group 1 to nova-1 color", () => {
+      render(<NovaBadge group={1} />);
+      const badge = screen.getByText("1");
+      expect(badge.className).toContain("text-nova-1");
+      expect(badge.className).toContain("bg-nova-1/10");
+    });
+
+    it("maps group 4 to nova-4 color", () => {
+      render(<NovaBadge group={4} />);
+      const badge = screen.getByText("4");
+      expect(badge.className).toContain("text-nova-4");
+    });
+
+    it("renders ? for null group", () => {
+      render(<NovaBadge group={null} />);
+      expect(screen.getByText("?")).toBeTruthy();
+      expect(screen.getByText("?").className).toContain(
+        "text-foreground-muted",
+      );
+    });
+
+    it("renders ? for invalid group", () => {
+      render(<NovaBadge group={5} />);
+      expect(screen.getByText("?")).toBeTruthy();
+    });
+
+    it("shows label when showLabel is true", () => {
+      render(<NovaBadge group={1} showLabel />);
+      expect(screen.getByText("Unprocessed")).toBeTruthy();
+    });
+
+    it("shows Ultra-processed label for group 4", () => {
+      render(<NovaBadge group={4} showLabel />);
+      expect(screen.getByText("Ultra-processed")).toBeTruthy();
+    });
   });
 
-  it("maps group 1 to nova-1 color", () => {
-    render(<NovaBadge group={1} />);
-    const badge = screen.getByText("1");
-    expect(badge.className).toContain("text-nova-1");
-    expect(badge.className).toContain("bg-nova-1/10");
+  // ─── lg: circular SVG ──────────────────────────────────────────────────
+
+  describe("circle badge (lg)", () => {
+    it("renders SVG circle for valid group", () => {
+      render(<NovaBadge group={1} size="lg" />);
+      const svg = screen.getByTestId("nova-circle");
+      expect(svg.tagName).toBe("svg");
+      expect(svg.querySelector("circle")).toBeTruthy();
+    });
+
+    it("fills circle with group color", () => {
+      render(<NovaBadge group={4} size="lg" />);
+      const circle = screen.getByTestId("nova-circle").querySelector("circle");
+      expect(circle?.getAttribute("fill")).toContain("--color-nova-4");
+    });
+
+    it("renders group number inside circle", () => {
+      render(<NovaBadge group={3} size="lg" />);
+      const text = screen.getByTestId("nova-circle").querySelector("text");
+      expect(text?.textContent).toBe("3");
+    });
+
+    it("uses inverse text for groups 1 and 4 (dark backgrounds)", () => {
+      render(<NovaBadge group={1} size="lg" />);
+      const text = screen.getByTestId("nova-circle").querySelector("text");
+      expect(text?.getAttribute("fill")).toContain("--color-text-inverse");
+    });
+
+    it("uses primary text for groups 2 and 3 (light backgrounds)", () => {
+      render(<NovaBadge group={2} size="lg" />);
+      const text = screen.getByTestId("nova-circle").querySelector("text");
+      expect(text?.getAttribute("fill")).toContain("--color-text-primary");
+    });
+
+    it("renders ? for null group (lg)", () => {
+      render(<NovaBadge group={null} size="lg" />);
+      const text = screen.getByTestId("nova-circle").querySelector("text");
+      expect(text?.textContent).toBe("?");
+    });
+
+    it("renders muted fill for null group (lg)", () => {
+      render(<NovaBadge group={null} size="lg" />);
+      const circle = screen.getByTestId("nova-circle").querySelector("circle");
+      expect(circle?.getAttribute("fill")).toContain("--color-surface-muted");
+    });
+
+    it("shows label below circle when showLabel is true", () => {
+      render(<NovaBadge group={1} size="lg" showLabel />);
+      expect(screen.getByText("Unprocessed")).toBeTruthy();
+    });
+
+    it("does not show label below circle by default", () => {
+      render(<NovaBadge group={1} size="lg" />);
+      expect(screen.queryByText("Unprocessed")).toBeNull();
+    });
+
+    it("has role=img on lg container", () => {
+      render(<NovaBadge group={1} size="lg" />);
+      expect(screen.getByRole("img")).toBeTruthy();
+    });
   });
 
-  it("maps group 4 to nova-4 color", () => {
-    render(<NovaBadge group={4} />);
-    const badge = screen.getByText("4");
-    expect(badge.className).toContain("text-nova-4");
+  // ─── Accessibility ──────────────────────────────────────────────────────
+
+  describe("accessibility", () => {
+    it("has accessible aria-label for valid group", () => {
+      render(<NovaBadge group={2} />);
+      expect(
+        screen.getByLabelText("NOVA Group 2: Processed ingredients"),
+      ).toBeTruthy();
+    });
+
+    it("has accessible aria-label for unknown group", () => {
+      render(<NovaBadge group={null} />);
+      expect(screen.getByLabelText("NOVA unknown")).toBeTruthy();
+    });
   });
 
-  it("renders ? for null group", () => {
-    render(<NovaBadge group={null} />);
-    expect(screen.getByText("?")).toBeTruthy();
-    expect(screen.getByText("?").className).toContain("text-foreground-muted");
-  });
+  // ─── Tooltip ────────────────────────────────────────────────────────────
 
-  it("renders ? for invalid group", () => {
-    render(<NovaBadge group={5} />);
-    expect(screen.getByText("?")).toBeTruthy();
-  });
+  describe("tooltip", () => {
+    it("shows tooltip on hover when showTooltip is true", async () => {
+      const user = userEvent.setup();
+      render(
+        <TooltipPrimitive.Provider delayDuration={0}>
+          <NovaBadge group={4} showTooltip />
+        </TooltipPrimitive.Provider>,
+      );
 
-  it("shows label when showLabel is true", () => {
-    render(<NovaBadge group={1} showLabel />);
-    expect(screen.getByText("Unprocessed")).toBeTruthy();
-  });
-
-  it("shows Ultra-processed label for group 4", () => {
-    render(<NovaBadge group={4} showLabel />);
-    expect(screen.getByText("Ultra-processed")).toBeTruthy();
-  });
-
-  it("has accessible aria-label for valid group", () => {
-    render(<NovaBadge group={2} />);
-    expect(
-      screen.getByLabelText("NOVA Group 2: Processed ingredients"),
-    ).toBeTruthy();
-  });
-
-  it("has accessible aria-label for unknown group", () => {
-    render(<NovaBadge group={null} />);
-    expect(screen.getByLabelText("NOVA unknown")).toBeTruthy();
-  });
-
-  it("shows tooltip on hover when showTooltip is true", async () => {
-    const user = userEvent.setup();
-    render(
-      <TooltipPrimitive.Provider delayDuration={0}>
-        <NovaBadge group={4} showTooltip />
-      </TooltipPrimitive.Provider>,
-    );
-
-    await user.hover(screen.getByText("4"));
-    const tooltip = await screen.findByRole("tooltip");
-    expect(tooltip.textContent).toContain("NOVA 4");
+      await user.hover(screen.getByText("4"));
+      const tooltip = await screen.findByRole("tooltip");
+      expect(tooltip.textContent).toContain("NOVA 4");
+    });
   });
 });

--- a/frontend/src/components/common/NovaBadge.tsx
+++ b/frontend/src/components/common/NovaBadge.tsx
@@ -3,11 +3,16 @@
  *
  * Groups:
  *   1 → Unprocessed/minimally processed (green)
- *   2 → Processed culinary ingredients (yellow)
- *   3 → Processed foods (orange)
+ *   2 → Processed culinary ingredients (lime)
+ *   3 → Processed foods (amber)
  *   4 → Ultra-processed (red)
  *
  * Uses `--color-nova-1` through `--color-nova-4` design tokens.
+ *
+ * Size variants:
+ *   sm  → compact text pill
+ *   md  → standard text pill
+ *   lg  → circular SVG badge with large number + optional label
  */
 
 import React from "react";
@@ -21,7 +26,7 @@ export type NovaBadgeSize = "sm" | "md" | "lg";
 export interface NovaBadgeProps {
   /** NOVA group 1–4. Null/invalid → neutral badge. */
   readonly group: number | null | undefined;
-  /** Size preset. @default "md" */
+  /** Size preset. sm/md = pill, lg = circular SVG. @default "md" */
   readonly size?: NovaBadgeSize;
   /** Show group label text. */
   readonly showLabel?: boolean;
@@ -37,24 +42,53 @@ interface NovaConfig {
   label: string;
   bg: string;
   text: string;
+  /** CSS variable for SVG fill (lg circle). */
+  color: string;
 }
 
 const GROUP_CONFIGS: Record<NovaGroup, NovaConfig> = {
-  1: { label: "Unprocessed", bg: "bg-nova-1/10", text: "text-nova-1" },
+  1: {
+    label: "Unprocessed",
+    bg: "bg-nova-1/10",
+    text: "text-nova-1",
+    color: "var(--color-nova-1)",
+  },
   2: {
     label: "Processed ingredients",
     bg: "bg-nova-2/10",
     text: "text-nova-2",
+    color: "var(--color-nova-2)",
   },
-  3: { label: "Processed", bg: "bg-nova-3/10", text: "text-nova-3" },
-  4: { label: "Ultra-processed", bg: "bg-nova-4/10", text: "text-nova-4" },
+  3: {
+    label: "Processed",
+    bg: "bg-nova-3/10",
+    text: "text-nova-3",
+    color: "var(--color-nova-3)",
+  },
+  4: {
+    label: "Ultra-processed",
+    bg: "bg-nova-4/10",
+    text: "text-nova-4",
+    color: "var(--color-nova-4)",
+  },
 };
 
-const SIZE_CLASSES: Record<NovaBadgeSize, string> = {
+const FALLBACK_CONFIG: NovaConfig = {
+  label: "Unknown",
+  bg: "bg-surface-muted",
+  text: "text-foreground-muted",
+  color: "var(--color-surface-muted, #e5e7eb)",
+};
+
+const SIZE_CLASSES: Record<"sm" | "md", string> = {
   sm: "px-2 py-0.5 text-xs",
   md: "px-2.5 py-1 text-sm",
-  lg: "px-3 py-1.5 text-base",
 };
+
+// ─── Circle constants (lg size) ─────────────────────────────────────────────
+
+const CIRCLE_SIZE = 40;
+const CIRCLE_RADIUS = CIRCLE_SIZE / 2 - 2;
 
 // ─── Component ──────────────────────────────────────────────────────────────
 
@@ -67,19 +101,74 @@ export const NovaBadge = React.memo(function NovaBadge({
 }: Readonly<NovaBadgeProps>) {
   const isValid =
     group != null && Number.isInteger(group) && group >= 1 && group <= 4;
-  const config = isValid
-    ? GROUP_CONFIGS[group as NovaGroup]
-    : {
-        label: "Unknown",
-        bg: "bg-surface-muted",
-        text: "text-foreground-muted",
-      };
+  const config = isValid ? GROUP_CONFIGS[group as NovaGroup] : FALLBACK_CONFIG;
 
   if (!isValid && group != null && process.env.NODE_ENV === "development") {
     console.warn(`NovaBadge: unexpected group ${group}, expected 1–4`);
   }
 
   const tooltipKey = isValid ? `tooltip.nova.${group}` : undefined;
+  const ariaLabel = isValid
+    ? `NOVA Group ${group}: ${config.label}`
+    : "NOVA unknown";
+
+  // ─── lg: circular SVG badge ─────────────────────────────────────────────
+
+  if (size === "lg") {
+    const fillColor = config.color;
+    const textFill = isValid
+      ? group === 2 || group === 3
+        ? "var(--color-text-primary, #1f2937)"
+        : "var(--color-text-inverse, #fff)"
+      : "var(--color-text-muted, #9ca3af)";
+
+    const circle = (
+      <span
+        className={["inline-flex flex-col items-center gap-1", className]
+          .filter(Boolean)
+          .join(" ")}
+        aria-label={ariaLabel}
+        role="img"
+      >
+        <svg
+          width={CIRCLE_SIZE}
+          height={CIRCLE_SIZE}
+          viewBox={`0 0 ${CIRCLE_SIZE} ${CIRCLE_SIZE}`}
+          className="block"
+          data-testid="nova-circle"
+        >
+          <circle
+            cx={CIRCLE_SIZE / 2}
+            cy={CIRCLE_SIZE / 2}
+            r={CIRCLE_RADIUS}
+            fill={fillColor}
+          />
+          <text
+            x="50%"
+            y="50%"
+            textAnchor="middle"
+            dominantBaseline="central"
+            fill={textFill}
+            style={{ fontSize: "1.125rem", fontWeight: 700 }}
+          >
+            {isValid ? group : "?"}
+          </text>
+        </svg>
+        {showLabel && (
+          <span className="text-xs font-medium text-foreground-secondary whitespace-nowrap">
+            {config.label}
+          </span>
+        )}
+      </span>
+    );
+
+    if (showTooltip && tooltipKey) {
+      return <InfoTooltip messageKey={tooltipKey}>{circle}</InfoTooltip>;
+    }
+    return circle;
+  }
+
+  // ─── sm / md: pill badge ────────────────────────────────────────────────
 
   const badge = (
     <span
@@ -92,9 +181,7 @@ export const NovaBadge = React.memo(function NovaBadge({
       ]
         .filter(Boolean)
         .join(" ")}
-      aria-label={
-        isValid ? `NOVA Group ${group}: ${config.label}` : "NOVA unknown"
-      }
+      aria-label={ariaLabel}
     >
       {isValid ? group : "?"}
       {showLabel && <span className="font-medium">{config.label}</span>}

--- a/frontend/src/components/common/NutriScoreBadge.test.tsx
+++ b/frontend/src/components/common/NutriScoreBadge.test.tsx
@@ -5,73 +5,186 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { NutriScoreBadge } from "./NutriScoreBadge";
 
 describe("NutriScoreBadge", () => {
-  it.each(["A", "B", "C", "D", "E"] as const)(
-    "renders grade %s with correct EU color",
-    (grade) => {
-      render(<NutriScoreBadge grade={grade} />);
-      const badge = screen.getByText(grade);
-      expect(badge).toBeTruthy();
-      expect(badge.className).toContain(`bg-nutri-${grade}`);
-    },
-  );
+  // ─── sm: single-letter badge ────────────────────────────────────────────
 
-  it("normalizes lowercase grades", () => {
-    render(<NutriScoreBadge grade="b" />);
-    expect(screen.getByText("B")).toBeTruthy();
-    expect(screen.getByText("B").className).toContain("bg-nutri-B");
-  });
-
-  it("renders ? for null grade", () => {
-    render(<NutriScoreBadge grade={null} />);
-    expect(screen.getByText("?")).toBeTruthy();
-    expect(screen.getByText("?").className).toContain("bg-surface-muted");
-  });
-
-  it("renders ? for invalid grade", () => {
-    render(<NutriScoreBadge grade="X" />);
-    expect(screen.getByText("?")).toBeTruthy();
-    expect(screen.getByText("?").className).toContain("text-foreground-muted");
-  });
-
-  it("has accessible aria-label for valid grade", () => {
-    render(<NutriScoreBadge grade="A" />);
-    expect(screen.getByLabelText("Nutri-Score A")).toBeTruthy();
-  });
-
-  it("has accessible aria-label for unknown grade", () => {
-    render(<NutriScoreBadge grade={null} />);
-    expect(screen.getByLabelText("Nutri-Score unknown")).toBeTruthy();
-  });
-
-  it("applies size classes", () => {
-    render(<NutriScoreBadge grade="A" size="lg" />);
-    expect(screen.getByText("A").className).toContain("h-9");
-  });
-
-  it("applies A text as foreground-inverse", () => {
-    render(<NutriScoreBadge grade="A" />);
-    expect(screen.getByText("A").className).toContain(
-      "text-foreground-inverse",
-    );
-  });
-
-  it("applies C text as foreground (not inverse, since C is yellow)", () => {
-    render(<NutriScoreBadge grade="C" />);
-    const el = screen.getByText("C");
-    expect(el.className).toContain("text-foreground");
-    expect(el.className).not.toContain("text-foreground-inverse");
-  });
-
-  it("shows tooltip on hover when showTooltip is true", async () => {
-    const user = userEvent.setup();
-    render(
-      <TooltipPrimitive.Provider delayDuration={0}>
-        <NutriScoreBadge grade="A" showTooltip />
-      </TooltipPrimitive.Provider>,
+  describe("sm size (single letter)", () => {
+    it.each(["A", "B", "C", "D", "E"] as const)(
+      "renders grade %s with correct EU color",
+      (grade) => {
+        render(<NutriScoreBadge grade={grade} size="sm" />);
+        const badge = screen.getByText(grade);
+        expect(badge).toBeTruthy();
+        expect(badge.className).toContain(`bg-nutri-${grade}`);
+      },
     );
 
-    await user.hover(screen.getByText("A"));
-    const tooltip = await screen.findByRole("tooltip");
-    expect(tooltip.textContent).toContain("Nutri-Score A");
+    it("normalizes lowercase grades", () => {
+      render(<NutriScoreBadge grade="b" size="sm" />);
+      expect(screen.getByText("B")).toBeTruthy();
+      expect(screen.getByText("B").className).toContain("bg-nutri-B");
+    });
+
+    it("renders ? for null grade", () => {
+      render(<NutriScoreBadge grade={null} size="sm" />);
+      expect(screen.getByText("?")).toBeTruthy();
+      expect(screen.getByText("?").className).toContain("bg-surface-muted");
+    });
+
+    it("renders ? for invalid grade", () => {
+      render(<NutriScoreBadge grade="X" size="sm" />);
+      expect(screen.getByText("?")).toBeTruthy();
+      expect(screen.getByText("?").className).toContain(
+        "text-foreground-muted",
+      );
+    });
+
+    it("renders – for UNKNOWN grade", () => {
+      render(<NutriScoreBadge grade="UNKNOWN" size="sm" />);
+      expect(screen.getByText("–")).toBeTruthy();
+    });
+
+    it("renders – for NOT-APPLICABLE grade", () => {
+      render(<NutriScoreBadge grade="NOT-APPLICABLE" size="sm" />);
+      expect(screen.getByText("–")).toBeTruthy();
+    });
+
+    it("applies A text as foreground-inverse", () => {
+      render(<NutriScoreBadge grade="A" size="sm" />);
+      expect(screen.getByText("A").className).toContain(
+        "text-foreground-inverse",
+      );
+    });
+
+    it("applies C text as foreground (not inverse, since C is yellow)", () => {
+      render(<NutriScoreBadge grade="C" size="sm" />);
+      const el = screen.getByText("C");
+      expect(el.className).toContain("text-foreground");
+      expect(el.className).not.toContain("text-foreground-inverse");
+    });
+  });
+
+  // ─── md/lg: horizontal strip ────────────────────────────────────────────
+
+  describe("md size (5-letter strip)", () => {
+    it("renders all 5 letters in a strip", () => {
+      render(<NutriScoreBadge grade="B" size="md" />);
+      for (const g of ["A", "B", "C", "D", "E"]) {
+        expect(screen.getByText(g)).toBeTruthy();
+      }
+    });
+
+    it("highlights the active grade with filled background", () => {
+      render(<NutriScoreBadge grade="B" size="md" />);
+      const b = screen.getByText("B");
+      expect(b.className).toContain("bg-nutri-B");
+      expect(b.className).toContain("text-foreground-inverse");
+    });
+
+    it("renders inactive grades with tinted background", () => {
+      render(<NutriScoreBadge grade="B" size="md" />);
+      const a = screen.getByText("A");
+      expect(a.className).toContain("bg-nutri-A/15");
+      expect(a.className).toContain("text-nutri-A");
+    });
+
+    it("makes active letter larger than inactive", () => {
+      render(<NutriScoreBadge grade="C" size="md" />);
+      const active = screen.getByText("C");
+      const inactive = screen.getByText("A");
+      expect(active.className).toContain("h-7");
+      expect(inactive.className).toContain("h-5");
+    });
+
+    it("renders strip container with role=img", () => {
+      render(<NutriScoreBadge grade="A" size="md" />);
+      expect(screen.getByRole("img")).toBeTruthy();
+    });
+
+    it("renders null grade without active letter (all faded)", () => {
+      render(<NutriScoreBadge grade={null} size="md" />);
+      for (const g of ["A", "B", "C", "D", "E"]) {
+        const letter = screen.getByText(g);
+        expect(letter.className).toContain("/15");
+      }
+    });
+  });
+
+  describe("lg size (larger strip)", () => {
+    it("renders larger active and inactive letters", () => {
+      render(<NutriScoreBadge grade="D" size="lg" />);
+      const active = screen.getByText("D");
+      const inactive = screen.getByText("A");
+      expect(active.className).toContain("h-9");
+      expect(inactive.className).toContain("h-7");
+    });
+  });
+
+  // ─── Special grades (UNKNOWN / NOT-APPLICABLE) ─────────────────────────
+
+  describe("special grades", () => {
+    it("renders ? label for UNKNOWN in md strip", () => {
+      render(<NutriScoreBadge grade="UNKNOWN" size="md" />);
+      expect(screen.getByText("?")).toBeTruthy();
+      expect(screen.getByRole("img")).toBeTruthy();
+    });
+
+    it("renders N/A label for NOT-APPLICABLE in md strip", () => {
+      render(<NutriScoreBadge grade="NOT-APPLICABLE" size="md" />);
+      expect(screen.getByText("N/A")).toBeTruthy();
+    });
+
+    it("does NOT render 5-letter strip for UNKNOWN", () => {
+      render(<NutriScoreBadge grade="UNKNOWN" size="md" />);
+      expect(screen.queryByText("A")).toBeNull();
+    });
+  });
+
+  // ─── Accessibility ──────────────────────────────────────────────────────
+
+  describe("accessibility", () => {
+    it("has aria-label for valid grade (sm)", () => {
+      render(<NutriScoreBadge grade="A" size="sm" />);
+      expect(screen.getByLabelText("Nutri-Score A")).toBeTruthy();
+    });
+
+    it("has aria-label for unknown (sm)", () => {
+      render(<NutriScoreBadge grade={null} size="sm" />);
+      expect(screen.getByLabelText("Nutri-Score unknown")).toBeTruthy();
+    });
+
+    it("has aria-label for UNKNOWN special", () => {
+      render(<NutriScoreBadge grade="UNKNOWN" size="md" />);
+      expect(screen.getByLabelText("Nutri-Score not available")).toBeTruthy();
+    });
+
+    it("has aria-label for NOT-APPLICABLE special", () => {
+      render(<NutriScoreBadge grade="NOT-APPLICABLE" size="md" />);
+      expect(screen.getByLabelText("Nutri-Score not applicable")).toBeTruthy();
+    });
+
+    it("marks inactive letters aria-hidden in strip", () => {
+      render(<NutriScoreBadge grade="C" size="md" />);
+      const a = screen.getByText("A");
+      expect(a.getAttribute("aria-hidden")).toBe("true");
+      const c = screen.getByText("C");
+      expect(c.getAttribute("aria-hidden")).toBe("false");
+    });
+  });
+
+  // ─── Tooltip ────────────────────────────────────────────────────────────
+
+  describe("tooltip", () => {
+    it("shows tooltip on hover when showTooltip is true (sm)", async () => {
+      const user = userEvent.setup();
+      render(
+        <TooltipPrimitive.Provider delayDuration={0}>
+          <NutriScoreBadge grade="A" size="sm" showTooltip />
+        </TooltipPrimitive.Provider>,
+      );
+
+      await user.hover(screen.getByText("A"));
+      const tooltip = await screen.findByRole("tooltip");
+      expect(tooltip.textContent).toContain("Nutri-Score A");
+    });
   });
 });

--- a/frontend/src/components/common/NutriScoreBadge.tsx
+++ b/frontend/src/components/common/NutriScoreBadge.tsx
@@ -5,7 +5,13 @@
  *   A → #038141, B → #85BB2F, C → #FECB02, D → #EE8100, E → #E63E11
  *
  * Uses `--color-nutri-A` through `--color-nutri-E` design tokens.
- * Falls back gracefully for unknown grades.
+ *
+ * Design variants:
+ *   sm  → single-letter square badge (compact inline use)
+ *   md  → horizontal strip with all 5 letters, active highlighted
+ *   lg  → horizontal strip with all 5 letters, larger sizing
+ *
+ * Falls back gracefully for UNKNOWN, NOT-APPLICABLE, and invalid grades.
  */
 
 import React from "react";
@@ -14,12 +20,13 @@ import { InfoTooltip } from "./InfoTooltip";
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export type NutriGrade = "A" | "B" | "C" | "D" | "E";
+export type NutriScoreSpecial = "UNKNOWN" | "NOT-APPLICABLE";
 export type NutriScoreBadgeSize = "sm" | "md" | "lg";
 
 export interface NutriScoreBadgeProps {
-  /** Nutri-Score grade A–E. Null/invalid → neutral "?" badge. */
+  /** Nutri-Score grade A–E, UNKNOWN, NOT-APPLICABLE. Null/invalid → neutral fallback. */
   readonly grade: string | null | undefined;
-  /** Size preset. @default "md" */
+  /** Size preset. sm = single letter, md/lg = 5-letter strip. @default "md" */
   readonly size?: NutriScoreBadgeSize;
   /** Show explanatory tooltip on hover. @default false */
   readonly showTooltip?: boolean;
@@ -27,9 +34,14 @@ export interface NutriScoreBadgeProps {
   readonly className?: string;
 }
 
-// ─── Grade styling ──────────────────────────────────────────────────────────
+// ─── Constants ──────────────────────────────────────────────────────────────
 
-const GRADE_CLASSES: Record<NutriGrade, string> = {
+const ALL_GRADES: readonly NutriGrade[] = ["A", "B", "C", "D", "E"] as const;
+const VALID_GRADES = new Set<string>(ALL_GRADES);
+const SPECIAL_GRADES = new Set<string>(["UNKNOWN", "NOT-APPLICABLE"]);
+
+/** Active letter styling (bg filled + high-contrast text). */
+const ACTIVE_CLASSES: Record<NutriGrade, string> = {
   A: "bg-nutri-A text-foreground-inverse",
   B: "bg-nutri-B text-foreground-inverse",
   C: "bg-nutri-C text-foreground",
@@ -37,12 +49,30 @@ const GRADE_CLASSES: Record<NutriGrade, string> = {
   E: "bg-nutri-E text-foreground-inverse",
 };
 
-const VALID_GRADES = new Set<string>(["A", "B", "C", "D", "E"]);
+/** Inactive letter styling (subtle tinted background). */
+const INACTIVE_CLASSES: Record<NutriGrade, string> = {
+  A: "bg-nutri-A/15 text-nutri-A",
+  B: "bg-nutri-B/15 text-nutri-B",
+  C: "bg-nutri-C/15 text-nutri-C",
+  D: "bg-nutri-D/15 text-nutri-D",
+  E: "bg-nutri-E/15 text-nutri-E",
+};
 
-const SIZE_CLASSES: Record<NutriScoreBadgeSize, string> = {
-  sm: "h-5 w-5 text-xs",
-  md: "h-7 w-7 text-sm",
-  lg: "h-9 w-9 text-base",
+const SM_SIZE = "h-5 w-5 text-xs";
+
+/** Strip letter sizing (md vs lg). */
+const STRIP_LETTER_SIZE: Record<
+  "md" | "lg",
+  { active: string; inactive: string }
+> = {
+  md: { active: "h-7 w-7 text-sm", inactive: "h-5 w-5 text-[10px]" },
+  lg: { active: "h-9 w-9 text-base", inactive: "h-7 w-7 text-xs" },
+};
+
+/** Special grade descriptions for aria-label. */
+const SPECIAL_LABELS: Record<string, string> = {
+  UNKNOWN: "not available",
+  "NOT-APPLICABLE": "not applicable",
 };
 
 // ─── Component ──────────────────────────────────────────────────────────────
@@ -55,38 +85,125 @@ export const NutriScoreBadge = React.memo(function NutriScoreBadge({
 }: Readonly<NutriScoreBadgeProps>) {
   const normalized = grade?.toUpperCase() ?? "";
   const isValid = VALID_GRADES.has(normalized);
+  const isSpecial = SPECIAL_GRADES.has(normalized);
 
-  if (!isValid && grade != null && process.env.NODE_ENV === "development") {
-    console.warn(`NutriScoreBadge: unexpected grade "${grade}", expected A–E`);
+  if (
+    !isValid &&
+    !isSpecial &&
+    grade != null &&
+    process.env.NODE_ENV === "development"
+  ) {
+    console.warn(
+      `NutriScoreBadge: unexpected grade "${grade}", expected A–E, UNKNOWN, or NOT-APPLICABLE`,
+    );
   }
 
-  const bgClass = isValid
-    ? GRADE_CLASSES[normalized as NutriGrade]
-    : "bg-surface-muted text-foreground-muted";
-  const displayText = isValid ? normalized : "?";
   const tooltipKey = isValid
     ? `tooltip.nutriScore.${normalized}`
     : "tooltip.nutriScore.unknown";
 
-  const badge = (
+  const ariaLabel = isValid
+    ? `Nutri-Score ${normalized}`
+    : isSpecial
+      ? `Nutri-Score ${SPECIAL_LABELS[normalized]}`
+      : "Nutri-Score unknown";
+
+  // ─── sm: single-letter badge ────────────────────────────────────────────
+
+  if (size === "sm") {
+    const bgClass = isValid
+      ? ACTIVE_CLASSES[normalized as NutriGrade]
+      : "bg-surface-muted text-foreground-muted";
+    const displayText = isValid ? normalized : isSpecial ? "–" : "?";
+
+    const badge = (
+      <span
+        className={[
+          "inline-flex items-center justify-center rounded-md font-bold",
+          bgClass,
+          SM_SIZE,
+          className,
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        aria-label={ariaLabel}
+      >
+        {displayText}
+      </span>
+    );
+
+    if (showTooltip) {
+      return <InfoTooltip messageKey={tooltipKey}>{badge}</InfoTooltip>;
+    }
+    return badge;
+  }
+
+  // ─── md / lg: horizontal 5-letter strip ─────────────────────────────────
+
+  if (isSpecial) {
+    const label = normalized === "NOT-APPLICABLE" ? "N/A" : "?";
+    const strip = (
+      <span
+        className={[
+          "inline-flex items-center gap-0.5 rounded-lg bg-surface-muted px-1 py-0.5",
+          className,
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        aria-label={ariaLabel}
+        role="img"
+      >
+        <span
+          className={[
+            "inline-flex items-center justify-center rounded-md font-bold text-foreground-muted",
+            STRIP_LETTER_SIZE[size].active,
+          ].join(" ")}
+        >
+          {label}
+        </span>
+      </span>
+    );
+
+    if (showTooltip) {
+      return <InfoTooltip messageKey={tooltipKey}>{strip}</InfoTooltip>;
+    }
+    return strip;
+  }
+
+  const letterSizes = STRIP_LETTER_SIZE[size];
+
+  const strip = (
     <span
       className={[
-        "inline-flex items-center justify-center rounded-md font-bold",
-        bgClass,
-        SIZE_CLASSES[size],
+        "inline-flex items-center gap-0.5 rounded-lg bg-surface-muted px-1 py-0.5",
         className,
       ]
         .filter(Boolean)
         .join(" ")}
-      aria-label={`Nutri-Score ${isValid ? normalized : "unknown"}`}
+      aria-label={ariaLabel}
+      role="img"
     >
-      {displayText}
+      {ALL_GRADES.map((g) => {
+        const active = isValid && g === normalized;
+        return (
+          <span
+            key={g}
+            className={[
+              "inline-flex items-center justify-center rounded-md font-bold transition-all",
+              active ? ACTIVE_CLASSES[g] : INACTIVE_CLASSES[g],
+              active ? letterSizes.active : letterSizes.inactive,
+            ].join(" ")}
+            aria-hidden={!active}
+          >
+            {g}
+          </span>
+        );
+      })}
     </span>
   );
 
   if (showTooltip) {
-    return <InfoTooltip messageKey={tooltipKey}>{badge}</InfoTooltip>;
+    return <InfoTooltip messageKey={tooltipKey}>{strip}</InfoTooltip>;
   }
-
-  return badge;
+  return strip;
 });


### PR DESCRIPTION
# Issue #421 — Nutri-Score + NOVA + Confidence Badge Enhancements

Closes #421

## Changes

### NutriScoreBadge
- **sm**: single-letter square badge (compact inline use, backward compatible)
- **md/lg**: horizontal 5-letter strip (A-B-C-D-E) with active grade highlighted/enlarged, inactive grades tinted/smaller
- Added `UNKNOWN` and `NOT-APPLICABLE` grade support (renders `?` / `N/A` respectively)
- 28 tests covering all sizes, grades, special values, and accessibility

### NovaBadge
- **sm/md**: existing pill badge (unchanged, backward compatible)
- **lg**: NEW circular SVG badge with filled color circle + large number inside, matching `ScoreBadge`'s `lg` ring pattern
- Inverse text for groups 1/4 (dark bg), primary text for 2/3 (light bg) for WCAG contrast
- 23 tests covering pill + circle + labels + accessibility

### ConfidenceBadge
- Added inline SVG shield icon with level-specific symbols: ✓ (high/verified), ~ (medium/estimated), ! (low), ? (null)
- DB value aliases: accepts `verified`/`estimated` from `assign_confidence()` in addition to `high`/`medium`/`low` bands
- Labels updated: High → Verified, Medium → Estimated (matches DB semantics)
- Added `showLabel` prop (default: `true`, backward compatible)
- 22 tests covering shield icons, aliases, labels, and accessibility

## Cross-cutting
- All 3 components support dark mode via CSS variables
- Full `aria-label` coverage + tooltip integration
- Graceful null/invalid input fallback
- Pattern consistent with `ScoreBadge` (sm=compact, lg=SVG visual)

## Verification
- `npx tsc --noEmit` — clean
- `npx vitest run` — **4,028 tests passed** (242 files, 0 failures)
- Net +35 new tests (73 total across 3 files, replacing 38 old tests)

**6 files changed, +781 / -197 lines**