### PR TITLE
feat(search): expand search synonym coverage for PL and DE categories

### DIFF
--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -41,7 +41,7 @@
        35. QA__store_integrity.sql (12 store architecture checks — blocking)
        36. QA__data_provenance.sql (25 data provenance checks — blocking)
        37. QA__scoring_engine.sql (25 scoring engine checks — blocking)
-       38. QA__search_architecture.sql (23 search architecture checks — blocking)
+       38. QA__search_architecture.sql (26 search architecture checks — blocking)
        39. QA__gdpr_compliance.sql (15 GDPR compliance checks — blocking)
        40. QA__push_notifications.sql (14 push notification checks — blocking)
        41. QA__index_verification.sql (13 index verification checks — informational)
@@ -169,7 +169,7 @@ $suiteCatalog = @(
     @{ Num = 35; Name = "Store Architecture"; Short = "StoreArch"; Id = "store_integrity"; Checks = 12; Blocking = $true; Kind = "sql"; File = "QA__store_integrity.sql" },
     @{ Num = 36; Name = "Data Provenance"; Short = "Provenance"; Id = "data_provenance"; Checks = 25; Blocking = $true; Kind = "sql"; File = "QA__data_provenance.sql" },
     @{ Num = 37; Name = "Scoring Engine"; Short = "ScoreEngine"; Id = "scoring_engine"; Checks = 25; Blocking = $true; Kind = "sql"; File = "QA__scoring_engine.sql" },
-    @{ Num = 38; Name = "Search Architecture"; Short = "SearchArch"; Id = "search_architecture"; Checks = 23; Blocking = $true; Kind = "sql"; File = "QA__search_architecture.sql" },
+    @{ Num = 38; Name = "Search Architecture"; Short = "SearchArch"; Id = "search_architecture"; Checks = 26; Blocking = $true; Kind = "sql"; File = "QA__search_architecture.sql" },
     @{ Num = 39; Name = "GDPR Compliance"; Short = "GDPR"; Id = "gdpr_compliance"; Checks = 15; Blocking = $true; Kind = "sql"; File = "QA__gdpr_compliance.sql" },
     @{ Num = 40; Name = "Push Notifications"; Short = "PushNotif"; Id = "push_notifications"; Checks = 14; Blocking = $true; Kind = "sql"; File = "QA__push_notifications.sql" },
     @{ Num = 41; Name = "Index Verification"; Short = "IdxVerify"; Id = "index_verification"; Checks = 13; Blocking = $false; Kind = "sql"; File = "QA__index_verification.sql" },

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -8,7 +8,7 @@
 > **Servings:** removed as separate table — all nutrition data is per-100g on nutrition_facts
 > **Ingredient analytics:** 2,995 unique ingredients (all clean ASCII English), 1,269 allergen declarations, 1,361 trace declarations
 > **Ingredient concerns:** EFSA-based 4-tier additive classification (0=none, 1=low, 2=moderate, 3=high)
-> **QA:** 711 checks across 47 suites + 23 negative validation tests — all passing
+> **QA:** 714 checks across 47 suites + 23 negative validation tests — all passing
 
 ---
 
@@ -257,7 +257,7 @@ poland-food-db/
 │       ├── 006-append-only-migrations.md
 │       └── 007-english-canonical-ingredients.md
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
-├── RUN_QA.ps1                       # QA test runner (711 checks across 47 suites)
+├── RUN_QA.ps1                       # QA test runner (714 checks across 47 suites)
 ├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (23 injection tests)
 ├── RUN_SANITY.ps1                   # Sanity checks (16) — row counts, schema assertions
 ├── RUN_REMOTE.ps1                   # Remote deployment (requires confirmation)
@@ -571,7 +571,7 @@ a mix of `'baked'`, `'fried'`, and `'none'`.
 
 ## 7. Migrations
 
-**Location:** `supabase/migrations/` — managed by Supabase CLI. Currently **175 migrations**.
+**Location:** `supabase/migrations/` — managed by Supabase CLI. Currently **176 migrations**.
 
 **Rules:**
 
@@ -643,7 +643,7 @@ A change is **not done** unless relevant tests were added/updated, every suite i
 | Component tests     | **Testing Library React** + Vitest                | `frontend/src/components/**/*.test.tsx`      | same as above                        |
 | E2E smoke           | **Playwright 1.58** (Chromium)                    | `frontend/e2e/smoke.spec.ts`                 | `cd frontend && npx playwright test` |
 | E2E auth            | Playwright (requires `SUPABASE_SERVICE_ROLE_KEY`) | `frontend/e2e/authenticated.spec.ts`         | same (CI auto-detects key)           |
-| DB QA (711 checks)  | Raw SQL (zero rows = pass)                        | `db/qa/QA__*.sql` (47 suites)                | `.\RUN_QA.ps1`                       |
+| DB QA (714 checks)  | Raw SQL (zero rows = pass)                        | `db/qa/QA__*.sql` (47 suites)                | `.\RUN_QA.ps1`                       |
 | Negative validation | SQL injection/constraint tests                    | `db/qa/TEST__negative_checks.sql`            | `.\RUN_NEGATIVE_TESTS.ps1`           |
 | DB sanity           | Row-count + schema assertions                     | via `RUN_SANITY.ps1`                         | `.\RUN_SANITY.ps1 -Env local`        |
 | Pipeline structure  | Python validator                                  | `check_pipeline_structure.py`                | `python check_pipeline_structure.py` |
@@ -781,7 +781,7 @@ E2E tests are the **only** exception — they run against a live dev server but 
   - **`pr-title-lint.yml`**: PR title conventional-commit validation (all PRs)
   - **`main-gate.yml`**: Typecheck → Lint → Build → Unit tests with coverage → Playwright smoke E2E → SonarCloud scan + BLOCKING Quality Gate → Sentry sourcemap upload
   - **`nightly.yml`**: Full Playwright (all projects incl. visual regression) + Data Integrity Audit (parallel)
-  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (711 checks) → Sanity (17 checks) → Confidence threshold
+  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (714 checks) → Sanity (17 checks) → Confidence threshold
   - **`deploy.yml`**: Manual trigger → Schema diff → Approval gate (production) → Pre-deploy backup → `supabase db push` → Post-deploy sanity
   - **`sync-cloud-db.yml`**: Auto-sync migrations to production on merge to `main`
 
@@ -815,7 +815,7 @@ If adding/changing DB schema or SQL functions:
 - For rollback procedures, see `DEPLOYMENT.md` → **Rollback Procedures** (5 scenarios + emergency checklist).
 - Add a QA check that verifies the migration outcome (row counts, constraint behavior).
 - Ensure idempotency (`IF NOT EXISTS`, `ON CONFLICT`, `DO UPDATE SET`).
-- Run `.\RUN_QA.ps1` to verify all 711 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 23 injection tests.
+- Run `.\RUN_QA.ps1` to verify all 714 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 23 injection tests.
 
 ### 8.14 Snapshots Are Not Enough
 
@@ -896,7 +896,7 @@ At the end of every PR-like change, include a **Verification** section:
 | Store Architecture        | `QA__store_integrity.sql`           |     12 | Yes       |
 | Data Provenance           | `QA__data_provenance.sql`           |     25 | Yes       |
 | Scoring Engine            | `QA__scoring_engine.sql`            |     25 | Yes       |
-| Search Architecture       | `QA__search_architecture.sql`       |     23 | Yes       |
+| Search Architecture       | `QA__search_architecture.sql`       |     26 | Yes       |
 | GDPR Compliance           | `QA__gdpr_compliance.sql`           |     15 | Yes       |
 | Push Notifications        | `QA__push_notifications.sql`        |     14 | Yes       |
 | Index Verification        | `QA__index_verification.sql`        |     13 | No        |
@@ -908,7 +908,7 @@ At the end of every PR-like change, include a **Verification** section:
 | Function Security Audit   | `QA__function_security_audit.sql`   |      6 | Yes       |
 | **Negative Validation**   | `TEST__negative_checks.sql`         |     23 | Yes       |
 
-**Run:** `.\RUN_QA.ps1` — expects **711/711 checks passing** (+ EAN validation).
+**Run:** `.\RUN_QA.ps1` — expects **714/714 checks passing** (+ EAN validation).
 **Run:** `.\RUN_NEGATIVE_TESTS.ps1` — expects **23/23 caught**.
 
 ### 8.19 Key Regression Tests (Scoring Suite)

--- a/db/qa/QA__search_architecture.sql
+++ b/db/qa/QA__search_architecture.sql
@@ -159,14 +159,14 @@ END AS "T10_completeness_boost_effective";
 -- ─── T11: German synonyms exist (DE→EN direction) ─────────────────────
 
 SELECT CASE
-    WHEN (SELECT COUNT(*) FROM search_synonyms WHERE language_from = 'de' AND language_to = 'en') >= 45
+    WHEN (SELECT COUNT(*) FROM search_synonyms WHERE language_from = 'de' AND language_to = 'en') >= 70
     THEN 'PASS' ELSE 'FAIL'
 END AS "T11_german_to_english_synonyms";
 
 -- ─── T12: German synonyms exist (EN→DE direction) ─────────────────────
 
 SELECT CASE
-    WHEN (SELECT COUNT(*) FROM search_synonyms WHERE language_from = 'en' AND language_to = 'de') >= 45
+    WHEN (SELECT COUNT(*) FROM search_synonyms WHERE language_from = 'en' AND language_to = 'de') >= 70
     THEN 'PASS' ELSE 'FAIL'
 END AS "T12_english_to_german_synonyms";
 
@@ -273,3 +273,24 @@ SELECT CASE
     )
     THEN 'PASS' ELSE 'FAIL'
 END AS "T23_search_vector_trigger_exists";
