### PR TITLE
feat(security): add rate limiting on product submissions & barcode scans

### DIFF
--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -19,7 +19,7 @@
        13. QA__allergen_integrity.sql (14 allergen & trace integrity checks — blocking)
        14. QA__serving_source_validation.sql (16 serving & source checks — blocking)
        15. QA__ingredient_quality.sql (14 ingredient quality checks — blocking)
-       16. QA__security_posture.sql (29 security posture checks — blocking)
+       16. QA__security_posture.sql (32 security posture checks — blocking)
        17. QA__api_contract.sql (30 API contract checks — blocking)
        18. QA__scale_guardrails.sql (23 scale guardrails checks — blocking)
        19. QA__country_isolation.sql (6 country isolation checks — blocking)
@@ -147,7 +147,7 @@ $suiteCatalog = @(
     @{ Num = 13; Name = "Allergen & Trace Integrity"; Short = "Allergen"; Id = "allergen_integrity"; Checks = 15; Blocking = $true; Kind = "sql"; File = "QA__allergen_integrity.sql" },
     @{ Num = 14; Name = "Serving & Source Validation"; Short = "ServSource"; Id = "serving_source"; Checks = 16; Blocking = $true; Kind = "sql"; File = "QA__serving_source_validation.sql" },
     @{ Num = 15; Name = "Ingredient Data Quality"; Short = "IngredQual"; Id = "ingredient_quality"; Checks = 14; Blocking = $true; Kind = "sql"; File = "QA__ingredient_quality.sql" },
-    @{ Num = 16; Name = "Security Posture"; Short = "Security"; Id = "security_posture"; Checks = 29; Blocking = $true; Kind = "sql"; File = "QA__security_posture.sql" },
+    @{ Num = 16; Name = "Security Posture"; Short = "Security"; Id = "security_posture"; Checks = 32; Blocking = $true; Kind = "sql"; File = "QA__security_posture.sql" },
     @{ Num = 17; Name = "API Contract"; Short = "Contract"; Id = "api_contract"; Checks = 33; Blocking = $true; Kind = "sql"; File = "QA__api_contract.sql" },
     @{ Num = 18; Name = "Scale Guardrails"; Short = "Scale"; Id = "scale_guardrails"; Checks = 23; Blocking = $true; Kind = "sql"; File = "QA__scale_guardrails.sql" },
     @{ Num = 19; Name = "Country Isolation"; Short = "Country"; Id = "country_isolation"; Checks = 11; Blocking = $true; Kind = "sql"; File = "QA__country_isolation.sql" },

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -8,7 +8,7 @@
 > **Servings:** removed as separate table — all nutrition data is per-100g on nutrition_facts
 > **Ingredient analytics:** 2,995 unique ingredients (all clean ASCII English), 1,269 allergen declarations, 1,361 trace declarations
 > **Ingredient concerns:** EFSA-based 4-tier additive classification (0=none, 1=low, 2=moderate, 3=high)
-> **QA:** 693 checks across 47 suites + 23 negative validation tests — all passing
+> **QA:** 696 checks across 47 suites + 23 negative validation tests — all passing
 
 ---
 
@@ -103,7 +103,7 @@ poland-food-db/
 │   │   ├── QA__allergen_filtering.sql    # 6 allergen filtering checks
 │   │   ├── QA__serving_source_validation.sql # 16 serving & source checks
 │   │   ├── QA__ingredient_quality.sql    # 14 ingredient quality checks
-│   │   ├── QA__security_posture.sql      # 22 security posture checks
+│   │   ├── QA__security_posture.sql      # 32 security posture checks
 │   │   ├── QA__scale_guardrails.sql      # 23 scale guardrails checks
 │   │   ├── QA__country_isolation.sql     # 11 country isolation checks
 │   │   ├── QA__diet_filtering.sql        # 6 diet filtering checks
@@ -257,7 +257,7 @@ poland-food-db/
 │       ├── 006-append-only-migrations.md
 │       └── 007-english-canonical-ingredients.md
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
-├── RUN_QA.ps1                       # QA test runner (693 checks across 47 suites)
+├── RUN_QA.ps1                       # QA test runner (696 checks across 47 suites)
 ├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (23 injection tests)
 ├── RUN_SANITY.ps1                   # Sanity checks (16) — row counts, schema assertions
 ├── RUN_REMOTE.ps1                   # Remote deployment (requires confirmation)
@@ -331,7 +331,7 @@ poland-food-db/
 │   ├── pr-gate.yml                  # Lint → Typecheck → Build → Playwright E2E
 │   ├── pr-title-lint.yml            # PR title conventional-commit validation (all PRs)
 │   ├── main-gate.yml                # Build → Unit tests + coverage → SonarCloud
-│   ├── qa.yml                       # Schema → Pipelines → QA (693) → Sanity
+│   ├── qa.yml                       # Schema → Pipelines → QA (696) → Sanity
 │   ├── nightly.yml                  # Full Playwright (all projects) + Data Integrity Audit
 │   ├── deploy.yml                   # Manual trigger → Schema diff → Approval → db push
 │   ├── sync-cloud-db.yml            # Remote DB sync
@@ -368,32 +368,32 @@ poland-food-db/
 
 ### Tables
 
-| Table                     | Purpose                                         | Primary Key                             | Notes                                                                                                                                     |
-| ------------------------- | ----------------------------------------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `products`                | Product identity, scores, flags, provenance     | `product_id` (identity)                 | Upsert key: `(country, brand, product_name)`. Scores, flags, source columns all inline.                                                   |
-| `nutrition_facts`         | Nutrition per product (per 100g)                | `product_id`                            | Numeric columns (calories, fat, sugar…)                                                                                                   |
-| `ingredient_ref`          | Canonical ingredient dictionary                 | `ingredient_id` (identity)              | 2,995 unique ingredients; name_en (UNIQUE), vegan/vegetarian/palm_oil/is_additive/concern_tier flags                                      |
-| `product_ingredient`      | Product ↔ ingredient junction                   | `(product_id, ingredient_id, position)` | ~13,858 rows across 913 products; tracks percent, percent_estimate, sub-ingredients, position order                                       |
-| `product_allergen_info`   | Allergens + traces per product (unified)        | `(product_id, tag, type)`               | ~2,630 rows (1,269 allergens + 1,361 traces) across 655 products; type IN ('contains','traces'); source: OFF allergens_tags / traces_tags |
-| `country_ref`             | ISO 3166-1 alpha-2 country codes                | `country_code` (text PK)                | 2 rows (PL, DE); is_active flag, nutri_score_official boolean; FK from products.country                                                   |
-| `category_ref`            | Product category master list                    | `category` (text PK)                    | 20 rows; FK from products.category; display_name, description, icon_emoji, sort_order                                                     |
-| `nutri_score_ref`         | Nutri-Score label definitions                   | `label` (text PK)                       | 7 rows (A–E + UNKNOWN + NOT-APPLICABLE); FK from scores.nutri_score_label; color_hex, description                                         |
-| `concern_tier_ref`        | EFSA ingredient concern tiers                   | `tier` (integer PK)                     | 4 rows (0–3); FK from ingredient_ref.concern_tier; score_impact, examples, EFSA guidance                                                  |
-| `user_preferences`        | User personalization (country, diet, allergens) | `user_id` (FK → auth.users)             | One row per user; diet enum, allergen arrays, strict_mode flags; RLS by user                                                              |
-| `user_health_profiles`    | Health condition profiles                       | `profile_id` (identity)                 | Conditions + nutrient thresholds (sodium, sugar, sat fat limits). One active profile per user. RLS by user                                |
-| `user_product_lists`      | User-created product lists                      | `list_id` (identity)                    | Name, description, share_token, is_public. Default lists: Favorites, Avoid. RLS by user                                                   |
-| `user_product_list_items` | Items in product lists                          | `(list_id, product_id)`                 | sort_order, notes. FK to user_product_lists + products. RLS by user                                                                       |
-| `user_comparisons`        | Saved product comparisons                       | `comparison_id` (identity)              | product_ids array (2-4), share_token, title. RLS by user                                                                                  |
-| `user_saved_searches`     | Saved search queries                            | `search_id` (identity)                  | Query text, filters JSONB, notification preferences. RLS by user                                                                          |
-| `scan_history`            | Barcode scan history                            | `scan_id` (identity)                    | user_id, ean, scanned_at, product_id (if matched). RLS by user                                                                            |
+| Table                     | Purpose                                         | Primary Key                             | Notes                                                                                                                                                    |
+| ------------------------- | ----------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `products`                | Product identity, scores, flags, provenance     | `product_id` (identity)                 | Upsert key: `(country, brand, product_name)`. Scores, flags, source columns all inline.                                                                  |
+| `nutrition_facts`         | Nutrition per product (per 100g)                | `product_id`                            | Numeric columns (calories, fat, sugar…)                                                                                                                  |
+| `ingredient_ref`          | Canonical ingredient dictionary                 | `ingredient_id` (identity)              | 2,995 unique ingredients; name_en (UNIQUE), vegan/vegetarian/palm_oil/is_additive/concern_tier flags                                                     |
+| `product_ingredient`      | Product ↔ ingredient junction                   | `(product_id, ingredient_id, position)` | ~13,858 rows across 913 products; tracks percent, percent_estimate, sub-ingredients, position order                                                      |
+| `product_allergen_info`   | Allergens + traces per product (unified)        | `(product_id, tag, type)`               | ~2,630 rows (1,269 allergens + 1,361 traces) across 655 products; type IN ('contains','traces'); source: OFF allergens_tags / traces_tags                |
+| `country_ref`             | ISO 3166-1 alpha-2 country codes                | `country_code` (text PK)                | 2 rows (PL, DE); is_active flag, nutri_score_official boolean; FK from products.country                                                                  |
+| `category_ref`            | Product category master list                    | `category` (text PK)                    | 20 rows; FK from products.category; display_name, description, icon_emoji, sort_order                                                                    |
+| `nutri_score_ref`         | Nutri-Score label definitions                   | `label` (text PK)                       | 7 rows (A–E + UNKNOWN + NOT-APPLICABLE); FK from scores.nutri_score_label; color_hex, description                                                        |
+| `concern_tier_ref`        | EFSA ingredient concern tiers                   | `tier` (integer PK)                     | 4 rows (0–3); FK from ingredient_ref.concern_tier; score_impact, examples, EFSA guidance                                                                 |
+| `user_preferences`        | User personalization (country, diet, allergens) | `user_id` (FK → auth.users)             | One row per user; diet enum, allergen arrays, strict_mode flags; RLS by user                                                                             |
+| `user_health_profiles`    | Health condition profiles                       | `profile_id` (identity)                 | Conditions + nutrient thresholds (sodium, sugar, sat fat limits). One active profile per user. RLS by user                                               |
+| `user_product_lists`      | User-created product lists                      | `list_id` (identity)                    | Name, description, share_token, is_public. Default lists: Favorites, Avoid. RLS by user                                                                  |
+| `user_product_list_items` | Items in product lists                          | `(list_id, product_id)`                 | sort_order, notes. FK to user_product_lists + products. RLS by user                                                                                      |
+| `user_comparisons`        | Saved product comparisons                       | `comparison_id` (identity)              | product_ids array (2-4), share_token, title. RLS by user                                                                                                 |
+| `user_saved_searches`     | Saved search queries                            | `search_id` (identity)                  | Query text, filters JSONB, notification preferences. RLS by user                                                                                         |
+| `scan_history`            | Barcode scan history                            | `scan_id` (identity)                    | user_id, ean, scanned_at, product_id (if matched). RLS by user                                                                                           |
 | `product_submissions`     | User-submitted products                         | `submission_id` (identity)              | ean, product_name, brand, photo_url, review_notes, status ('pending'/'approved'/'rejected'/'merged'). EAN checksum trigger auto-rejects invalid barcodes |
-| `event_schema_registry`   | Schema-versioned event definitions              | `id` (identity)                         | event_type + schema_version UNIQUE; json_schema, status(active/deprecated/retired), pii_fields, retention_days. RLS: anon-read            |
-| `backfill_registry`       | Batch data operation tracking                   | `backfill_id` (uuid PK)                 | name (unique), status, rows_processed/expected, batch_size, rollback_sql, validation_passed. RLS: service-write / auth-read               |
-| `log_level_ref`           | Severity level definitions for structured logs  | `level` (text PK)                       | 5 rows (DEBUG–CRITICAL); numeric_level, retention_days, escalation_target. RLS: service-write / auth-read                                 |
-| `error_code_registry`     | Known error codes with domain/category/severity | `error_code` (text PK)                  | {DOMAIN}_{CATEGORY}_{NNN} format; FK to log_level_ref(level); 13 starter codes. RLS: service-write / auth-read                            |
-| `retention_policies`      | Audit log retention configuration               | `policy_id` (identity)                  | table_name (unique), timestamp_column, retention_days (30–3650), is_enabled. RLS: service_role only                                       |
-| `mv_refresh_log`          | Audit trail for MV refreshes                    | `refresh_id` (identity)                 | mv_name, refreshed_at, duration_ms, row_count, triggered_by. Index on (mv_name, refreshed_at DESC). RLS: service-write / auth-read        |
-| `deletion_audit_log`      | GDPR Art.17 deletion audit trail (no PII)       | `id` (uuid)                             | deleted_at (timestamptz), tables_affected (text[]). NO user_id column. RLS enabled, service-role only                                     |
+| `event_schema_registry`   | Schema-versioned event definitions              | `id` (identity)                         | event_type + schema_version UNIQUE; json_schema, status(active/deprecated/retired), pii_fields, retention_days. RLS: anon-read                           |
+| `backfill_registry`       | Batch data operation tracking                   | `backfill_id` (uuid PK)                 | name (unique), status, rows_processed/expected, batch_size, rollback_sql, validation_passed. RLS: service-write / auth-read                              |
+| `log_level_ref`           | Severity level definitions for structured logs  | `level` (text PK)                       | 5 rows (DEBUG–CRITICAL); numeric_level, retention_days, escalation_target. RLS: service-write / auth-read                                                |
+| `error_code_registry`     | Known error codes with domain/category/severity | `error_code` (text PK)                  | {DOMAIN}_{CATEGORY}_{NNN} format; FK to log_level_ref(level); 13 starter codes. RLS: service-write / auth-read                                           |
+| `retention_policies`      | Audit log retention configuration               | `policy_id` (identity)                  | table_name (unique), timestamp_column, retention_days (30–3650), is_enabled. RLS: service_role only                                                      |
+| `mv_refresh_log`          | Audit trail for MV refreshes                    | `refresh_id` (identity)                 | mv_name, refreshed_at, duration_ms, row_count, triggered_by. Index on (mv_name, refreshed_at DESC). RLS: service-write / auth-read                       |
+| `deletion_audit_log`      | GDPR Art.17 deletion audit trail (no PII)       | `id` (uuid)                             | deleted_at (timestamptz), tables_affected (text[]). NO user_id column. RLS enabled, service-role only                                                    |
 
 ### Products Columns (key)
 
@@ -444,6 +444,8 @@ poland-food-db/
 | `api_export_user_data()`           | GDPR Art.15/20 — exports all user data as structured JSONB (preferences, health profiles, lists, comparisons, searches, scans). SECURITY DEFINER          |
 | `api_delete_user_data()`           | GDPR Art.17 — cascading delete across 8 tables in FK-safe order; writes anonymized audit to `deletion_audit_log`. SECURITY DEFINER                        |
 | `is_valid_ean()`                   | GS1 checksum validation for EAN-8/EAN-13 barcodes. IMMUTABLE STRICT — returns NULL for NULL, false for invalid                                            |
+| `check_submission_rate_limit()`     | Returns rate limit status for product submissions: 10 per 24h rolling window per user. SECURITY DEFINER                                                  |
+| `check_scan_rate_limit()`           | Returns rate limit status for barcode scans: 100 per 24h rolling window per user. SECURITY DEFINER                                                       |
 
 ### Views
 
@@ -561,7 +563,7 @@ a mix of `'baked'`, `'fried'`, and `'none'`.
 
 ## 7. Migrations
 
-**Location:** `supabase/migrations/` — managed by Supabase CLI. Currently **169 migrations**.
+**Location:** `supabase/migrations/` — managed by Supabase CLI. Currently **170 migrations**.
 
 **Rules:**
 
@@ -633,7 +635,7 @@ A change is **not done** unless relevant tests were added/updated, every suite i
 | Component tests     | **Testing Library React** + Vitest                | `frontend/src/components/**/*.test.tsx`      | same as above                        |
 | E2E smoke           | **Playwright 1.58** (Chromium)                    | `frontend/e2e/smoke.spec.ts`                 | `cd frontend && npx playwright test` |
 | E2E auth            | Playwright (requires `SUPABASE_SERVICE_ROLE_KEY`) | `frontend/e2e/authenticated.spec.ts`         | same (CI auto-detects key)           |
-| DB QA (693 checks)  | Raw SQL (zero rows = pass)                        | `db/qa/QA__*.sql` (47 suites)                | `.\RUN_QA.ps1`                       |
+| DB QA (696 checks)  | Raw SQL (zero rows = pass)                        | `db/qa/QA__*.sql` (47 suites)                | `.\RUN_QA.ps1`                       |
 | Negative validation | SQL injection/constraint tests                    | `db/qa/TEST__negative_checks.sql`            | `.\RUN_NEGATIVE_TESTS.ps1`           |
 | DB sanity           | Row-count + schema assertions                     | via `RUN_SANITY.ps1`                         | `.\RUN_SANITY.ps1 -Env local`        |
 | Pipeline structure  | Python validator                                  | `check_pipeline_structure.py`                | `python check_pipeline_structure.py` |
@@ -771,7 +773,7 @@ E2E tests are the **only** exception — they run against a live dev server but 
   - **`pr-title-lint.yml`**: PR title conventional-commit validation (all PRs)
   - **`main-gate.yml`**: Typecheck → Lint → Build → Unit tests with coverage → Playwright smoke E2E → SonarCloud scan + BLOCKING Quality Gate → Sentry sourcemap upload
   - **`nightly.yml`**: Full Playwright (all projects incl. visual regression) + Data Integrity Audit (parallel)
-  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (693 checks) → Sanity (17 checks) → Confidence threshold
+  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (696 checks) → Sanity (17 checks) → Confidence threshold
   - **`deploy.yml`**: Manual trigger → Schema diff → Approval gate (production) → Pre-deploy backup → `supabase db push` → Post-deploy sanity
   - **`sync-cloud-db.yml`**: Auto-sync migrations to production on merge to `main`
 
@@ -805,7 +807,7 @@ If adding/changing DB schema or SQL functions:
 - For rollback procedures, see `DEPLOYMENT.md` → **Rollback Procedures** (5 scenarios + emergency checklist).
 - Add a QA check that verifies the migration outcome (row counts, constraint behavior).
 - Ensure idempotency (`IF NOT EXISTS`, `ON CONFLICT`, `DO UPDATE SET`).
-- Run `.\RUN_QA.ps1` to verify all 693 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 23 injection tests.
+- Run `.\RUN_QA.ps1` to verify all 696 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 23 injection tests.
 
 ### 8.14 Snapshots Are Not Enough
 
@@ -867,7 +869,7 @@ At the end of every PR-like change, include a **Verification** section:
 | Allergen Filtering        | `QA__allergen_filtering.sql`        |      6 | Yes       |
 | Serving & Source          | `QA__serving_source_validation.sql` |     16 | Yes       |
 | Ingredient Quality        | `QA__ingredient_quality.sql`        |     14 | Yes       |
-| Security Posture          | `QA__security_posture.sql`          |     29 | Yes       |
+| Security Posture          | `QA__security_posture.sql`          |     32 | Yes       |
 | Scale Guardrails          | `QA__scale_guardrails.sql`          |     23 | Yes       |
 | Country Isolation         | `QA__country_isolation.sql`         |     11 | Yes       |
 | Diet Filtering            | `QA__diet_filtering.sql`            |      6 | Yes       |
@@ -898,7 +900,7 @@ At the end of every PR-like change, include a **Verification** section:
 | Function Security Audit   | `QA__function_security_audit.sql`   |      6 | Yes       |
 | **Negative Validation**   | `TEST__negative_checks.sql`         |     23 | Yes       |
 
-**Run:** `.\RUN_QA.ps1` — expects **693/693 checks passing** (+ EAN validation).
+**Run:** `.\RUN_QA.ps1` — expects **696/696 checks passing** (+ EAN validation).
 **Run:** `.\RUN_NEGATIVE_TESTS.ps1` — expects **23/23 caught**.
 
 ### 8.19 Key Regression Tests (Scoring Suite)
@@ -1387,7 +1389,7 @@ Before a feature is considered complete, verify against all CI gates:
 | Gate                | Command                               | Expected                        |
 | ------------------- | ------------------------------------- | ------------------------------- |
 | Pipeline structure  | `python check_pipeline_structure.py`  | 0 errors                        |
-| DB QA               | `.\RUN_QA.ps1`                        | All checks pass (currently 693) |
+| DB QA               | `.\RUN_QA.ps1`                        | All checks pass (currently 696) |
 | Negative tests      | `.\RUN_NEGATIVE_TESTS.ps1`            | All caught (currently 29)       |
 | pgTAP tests         | `supabase test db`                    | All pass                        |
 | TypeScript          | `cd frontend && npx tsc --noEmit`     | 0 errors                        |

--- a/supabase/migrations/20260315000200_rate_limiting.sql
+++ b/supabase/migrations/20260315000200_rate_limiting.sql
@@ -1,0 +1,328 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║ Rate Limiting on Product Submissions & Barcode Scans — Issue #466       ║
+-- ║                                                                          ║
+-- ║ 1. check_submission_rate_limit(uuid) — 10 submissions / 24h per user    ║
+-- ║ 2. check_scan_rate_limit(uuid)       — 100 scans / 24h per user         ║
+-- ║ 3. idx_ps_user_created — composite index for rate limit queries          ║
+-- ║ 4. Updated api_submit_product() — rate limit check before INSERT        ║
+-- ║ 5. Updated api_record_scan()   — rate limit check before INSERT         ║
+-- ║                                                                          ║
+-- ║ To roll back:                                                            ║
+-- ║   -- Restore original api_record_scan / api_submit_product from prior   ║
+-- ║   -- migration (no rate-limit check)                                     ║
+-- ║   DROP FUNCTION IF EXISTS check_submission_rate_limit(uuid);             ║
+-- ║   DROP FUNCTION IF EXISTS check_scan_rate_limit(uuid);                   ║
+-- ║   DROP INDEX IF EXISTS idx_ps_user_created;                              ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 1. Rate Limit Check Functions
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- Submission rate limit: 10 per 24h per user
+CREATE OR REPLACE FUNCTION public.check_submission_rate_limit(p_user_id uuid)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'allowed',             COUNT(*) < 10,
+    'current_count',       COUNT(*)::int,
+    'max_allowed',         10,
+    'window',              '24 hours',
+    'retry_after_seconds', CASE
+      WHEN COUNT(*) >= 10 THEN
+        GREATEST(0,
+          EXTRACT(EPOCH FROM (
+            MIN(created_at) + interval '24 hours' - now()
+          ))::integer
+        )
+      ELSE 0
+    END
+  )
+  FROM product_submissions
+  WHERE user_id = p_user_id
+    AND created_at > now() - interval '24 hours';
+$$;
+
+COMMENT ON FUNCTION public.check_submission_rate_limit(uuid) IS
+  'Returns rate limit status for product submissions: 10 per 24-hour rolling window per user.';
+
+-- Scan rate limit: 100 per 24h per user
+CREATE OR REPLACE FUNCTION public.check_scan_rate_limit(p_user_id uuid)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'allowed',             COUNT(*) < 100,
+    'current_count',       COUNT(*)::int,
+    'max_allowed',         100,
+    'window',              '24 hours',
+    'retry_after_seconds', CASE
+      WHEN COUNT(*) >= 100 THEN
+        GREATEST(0,
+          EXTRACT(EPOCH FROM (
+            MIN(scanned_at) + interval '24 hours' - now()
+          ))::integer
+        )
+      ELSE 0
+    END
+  )
+  FROM scan_history
+  WHERE user_id = p_user_id
+    AND scanned_at > now() - interval '24 hours';
+$$;
+
+COMMENT ON FUNCTION public.check_scan_rate_limit(uuid) IS
+  'Returns rate limit status for barcode scans: 100 per 24-hour rolling window per user.';
+
+-- Grant execute to authenticated users
+GRANT EXECUTE ON FUNCTION public.check_submission_rate_limit(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.check_scan_rate_limit(uuid) TO authenticated;
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 2. Performance Index for Submission Rate Limit Queries
+--    (scan_history already has idx_sh_user_recent on (user_id, scanned_at DESC))
+-- ════════════════════════════════════════════════════════════════════════════
+
+CREATE INDEX IF NOT EXISTS idx_ps_user_created
+  ON public.product_submissions (user_id, created_at DESC);
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 3. Updated api_submit_product() — add rate limit check
+-- ════════════════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION public.api_submit_product(
+  p_ean          text,
+  p_product_name text,
+  p_brand        text    DEFAULT NULL,
+  p_category     text    DEFAULT NULL,
+  p_photo_url    text    DEFAULT NULL,
+  p_notes        text    DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid        uuid;
+  v_ean        text;
+  v_existing   uuid;
+  v_result     jsonb;
+  v_rate_check jsonb;
+BEGIN
+  -- Auth check
+  v_uid := auth.uid();
+  IF v_uid IS NULL THEN
+    RETURN jsonb_build_object(
+      'api_version', '1.0',
+      'error',       'Authentication required'
+    );
+  END IF;
+
+  -- Rate limit check (before any processing)
+  v_rate_check := check_submission_rate_limit(v_uid);
+  IF NOT (v_rate_check->>'allowed')::boolean THEN
+    RETURN jsonb_build_object(
+      'api_version',         '1.0',
+      'error',               'rate_limit_exceeded',
+      'message',             'Too many submissions. Please try again later.',
+      'retry_after_seconds', (v_rate_check->>'retry_after_seconds')::integer,
+      'current_count',       (v_rate_check->>'current_count')::integer,
+      'max_allowed',         (v_rate_check->>'max_allowed')::integer
+    );
+  END IF;
+
+  -- Trim EAN
+  v_ean := TRIM(COALESCE(p_ean, ''));
+
+  -- Validate EAN (checksum + format)
+  IF NOT is_valid_ean(v_ean) THEN
+    RETURN jsonb_build_object(
+      'api_version', '1.0',
+      'error',       'Invalid EAN — must be a valid EAN-8 or EAN-13 barcode with correct checksum'
+    );
+  END IF;
+
+  -- Check product_name required
+  IF p_product_name IS NULL OR TRIM(p_product_name) = '' THEN
+    RETURN jsonb_build_object(
+      'api_version', '1.0',
+      'error',       'Product name is required'
+    );
+  END IF;
+
+  -- Check if EAN already exists in products
+  IF EXISTS (SELECT 1 FROM products WHERE ean = v_ean AND is_deprecated IS NOT TRUE) THEN
+    RETURN jsonb_build_object(
+      'api_version', '1.0',
+      'error',       'Product with this EAN already exists in database'
+    );
+  END IF;
+
+  -- Check if EAN already has a pending submission
+  SELECT id INTO v_existing
+  FROM product_submissions
+  WHERE ean = v_ean AND status = 'pending'
+  LIMIT 1;
+
+  IF v_existing IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'api_version', '1.0',
+      'error',       'A submission for this EAN is already pending review'
+    );
+  END IF;
+
+  -- Insert submission
+  INSERT INTO product_submissions (user_id, ean, product_name, brand, category, photo_url, notes)
+  VALUES (v_uid, v_ean, TRIM(p_product_name), NULLIF(TRIM(p_brand), ''),
+          NULLIF(TRIM(p_category), ''), NULLIF(TRIM(p_photo_url), ''),
+          NULLIF(TRIM(p_notes), ''))
+  RETURNING jsonb_build_object(
+    'api_version',   '1.0',
+    'submission_id', id::text,
+    'ean',           ean,
+    'product_name',  product_name,
+    'status',        status
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$$;
+
+COMMENT ON FUNCTION public.api_submit_product(text, text, text, text, text, text) IS
+  'Submit a new product for review. Validates EAN checksum and enforces 10/24h rate limit.';
+
+REVOKE ALL ON FUNCTION public.api_submit_product(text, text, text, text, text, text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.api_submit_product(text, text, text, text, text, text) TO authenticated;
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 4. Updated api_record_scan() — add rate limit check
+-- ════════════════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION public.api_record_scan(
+  p_ean text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id      uuid := auth.uid();
+  v_product      record;
+  v_found        boolean := false;
+  v_product_id   bigint;
+  v_language     text;
+  v_country_lang text;
+  v_cat_display  text;
+  v_cat_icon     text;
+  v_rate_check   jsonb;
+BEGIN
+  -- Validate EAN format
+  IF p_ean IS NULL OR LENGTH(TRIM(p_ean)) NOT IN (8, 13) THEN
+    RETURN jsonb_build_object(
+      'api_version', '1.0',
+      'error',       'EAN must be 8 or 13 digits'
+    );
+  END IF;
+
+  -- Rate limit check (only for authenticated users who will write)
+  IF v_user_id IS NOT NULL THEN
+    v_rate_check := check_scan_rate_limit(v_user_id);
+    IF NOT (v_rate_check->>'allowed')::boolean THEN
+      RETURN jsonb_build_object(
+        'api_version',         '1.0',
+        'error',               'rate_limit_exceeded',
+        'message',             'Too many scans. Please try again later.',
+        'retry_after_seconds', (v_rate_check->>'retry_after_seconds')::integer,
+        'current_count',       (v_rate_check->>'current_count')::integer,
+        'max_allowed',         (v_rate_check->>'max_allowed')::integer
+      );
+    END IF;
+  END IF;
+
+  -- Resolve user language
+  v_language := resolve_language(NULL);
+
+  -- Lookup product by EAN (now includes name_translations)
+  SELECT p.product_id, p.product_name, p.product_name_en, p.name_translations,
+         p.brand, p.category, p.country, p.unhealthiness_score, p.nutri_score_label
+    INTO v_product
+    FROM public.products p
+   WHERE p.ean = TRIM(p_ean)
+   LIMIT 1;
+
+  IF FOUND THEN
+    v_found := true;
+    v_product_id := v_product.product_id;
+
+    -- Resolve country default language
+    SELECT cref.default_language INTO v_country_lang
+    FROM public.country_ref cref
+    WHERE cref.country_code = v_product.country;
+    v_country_lang := COALESCE(v_country_lang, LOWER(v_product.country));
+
+    -- Resolve category display + icon
+    SELECT COALESCE(ct.display_name, cr.display_name),
+           COALESCE(cr.icon_emoji, '📦')
+    INTO v_cat_display, v_cat_icon
+    FROM public.category_ref cr
+    LEFT JOIN public.category_translations ct
+        ON ct.category = cr.category AND ct.language_code = v_language
+    WHERE cr.category = v_product.category;
+  END IF;
+
+  -- Record scan (only for authenticated users)
+  IF v_user_id IS NOT NULL THEN
+    INSERT INTO public.scan_history (user_id, ean, product_id, found)
+    VALUES (v_user_id, TRIM(p_ean), v_product_id, v_found);
+  END IF;
+
+  -- Return result
+  IF v_found THEN
+    RETURN jsonb_build_object(
+      'api_version',    '1.0',
+      'found',          true,
+      'product_id',     v_product.product_id,
+      'product_name',   v_product.product_name,
+      'product_name_en', v_product.product_name_en,
+      'product_name_display', CASE
+          WHEN v_language = v_country_lang THEN v_product.product_name
+          WHEN v_language = 'en' THEN COALESCE(v_product.product_name_en, v_product.product_name)
+          ELSE COALESCE(
+              v_product.name_translations->>v_language,
+              v_product.product_name_en,
+              v_product.product_name
+          )
+      END,
+      'brand',              v_product.brand,
+      'category',           v_product.category,
+      'category_display',   v_cat_display,
+      'category_icon',      v_cat_icon,
+      'unhealthiness_score', v_product.unhealthiness_score,
+      'nutri_score',        v_product.nutri_score_label
+    );
+  ELSE
+    RETURN jsonb_build_object(
+      'api_version', '1.0',
+      'found',       false,
+      'ean',         TRIM(p_ean),
+      'has_pending_submission', EXISTS (
+        SELECT 1 FROM public.product_submissions
+         WHERE ean = TRIM(p_ean) AND status = 'pending'
+      )
+    );
+  END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION public.api_record_scan(text) IS
+  'Record a barcode scan and lookup product. Enforces 100/24h rate limit per user.';
+
+REVOKE ALL ON FUNCTION public.api_record_scan(text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.api_record_scan(text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.api_record_scan(text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.api_record_scan(text) TO service_role;

--- a/supabase/tests/schema_contracts.test.sql
+++ b/supabase/tests/schema_contracts.test.sql
@@ -7,7 +7,7 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 
 BEGIN;
-SELECT plan(199);
+SELECT plan(201);
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 1. Core data tables exist
@@ -297,6 +297,10 @@ SELECT has_column('public', 'deletion_audit_log', 'deleted_at',   'column deleti
 SELECT has_function('public', 'is_valid_ean',                   'function is_valid_ean exists');
 SELECT has_column('public', 'product_submissions', 'review_notes', 'column product_submissions.review_notes exists');
 SELECT has_trigger('product_submissions', 'trg_submission_ean_check', 'EAN checksum trigger exists on product_submissions');
+
+-- ─── Rate Limiting (#466) ────────────────────────────────────────────────────
+SELECT has_function('public', 'check_submission_rate_limit',  'function check_submission_rate_limit exists');
+SELECT has_function('public', 'check_scan_rate_limit',        'function check_scan_rate_limit exists');
 
 SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
## Summary

Implements database-level rate limiting for product submissions and barcode scans as defense-in-depth security controls.

### Rate Limits
| Endpoint | Limit | Window |
|----------|-------|--------|
| `api_submit_product()` | 10 submissions | 24h rolling |
| `api_record_scan()` | 100 scans | 24h rolling |

### Changes

**Migration `20260315000200_rate_limiting.sql`:**
- `check_submission_rate_limit(uuid)` — returns JSONB `{allowed, current_count, max_allowed, window, retry_after_seconds}`
- `check_scan_rate_limit(uuid)` — same response shape, 100/24h limit
- Both functions: `STABLE SECURITY DEFINER SET search_path = public`
- `idx_ps_user_created` composite index on `product_submissions(user_id, created_at DESC)`
- Updated `api_submit_product()` with rate limit check (after auth, before EAN validation)
- Updated `api_record_scan()` with rate limit check (after EAN validation, only for authenticated users)

**Rate limit error response:**
```json
{"api_version": "1.0", "error": "rate_limit_exceeded", "message": "...", "retry_after_seconds": N, "current_count": N, "max_allowed": N}
```

### Testing
- 7 pgTAP tests (scanner plan 38→45): function existence, JSONB keys, max_allowed values, retry_after_seconds
- 2 schema contract assertions (plan 199→201)
- 3 QA security posture checks (29→32, total QA: 696)

### Docs
- Updated `copilot-instructions.md` (functions table, QA counts, migration count)
- Updated `RUN_QA.ps1` (security posture 29→32)

Closes #466