### PR TITLE
feat(api): admin submission dashboard with trust enrichment

### DIFF
--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -19,7 +19,7 @@
        13. QA__allergen_integrity.sql (14 allergen & trace integrity checks — blocking)
        14. QA__serving_source_validation.sql (16 serving & source checks — blocking)
        15. QA__ingredient_quality.sql (14 ingredient quality checks — blocking)
-       16. QA__security_posture.sql (38 security posture checks — blocking)
+       16. QA__security_posture.sql (40 security posture checks — blocking)
        17. QA__api_contract.sql (30 API contract checks — blocking)
        18. QA__scale_guardrails.sql (23 scale guardrails checks — blocking)
        19. QA__country_isolation.sql (6 country isolation checks — blocking)
@@ -147,7 +147,7 @@ $suiteCatalog = @(
     @{ Num = 13; Name = "Allergen & Trace Integrity"; Short = "Allergen"; Id = "allergen_integrity"; Checks = 15; Blocking = $true; Kind = "sql"; File = "QA__allergen_integrity.sql" },
     @{ Num = 14; Name = "Serving & Source Validation"; Short = "ServSource"; Id = "serving_source"; Checks = 16; Blocking = $true; Kind = "sql"; File = "QA__serving_source_validation.sql" },
     @{ Num = 15; Name = "Ingredient Data Quality"; Short = "IngredQual"; Id = "ingredient_quality"; Checks = 14; Blocking = $true; Kind = "sql"; File = "QA__ingredient_quality.sql" },
-    @{ Num = 16; Name = "Security Posture"; Short = "Security"; Id = "security_posture"; Checks = 38; Blocking = $true; Kind = "sql"; File = "QA__security_posture.sql" },
+    @{ Num = 16; Name = "Security Posture"; Short = "Security"; Id = "security_posture"; Checks = 40; Blocking = $true; Kind = "sql"; File = "QA__security_posture.sql" },
     @{ Num = 17; Name = "API Contract"; Short = "Contract"; Id = "api_contract"; Checks = 33; Blocking = $true; Kind = "sql"; File = "QA__api_contract.sql" },
     @{ Num = 18; Name = "Scale Guardrails"; Short = "Scale"; Id = "scale_guardrails"; Checks = 23; Blocking = $true; Kind = "sql"; File = "QA__scale_guardrails.sql" },
     @{ Num = 19; Name = "Country Isolation"; Short = "Country"; Id = "country_isolation"; Checks = 11; Blocking = $true; Kind = "sql"; File = "QA__country_isolation.sql" },

--- a/db/qa/QA__security_posture.sql
+++ b/db/qa/QA__security_posture.sql
@@ -1,5 +1,5 @@
 -- ============================================================
--- QA: Security Posture Validation — 38 checks
+-- QA: Security Posture Validation — 40 checks
 -- Ensures RLS, grant restrictions, SECURITY DEFINER attributes,
 -- and function access controls are in place.
 -- ============================================================
@@ -456,4 +456,20 @@ SELECT '38. user_trust_scores has trust_score range CHECK' AS check_name,
        CASE WHEN EXISTS (
            SELECT 1 FROM information_schema.check_constraints
            WHERE constraint_name = 'chk_trust_score_range'
+       ) THEN 0 ELSE 1 END AS violations;
+
+-- 39. api_admin_batch_reject_user is SECURITY DEFINER
+SELECT '39. api_admin_batch_reject_user is SECURITY DEFINER' AS check_name,
+       CASE WHEN EXISTS (
+           SELECT 1 FROM pg_proc
+           WHERE proname = 'api_admin_batch_reject_user'
+             AND prosecdef = true
+       ) THEN 0 ELSE 1 END AS violations;
+
+-- 40. api_admin_submission_velocity is SECURITY DEFINER
+SELECT '40. api_admin_submission_velocity is SECURITY DEFINER' AS check_name,
+       CASE WHEN EXISTS (
+           SELECT 1 FROM pg_proc
+           WHERE proname = 'api_admin_submission_velocity'
+             AND prosecdef = true
        ) THEN 0 ELSE 1 END AS violations;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1064,6 +1064,16 @@ export interface AdminSubmission extends Submission {
   notes: string | null;
   user_id: string;
   reviewed_at: string | null;
+  // Trust enrichment (#474)
+  user_trust_score: number;
+  user_total_submissions: number;
+  user_approved_pct: number | null;
+  user_flagged: boolean;
+  review_notes: string | null;
+  existing_product_match: {
+    product_id: number;
+    product_name: string;
+  } | null;
 }
 
 export interface AdminSubmissionsResponse {
@@ -1081,6 +1091,33 @@ export interface AdminReviewResponse {
   submission_id: string;
   status: string;
   merged_product_id?: number;
+  error?: string;
+}
+
+// ─── Admin Dashboard (#474) ─────────────────────────────────────────────────
+
+export interface AdminVelocityResponse {
+  api_version: string;
+  last_24h: number;
+  last_7d: number;
+  pending_count: number;
+  auto_rejected_24h: number;
+  status_breakdown: Record<string, number>;
+  top_submitters: {
+    user_id: string;
+    submission_count: number;
+    trust_score: number;
+    flagged: boolean;
+  }[];
+  error?: string;
+}
+
+export interface AdminBatchRejectResponse {
+  api_version: string;
+  rejected_count: number;
+  user_id: string;
+  user_flagged: boolean;
+  flag_reason: string;
   error?: string;
 }
 

--- a/supabase/migrations/20260315000600_admin_submission_dashboard.sql
+++ b/supabase/migrations/20260315000600_admin_submission_dashboard.sql
@@ -1,0 +1,235 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Migration: 20260315000600_admin_submission_dashboard.sql
+-- Ticket:    #474 — Admin dashboard for submission review & user flagging
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Enhances admin workflow with trust score visibility, batch operations,
+-- and submission velocity monitoring.
+--
+-- Phase 1: Enhanced api_admin_get_submissions (add trust score + quality data)
+-- Phase 2: api_admin_batch_reject_user (batch reject + flag user)
+-- Phase 3: api_admin_submission_velocity (velocity dashboard data)
+-- ═══════════════════════════════════════════════════════════════════════════
+-- To roll back: redeploy api_admin_get_submissions from 20260215200000;
+--               DROP FUNCTION IF EXISTS api_admin_batch_reject_user;
+--               DROP FUNCTION IF EXISTS api_admin_submission_velocity;
+-- ═══════════════════════════════════════════════════════════════════════════
+
+
+-- ─── Phase 1: Enhanced api_admin_get_submissions ───────────────────────────
+-- Adds: user_trust_score, user_total_submissions, user_approved_pct,
+--       review_notes (auto-triage), existing_product_match
+-- Backward compatible: all new keys are additive.
+
+CREATE OR REPLACE FUNCTION public.api_admin_get_submissions(
+  p_status    text    DEFAULT 'pending',
+  p_page      integer DEFAULT 1,
+  p_page_size integer DEFAULT 20
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_offset  integer;
+  v_total   bigint;
+  v_items   jsonb;
+BEGIN
+  v_offset := (GREATEST(p_page, 1) - 1) * LEAST(p_page_size, 50);
+
+  SELECT COUNT(*) INTO v_total
+    FROM public.product_submissions
+   WHERE (p_status = 'all' OR status = p_status);
+
+  SELECT COALESCE(jsonb_agg(row_obj ORDER BY rn), '[]'::jsonb)
+    INTO v_items
+    FROM (
+      SELECT
+        ROW_NUMBER() OVER (ORDER BY ps.created_at ASC) AS rn,
+        jsonb_build_object(
+          'id',               ps.id,
+          'ean',              ps.ean,
+          'product_name',     ps.product_name,
+          'brand',            ps.brand,
+          'category',         ps.category,
+          'photo_url',        ps.photo_url,
+          'notes',            ps.notes,
+          'status',           ps.status,
+          'user_id',          ps.user_id,
+          'merged_product_id', ps.merged_product_id,
+          'created_at',       ps.created_at,
+          'updated_at',       ps.updated_at,
+          'reviewed_at',      ps.reviewed_at,
+          -- ── Trust & quality enrichment (#474) ──────────────
+          'user_trust_score',       COALESCE(uts.trust_score, 50),
+          'user_total_submissions', COALESCE(uts.total_submissions, 0),
+          'user_approved_pct',      CASE
+            WHEN COALESCE(uts.total_submissions, 0) > 0
+            THEN round(100.0 * uts.approved_submissions / uts.total_submissions)
+            ELSE NULL
+          END,
+          'user_flagged',           (uts.flagged_at IS NOT NULL),
+          'review_notes',           ps.review_notes,
+          'existing_product_match', (
+            SELECT jsonb_build_object(
+              'product_id', p.product_id,
+              'product_name', p.product_name
+            )
+            FROM products p
+            WHERE p.ean = ps.ean AND p.is_deprecated IS NOT TRUE
+            LIMIT 1
+          )
+        ) AS row_obj
+      FROM public.product_submissions ps
+      LEFT JOIN public.user_trust_scores uts ON uts.user_id = ps.user_id
+      WHERE (p_status = 'all' OR ps.status = p_status)
+      ORDER BY ps.created_at ASC
+      OFFSET v_offset
+      LIMIT LEAST(p_page_size, 50)
+    ) sub;
+
+  RETURN jsonb_build_object(
+    'api_version', '1.0',
+    'total',       v_total,
+    'page',        GREATEST(p_page, 1),
+    'pages',       GREATEST(CEIL(v_total::numeric / LEAST(p_page_size, 50)), 1),
+    'page_size',   LEAST(p_page_size, 50),
+    'status_filter', p_status,
+    'submissions', v_items
+  );
+END;
+$$;
+
+-- Grants unchanged
+GRANT EXECUTE ON FUNCTION public.api_admin_get_submissions(text, integer, integer)
+  TO service_role, authenticated;
+
+
+-- ─── Phase 2: api_admin_batch_reject_user ──────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.api_admin_batch_reject_user(
+  p_user_id uuid,
+  p_reason  text DEFAULT 'Batch rejected: flagged user'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller uuid := auth.uid();
+  v_count  integer;
+BEGIN
+  -- Require authenticated caller
+  IF v_caller IS NULL THEN
+    RETURN jsonb_build_object(
+      'api_version', '1.0',
+      'error', 'authentication_required'
+    );
+  END IF;
+
+  -- Reject all pending submissions from the target user
+  UPDATE product_submissions
+     SET status      = 'rejected',
+         review_notes = p_reason,
+         reviewed_by  = v_caller,
+         reviewed_at  = now(),
+         updated_at   = now()
+   WHERE user_id = p_user_id
+     AND status IN ('pending', 'manual_review', 'flag_for_review');
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+
+  -- Flag user in trust scores (cap at 10, set flag)
+  INSERT INTO user_trust_scores (user_id, trust_score, flagged_at, flag_reason)
+  VALUES (p_user_id, 10, now(), p_reason)
+  ON CONFLICT (user_id) DO UPDATE SET
+    trust_score = LEAST(user_trust_scores.trust_score, 10),
+    flagged_at  = now(),
+    flag_reason = p_reason,
+    updated_at  = now();
+
+  RETURN jsonb_build_object(
+    'api_version', '1.0',
+    'rejected_count', v_count,
+    'user_id', p_user_id,
+    'user_flagged', true,
+    'flag_reason', p_reason
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.api_admin_batch_reject_user(uuid, text) IS
+  'Admin: batch-reject all pending/review submissions from a user + flag trust score. '
+  'Caps trust_score at 10, sets flagged_at + flag_reason.';
+
+REVOKE ALL ON FUNCTION public.api_admin_batch_reject_user(uuid, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.api_admin_batch_reject_user(uuid, text) TO service_role, authenticated;
+
+
+-- ─── Phase 3: api_admin_submission_velocity ────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.api_admin_submission_velocity()
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller uuid := auth.uid();
+BEGIN
+  IF v_caller IS NULL THEN
+    RETURN jsonb_build_object(
+      'api_version', '1.0',
+      'error', 'authentication_required'
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'api_version', '1.0',
+    'last_24h',          (SELECT COUNT(*) FROM product_submissions
+                          WHERE created_at > now() - interval '24 hours'),
+    'last_7d',           (SELECT COUNT(*) FROM product_submissions
+                          WHERE created_at > now() - interval '7 days'),
+    'pending_count',     (SELECT COUNT(*) FROM product_submissions
+                          WHERE status IN ('pending', 'manual_review', 'flag_for_review')),
+    'auto_rejected_24h', (SELECT COUNT(*) FROM product_submissions
+                          WHERE status = 'auto_reject'
+                            AND created_at > now() - interval '24 hours'),
+    'status_breakdown',  (
+      SELECT COALESCE(jsonb_object_agg(status, cnt), '{}'::jsonb)
+      FROM (
+        SELECT status, COUNT(*) AS cnt
+          FROM product_submissions
+         GROUP BY status
+      ) s
+    ),
+    'top_submitters',    (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'user_id', sub.user_id,
+        'submission_count', sub.cnt,
+        'trust_score', COALESCE(uts.trust_score, 50),
+        'flagged', (uts.flagged_at IS NOT NULL)
+      ) ORDER BY sub.cnt DESC), '[]'::jsonb)
+      FROM (
+        SELECT user_id, COUNT(*) AS cnt
+          FROM product_submissions
+         WHERE created_at > now() - interval '7 days'
+         GROUP BY user_id
+         ORDER BY cnt DESC
+         LIMIT 10
+      ) sub
+      LEFT JOIN user_trust_scores uts ON uts.user_id = sub.user_id
+    )
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.api_admin_submission_velocity() IS
+  'Admin: submission velocity dashboard — counts, status breakdown, top submitters. '
+  'Returns aggregated stats for the last 24h and 7d.';
+
+REVOKE ALL ON FUNCTION public.api_admin_submission_velocity() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.api_admin_submission_velocity() TO service_role, authenticated;

--- a/supabase/tests/scanner_functions.test.sql
+++ b/supabase/tests/scanner_functions.test.sql
@@ -7,7 +7,7 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 
 BEGIN;
-SELECT plan(59);
+SELECT plan(64);
 
 -- ─── Fixtures ───────────────────────────────────────────────────────────────
 
@@ -402,6 +402,39 @@ SELECT has_trigger(
 
 
 -- ─── 13. User trust scoring (#471) ──────────────────────────────────────────
+
+-- Admin dashboard functions (#474)
+SELECT has_function(
+  'api_admin_batch_reject_user',
+  'api_admin_batch_reject_user function exists'
+);
+
+SELECT has_function(
+  'api_admin_submission_velocity',
+  'api_admin_submission_velocity function exists'
+);
+
+-- api_admin_get_submissions returns trust enrichment keys
+SELECT lives_ok(
+  $$SELECT public.api_admin_get_submissions('all', 1, 5)$$,
+  'api_admin_get_submissions lives_ok with trust enrichment'
+);
+
+-- api_admin_submission_velocity returns expected keys
+SELECT ok(
+  public.api_admin_submission_velocity() ?& ARRAY['api_version', 'last_24h', 'last_7d', 'pending_count', 'status_breakdown', 'top_submitters'],
+  'api_admin_submission_velocity returns all expected keys'
+);
+
+-- api_admin_batch_reject_user returns auth error for anon
+SELECT is(
+  (public.api_admin_batch_reject_user('00000000-0000-0000-0000-000000000099'::uuid))->>'error',
+  'authentication_required',
+  'api_admin_batch_reject_user requires authentication'
+);
+
+
+-- ─── 14. User trust scoring (#471) ──────────────────────────────────────────
 
 -- Trust score adjustment trigger exists
 SELECT has_trigger(

--- a/supabase/tests/schema_contracts.test.sql
+++ b/supabase/tests/schema_contracts.test.sql
@@ -7,7 +7,7 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 
 BEGIN;
-SELECT plan(210);
+SELECT plan(212);
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 1. Core data tables exist
@@ -316,6 +316,10 @@ SELECT has_function('public', 'check_api_rate_limit',      'function check_api_r
 SELECT has_table('public', 'user_trust_scores',            'table user_trust_scores exists');
 SELECT has_column('public', 'user_trust_scores', 'trust_score', 'user_trust_scores has trust_score column');
 SELECT has_function('public', 'trig_adjust_trust_score',   'function trig_adjust_trust_score exists');
+
+-- ─── Admin Submission Dashboard (#474) ────────────────────────────────────────
+SELECT has_function('public', 'api_admin_batch_reject_user',     'function api_admin_batch_reject_user exists');
+SELECT has_function('public', 'api_admin_submission_velocity',   'function api_admin_submission_velocity exists');
 
 SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
## Summary

Closes #474 — Admin dashboard for submission review & user flagging.

Builds on #471 (user trust scoring) and #468 (auto-triage) to provide admins with:
- Trust-enriched submission cards (trust score badges, flagged indicators, auto-triage notes)
- Batch user rejection (reject all pending + flag account)
- Submission velocity dashboard (4-card grid: pending, 24h, 7d, auto-rejected)

## Changes

### Database (Migration `20260315000600`)
- **Enhanced `api_admin_get_submissions`**: LEFT JOIN to `user_trust_scores`, adds `user_trust_score`, `user_total_submissions`, `user_approved_pct`, `user_flagged`, `review_notes`, `existing_product_match` fields
- **New `api_admin_batch_reject_user(uuid, text)`**: Batch rejects all pending/manual_review/flag_for_review submissions from a user. Flags trust score (cap at 10). SECURITY DEFINER
- **New `api_admin_submission_velocity()`**: Returns submission velocity stats with status breakdown and top submitters with trust scores. SECURITY DEFINER

### Frontend
- **Velocity widget**: 4-card grid (Pending, Last 24h, Last 7d, Auto-Rejected 24h) at top of admin page
- **Enhanced `AdminSubmissionCard`**: Trust score badge (color-coded), flagged user indicator (ShieldAlert), auto-triage review notes, duplicate product warning, user submission stats, "Reject All" batch action button
- **Types**: Enhanced `AdminSubmission`, added `AdminVelocityResponse`, `AdminBatchRejectResponse`

### Tests
- **5 pgTAP tests** (scanner functions plan 59→64): function existence, lives_ok, auth error branches
- **2 schema contracts** (plan 210→212): has_function for batch_reject and velocity
- **2 QA security posture checks** (38→40): SECURITY DEFINER validation
- **10 frontend tests** (page.test.tsx 17→27): trust badge, flagged user, review notes, duplicate warning, user stats, velocity widget, batch reject button + mutation + toast

## Verification

- `npx tsc --noEmit` — 0 errors
- `npx vitest run page.test.tsx` — 27/27 pass
- QA count: 705→707
- Migration count: 173→174