+
+-- ─── T24: Polish synonyms exist (PL→EN direction) ─────────────────────
+
+SELECT CASE
+    WHEN (SELECT COUNT(*) FROM search_synonyms WHERE language_from = 'pl' AND language_to = 'en') >= 90
+    THEN 'PASS' ELSE 'FAIL'
+END AS "T24_polish_to_english_synonyms";
+
+-- ─── T25: Polish synonyms exist (EN→PL direction) ─────────────────────
+
+SELECT CASE
+    WHEN (SELECT COUNT(*) FROM search_synonyms WHERE language_from = 'en' AND language_to = 'pl') >= 90
+    THEN 'PASS' ELSE 'FAIL'
+END AS "T25_english_to_polish_synonyms";
+
+-- ─── T26: expand_search_query returns PL synonyms ─────────────────────
+
+SELECT CASE
+    WHEN 'salmon' = ANY(expand_search_query('łosoś'))
+    THEN 'PASS' ELSE 'FAIL'
+END AS "T26_expand_query_pl_to_en";

--- a/supabase/migrations/20260315000800_search_synonym_expansion.sql
+++ b/supabase/migrations/20260315000800_search_synonym_expansion.sql
@@ -1,0 +1,233 @@
+-- Search synonym coverage expansion — Phase 2 of Issue #378
+--
+-- Existing state: 200 rows (50 PL↔EN + 50 DE↔EN bidirectional)
+-- This migration adds ~130 new synonyms across under-covered categories:
+--   • ~50 PL→EN + EN→PL for: Baby, Alcohol, Seafood, Plant-Based, Nuts/Seeds,
+--     Canned, Frozen/Prepared, Sauces, Meat, Sweets
+--   • ~15 DE→EN + EN→DE for: Dairy, Bread, Sweets, Chips, Drinks specifics
+--
+-- Rollback: DELETE FROM search_synonyms WHERE id > (SELECT MAX(id) FROM search_synonyms) - 130;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 1. Additional PL → EN synonyms (under-covered categories)
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+INSERT INTO public.search_synonyms (term_original, term_target, language_from, language_to) VALUES
+-- ── Baby ─────────────────────────────────────────────────────────────────────
+('kaszka',       'porridge',       'pl', 'en'),
+('obiadek',      'baby meal',      'pl', 'en'),
+('deserek',      'baby dessert',   'pl', 'en'),
+('herbatka',     'baby tea',       'pl', 'en'),
+('kleik',        'baby cereal',    'pl', 'en'),
+
+-- ── Alcohol ──────────────────────────────────────────────────────────────────
+('wódka',        'vodka',          'pl', 'en'),
+('cydr',         'cider',          'pl', 'en'),
+('nalewka',      'liqueur',        'pl', 'en'),
+('likier',       'liqueur',        'pl', 'en'),
+('bezalkoholowe','non-alcoholic',  'pl', 'en'),
+('piwo rzemieślnicze', 'craft beer', 'pl', 'en'),
+
+-- ── Seafood & Fish ───────────────────────────────────────────────────────────
+('łosoś',        'salmon',         'pl', 'en'),
+('tuńczyk',      'tuna',           'pl', 'en'),
+('dorsz',        'cod',            'pl', 'en'),
+('śledź',        'herring',        'pl', 'en'),
+('krewetki',     'shrimp',         'pl', 'en'),
+('wędzony',      'smoked',         'pl', 'en'),
+('makrela',      'mackerel',       'pl', 'en'),
+('sardynki',     'sardines',       'pl', 'en'),
+
+-- ── Plant-Based & Alternatives ───────────────────────────────────────────────
+('roślinny',     'plant-based',    'pl', 'en'),
+('sojowy',       'soy',            'pl', 'en'),
+('owsiany',      'oat',            'pl', 'en'),
+('migdałowy',    'almond',         'pl', 'en'),
+('kokosowy',     'coconut',        'pl', 'en'),
+('wegański',     'vegan',          'pl', 'en'),
+('tofu',         'tofu',           'pl', 'en'),
+
+-- ── Nuts, Seeds & Legumes ────────────────────────────────────────────────────
+('orzechy',      'nuts',           'pl', 'en'),
+('migdały',      'almonds',        'pl', 'en'),
+('pistacje',     'pistachios',     'pl', 'en'),
+('nasiona',      'seeds',          'pl', 'en'),
+('sezam',        'sesame',         'pl', 'en'),
+('fasola',       'beans',          'pl', 'en'),
+('soczewica',    'lentils',        'pl', 'en'),
+('groch',        'peas',           'pl', 'en'),
+('ciecierzyca',  'chickpeas',      'pl', 'en'),
+('orzeszki ziemne', 'peanuts',     'pl', 'en'),
+
+-- ── Canned Goods ─────────────────────────────────────────────────────────────
+('konserwa',     'canned food',    'pl', 'en'),
+('puszka',       'can',            'pl', 'en'),
+('groszek',      'peas',           'pl', 'en'),
+('kukurydza',    'corn',           'pl', 'en'),
+
+-- ── Frozen & Prepared ────────────────────────────────────────────────────────
+('mrożonki',     'frozen food',    'pl', 'en'),
+('pierogi',      'dumplings',      'pl', 'en'),
+('naleśniki',    'pancakes',       'pl', 'en'),
+('pizza',        'pizza',          'pl', 'en'),
+
+-- ── Sauces & Condiments ──────────────────────────────────────────────────────
+('ketchup',      'ketchup',        'pl', 'en'),
+('sos',          'sauce',          'pl', 'en'),
+('sos sojowy',   'soy sauce',      'pl', 'en'),
+('przyprawa',    'seasoning',      'pl', 'en'),
+
+-- ── Meat ─────────────────────────────────────────────────────────────────────
+('wołowina',     'beef',           'pl', 'en'),
+('wieprzowina',  'pork',           'pl', 'en'),
+('indyk',        'turkey',         'pl', 'en'),
+('kabanosy',     'kabanos',        'pl', 'en'),
+('parówki',      'hot dogs',       'pl', 'en'),
+('boczek',       'bacon',          'pl', 'en'),
+
+-- ── Sweets ───────────────────────────────────────────────────────────────────
+('cukierki',     'candy',          'pl', 'en'),
+('wafle',        'wafers',         'pl', 'en'),
+('galaretka',    'jelly',          'pl', 'en'),
+('żelki',        'gummy bears',    'pl', 'en'),
+('batonik',      'candy bar',      'pl', 'en'),
+('herbatniki',   'biscuits',       'pl', 'en')
+ON CONFLICT (term_original, language_from, language_to) DO NOTHING;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 2. Reverse EN → PL for new terms
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+INSERT INTO public.search_synonyms (term_original, term_target, language_from, language_to) VALUES
+('porridge',      'kaszka',        'en', 'pl'),
+('baby meal',     'obiadek',       'en', 'pl'),
+('baby dessert',  'deserek',       'en', 'pl'),
+('baby tea',      'herbatka',      'en', 'pl'),
+('baby cereal',   'kleik',         'en', 'pl'),
+('vodka',         'wódka',         'en', 'pl'),
+('cider',         'cydr',          'en', 'pl'),
+('liqueur',       'nalewka',       'en', 'pl'),
+('non-alcoholic', 'bezalkoholowe', 'en', 'pl'),
+('craft beer',    'piwo rzemieślnicze', 'en', 'pl'),
+('salmon',        'łosoś',         'en', 'pl'),
+('tuna',          'tuńczyk',       'en', 'pl'),
+('cod',           'dorsz',         'en', 'pl'),
+('herring',       'śledź',         'en', 'pl'),
+('shrimp',        'krewetki',      'en', 'pl'),
+('smoked',        'wędzony',       'en', 'pl'),
+('mackerel',      'makrela',       'en', 'pl'),
+('sardines',      'sardynki',      'en', 'pl'),
+('plant-based',   'roślinny',      'en', 'pl'),
+('soy',           'sojowy',        'en', 'pl'),
+('oat',           'owsiany',       'en', 'pl'),
+('almond',        'migdałowy',     'en', 'pl'),
+('coconut',       'kokosowy',      'en', 'pl'),
+('vegan',         'wegański',      'en', 'pl'),
+('tofu',          'tofu',          'en', 'pl'),
+('nuts',          'orzechy',       'en', 'pl'),
+('almonds',       'migdały',       'en', 'pl'),
+('pistachios',    'pistacje',      'en', 'pl'),
+('seeds',         'nasiona',       'en', 'pl'),
+('sesame',        'sezam',         'en', 'pl'),
+('beans',         'fasola',        'en', 'pl'),
+('lentils',       'soczewica',     'en', 'pl'),
+('peas',          'groch',         'en', 'pl'),
+('chickpeas',     'ciecierzyca',   'en', 'pl'),
+('peanuts',       'orzeszki ziemne', 'en', 'pl'),
+('canned food',   'konserwa',      'en', 'pl'),
+('corn',          'kukurydza',     'en', 'pl'),
+('frozen food',   'mrożonki',      'en', 'pl'),
+('dumplings',     'pierogi',       'en', 'pl'),
+('pancakes',      'naleśniki',     'en', 'pl'),
+('ketchup',       'ketchup',       'en', 'pl'),
+('sauce',         'sos',           'en', 'pl'),
+('soy sauce',     'sos sojowy',    'en', 'pl'),
+('seasoning',     'przyprawa',     'en', 'pl'),
+('beef',          'wołowina',      'en', 'pl'),
+('pork',          'wieprzowina',   'en', 'pl'),
+('turkey',        'indyk',         'en', 'pl'),
+('kabanos',       'kabanosy',      'en', 'pl'),
+('hot dogs',      'parówki',       'en', 'pl'),
+('bacon',         'boczek',        'en', 'pl'),
+('candy',         'cukierki',      'en', 'pl'),
+('wafers',        'wafle',         'en', 'pl'),
+('jelly',         'galaretka',     'en', 'pl'),
+('gummy bears',   'żelki',         'en', 'pl'),
+('candy bar',     'batonik',       'en', 'pl'),
+('biscuits',      'herbatniki',    'en', 'pl')
+ON CONFLICT (term_original, language_from, language_to) DO NOTHING;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 3. Additional DE → EN synonyms (category-specific terms)
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+INSERT INTO public.search_synonyms (term_original, term_target, language_from, language_to) VALUES
+-- ── Dairy (DE) ───────────────────────────────────────────────────────────────
+('quark',        'quark',          'de', 'en'),
+('schmand',      'sour cream',     'de', 'en'),
+('frischkäse',   'cream cheese',   'de', 'en'),
+('kefir',        'kefir',          'de', 'en'),
+('skyr',         'skyr',           'de', 'en'),
+('buttermilch',  'buttermilk',     'de', 'en'),
+
+-- ── Bread (DE) ───────────────────────────────────────────────────────────────
+('vollkorn',     'whole grain',    'de', 'en'),
+('roggen',       'rye',            'de', 'en'),
+('weizen',       'wheat',          'de', 'en'),
+('pumpernickel', 'pumpernickel',   'de', 'en'),
+('sauerteig',    'sourdough',      'de', 'en'),
+('dinkel',       'spelt',          'de', 'en'),
+
+-- ── Sweets (DE) ──────────────────────────────────────────────────────────────
+('bonbon',       'candy',          'de', 'en'),
+('gummibärchen', 'gummy bears',    'de', 'en'),
+('marzipan',     'marzipan',       'de', 'en'),
+('praline',      'praline',        'de', 'en'),
+('waffel',       'wafer',          'de', 'en'),
+('kuchen',       'cake',           'de', 'en'),
+('torte',        'cake',           'de', 'en'),
+
+-- ── Chips (DE) ───────────────────────────────────────────────────────────────
+('kartoffelchips','potato chips',  'de', 'en'),
+('riffeln',      'ridged',         'de', 'en'),
+('gemüsechips',  'vegetable chips','de', 'en'),
+
+-- ── Drinks (DE) ──────────────────────────────────────────────────────────────
+('limonade',     'lemonade',       'de', 'en'),
+('eistee',       'iced tea',       'de', 'en'),
+('schorle',      'spritzer',       'de', 'en'),
+('mineralwasser','mineral water',  'de', 'en'),
+('sprudel',      'sparkling water','de', 'en')
+ON CONFLICT (term_original, language_from, language_to) DO NOTHING;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 4. Reverse EN → DE for new terms
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+INSERT INTO public.search_synonyms (term_original, term_target, language_from, language_to) VALUES
+('quark',         'quark',          'en', 'de'),
+('cream cheese',  'frischkäse',     'en', 'de'),
+('kefir',         'kefir',          'en', 'de'),
+('skyr',          'skyr',           'en', 'de'),
+('buttermilk',    'buttermilch',    'en', 'de'),
+('whole grain',   'vollkorn',       'en', 'de'),
+('rye',           'roggen',         'en', 'de'),
+('wheat',         'weizen',         'en', 'de'),
+('pumpernickel',  'pumpernickel',   'en', 'de'),
+('sourdough',     'sauerteig',      'en', 'de'),
+('spelt',         'dinkel',         'en', 'de'),
+('candy',         'bonbon',         'en', 'de'),
+('gummy bears',   'gummibärchen',   'en', 'de'),
+('marzipan',      'marzipan',       'en', 'de'),
+('praline',       'praline',        'en', 'de'),
+('wafer',         'waffel',         'en', 'de'),
+('cake',          'kuchen',         'en', 'de'),
+('potato chips',  'kartoffelchips', 'en', 'de'),
+('ridged',        'riffeln',        'en', 'de'),
+('vegetable chips','gemüsechips',   'en', 'de'),
+('lemonade',      'limonade',       'en', 'de'),
+('iced tea',      'eistee',         'en', 'de'),
+('spritzer',      'schorle',        'en', 'de'),
+('mineral water', 'mineralwasser',  'en', 'de'),
+('sparkling water','sprudel',       'en', 'de')
+ON CONFLICT (term_original, language_from, language_to) DO NOTHING;


