### PR TITLE
schema(migration): add per-product freshness tracking columns and view

### DIFF
--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -39,7 +39,7 @@
        33. QA__performance_regression.sql (6 performance regression checks — informational)
        34. QA__event_intelligence.sql (18 event intelligence checks — blocking)
        35. QA__store_integrity.sql (12 store architecture checks — blocking)
-       36. QA__data_provenance.sql (25 data provenance checks — blocking)
+       36. QA__data_provenance.sql (28 data provenance checks — blocking)
        37. QA__scoring_engine.sql (25 scoring engine checks — blocking)
        38. QA__search_architecture.sql (26 search architecture checks — blocking)
        39. QA__gdpr_compliance.sql (15 GDPR compliance checks — blocking)
@@ -167,7 +167,7 @@ $suiteCatalog = @(
     @{ Num = 33; Name = "Performance Regression"; Short = "PerfRegress"; Id = "performance_regression"; Checks = 6; Blocking = $false; Kind = "sql"; File = "QA__performance_regression.sql" },
     @{ Num = 34; Name = "Event Intelligence"; Short = "EventIntel"; Id = "event_intelligence"; Checks = 18; Blocking = $true; Kind = "sql"; File = "QA__event_intelligence.sql" },
     @{ Num = 35; Name = "Store Architecture"; Short = "StoreArch"; Id = "store_integrity"; Checks = 12; Blocking = $true; Kind = "sql"; File = "QA__store_integrity.sql" },
-    @{ Num = 36; Name = "Data Provenance"; Short = "Provenance"; Id = "data_provenance"; Checks = 25; Blocking = $true; Kind = "sql"; File = "QA__data_provenance.sql" },
+    @{ Num = 36; Name = "Data Provenance"; Short = "Provenance"; Id = "data_provenance"; Checks = 28; Blocking = $true; Kind = "sql"; File = "QA__data_provenance.sql" },
     @{ Num = 37; Name = "Scoring Engine"; Short = "ScoreEngine"; Id = "scoring_engine"; Checks = 25; Blocking = $true; Kind = "sql"; File = "QA__scoring_engine.sql" },
     @{ Num = 38; Name = "Search Architecture"; Short = "SearchArch"; Id = "search_architecture"; Checks = 26; Blocking = $true; Kind = "sql"; File = "QA__search_architecture.sql" },
     @{ Num = 39; Name = "GDPR Compliance"; Short = "GDPR"; Id = "gdpr_compliance"; Checks = 15; Blocking = $true; Kind = "sql"; File = "QA__gdpr_compliance.sql" },

--- a/supabase/migrations/20260315000900_data_freshness_tracking.sql
+++ b/supabase/migrations/20260315000900_data_freshness_tracking.sql
@@ -1,0 +1,112 @@
+-- Data freshness tracking — Phase 1 of Issue #357
+--
+-- Adds per-product freshness tracking columns:
+--   • last_fetched_at  — when data was last fetched/refreshed from source API
+--   • off_revision     — Open Food Facts internal revision number at time of fetch
+--
+-- Backfills last_fetched_at from created_at for all existing products.
+--
+-- Creates v_data_freshness_summary view for monitoring freshness by category/country.
+--
+-- Rollback: ALTER TABLE products DROP COLUMN IF EXISTS last_fetched_at, DROP COLUMN IF EXISTS off_revision;
+--           DROP VIEW IF EXISTS v_data_freshness_summary;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 1. Add columns
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+ALTER TABLE products
+  ADD COLUMN IF NOT EXISTS last_fetched_at timestamptz,
+  ADD COLUMN IF NOT EXISTS off_revision    integer;
+
+COMMENT ON COLUMN products.last_fetched_at IS
+  'Timestamp when this product was last fetched or refreshed from the source API (OFF).';
+COMMENT ON COLUMN products.off_revision IS
+  'Open Food Facts internal revision number at time of last fetch.';
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 2. Backfill existing products — set last_fetched_at to created_at
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+UPDATE products
+SET last_fetched_at = created_at
+WHERE last_fetched_at IS NULL
+  AND created_at IS NOT NULL;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 3. Check constraint — last_fetched_at must not be in the future
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'chk_products_last_fetched_not_future'
+  ) THEN
+    ALTER TABLE products
+      ADD CONSTRAINT chk_products_last_fetched_not_future
+      CHECK (last_fetched_at <= now() + interval '1 hour');
+  END IF;
+END $$;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 4. Check constraint — off_revision must be positive
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'chk_products_off_revision_positive'
+  ) THEN
+    ALTER TABLE products
+      ADD CONSTRAINT chk_products_off_revision_positive
+      CHECK (off_revision IS NULL OR off_revision > 0);
+  END IF;
+END $$;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 5. Index for freshness queries (stale product detection)
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+CREATE INDEX IF NOT EXISTS idx_products_last_fetched
+  ON products (last_fetched_at)
+  WHERE is_deprecated IS NOT TRUE AND last_fetched_at IS NOT NULL;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 6. Freshness summary view — monitoring dashboard
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE VIEW v_data_freshness_summary AS
+SELECT
+  p.country,
+  p.category,
+  COUNT(*)                                                        AS total_products,
+  COUNT(*) FILTER (WHERE p.last_fetched_at IS NOT NULL)           AS has_fetch_date,
+  COUNT(*) FILTER (WHERE p.last_fetched_at >= now() - interval '30 days')  AS fresh_30d,
+  COUNT(*) FILTER (WHERE p.last_fetched_at >= now() - interval '90 days'
+                     AND p.last_fetched_at <  now() - interval '30 days')  AS aging_30_90d,
+  COUNT(*) FILTER (WHERE p.last_fetched_at <  now() - interval '90 days')  AS stale_90d,
+  COUNT(*) FILTER (WHERE p.last_fetched_at IS NULL)               AS never_fetched,
+  MIN(p.last_fetched_at)                                          AS oldest_fetch,
+  MAX(p.last_fetched_at)                                          AS newest_fetch,
+  ROUND(
+    100.0 * COUNT(*) FILTER (WHERE p.last_fetched_at >= now() - interval '90 days')
+    / NULLIF(COUNT(*), 0), 1
+  )                                                                AS pct_fresh
+FROM products p
+WHERE p.is_deprecated IS NOT TRUE
+GROUP BY p.country, p.category
+ORDER BY pct_fresh NULLS LAST, p.country, p.category;
+
+COMMENT ON VIEW v_data_freshness_summary IS
+  'Per-country, per-category freshness breakdown. Used for monitoring data staleness.';
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 7. Grant permissions
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+GRANT SELECT ON v_data_freshness_summary TO anon, authenticated, service_role;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 8. Update v_master to include last_fetched_at
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+-- v_master already selects p.* columns, so last_fetched_at and off_revision
+-- are automatically included via the products table alias. No v_master change needed.

