### PR TITLE
security(api): add track-event and save-search gateway actions (#478 Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ Adheres to [Semantic Versioning](https://semver.org/).
   forbidden character rejection), 10/day rate limiting; frontend
   `submitProductViaGateway()` with graceful degradation fallback; 14 new Vitest
   tests (32 total) (#478)
+- Add telemetry and search gateway protection (Phase 4): `track-event` action
+  (10K/day rate limit, event_name/device_type/event_data validation, payload size
+  cap) + `save-search` action (50/day rate limit, name/query sanitization, filters
+  validation); frontend `trackEventViaGateway()` and `saveSearchViaGateway()` with
+  graceful degradation fallback; 17 new Vitest tests (49 total) (#478)
 
 ### Schema & Migrations
 


### PR DESCRIPTION
## Summary

Phase 4 of #478: adds **track-event** and **save-search** write-path actions to the API gateway Edge Function.

### Gateway Changes (supabase/functions/api-gateway/index.ts)
- **track-event** (10,000/day/user): validates event_name (required, ≤100 chars), device_type (mobile/tablet/desktop), event_data (object, ≤10KB), session_id (≤100 chars); forwards to \pi_track_event\ RPC
- **save-search** (50/day/user): validates name (required), sanitizes name/query via \sanitizeField()\, validates filters (object); forwards to \pi_save_search\ RPC

### Frontend Changes (\rontend/src/lib/api-gateway.ts\)
- \	rackEventViaGateway()\ with graceful degradation fallback to direct \pi_track_event\ RPC
- \saveSearchViaGateway()\ with graceful degradation fallback to direct \pi_save_search\ RPC
- \TrackEventParams\ + \SaveSearchParams\ interfaces
- Updated \ApiGateway\ factory with \	rackEvent\ and \saveSearch\ methods

### Tests (\rontend/src/lib/api-gateway.test.ts\)
- 17 new tests (49 total): success, optional params, rate limiting, validation errors, graceful degradation (3 per action), factory forwarding

### Verification
- ESLint: 0 warnings/errors
- TypeScript: 0 errors
- Vitest: 49/49 passing

Closes phase 4 of #478.