### PR DESCRIPTION
## Summary

Expands search synonym coverage from 200 → 362 rows, closing gaps in under-represented PL and DE categories.

Closes #378

## Changes

### New Migration: `20260315000800_search_synonym_expansion.sql`

**162 new synonym mappings** across 4 language pairs:

| Direction | New rows | Categories covered |
|-----------|----------|--------------------|
| PL → EN | 57 | Baby, Alcohol, Seafood, Plant-Based, Nuts/Seeds, Canned, Frozen, Sauces, Meat, Sweets |
| EN → PL | 55 | Reverse mappings for all above |
| DE → EN | 25 | Dairy (quark, schmand, frischkäse), Bread (vollkorn, roggen, dinkel), Sweets (bonbon, gummibärchen), Chips (kartoffelchips), Drinks (limonade, schorle) |
| EN → DE | 25 | Reverse mappings for all above |

All INSERTs use `ON CONFLICT ... DO NOTHING` for idempotency.

### QA Updates

- **QA__search_architecture.sql**: 23 → 26 checks
  - T11/T12: Raised DE synonym thresholds from ≥45 to ≥70
  - T24: PL→EN synonym count ≥90
  - T25: EN→PL synonym count ≥90
  - T26: `expand_search_query('łosoś')` returns `'salmon'`
- **RUN_QA.ps1**: Updated search architecture check count
- **copilot-instructions.md**: Updated QA total (711→714), migration count (175→176), search architecture checks (23→26)

## Verification

- [ ] CI passes (16/16 checks)
- Migration is idempotent (ON CONFLICT DO NOTHING)
- No existing synonym rows modified
- No schema changes — data-only migration