--- a/supabase/tests/schema_contracts.test.sql
+++ b/supabase/tests/schema_contracts.test.sql
@@ -7,7 +7,7 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 
 BEGIN;
-SELECT plan(212);
+SELECT plan(216);
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 1. Core data tables exist
@@ -320,6 +320,12 @@ SELECT has_function('public', 'trig_adjust_trust_score',   'function trig_adjust
 -- ─── Admin Submission Dashboard (#474) ────────────────────────────────────────
 SELECT has_function('public', 'api_admin_batch_reject_user',     'function api_admin_batch_reject_user exists');
 SELECT has_function('public', 'api_admin_submission_velocity',   'function api_admin_submission_velocity exists');
+
+-- ─── Data Freshness Tracking (#357) ──────────────────────────────────────────
+SELECT has_column('public', 'products', 'last_fetched_at',       'products.last_fetched_at exists');
+SELECT has_column('public', 'products', 'off_revision',          'products.off_revision exists');
+SELECT has_view('public', 'v_data_freshness_summary',            'view v_data_freshness_summary exists');
+SELECT has_index('public', 'products', 'idx_products_last_fetched', 'index idx_products_last_fetched exists');
 
 SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
## Summary

Phase 1 of #357 — adds per-product freshness tracking to enable data refresh monitoring and stale product detection.

## Changes

### Migration `20260315000900_data_freshness_tracking.sql`
- **`last_fetched_at`** (timestamptz) — when product data was last fetched from source API
- **`off_revision`** (integer) — Open Food Facts internal revision number at time of last fetch
- Backfill `last_fetched_at = created_at` for all existing products (no NULLs after migration)
- CHECK constraint: `last_fetched_at` cannot be in the future (+ 1h tolerance)
- CHECK constraint: `off_revision` must be positive or NULL
- Partial index `idx_products_last_fetched` for stale product queries
- **`v_data_freshness_summary`** view — per-country, per-category breakdown (total, fresh/aging/stale/never counts, pct_fresh)

### Tests & QA
- **pgTAP**: schema_contracts plan 212→216 — 4 new assertions (2 columns, 1 view, 1 index)
- **QA**: data_provenance checks 25→28:
  - T26: All active products have non-NULL `last_fetched_at` (backfill verification)
  - T27: No `last_fetched_at` values in the future
  - T28: `v_data_freshness_summary` covers all active categories

### Doc Updates
- `copilot-instructions.md`: 714→717 checks, 176→177 migrations, products column table + views section updated
- `RUN_QA.ps1`: data_provenance 25→28

## Phases Remaining
- **Phase 2**: Pipeline `--refresh` mode (re-fetch stale products, update `last_fetched_at` + `off_revision`)
- **Phase 3**: Freshness monitoring dashboard + alerts