### PR TITLE
feat(security): add generic API rate limiting for 6 endpoints

### DIFF
--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -19,7 +19,7 @@
        13. QA__allergen_integrity.sql (14 allergen & trace integrity checks — blocking)
        14. QA__serving_source_validation.sql (16 serving & source checks — blocking)
        15. QA__ingredient_quality.sql (14 ingredient quality checks — blocking)
-       16. QA__security_posture.sql (32 security posture checks — blocking)
+       16. QA__security_posture.sql (35 security posture checks — blocking)
        17. QA__api_contract.sql (30 API contract checks — blocking)
        18. QA__scale_guardrails.sql (23 scale guardrails checks — blocking)
        19. QA__country_isolation.sql (6 country isolation checks — blocking)
@@ -147,7 +147,7 @@ $suiteCatalog = @(
     @{ Num = 13; Name = "Allergen & Trace Integrity"; Short = "Allergen"; Id = "allergen_integrity"; Checks = 15; Blocking = $true; Kind = "sql"; File = "QA__allergen_integrity.sql" },
     @{ Num = 14; Name = "Serving & Source Validation"; Short = "ServSource"; Id = "serving_source"; Checks = 16; Blocking = $true; Kind = "sql"; File = "QA__serving_source_validation.sql" },
     @{ Num = 15; Name = "Ingredient Data Quality"; Short = "IngredQual"; Id = "ingredient_quality"; Checks = 14; Blocking = $true; Kind = "sql"; File = "QA__ingredient_quality.sql" },
-    @{ Num = 16; Name = "Security Posture"; Short = "Security"; Id = "security_posture"; Checks = 32; Blocking = $true; Kind = "sql"; File = "QA__security_posture.sql" },
+    @{ Num = 16; Name = "Security Posture"; Short = "Security"; Id = "security_posture"; Checks = 35; Blocking = $true; Kind = "sql"; File = "QA__security_posture.sql" },
     @{ Num = 17; Name = "API Contract"; Short = "Contract"; Id = "api_contract"; Checks = 33; Blocking = $true; Kind = "sql"; File = "QA__api_contract.sql" },
     @{ Num = 18; Name = "Scale Guardrails"; Short = "Scale"; Id = "scale_guardrails"; Checks = 23; Blocking = $true; Kind = "sql"; File = "QA__scale_guardrails.sql" },
     @{ Num = 19; Name = "Country Isolation"; Short = "Country"; Id = "country_isolation"; Checks = 11; Blocking = $true; Kind = "sql"; File = "QA__country_isolation.sql" },

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -8,7 +8,7 @@
 > **Servings:** removed as separate table — all nutrition data is per-100g on nutrition_facts
 > **Ingredient analytics:** 2,995 unique ingredients (all clean ASCII English), 1,269 allergen declarations, 1,361 trace declarations
 > **Ingredient concerns:** EFSA-based 4-tier additive classification (0=none, 1=low, 2=moderate, 3=high)
-> **QA:** 699 checks across 47 suites + 23 negative validation tests — all passing
+> **QA:** 702 checks across 47 suites + 23 negative validation tests — all passing
 
 ---
 
@@ -103,7 +103,7 @@ poland-food-db/
 │   │   ├── QA__allergen_filtering.sql    # 6 allergen filtering checks
 │   │   ├── QA__serving_source_validation.sql # 16 serving & source checks
 │   │   ├── QA__ingredient_quality.sql    # 14 ingredient quality checks
-│   │   ├── QA__security_posture.sql      # 32 security posture checks
+│   │   ├── QA__security_posture.sql      # 35 security posture checks
 │   │   ├── QA__scale_guardrails.sql      # 23 scale guardrails checks
 │   │   ├── QA__country_isolation.sql     # 11 country isolation checks
 │   │   ├── QA__diet_filtering.sql        # 6 diet filtering checks
@@ -257,7 +257,7 @@ poland-food-db/
 │       ├── 006-append-only-migrations.md
 │       └── 007-english-canonical-ingredients.md
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
-├── RUN_QA.ps1                       # QA test runner (699 checks across 47 suites)
+├── RUN_QA.ps1                       # QA test runner (702 checks across 47 suites)
 ├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (23 injection tests)
 ├── RUN_SANITY.ps1                   # Sanity checks (16) — row counts, schema assertions
 ├── RUN_REMOTE.ps1                   # Remote deployment (requires confirmation)
@@ -394,6 +394,8 @@ poland-food-db/
 | `retention_policies`      | Audit log retention configuration               | `policy_id` (identity)                  | table_name (unique), timestamp_column, retention_days (30–3650), is_enabled. RLS: service_role only                                                      |
 | `mv_refresh_log`          | Audit trail for MV refreshes                    | `refresh_id` (identity)                 | mv_name, refreshed_at, duration_ms, row_count, triggered_by. Index on (mv_name, refreshed_at DESC). RLS: service-write / auth-read                       |
 | `deletion_audit_log`      | GDPR Art.17 deletion audit trail (no PII)       | `id` (uuid)                             | deleted_at (timestamptz), tables_affected (text[]). NO user_id column. RLS enabled, service-role only                                                    |
+| `api_rate_limits`         | Per-endpoint rate limit configuration           | `endpoint` (text PK)                    | max_requests, window_seconds, description. 6 seeded endpoints. RLS: auth-read / service-write                                                           |
+| `api_rate_limit_log`      | Ephemeral request tracking for rate limiting    | `id` (identity)                         | user_id, endpoint, called_at. Retention: 2 days. Index on (user_id, endpoint, called_at DESC). RLS: service-role only                                    |
 
 ### Products Columns (key)
 
@@ -444,9 +446,10 @@ poland-food-db/
 | `api_export_user_data()`           | GDPR Art.15/20 — exports all user data as structured JSONB (preferences, health profiles, lists, comparisons, searches, scans). SECURITY DEFINER          |
 | `api_delete_user_data()`           | GDPR Art.17 — cascading delete across 8 tables in FK-safe order; writes anonymized audit to `deletion_audit_log`. SECURITY DEFINER                        |
 | `is_valid_ean()`                   | GS1 checksum validation for EAN-8/EAN-13 barcodes. IMMUTABLE STRICT — returns NULL for NULL, false for invalid                                            |
-| `check_submission_rate_limit()`     | Returns rate limit status for product submissions: 10 per 24h rolling window per user. SECURITY DEFINER                                                  |
-| `check_scan_rate_limit()`           | Returns rate limit status for barcode scans: 100 per 24h rolling window per user. SECURITY DEFINER                                                       |
-| `score_submission_quality()`        | Scores a submission's quality (0-100) from 6 signals: account age, velocity, EAN match, photo, brand/name quality. SECURITY DEFINER                      |
+| `check_submission_rate_limit()`    | Returns rate limit status for product submissions: 10 per 24h rolling window per user. SECURITY DEFINER                                                   |
+| `check_scan_rate_limit()`          | Returns rate limit status for barcode scans: 100 per 24h rolling window per user. SECURITY DEFINER                                                        |
+| `check_api_rate_limit()`           | Generic per-endpoint rate limiter: checks `api_rate_limits` config, logs to `api_rate_limit_log`. Returns `{allowed, remaining}` or blocked JSONB. SECURITY DEFINER |
+| `score_submission_quality()`       | Scores a submission's quality (0-100) from 6 signals: account age, velocity, EAN match, photo, brand/name quality. SECURITY DEFINER                       |
 
 ### Views
 
@@ -564,7 +567,7 @@ a mix of `'baked'`, `'fried'`, and `'none'`.
 
 ## 7. Migrations
 
-**Location:** `supabase/migrations/` — managed by Supabase CLI. Currently **171 migrations**.
+**Location:** `supabase/migrations/` — managed by Supabase CLI. Currently **172 migrations**.
 
 **Rules:**
 
@@ -636,7 +639,7 @@ A change is **not done** unless relevant tests were added/updated, every suite i
 | Component tests     | **Testing Library React** + Vitest                | `frontend/src/components/**/*.test.tsx`      | same as above                        |
 | E2E smoke           | **Playwright 1.58** (Chromium)                    | `frontend/e2e/smoke.spec.ts`                 | `cd frontend && npx playwright test` |
 | E2E auth            | Playwright (requires `SUPABASE_SERVICE_ROLE_KEY`) | `frontend/e2e/authenticated.spec.ts`         | same (CI auto-detects key)           |
-| DB QA (699 checks)  | Raw SQL (zero rows = pass)                        | `db/qa/QA__*.sql` (47 suites)                | `.\RUN_QA.ps1`                       |
+| DB QA (702 checks)  | Raw SQL (zero rows = pass)                        | `db/qa/QA__*.sql` (47 suites)                | `.\RUN_QA.ps1`                       |
 | Negative validation | SQL injection/constraint tests                    | `db/qa/TEST__negative_checks.sql`            | `.\RUN_NEGATIVE_TESTS.ps1`           |
 | DB sanity           | Row-count + schema assertions                     | via `RUN_SANITY.ps1`                         | `.\RUN_SANITY.ps1 -Env local`        |
 | Pipeline structure  | Python validator                                  | `check_pipeline_structure.py`                | `python check_pipeline_structure.py` |
@@ -774,7 +777,7 @@ E2E tests are the **only** exception — they run against a live dev server but 
   - **`pr-title-lint.yml`**: PR title conventional-commit validation (all PRs)
   - **`main-gate.yml`**: Typecheck → Lint → Build → Unit tests with coverage → Playwright smoke E2E → SonarCloud scan + BLOCKING Quality Gate → Sentry sourcemap upload
   - **`nightly.yml`**: Full Playwright (all projects incl. visual regression) + Data Integrity Audit (parallel)
-  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (699 checks) → Sanity (17 checks) → Confidence threshold
+  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (702 checks) → Sanity (17 checks) → Confidence threshold
   - **`deploy.yml`**: Manual trigger → Schema diff → Approval gate (production) → Pre-deploy backup → `supabase db push` → Post-deploy sanity
   - **`sync-cloud-db.yml`**: Auto-sync migrations to production on merge to `main`
 
@@ -808,7 +811,7 @@ If adding/changing DB schema or SQL functions:
 - For rollback procedures, see `DEPLOYMENT.md` → **Rollback Procedures** (5 scenarios + emergency checklist).
 - Add a QA check that verifies the migration outcome (row counts, constraint behavior).
 - Ensure idempotency (`IF NOT EXISTS`, `ON CONFLICT`, `DO UPDATE SET`).
-- Run `.\RUN_QA.ps1` to verify all 699 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 23 injection tests.
+- Run `.\RUN_QA.ps1` to verify all 702 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 23 injection tests.
 
 ### 8.14 Snapshots Are Not Enough
 
@@ -870,7 +873,7 @@ At the end of every PR-like change, include a **Verification** section:
 | Allergen Filtering        | `QA__allergen_filtering.sql`        |      6 | Yes       |
 | Serving & Source          | `QA__serving_source_validation.sql` |     16 | Yes       |
 | Ingredient Quality        | `QA__ingredient_quality.sql`        |     14 | Yes       |
-| Security Posture          | `QA__security_posture.sql`          |     32 | Yes       |
+| Security Posture          | `QA__security_posture.sql`          |     35 | Yes       |
 | Scale Guardrails          | `QA__scale_guardrails.sql`          |     23 | Yes       |
 | Country Isolation         | `QA__country_isolation.sql`         |     11 | Yes       |
 | Diet Filtering            | `QA__diet_filtering.sql`            |      6 | Yes       |
@@ -901,7 +904,7 @@ At the end of every PR-like change, include a **Verification** section:
 | Function Security Audit   | `QA__function_security_audit.sql`   |      6 | Yes       |
 | **Negative Validation**   | `TEST__negative_checks.sql`         |     23 | Yes       |
 
-**Run:** `.\RUN_QA.ps1` — expects **699/699 checks passing** (+ EAN validation).
+**Run:** `.\RUN_QA.ps1` — expects **702/702 checks passing** (+ EAN validation).
 **Run:** `.\RUN_NEGATIVE_TESTS.ps1` — expects **23/23 caught**.
 
 ### 8.19 Key Regression Tests (Scoring Suite)

--- a/supabase/migrations/20260315000400_api_rate_limiting.sql
+++ b/supabase/migrations/20260315000400_api_rate_limiting.sql
@@ -1,0 +1,365 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Migration: 20260315000400_api_rate_limiting.sql
+-- Ticket:    #472 — API abuse rate limiting (search, events, EAN enumeration)
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Adds generic per-endpoint rate limiting to 6 API functions.
+--
+-- Phase 1: Configuration + tracking tables + generic check function
+-- Phase 2: Inject rate limit checks into 5 plpgsql API functions
+-- Phase 3: Convert api_better_alternatives (SQL → plpgsql) with rate limit
+-- Phase 4: Retention policy (2-day cleanup)
+-- Phase 5: RLS + grants
+-- ═══════════════════════════════════════════════════════════════════════════
+-- To roll back: DROP TABLE IF EXISTS api_rate_limit_log, api_rate_limits CASCADE;
+--               then redeploy functions from their previous migrations.
+-- ═══════════════════════════════════════════════════════════════════════════
+
+
+-- ─── Phase 1A: Rate limit configuration table ──────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.api_rate_limits (
+    endpoint       text    PRIMARY KEY,
+    max_requests   integer NOT NULL
+        CONSTRAINT chk_arl_max_positive CHECK (max_requests > 0),
+    window_seconds integer NOT NULL
+        CONSTRAINT chk_arl_window_positive CHECK (window_seconds > 0),
+    description    text
+);
+
+COMMENT ON TABLE public.api_rate_limits IS
+    'Per-endpoint rate limit configuration. Each row defines max_requests '
+    'within a sliding window of window_seconds for authenticated users.';
+
+-- Seed default limits
+INSERT INTO api_rate_limits (endpoint, max_requests, window_seconds, description) VALUES
+    ('api_search_products',        30,   60, 'Search: 30 requests per minute'),
+    ('api_search_autocomplete',    60,   60, 'Autocomplete: 60 requests per minute'),
+    ('api_product_detail_by_ean', 100, 3600, 'EAN lookup: 100 per hour'),
+    ('api_track_event',           500, 3600, 'Events: 500 per hour'),
+    ('api_get_filter_options',     10,   60, 'Filter options: 10 per minute'),
+    ('api_better_alternatives',    30,   60, 'Alternatives: 30 per minute')
+ON CONFLICT (endpoint) DO UPDATE SET
+    max_requests   = EXCLUDED.max_requests,
+    window_seconds = EXCLUDED.window_seconds,
+    description    = EXCLUDED.description;
+
+
+-- ─── Phase 1B: Rate limit tracking log ─────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.api_rate_limit_log (
+    id        bigint      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id   uuid        NOT NULL,
+    endpoint  text        NOT NULL,
+    called_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.api_rate_limit_log IS
+    'Ephemeral request log for rate limit enforcement. '
+    'Cleaned by retention_policies (2-day window). '
+    'Not FK-constrained to api_rate_limits for cleanup flexibility.';
+
+CREATE INDEX IF NOT EXISTS idx_rate_limit_log_lookup
+    ON api_rate_limit_log (user_id, endpoint, called_at DESC);
+
+
+-- ─── Phase 1C: Generic rate limit check function ───────────────────────────
+
+CREATE OR REPLACE FUNCTION public.check_api_rate_limit(
+    p_user_id  uuid,
+    p_endpoint text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_max_requests   integer;
+    v_window_seconds integer;
+    v_count          integer;
+    v_oldest         timestamptz;
+    v_window         interval;
+BEGIN
+    -- NULL user → always allowed (anon users not rate-limited at DB level)
+    IF p_user_id IS NULL THEN
+        RETURN jsonb_build_object('allowed', true);
+    END IF;
+
+    -- Lookup endpoint configuration
+    SELECT arl.max_requests, arl.window_seconds
+    INTO   v_max_requests, v_window_seconds
+    FROM   api_rate_limits arl
+    WHERE  arl.endpoint = p_endpoint;
+
+    -- No limit configured → allow
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('allowed', true);
+    END IF;
+
+    v_window := make_interval(secs => v_window_seconds);
+
+    -- Count recent calls within window
+    SELECT COUNT(*), MIN(l.called_at)
+    INTO   v_count, v_oldest
+    FROM   api_rate_limit_log l
+    WHERE  l.user_id  = p_user_id
+      AND  l.endpoint = p_endpoint
+      AND  l.called_at > now() - v_window;
+
+    -- Over limit → reject
+    IF v_count >= v_max_requests THEN
+        RETURN jsonb_build_object(
+            'allowed',            false,
+            'current_count',      v_count,
+            'max_allowed',        v_max_requests,
+            'window_seconds',     v_window_seconds,
+            'retry_after_seconds', GREATEST(0,
+                EXTRACT(EPOCH FROM (v_oldest + v_window - now()))::integer)
+        );
+    END IF;
+
+    -- Under limit → log and allow
+    INSERT INTO api_rate_limit_log (user_id, endpoint)
+    VALUES (p_user_id, p_endpoint);
+
+    RETURN jsonb_build_object(
+        'allowed',   true,
+        'remaining', v_max_requests - v_count - 1
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION public.check_api_rate_limit(uuid, text) IS
+    'Generic per-endpoint rate limiter. Returns {allowed, remaining} or '
+    '{allowed:false, retry_after_seconds, current_count, max_allowed, window_seconds}. '
+    'NULL user_id always returns allowed:true (anon bypass). '
+    'Unconfigured endpoints always return allowed:true.';
+
+
+-- ─── Phase 2: Inject rate limit checks into 5 plpgsql API functions ────────
+-- Uses pg_get_functiondef() to dynamically patch existing function bodies.
+-- This avoids duplicating ~500 lines of function source in the migration.
+-- Idempotent: skips functions that already contain check_api_rate_limit.
+
+DO $patch$
+DECLARE
+    v_funcs   text[] := ARRAY[
+        'api_search_products',
+        'api_search_autocomplete',
+        'api_product_detail_by_ean',
+        'api_track_event',
+        'api_get_filter_options'
+    ];
+    v_func    text;
+    v_def     text;
+    v_patched text;
+    v_block   text;
+BEGIN
+    FOREACH v_func IN ARRAY v_funcs LOOP
+        -- Get current function definition
+        SELECT pg_get_functiondef(p.oid)
+        INTO   v_def
+        FROM   pg_proc p
+        WHERE  p.proname = v_func
+          AND  p.pronamespace = 'public'::regnamespace;
+
+        IF v_def IS NULL THEN
+            RAISE EXCEPTION 'Function public.% not found', v_func;
+        END IF;
+
+        -- Skip if already patched (idempotency)
+        IF v_def LIKE '%check_api_rate_limit%' THEN
+            RAISE NOTICE 'Function % already has rate limit check, skipping', v_func;
+            CONTINUE;
+        END IF;
+
+        -- Build the rate limit injection block
+        v_block := '    -- Rate limit enforcement (#472)' || chr(10)
+                || '    v_rate_check := check_api_rate_limit(auth.uid(), '
+                || quote_literal(v_func) || ');' || chr(10)
+                || '    IF NOT (v_rate_check->>''allowed'')::boolean THEN' || chr(10)
+                || '        RETURN jsonb_build_object(' || chr(10)
+                || '            ''api_version'',         ''1.0'',' || chr(10)
+                || '            ''error'',               ''rate_limit_exceeded'',' || chr(10)
+                || '            ''message'',             ''Too many requests. Please try again later.'',' || chr(10)
+                || '            ''retry_after_seconds'', (v_rate_check->>''retry_after_seconds'')::integer,' || chr(10)
+                || '            ''current_count'',       (v_rate_check->>''current_count'')::integer,' || chr(10)
+                || '            ''max_allowed'',         (v_rate_check->>''max_allowed'')::integer' || chr(10)
+                || '        );' || chr(10)
+                || '    END IF;' || chr(10) || chr(10);
+
+        v_patched := v_def;
+
+        -- Add v_rate_check variable to DECLARE section
+        v_patched := regexp_replace(
+            v_patched,
+            'DECLARE' || chr(10),
+            'DECLARE' || chr(10) || '    v_rate_check  jsonb;' || chr(10)
+        );
+
+        -- Inject rate limit check block after BEGIN
+        v_patched := regexp_replace(
+            v_patched,
+            'BEGIN' || chr(10),
+            'BEGIN' || chr(10) || v_block
+        );
+
+        -- Verify the patch was applied
+        IF v_patched NOT LIKE '%check_api_rate_limit%' THEN
+            RAISE EXCEPTION 'Failed to patch % — rate limit check not found in output', v_func;
+        END IF;
+
+        -- Execute the patched CREATE OR REPLACE FUNCTION
+        EXECUTE v_patched;
+        RAISE NOTICE 'Patched % with rate limit check', v_func;
+    END LOOP;
+END;
+$patch$;
+
+
+-- ─── Phase 3: Convert api_better_alternatives to plpgsql with rate limit ───
+-- Original was LANGUAGE sql — cannot inject IF/THEN logic without conversion.
+
+CREATE OR REPLACE FUNCTION public.api_better_alternatives(
+    p_product_id              bigint,
+    p_same_category           boolean  DEFAULT true,
+    p_limit                   integer  DEFAULT 5,
+    p_diet_preference         text     DEFAULT NULL,
+    p_avoid_allergens         text[]   DEFAULT NULL,
+    p_strict_diet             boolean  DEFAULT false,
+    p_strict_allergen         boolean  DEFAULT false,
+    p_treat_may_contain       boolean  DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+    v_rate_check jsonb;
+    v_result     jsonb;
+BEGIN
+    -- Rate limit enforcement (#472)
+    v_rate_check := check_api_rate_limit(auth.uid(), 'api_better_alternatives');
+    IF NOT (v_rate_check->>'allowed')::boolean THEN
+        RETURN jsonb_build_object(
+            'api_version',         '1.0',
+            'error',               'rate_limit_exceeded',
+            'message',             'Too many requests. Please try again later.',
+            'retry_after_seconds', (v_rate_check->>'retry_after_seconds')::integer,
+            'current_count',       (v_rate_check->>'current_count')::integer,
+            'max_allowed',         (v_rate_check->>'max_allowed')::integer
+        );
+    END IF;
+
+    -- Original SQL body preserved as SELECT ... INTO
+    SELECT jsonb_build_object(
+        'api_version',     '1.0',
+        'source_product', jsonb_build_object(
+            'product_id',         m.product_id,
+            'product_name',       m.product_name,
+            'brand',              m.brand,
+            'category',           m.category,
+            'unhealthiness_score',m.unhealthiness_score,
+            'nutri_score',        m.nutri_score_label
+        ),
+        'search_scope',    CASE WHEN p_same_category THEN 'same_category' ELSE 'all_categories' END,
+        'alternatives',    COALESCE((
+            SELECT jsonb_agg(jsonb_build_object(
+                'product_id',         alt.alt_product_id,
+                'product_name',       alt.product_name,
+                'brand',              alt.brand,
+                'category',           alt.category,
+                'unhealthiness_score',alt.unhealthiness_score,
+                'score_improvement',  alt.score_improvement,
+                'nutri_score',        alt.nutri_score_label,
+                'similarity',         alt.jaccard_similarity,
+                'shared_ingredients', alt.shared_ingredients
+            ))
+            FROM find_better_alternatives(
+                p_product_id, p_same_category,
+                LEAST(GREATEST(p_limit, 1), 20),
+                p_diet_preference, p_avoid_allergens,
+                p_strict_diet, p_strict_allergen, p_treat_may_contain
+            ) alt
+        ), '[]'::jsonb),
+        'alternatives_count', COALESCE((
+            SELECT COUNT(*)::int
+            FROM find_better_alternatives(
+                p_product_id, p_same_category,
+                LEAST(GREATEST(p_limit, 1), 20),
+                p_diet_preference, p_avoid_allergens,
+                p_strict_diet, p_strict_allergen, p_treat_may_contain
+            )
+        ), 0)
+    )
+    INTO v_result
+    FROM v_master m
+    WHERE m.product_id = p_product_id;
+
+    RETURN v_result;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.api_better_alternatives(
+    bigint, boolean, integer, text, text[], boolean, boolean, boolean
+) IS
+    'Healthier alternatives with optional diet/allergen filtering. '
+    'Country isolation is automatic (inferred from source product). '
+    'All preference params default to NULL/false — existing callers unaffected. '
+    'Rate-limited via check_api_rate_limit (#472).';
+
+
+-- ─── Phase 4: Retention policy for rate limit log ──────────────────────────
+
+INSERT INTO retention_policies (table_name, timestamp_column, active_retention_days, is_enabled)
+VALUES ('api_rate_limit_log', 'called_at', 2, true)
+ON CONFLICT (table_name) DO UPDATE SET
+    active_retention_days = EXCLUDED.active_retention_days,
+    is_enabled            = EXCLUDED.is_enabled;
+
+
+-- ─── Phase 5: RLS + grants ─────────────────────────────────────────────────
+
+-- api_rate_limits: config table — read for authenticated, full for service_role
+ALTER TABLE public.api_rate_limits ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'api_rate_limits_select_authenticated') THEN
+        CREATE POLICY api_rate_limits_select_authenticated
+            ON api_rate_limits FOR SELECT TO authenticated USING (true);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'api_rate_limits_all_service') THEN
+        CREATE POLICY api_rate_limits_all_service
+            ON api_rate_limits FOR ALL TO service_role USING (true) WITH CHECK (true);
+    END IF;
+END $$;
+
+GRANT SELECT ON api_rate_limits TO authenticated;
+GRANT ALL    ON api_rate_limits TO service_role;
+
+-- api_rate_limit_log: ephemeral tracking — no direct access for users, full for service_role
+ALTER TABLE public.api_rate_limit_log ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'api_rate_limit_log_all_service') THEN
+        CREATE POLICY api_rate_limit_log_all_service
+            ON api_rate_limit_log FOR ALL TO service_role USING (true) WITH CHECK (true);
+    END IF;
+END $$;
+
+GRANT ALL ON api_rate_limit_log TO service_role;
+
+-- check_api_rate_limit: callable by authenticated users and service_role
+REVOKE EXECUTE ON FUNCTION public.check_api_rate_limit(uuid, text) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.check_api_rate_limit(uuid, text) TO authenticated, service_role;
+
+-- Preserve existing grants on patched functions (CREATE OR REPLACE preserves them,
+-- but explicitly ensure api_better_alternatives retains correct grants after
+-- SQL → plpgsql conversion)
+REVOKE EXECUTE ON FUNCTION public.api_better_alternatives(
+    bigint, boolean, integer, text, text[], boolean, boolean, boolean
+) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.api_better_alternatives(
+    bigint, boolean, integer, text, text[], boolean, boolean, boolean
+) TO authenticated, service_role;

--- a/supabase/tests/schema_contracts.test.sql
+++ b/supabase/tests/schema_contracts.test.sql
@@ -7,7 +7,7 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 
 BEGIN;
-SELECT plan(204);
+SELECT plan(207);
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 1. Core data tables exist
@@ -306,6 +306,11 @@ SELECT has_function('public', 'check_scan_rate_limit',        'function check_sc
 SELECT has_function('public', 'score_submission_quality',         'function score_submission_quality exists');
 SELECT has_function('public', '_score_submission_quality',        'function _score_submission_quality exists');
 SELECT has_trigger('product_submissions', 'trg_submission_quality_triage', 'auto-triage trigger exists on product_submissions');
+
+-- ─── API Rate Limiting (#472) ────────────────────────────────────────────────
+SELECT has_table('public', 'api_rate_limits',              'table api_rate_limits exists');
+SELECT has_table('public', 'api_rate_limit_log',           'table api_rate_limit_log exists');
+SELECT has_function('public', 'check_api_rate_limit',      'function check_api_rate_limit exists');
 
 SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
## Summary

Implements #472 — generic per-endpoint rate limiting for 6 API functions that were previously unprotected against abuse.

Complements #466 (submission/scan rate limiting) by covering the remaining attack surface: search, autocomplete, EAN enumeration, telemetry, filter options, and alternatives endpoints.

## Changes

### Infrastructure (Phase 1)
- **`api_rate_limits`** config table — 6 seeded endpoints with per-endpoint max_requests + window_seconds
- **`api_rate_limit_log`** ephemeral tracking table — indexed on (user_id, endpoint, called_at DESC)
- **`check_api_rate_limit(uuid, text)`** — generic rate checker (SECURITY DEFINER). Returns `{allowed, remaining}` or `{allowed:false, retry_after_seconds, current_count, max_allowed}`
- NULL user_id → always allowed (anon bypass; edge/Cloudflare handles anon abuse)
- Unconfigured endpoints → always allowed

### Rate Limits

| Endpoint | Limit | Window |
|----------|-------|--------|
| `api_search_products` | 30 | 1 min |
| `api_search_autocomplete` | 60 | 1 min |
| `api_product_detail_by_ean` | 100 | 1 hour |
| `api_track_event` | 500 | 1 hour |
| `api_get_filter_options` | 10 | 1 min |
| `api_better_alternatives` | 30 | 1 min |

### Integration (Phase 2-3)
- **5 plpgsql functions** patched via `pg_get_functiondef()` dynamic injection (idempotent: skips if already patched)
- **`api_better_alternatives`** converted from `LANGUAGE sql` to `LANGUAGE plpgsql` with rate limit block (SQL cannot support IF/THEN)
- All rate-limited responses follow canonical JSONB pattern: `{api_version, error: 'rate_limit_exceeded', message, retry_after_seconds, current_count, max_allowed}`

### Retention & Security (Phase 4-5)
- 2-day retention policy for `api_rate_limit_log`
- RLS: config table auth-read/service-write, log table service-role only
- Grants: `check_api_rate_limit` → authenticated + service_role

## Tests & QA
- **7 pgTAP tests** in search_functions (plan 30→37): NULL bypass, unconfigured endpoint, under/over limit, remaining count, retry_after_seconds, endpoint count
- **3 schema contracts** (plan 204→207): api_rate_limits, api_rate_limit_log, check_api_rate_limit
- **3 QA checks** in security_posture (32→35): SECURITY DEFINER, 6 endpoints, retention policy
- **Total QA: 699→702**

## File Impact
**6 files changed, +468 / -18 lines:**
- 1 new migration (287 lines)
- 3 modified test files
- 1 updated QA suite
- 2 doc/config updates