### PR TITLE
schema(migration): add cross-country product_links table and API

### DIFF
--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -35,7 +35,7 @@
        29. QA__attribute_contradiction.sql (5 attribute contradiction checks — blocking)
        30. QA__monitoring.sql (14 monitoring & health checks — blocking)
        31. QA__scoring_determinism.sql (17 scoring determinism checks — blocking)
-       32. QA__multi_country_consistency.sql (10 multi-country consistency checks — blocking)
+       32. QA__multi_country_consistency.sql (13 multi-country consistency checks — blocking)
        33. QA__performance_regression.sql (6 performance regression checks — informational)
        34. QA__event_intelligence.sql (18 event intelligence checks — blocking)
        35. QA__store_integrity.sql (12 store architecture checks — blocking)
@@ -163,7 +163,7 @@ $suiteCatalog = @(
     @{ Num = 29; Name = "Attribute Contradictions"; Short = "AttrContra"; Id = "attribute_contradiction"; Checks = 5; Blocking = $true; Kind = "sql"; File = "QA__attribute_contradiction.sql" },
     @{ Num = 30; Name = "Monitoring & Health Check"; Short = "Monitoring"; Id = "monitoring"; Checks = 14; Blocking = $true; Kind = "sql"; File = "QA__monitoring.sql" },
     @{ Num = 31; Name = "Scoring Determinism"; Short = "Determinism"; Id = "scoring_determinism"; Checks = 17; Blocking = $true; Kind = "sql"; File = "QA__scoring_determinism.sql" },
-    @{ Num = 32; Name = "Multi-Country Consistency"; Short = "MultiCountry"; Id = "multi_country_consistency"; Checks = 10; Blocking = $true; Kind = "sql"; File = "QA__multi_country_consistency.sql" },
+    @{ Num = 32; Name = "Multi-Country Consistency"; Short = "MultiCountry"; Id = "multi_country_consistency"; Checks = 13; Blocking = $true; Kind = "sql"; File = "QA__multi_country_consistency.sql" },
     @{ Num = 33; Name = "Performance Regression"; Short = "PerfRegress"; Id = "performance_regression"; Checks = 6; Blocking = $false; Kind = "sql"; File = "QA__performance_regression.sql" },
     @{ Num = 34; Name = "Event Intelligence"; Short = "EventIntel"; Id = "event_intelligence"; Checks = 18; Blocking = $true; Kind = "sql"; File = "QA__event_intelligence.sql" },
     @{ Num = 35; Name = "Store Architecture"; Short = "StoreArch"; Id = "store_integrity"; Checks = 12; Blocking = $true; Kind = "sql"; File = "QA__store_integrity.sql" },

--- a/db/qa/QA__security_posture.sql
+++ b/db/qa/QA__security_posture.sql
@@ -131,7 +131,8 @@ WHERE n.nspname = 'public'
     'api_get_product_allergens',     -- public allergen batch lookup
     'api_product_provenance',         -- public product provenance/trust score (#193)
     'api_validate_event_schema',       -- public schema validation (#190)
-    'api_completeness_gap_analysis'    -- public completeness diagnostic (#376)
+    'api_completeness_gap_analysis',   -- public completeness diagnostic (#376)
+    'api_get_cross_country_links'      -- public cross-country links (#352)
   );
 
 -- 10. anon cannot EXECUTE internal computation functions

--- a/supabase/migrations/20260315001100_product_links.sql
+++ b/supabase/migrations/20260315001100_product_links.sql
@@ -1,0 +1,129 @@
+-- ============================================================
+-- Migration: product_links junction table
+-- Issue: #352 Phase 1 — Cross-country product linking
+-- Purpose: Enable explicit linking between products across
+--          countries (PL ↔ DE). Supports relationship types:
+--          identical, equivalent, variant, related.
+--          11 brands overlap between PL and DE but 0 EAN
+--          matches exist — all links require manual creation.
+-- Rollback: DROP TABLE IF EXISTS product_links CASCADE;
+-- ============================================================
+
+-- ─── 1. Create product_links table ──────────────────────────
+CREATE TABLE IF NOT EXISTS public.product_links (
+    link_id         bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    product_id_a    bigint NOT NULL REFERENCES products(product_id),
+    product_id_b    bigint NOT NULL REFERENCES products(product_id),
+    link_type       text NOT NULL CHECK (link_type IN (
+                      'identical', 'equivalent', 'variant', 'related'
+                    )),
+    confidence      text NOT NULL DEFAULT 'manual' CHECK (confidence IN (
+                      'manual', 'ean_match', 'brand_match', 'verified'
+                    )),
+    notes           text,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    -- Enforce ordering to prevent duplicate bidirectional rows
+    CONSTRAINT chk_product_links_ordered CHECK (product_id_a < product_id_b),
+    -- One link per product pair
+    CONSTRAINT uq_product_links_pair UNIQUE (product_id_a, product_id_b)
+);
+
+COMMENT ON TABLE public.product_links IS
+  'Cross-country product links. Bidirectional by design: '
+  'if PL→DE link exists, DE→PL is implicit. product_id_a < product_id_b enforced. '
+  'Issue #352.';
+
+COMMENT ON COLUMN public.product_links.link_type IS
+  'identical: same product/recipe, different market. '
+  'equivalent: same brand+category, minor regional differences. '
+  'variant: same brand, different flavor/size. '
+  'related: same category, comparable positioning by different brands.';
+
+COMMENT ON COLUMN public.product_links.confidence IS
+  'How the link was established: '
+  'manual: human-created. ean_match: same EAN found. '
+  'brand_match: heuristic brand+name match. verified: human-reviewed match.';
+
+-- ─── 2. Indexes ──────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_product_links_a
+    ON product_links(product_id_a);
+CREATE INDEX IF NOT EXISTS idx_product_links_b
+    ON product_links(product_id_b);
+
+-- ─── 3. RLS ──────────────────────────────────────────────────
+ALTER TABLE public.product_links ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'product_links'
+      AND policyname = 'product_links_read_all'
+  ) THEN
+    CREATE POLICY product_links_read_all
+      ON public.product_links FOR SELECT
+      USING (true);
+  END IF;
+END $$;
+
+-- Service role can insert/update/delete links
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'product_links'
+      AND policyname = 'product_links_service_write'
+  ) THEN
+    CREATE POLICY product_links_service_write
+      ON public.product_links FOR ALL
+      TO service_role
+      USING (true)
+      WITH CHECK (true);
+  END IF;
+END $$;
+
+GRANT SELECT ON public.product_links TO anon, authenticated;
+GRANT ALL ON public.product_links TO service_role;
+
+-- ─── 4. Helper function: get linked products ─────────────────
+CREATE OR REPLACE FUNCTION public.api_get_cross_country_links(
+    p_product_id bigint
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT COALESCE(jsonb_agg(
+        jsonb_build_object(
+            'link_id',    pl.link_id,
+            'link_type',  pl.link_type,
+            'confidence', pl.confidence,
+            'notes',      pl.notes,
+            'created_at', pl.created_at,
+            'product',    jsonb_build_object(
+                'product_id',   p.product_id,
+                'product_name', p.product_name,
+                'brand',        p.brand,
+                'country',      p.country,
+                'category',     p.category,
+                'unhealthiness_score', p.unhealthiness_score,
+                'nutri_score_label',   p.nutri_score_label
+            )
+        )
+        ORDER BY pl.link_type, p.product_name
+    ), '[]'::jsonb)
+    FROM product_links pl
+    JOIN products p ON p.product_id = CASE
+        WHEN pl.product_id_a = p_product_id THEN pl.product_id_b
+        ELSE pl.product_id_a
+    END
+    WHERE (pl.product_id_a = p_product_id OR pl.product_id_b = p_product_id)
+      AND p.is_deprecated IS NOT TRUE;
+$$;
+
+COMMENT ON FUNCTION public.api_get_cross_country_links IS
+  'Returns linked products for a given product_id. '
+  'Bidirectional: queries both product_id_a and product_id_b. '
+  'Returns empty JSON array if no links exist.';
+
+GRANT EXECUTE ON FUNCTION public.api_get_cross_country_links(bigint) TO anon, authenticated, service_role;

--- a/supabase/tests/schema_contracts.test.sql
+++ b/supabase/tests/schema_contracts.test.sql
@@ -7,7 +7,7 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 
 BEGIN;
-SELECT plan(219);
+SELECT plan(225);
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 1. Core data tables exist
@@ -331,6 +331,14 @@ SELECT has_index('public', 'products', 'idx_products_last_fetched', 'index idx_p
 SELECT has_table('public', 'product_type_ref',                   'table product_type_ref exists');
 SELECT has_column('public', 'product_type_ref', 'category',      'product_type_ref has category column');
 SELECT has_column('public', 'product_type_ref', 'display_name',  'product_type_ref has display_name column');
+
+-- ─── Cross-Country Product Links (#352) ──────────────────────────────────────
+SELECT has_table('public', 'product_links',                      'table product_links exists');
+SELECT has_column('public', 'product_links', 'product_id_a',     'product_links has product_id_a column');
+SELECT has_column('public', 'product_links', 'product_id_b',     'product_links has product_id_b column');
+SELECT has_column('public', 'product_links', 'link_type',        'product_links has link_type column');
+SELECT has_column('public', 'product_links', 'confidence',       'product_links has confidence column');
+SELECT has_function('public', 'api_get_cross_country_links',     'function api_get_cross_country_links exists');
 
 SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
## Summary

Phase 1 of #352 — adds the `product_links` junction table and `api_get_cross_country_links()` function for cross-country product linking between PL and DE.

Closes #352

## Changes

### Migration `20260315001100_product_links.sql`
- **`product_links`** table:
  - `link_id` (identity PK)
  - `product_id_a`, `product_id_b` (FK to products, ordered: a < b)
  - `link_type`: `identical` | `equivalent` | `variant` | `related`
  - `confidence`: `manual` | `ean_match` | `brand_match` | `verified`
  - `notes`, `created_at`
  - UNIQUE constraint on `(product_id_a, product_id_b)`
- **`api_get_cross_country_links(p_product_id)`** — returns linked products as JSONB array (bidirectional query)
- RLS: public SELECT, service_role ALL
- B-tree indexes on both FK columns

### 11 Overlapping Brands (PL ↔ DE)
Almette, Doritos, Dr. Oetker, GutBio, Lidl, Lorenz, Mestemacher, Milka, Pepsi, Vemondo, Wasa — links can now be manually created between their products.

### Tests & QA
- **pgTAP**: schema_contracts plan 219→225 — 6 new assertions (table, 4 columns, function)
- **QA**: multi_country_consistency 10→13:
  - T11: No links reference deprecated products
  - T12: All link_type values valid
  - T13: Ordering constraint (product_id_a < product_id_b)

### Doc Updates
- `copilot-instructions.md`: 719→722 checks, 178→179 migrations
- Tables section: added `product_links`
- Functions: added `api_get_cross_country_links()`

## Future Phases
- **Phase 2**: API surface updates (add `cross_country_links` to `api_product_detail`)
- **Phase 3**: Pipeline-assisted heuristic matching (brand+name similarity)