### PR TITLE
feat(schema): add recipe API functions + QA + pgTAP tests (#364)

### DIFF
--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -51,6 +51,7 @@
        45. QA__governance_drift.sql (8 governance drift checks — blocking)
        46. QA__rls_audit.sql (7 RLS audit checks — blocking)
        47. QA__function_security_audit.sql (6 function security audit checks — blocking)
+       48. QA__recipe_integrity.sql (6 recipe data integrity checks — blocking)
 
     Returns exit code 0 if all tests pass, 1 if any violations found.
     Test Suites 3, 33, 41, 42, 43, and 44 are informational and do not affect the exit code.
@@ -178,7 +179,8 @@ $suiteCatalog = @(
     @{ Num = 44; Name = "MV Refresh Cost"; Short = "MVRefresh"; Id = "mv_refresh_cost"; Checks = 10; Blocking = $false; Kind = "sql"; File = "QA__mv_refresh_cost.sql" },
     @{ Num = 45; Name = "Governance Drift"; Short = "GovDrift"; Id = "governance_drift"; Checks = 8; Blocking = $true; Kind = "sql"; File = "QA__governance_drift.sql" },
     @{ Num = 46; Name = "RLS Audit"; Short = "RLSAudit"; Id = "rls_audit"; Checks = 7; Blocking = $true; Kind = "sql"; File = "QA__rls_audit.sql" },
-    @{ Num = 47; Name = "Function Security Audit"; Short = "FuncSecAudit"; Id = "function_security_audit"; Checks = 6; Blocking = $true; Kind = "sql"; File = "QA__function_security_audit.sql" }
+    @{ Num = 47; Name = "Function Security Audit"; Short = "FuncSecAudit"; Id = "function_security_audit"; Checks = 6; Blocking = $true; Kind = "sql"; File = "QA__function_security_audit.sql" },
+    @{ Num = 48; Name = "Recipe Integrity"; Short = "RecipeInteg"; Id = "recipe_integrity"; Checks = 6; Blocking = $true; Kind = "sql"; File = "QA__recipe_integrity.sql" }
 )
 
 $suiteByNum = @{}

--- a/db/qa/QA__recipe_integrity.sql
+++ b/db/qa/QA__recipe_integrity.sql
@@ -1,0 +1,72 @@
+-- ============================================================
+-- QA: Recipe Data Integrity
+-- Validates recipe tables, FK relationships, and data quality.
+-- 6 checks — all BLOCKING.
+-- Issue: #364 — Recipe system completion
+-- ============================================================
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 1. All recipe_step rows reference existing recipes
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '1. recipe_step.recipe_id references recipe' AS check_name,
+       COUNT(*) AS violations
+FROM recipe_step rs
+LEFT JOIN recipe r ON r.id = rs.recipe_id
+WHERE r.id IS NULL;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 2. All recipe_ingredient rows reference existing recipes
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '2. recipe_ingredient.recipe_id references recipe' AS check_name,
+       COUNT(*) AS violations
+FROM recipe_ingredient ri
+LEFT JOIN recipe r ON r.id = ri.recipe_id
+WHERE r.id IS NULL;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 3. All recipe_ingredient_product rows reference active products
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '3. recipe_ingredient_product references active products' AS check_name,
+       COUNT(*) AS violations
+FROM recipe_ingredient_product rip
+JOIN products p ON p.product_id = rip.product_id
+WHERE p.is_deprecated = TRUE;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 4. Published recipes must have at least 1 ingredient and 1 step
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '4. published recipes have ingredients and steps' AS check_name,
+       COUNT(*) AS violations
+FROM recipe r
+WHERE r.is_published = TRUE
+  AND (
+    NOT EXISTS (SELECT 1 FROM recipe_ingredient ri WHERE ri.recipe_id = r.id)
+    OR
+    NOT EXISTS (SELECT 1 FROM recipe_step rs WHERE rs.recipe_id = r.id)
+  );
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 5. No duplicate step numbers within a recipe
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '5. no duplicate step numbers per recipe' AS check_name,
+       COUNT(*) AS violations
+FROM (
+    SELECT rs.recipe_id, rs.step_number, COUNT(*) AS cnt
+    FROM recipe_step rs
+    GROUP BY rs.recipe_id, rs.step_number
+    HAVING COUNT(*) > 1
+) dupes;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 6. API functions exist and are callable
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '6. recipe API functions exist' AS check_name,
+       3 - COUNT(*)::int AS violations
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+  AND p.proname IN (
+    'api_get_recipes',
+    'api_get_recipe_detail',
+    'api_get_recipe_nutrition'
+  );

--- a/db/qa/QA__security_posture.sql
+++ b/db/qa/QA__security_posture.sql
@@ -132,7 +132,10 @@ WHERE n.nspname = 'public'
     'api_product_provenance',         -- public product provenance/trust score (#193)
     'api_validate_event_schema',       -- public schema validation (#190)
     'api_completeness_gap_analysis',   -- public completeness diagnostic (#376)
-    'api_get_cross_country_links'      -- public cross-country links (#352)
+    'api_get_cross_country_links',     -- public cross-country links (#352)
+    'api_get_recipes',                 -- public recipe browsing (#364)
+    'api_get_recipe_detail',           -- public recipe detail (#364)
+    'api_get_recipe_nutrition'         -- public recipe nutrition (#364)
   );
 
 -- 10. anon cannot EXECUTE internal computation functions

--- a/supabase/migrations/20260315001400_recipe_api_functions.sql
+++ b/supabase/migrations/20260315001400_recipe_api_functions.sql
@@ -1,0 +1,298 @@
+-- ============================================================================
+-- Migration: 20260315001400_recipe_api_functions.sql
+-- Issue: #364 — Recipe system completion — API functions + QA
+-- Description: Creates api_get_recipes(), api_get_recipe_detail(), and
+--              api_get_recipe_nutrition() functions following API naming
+--              conventions. These wrap/extend the existing browse_recipes()
+--              and get_recipe_detail() RPCs with structured JSONB envelopes.
+-- Rollback: DROP FUNCTION IF EXISTS api_get_recipe_nutrition;
+--           DROP FUNCTION IF EXISTS api_get_recipe_detail;
+--           DROP FUNCTION IF EXISTS api_get_recipes;
+-- ============================================================================
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 1. api_get_recipes() — Browse published recipes with filters
+-- ════════════════════════════════════════════════════════════════════════════
+-- Used by: Recipe listing screen
+-- Supports filtering by country, category, tag, difficulty, max total time.
+-- Returns a JSON object with total_count + recipes array.
+
+CREATE OR REPLACE FUNCTION api_get_recipes(
+    p_country    text    DEFAULT NULL,
+    p_category   text    DEFAULT NULL,
+    p_tag        text    DEFAULT NULL,
+    p_difficulty text    DEFAULT NULL,
+    p_max_time   integer DEFAULT NULL,
+    p_limit      integer DEFAULT 20,
+    p_offset     integer DEFAULT 0
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+    v_total  integer;
+    v_rows   jsonb;
+BEGIN
+    -- Clamp pagination
+    p_limit  := LEAST(GREATEST(p_limit, 1), 100);
+    p_offset := GREATEST(p_offset, 0);
+
+    -- Total matching count
+    SELECT COUNT(*)::int INTO v_total
+    FROM recipe r
+    WHERE r.is_published = TRUE
+      AND (p_country IS NULL OR r.country IS NULL OR r.country = p_country)
+      AND (p_category IS NULL OR r.category = p_category)
+      AND (p_tag IS NULL OR p_tag = ANY(r.tags))
+      AND (p_difficulty IS NULL OR r.difficulty = p_difficulty)
+      AND (p_max_time IS NULL OR (r.prep_time_min + r.cook_time_min) <= p_max_time);
+
+    -- Build result rows
+    SELECT COALESCE(jsonb_agg(row_data ORDER BY created_at DESC), '[]'::jsonb)
+    INTO v_rows
+    FROM (
+        SELECT jsonb_build_object(
+            'id',              r.id,
+            'slug',            r.slug,
+            'title_key',       r.title_key,
+            'description_key', r.description_key,
+            'category',        r.category,
+            'difficulty',      r.difficulty,
+            'prep_time_min',   r.prep_time_min,
+            'cook_time_min',   r.cook_time_min,
+            'total_time_min',  r.prep_time_min + r.cook_time_min,
+            'servings',        r.servings,
+            'image_url',       r.image_url,
+            'country',         r.country,
+            'tags',            to_jsonb(r.tags),
+            'ingredient_count', (SELECT COUNT(*)::int FROM recipe_ingredient ri
+                                 WHERE ri.recipe_id = r.id),
+            'step_count',       (SELECT COUNT(*)::int FROM recipe_step rs
+                                 WHERE rs.recipe_id = r.id)
+        ) AS row_data,
+        r.created_at
+        FROM recipe r
+        WHERE r.is_published = TRUE
+          AND (p_country IS NULL OR r.country IS NULL OR r.country = p_country)
+          AND (p_category IS NULL OR r.category = p_category)
+          AND (p_tag IS NULL OR p_tag = ANY(r.tags))
+          AND (p_difficulty IS NULL OR r.difficulty = p_difficulty)
+          AND (p_max_time IS NULL OR (r.prep_time_min + r.cook_time_min) <= p_max_time)
+        ORDER BY r.created_at DESC
+        LIMIT p_limit OFFSET p_offset
+    ) sub;
+
+    RETURN jsonb_build_object(
+        'total_count',   v_total,
+        'limit',         p_limit,
+        'offset',        p_offset,
+        'filters',       jsonb_build_object(
+            'country',    p_country,
+            'category',   p_category,
+            'tag',        p_tag,
+            'difficulty', p_difficulty,
+            'max_time',   p_max_time
+        ),
+        'recipes',       v_rows
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION api_get_recipes IS
+    'Browse published recipes with optional filters. '
+    'Params: p_country, p_category (breakfast|lunch|dinner|snack|dessert|drink|salad|soup), '
+    'p_tag, p_difficulty (easy|medium|hard), p_max_time (minutes), p_limit (1-100), p_offset. '
+    'Returns JSON with total_count + recipes array. Each recipe includes id, slug, title_key, '
+    'description_key, category, difficulty, timing, servings, tags, ingredient_count, step_count.';
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 2. api_get_recipe_detail() — Full recipe with ingredients, steps, products
+-- ════════════════════════════════════════════════════════════════════════════
+-- Used by: Recipe detail screen
+-- Wraps get_recipe_detail() with additional metadata.
+-- Accepts slug (not UUID) following URL-friendly convention.
+
+CREATE OR REPLACE FUNCTION api_get_recipe_detail(
+    p_slug text
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+    v_recipe   record;
+    v_steps    jsonb;
+    v_ingredients jsonb;
+BEGIN
+    -- Find published recipe by slug
+    SELECT * INTO v_recipe
+    FROM recipe
+    WHERE slug = p_slug AND is_published = TRUE;
+
+    IF v_recipe IS NULL THEN
+        RETURN jsonb_build_object(
+            'error', 'Recipe not found',
+            'slug',  p_slug
+        );
+    END IF;
+
+    -- Build steps array
+    SELECT COALESCE(jsonb_agg(
+        jsonb_build_object(
+            'step_number', rs.step_number,
+            'content_key', rs.content_key
+        ) ORDER BY rs.step_number
+    ), '[]'::jsonb)
+    INTO v_steps
+    FROM recipe_step rs
+    WHERE rs.recipe_id = v_recipe.id;
+
+    -- Build ingredients array with linked products
+    SELECT COALESCE(jsonb_agg(
+        jsonb_build_object(
+            'id',                ri.id,
+            'name_key',          ri.name_key,
+            'sort_order',        ri.sort_order,
+            'optional',          ri.optional,
+            'ingredient_ref_id', ri.ingredient_ref_id,
+            'linked_products',   COALESCE((
+                SELECT jsonb_agg(jsonb_build_object(
+                    'product_id',          p.product_id,
+                    'product_name',        p.product_name,
+                    'brand',               p.brand,
+                    'ean',                 p.ean,
+                    'unhealthiness_score', p.unhealthiness_score,
+                    'is_primary',          rip.is_primary
+                ) ORDER BY rip.is_primary DESC, p.unhealthiness_score ASC NULLS LAST)
+                FROM recipe_ingredient_product rip
+                JOIN products p ON p.product_id = rip.product_id
+                    AND p.is_deprecated = FALSE
+                WHERE rip.recipe_ingredient_id = ri.id
+            ), '[]'::jsonb)
+        ) ORDER BY ri.sort_order
+    ), '[]'::jsonb)
+    INTO v_ingredients
+    FROM recipe_ingredient ri
+    WHERE ri.recipe_id = v_recipe.id;
+
+    RETURN jsonb_build_object(
+        'recipe', jsonb_build_object(
+            'id',              v_recipe.id,
+            'slug',            v_recipe.slug,
+            'title_key',       v_recipe.title_key,
+            'description_key', v_recipe.description_key,
+            'category',        v_recipe.category,
+            'difficulty',      v_recipe.difficulty,
+            'prep_time_min',   v_recipe.prep_time_min,
+            'cook_time_min',   v_recipe.cook_time_min,
+            'total_time_min',  v_recipe.prep_time_min + v_recipe.cook_time_min,
+            'servings',        v_recipe.servings,
+            'image_url',       v_recipe.image_url,
+            'country',         v_recipe.country,
+            'tags',            to_jsonb(v_recipe.tags)
+        ),
+        'ingredients',     v_ingredients,
+        'steps',           v_steps,
+        'ingredient_count', jsonb_array_length(v_ingredients),
+        'step_count',       jsonb_array_length(v_steps)
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION api_get_recipe_detail IS
+    'Full recipe detail by slug. Returns recipe metadata, ingredients (with linked products), '
+    'and steps. Each ingredient includes linked_products array with product_id, name, brand, '
+    'ean, unhealthiness_score, is_primary. Returns {error} if recipe not found or unpublished.';
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 3. api_get_recipe_nutrition() — Aggregate nutrition from linked products
+-- ════════════════════════════════════════════════════════════════════════════
+-- Used by: Recipe detail screen — nutrition summary section
+-- Aggregates nutrition data from linked products (primary products preferred).
+-- Returns averaged nutrition per ingredient and totals for the recipe.
+
+CREATE OR REPLACE FUNCTION api_get_recipe_nutrition(
+    p_slug text
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+    v_recipe_id     uuid;
+    v_linked_count  integer;
+    v_total_ingredients integer;
+    v_nutrition     jsonb;
+BEGIN
+    -- Find published recipe by slug
+    SELECT id INTO v_recipe_id
+    FROM recipe
+    WHERE slug = p_slug AND is_published = TRUE;
+
+    IF v_recipe_id IS NULL THEN
+        RETURN jsonb_build_object(
+            'error', 'Recipe not found',
+            'slug',  p_slug
+        );
+    END IF;
+
+    -- Count total ingredients and those with linked products
+    SELECT COUNT(*)::int INTO v_total_ingredients
+    FROM recipe_ingredient ri
+    WHERE ri.recipe_id = v_recipe_id;
+
+    SELECT COUNT(DISTINCT ri.id)::int INTO v_linked_count
+    FROM recipe_ingredient ri
+    JOIN recipe_ingredient_product rip ON rip.recipe_ingredient_id = ri.id
+    JOIN products p ON p.product_id = rip.product_id AND p.is_deprecated = FALSE
+    WHERE ri.recipe_id = v_recipe_id;
+
+    -- Aggregate nutrition from primary linked products (or first linked if no primary)
+    -- Uses DISTINCT ON to pick one product per ingredient (primary first, then healthiest)
+    SELECT COALESCE(jsonb_build_object(
+        'avg_calories',       ROUND(AVG(nf.calories)::numeric, 1),
+        'avg_total_fat_g',    ROUND(AVG(nf.total_fat_g)::numeric, 1),
+        'avg_saturated_fat_g', ROUND(AVG(nf.saturated_fat_g)::numeric, 1),
+        'avg_carbs_g',        ROUND(AVG(nf.carbs_g)::numeric, 1),
+        'avg_sugars_g',       ROUND(AVG(nf.sugars_g)::numeric, 1),
+        'avg_protein_g',      ROUND(AVG(nf.protein_g)::numeric, 1),
+        'avg_salt_g',         ROUND(AVG(nf.salt_g)::numeric, 1),
+        'avg_fiber_g',        ROUND(AVG(nf.fiber_g)::numeric, 1),
+        'avg_unhealthiness',  ROUND(AVG(p.unhealthiness_score)::numeric, 0),
+        'sum_calories',       ROUND(SUM(nf.calories)::numeric, 0),
+        'sum_total_fat_g',    ROUND(SUM(nf.total_fat_g)::numeric, 1),
+        'sum_protein_g',      ROUND(SUM(nf.protein_g)::numeric, 1),
+        'sum_sugars_g',       ROUND(SUM(nf.sugars_g)::numeric, 1),
+        'sum_salt_g',         ROUND(SUM(nf.salt_g)::numeric, 1)
+    ), '{}'::jsonb)
+    INTO v_nutrition
+    FROM (
+        SELECT DISTINCT ON (ri.id) ri.id, rip.product_id
+        FROM recipe_ingredient ri
+        JOIN recipe_ingredient_product rip ON rip.recipe_ingredient_id = ri.id
+        JOIN products p2 ON p2.product_id = rip.product_id AND p2.is_deprecated = FALSE
+        WHERE ri.recipe_id = v_recipe_id
+        ORDER BY ri.id, rip.is_primary DESC, p2.unhealthiness_score ASC NULLS LAST
+    ) best
+    JOIN products p ON p.product_id = best.product_id
+    JOIN nutrition_facts nf ON nf.product_id = p.product_id;
+
+    RETURN jsonb_build_object(
+        'slug',                 p_slug,
+        'total_ingredients',    v_total_ingredients,
+        'linked_ingredients',   v_linked_count,
+        'coverage_pct',         CASE WHEN v_total_ingredients > 0
+                                    THEN ROUND(100.0 * v_linked_count / v_total_ingredients, 0)
+                                    ELSE 0 END,
+        'nutrition_per_100g',   v_nutrition,
+        'note',                 'Nutrition values are per 100g averages from linked products. '
+                                'Not a true recipe nutrition calculation (no portion weights).'
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION api_get_recipe_nutrition IS
+    'Aggregate nutrition summary for a recipe from linked products. '
+    'Picks one product per ingredient (primary first, then healthiest). '
+    'Returns per-100g averages and sums, plus coverage percentage. '
+    'Note: approximation only — does not account for ingredient portions.';

--- a/supabase/tests/recipe_functions.test.sql
+++ b/supabase/tests/recipe_functions.test.sql
@@ -1,0 +1,222 @@
+-- ─── pgTAP: Recipe API function tests ────────────────────────────────────────
+-- Tests api_get_recipes, api_get_recipe_detail, api_get_recipe_nutrition.
+-- Run via: supabase test db
+--
+-- Self-contained: inserts own fixture data so tests work on an empty DB.
+-- Issue: #364 — Recipe system completion
+-- ─────────────────────────────────────────────────────────────────────────────
+
+BEGIN;
+SELECT plan(25);
+
+-- ─── Fixtures ───────────────────────────────────────────────────────────────
+
+-- Insert a test recipe with ingredients and steps
+INSERT INTO public.recipe (
+  id, slug, title_key, description_key, category, difficulty,
+  prep_time_min, cook_time_min, servings, country, is_published, tags
+) VALUES (
+  'a0000000-0000-0000-0000-000000000001'::uuid,
+  'pgtap-test-recipe',
+  'test.recipe.title',
+  'test.recipe.description',
+  'breakfast', 'easy', 10, 5, 2, 'PL', TRUE,
+  ARRAY['vegetarian', 'quick']
+) ON CONFLICT (slug) DO NOTHING;
+
+-- Unpublished recipe (should be excluded from API results)
+INSERT INTO public.recipe (
+  id, slug, title_key, description_key, category, difficulty,
+  prep_time_min, cook_time_min, servings, country, is_published, tags
+) VALUES (
+  'a0000000-0000-0000-0000-000000000002'::uuid,
+  'pgtap-unpublished-recipe',
+  'test.unpublished.title',
+  'test.unpublished.description',
+  'dinner', 'hard', 30, 60, 4, 'PL', FALSE,
+  ARRAY['advanced']
+) ON CONFLICT (slug) DO NOTHING;
+
+-- Add steps to published recipe
+INSERT INTO public.recipe_step (recipe_id, step_number, content_key)
+VALUES
+  ('a0000000-0000-0000-0000-000000000001'::uuid, 1, 'test.recipe.steps.1'),
+  ('a0000000-0000-0000-0000-000000000001'::uuid, 2, 'test.recipe.steps.2')
+ON CONFLICT (recipe_id, step_number) DO NOTHING;
+
+-- Add ingredients to published recipe
+INSERT INTO public.recipe_ingredient (id, recipe_id, name_key, sort_order, optional)
+VALUES
+  ('b0000000-0000-0000-0000-000000000001'::uuid,
+   'a0000000-0000-0000-0000-000000000001'::uuid,
+   'test.recipe.ingredients.1', 1, FALSE),
+  ('b0000000-0000-0000-0000-000000000002'::uuid,
+   'a0000000-0000-0000-0000-000000000001'::uuid,
+   'test.recipe.ingredients.2', 2, TRUE)
+ON CONFLICT (recipe_id, sort_order) DO NOTHING;
+
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 1. api_get_recipes — basic contract
+-- ═══════════════════════════════════════════════════════════════════════════
+
+SELECT lives_ok(
+  $$SELECT public.api_get_recipes()$$,
+  'api_get_recipes() does not throw with no args'
+);
+
+SELECT lives_ok(
+  $$SELECT public.api_get_recipes('PL', 'breakfast')$$,
+  'api_get_recipes(PL, breakfast) does not throw'
+);
+
+-- Top-level keys
+SELECT ok(
+  (public.api_get_recipes()) ? 'total_count',
+  'recipes response has total_count'
+);
+
+SELECT ok(
+  (public.api_get_recipes()) ? 'recipes',
+  'recipes response has recipes array'
+);
+
+SELECT ok(
+  (public.api_get_recipes()) ? 'filters',
+  'recipes response has filters'
+);
+
+SELECT ok(
+  (public.api_get_recipes()) ? 'limit',
+  'recipes response has limit'
+);
+
+SELECT ok(
+  (public.api_get_recipes()) ? 'offset',
+  'recipes response has offset'
+);
+
+-- Should return at least one recipe (our fixture)
+SELECT ok(
+  jsonb_array_length((public.api_get_recipes('PL', 'breakfast'))->'recipes') > 0,
+  'returns at least 1 breakfast recipe for PL'
+);
+
+-- Unpublished recipe should not appear
+SELECT is(
+  (SELECT COUNT(*)::int FROM jsonb_array_elements(
+    (public.api_get_recipes('PL', 'dinner'))->'recipes'
+  ) elem WHERE elem->>'slug' = 'pgtap-unpublished-recipe'),
+  0,
+  'unpublished recipe excluded from results'
+);
+
+-- Recipe element has expected keys
+SELECT ok(
+  ((public.api_get_recipes('PL', 'breakfast'))->'recipes'->0) ? 'slug',
+  'recipe element has slug'
+);
+
+SELECT ok(
+  ((public.api_get_recipes('PL', 'breakfast'))->'recipes'->0) ? 'title_key',
+  'recipe element has title_key'
+);
+
+SELECT ok(
+  ((public.api_get_recipes('PL', 'breakfast'))->'recipes'->0) ? 'ingredient_count',
+  'recipe element has ingredient_count'
+);
+
+SELECT ok(
+  ((public.api_get_recipes('PL', 'breakfast'))->'recipes'->0) ? 'step_count',
+  'recipe element has step_count'
+);
+
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 2. api_get_recipe_detail — valid slug
+-- ═══════════════════════════════════════════════════════════════════════════
+
+SELECT lives_ok(
+  $$SELECT public.api_get_recipe_detail('pgtap-test-recipe')$$,
+  'api_get_recipe_detail does not throw for valid slug'
+);
+
+-- Top-level keys
+SELECT ok(
+  (public.api_get_recipe_detail('pgtap-test-recipe')) ? 'recipe',
+  'detail has recipe object'
+);
+
+SELECT ok(
+  (public.api_get_recipe_detail('pgtap-test-recipe')) ? 'ingredients',
+  'detail has ingredients array'
+);
+
+SELECT ok(
+  (public.api_get_recipe_detail('pgtap-test-recipe')) ? 'steps',
+  'detail has steps array'
+);
+
+SELECT ok(
+  (public.api_get_recipe_detail('pgtap-test-recipe')) ? 'ingredient_count',
+  'detail has ingredient_count'
+);
+
+-- Should have 2 steps and 2 ingredients
+SELECT is(
+  ((public.api_get_recipe_detail('pgtap-test-recipe'))->>'step_count')::int,
+  2,
+  'detail shows 2 steps'
+);
+
+SELECT is(
+  ((public.api_get_recipe_detail('pgtap-test-recipe'))->>'ingredient_count')::int,
+  2,
+  'detail shows 2 ingredients'
+);
+
+-- Not-found returns error
+SELECT ok(
+  (public.api_get_recipe_detail('nonexistent-slug')) ? 'error',
+  'detail returns error for nonexistent slug'
+);
+
+-- Unpublished returns error
+SELECT ok(
+  (public.api_get_recipe_detail('pgtap-unpublished-recipe')) ? 'error',
+  'detail returns error for unpublished recipe'
+);
+
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 3. api_get_recipe_nutrition — basic contract
+-- ═══════════════════════════════════════════════════════════════════════════
+
+SELECT lives_ok(
+  $$SELECT public.api_get_recipe_nutrition('pgtap-test-recipe')$$,
+  'api_get_recipe_nutrition does not throw'
+);
+
+-- Top-level keys
+SELECT ok(
+  (public.api_get_recipe_nutrition('pgtap-test-recipe')) ? 'total_ingredients',
+  'nutrition has total_ingredients'
+);
+
+SELECT ok(
+  (public.api_get_recipe_nutrition('pgtap-test-recipe')) ? 'coverage_pct',
+  'nutrition has coverage_pct'
+);
+
+-- Not-found returns error
+SELECT ok(
+  (public.api_get_recipe_nutrition('nonexistent-slug')) ? 'error',
+  'nutrition returns error for nonexistent slug'
+);
+
+
+-- ─── Finish ─────────────────────────────────────────────────────────────────
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/schema_contracts.test.sql
+++ b/supabase/tests/schema_contracts.test.sql
@@ -7,7 +7,7 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 
 BEGIN;
-SELECT plan(237);
+SELECT plan(247);
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 1. Core data tables exist
@@ -355,6 +355,18 @@ SELECT has_column('public', 'ingredient_translations', 'name',              'ing
 SELECT has_column('public', 'ingredient_translations', 'source',            'ingredient_translations has source column');
 SELECT has_column('public', 'ingredient_translations', 'reviewed_at',       'ingredient_translations has reviewed_at column');
 SELECT has_function('public', 'resolve_ingredient_name',                    'function resolve_ingredient_name exists');
+
+-- ─── Recipe System (#364) ────────────────────────────────────────────────────
+SELECT has_table('public', 'recipe',                             'table recipe exists');
+SELECT has_table('public', 'recipe_step',                        'table recipe_step exists');
+SELECT has_table('public', 'recipe_ingredient',                  'table recipe_ingredient exists');
+SELECT has_table('public', 'recipe_ingredient_product',          'table recipe_ingredient_product exists');
+SELECT has_function('public', 'browse_recipes',                  'function browse_recipes exists');
+SELECT has_function('public', 'get_recipe_detail',               'function get_recipe_detail exists');
+SELECT has_function('public', 'find_products_for_recipe_ingredient', 'function find_products_for_recipe_ingredient exists');
+SELECT has_function('public', 'api_get_recipes',                 'function api_get_recipes exists');
+SELECT has_function('public', 'api_get_recipe_detail',           'function api_get_recipe_detail exists');
+SELECT has_function('public', 'api_get_recipe_nutrition',        'function api_get_recipe_nutrition exists');
 
 SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
## Summary

Completes Issue #364 — Recipe system completion (Phases 1, 3, 4).

The recipe system already has 4 tables (recipe, recipe_step, recipe_ingredient, recipe_ingredient_product) with seed data (12 recipes, 51 ingredients, 39 steps) and internal functions (browse_recipes, get_recipe_detail, find_products_for_recipe_ingredient). This PR adds the missing **API-convention functions**, **QA checks**, **pgTAP tests**, and **documentation**.

## Changes

### New Migration: `20260315001400_recipe_api_functions.sql`
- **`api_get_recipes()`** — Browse published recipes with filters (country, category, tag, difficulty, max_time). Returns paginated JSONB with total_count + recipes array. Each recipe includes ingredient_count and step_count.
- **`api_get_recipe_detail()`** — Full recipe detail by slug. Returns recipe metadata, ingredients (with linked products), and steps. Returns `{error}` for not-found/unpublished.
- **`api_get_recipe_nutrition()`** — Aggregate nutrition summary from linked products. Picks primary product per ingredient, returns per-100g averages and coverage percentage.

### New QA Suite: `QA__recipe_integrity.sql` (6 checks)
1. recipe_step FK references existing recipes
2. recipe_ingredient FK references existing recipes
3. recipe_ingredient_product references active (non-deprecated) products
4. Published recipes have ≥1 ingredient and ≥1 step
5. No duplicate step numbers within a recipe
6. All 3 API functions exist in pg_proc

### New pgTAP Tests: `recipe_functions.test.sql` (25 tests)
- Self-contained fixtures (test recipe, unpublished recipe, steps, ingredients)
- `api_get_recipes()`: lives_ok, response keys (total_count, recipes, filters, limit, offset), filter behavior, unpublished exclusion, element keys
- `api_get_recipe_detail()`: lives_ok, response structure (recipe, ingredients, steps, counts), not-found error, unpublished error
- `api_get_recipe_nutrition()`: lives_ok, response keys (total_ingredients, coverage_pct), not-found error

### Updated: `schema_contracts.test.sql` (plan: 237 → 247)
+10 checks: 4 `has_table` + 6 `has_function` for recipe system

### Updated: `RUN_QA.ps1`
Suite #48 added (733 total checks across 48 suites)

### Updated: `copilot-instructions.md`
- §3: Added `QA__recipe_integrity.sql` and `recipe_functions.test.sql` to project layout
- §4: Added recipe tables (recipe, recipe_step, recipe_ingredient, recipe_ingredient_product) to Database Schema
- §4: Added recipe API functions to Key Functions table
- §8.18: Added Recipe Integrity suite (6 checks)
- §8.20: Added `recipe_functions.test.sql` to pgTAP test table
- Counts: 181→182 migrations, 727→733 QA checks, 47→48 suites

## Phase 2 (Deferred)
Product linkage data (populating recipe_ingredient_product with actual product matches) requires DB access and is deferred to a follow-up PR.

## Verification
- TypeScript: N/A (no frontend changes)
- Migration: SQL syntax validated
- pgTAP plan: 247 (was 237)
- QA checks: 733 (was 727)

Closes #364