### PR TITLE
chore(#414): set repo metadata, template headers, release banner

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,6 +6,8 @@ body:
   - type: markdown
     attributes:
       value: |
+        ![Bug Report](https://raw.githubusercontent.com/ericsocrat/poland-food-db/main/.github/assets/bug-report-header.svg)
+
         Thanks for reporting a bug! Please fill out the sections below so we can reproduce and fix it quickly.
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/data_schema.yml
+++ b/.github/ISSUE_TEMPLATE/data_schema.yml
@@ -6,6 +6,8 @@ body:
   - type: markdown
     attributes:
       value: |
+        ![Data / Schema Change](https://raw.githubusercontent.com/ericsocrat/poland-food-db/main/.github/assets/data-schema-header.svg)
+
         Database changes require special care. Please follow the project's [Migration Conventions](https://github.com/ericsocrat/poland-food-db/blob/main/docs/MIGRATION_CONVENTIONS.md) and [Database Safety Rules](https://github.com/ericsocrat/poland-food-db/blob/main/copilot-instructions.md#813-database-safety-rules).
 
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,6 +6,8 @@ body:
   - type: markdown
     attributes:
       value: |
+        ![Feature Request](https://raw.githubusercontent.com/ericsocrat/poland-food-db/main/.github/assets/feature-request-header.svg)
+
         Thanks for suggesting an improvement! Please follow the project's [Feature Implementation Standard](https://github.com/ericsocrat/poland-food-db/blob/main/copilot-instructions.md#15-feature-implementation-standard) for significant features.
 
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+![Pull Request](https://raw.githubusercontent.com/ericsocrat/poland-food-db/main/.github/assets/pr-header.svg)
+
 ## Summary
 
 <!-- Brief description of what this PR does -->

--- a/.github/REPOSITORY_SETTINGS.md
+++ b/.github/REPOSITORY_SETTINGS.md
@@ -1,0 +1,84 @@
+# Repository Settings Instructions
+
+> **Last updated:** 2026-03-13
+
+Step-by-step guide for configuring GitHub repository settings for `ericsocrat/poland-food-db`.
+
+---
+
+## 1. Repository Description & Topics
+
+**Already applied** (via `gh repo edit`):
+
+- **Description:** `Science-driven food quality database for Poland & Germany. 9-factor scoring (v3.2), 1,281 products, 2,995 ingredients, EFSA concern analysis, allergen tracking, barcode scanning. PostgreSQL + Supabase + Next.js + TypeScript.`
+- **Topics (20):** `food-database`, `food-quality`, `nutrition`, `health`, `nutri-score`, `nova-score`, `food-safety`, `allergens`, `ingredients`, `barcode-scanner`, `poland`, `germany`, `postgresql`, `supabase`, `nextjs`, `typescript`, `open-food-facts`, `efsa`, `food-science`, `health-tech`
+
+**To update manually:**
+
+1. Go to the repo main page → click the ⚙️ gear icon next to "About"
+2. Paste the description above
+3. Add/remove topics as needed
+4. Set **Website** URL (e.g., Vercel deployment URL) once available
+5. Click **Save changes**
+
+---
+
+## 2. Social Preview Image
+
+1. Go to **Settings → General**
+2. Scroll to **Social preview**
+3. Click **Edit → Upload an image**
+4. Upload `docs/assets/github-social-preview.png` (1280×640px) — _created in #411_
+5. Click **Save**
+
+> **Note:** Social preview image (#411) is not yet created. This step will be completed when #411 is done.
+
+---
+
+## 3. Repository Features
+
+1. Go to **Settings → General → Features**
+2. Ensure these are **enabled**:
+   - ✅ Issues
+   - ✅ Discussions (for community Q&A)
+3. Ensure these are **disabled**:
+   - ❌ Wiki (we use `docs/` instead)
+   - ❌ Projects (use GitHub Issues + Milestones)
+
+---
+
+## 4. Release Banner Usage
+
+A release banner SVG template is provided at:
+
+```
+docs/assets/banners/release-template.svg
+```
+
+**To customize for a new release:**
+
+1. Copy the template SVG
+2. Edit these text elements:
+   - `v0.0.0` → actual version number (e.g., `v3.2.1`)
+   - `Release Title Goes Here` → release name (e.g., `Recipe Integration`)
+   - 5 highlight lines → actual feature highlights
+3. Save as `release-vX.Y.Z.svg`
+4. Reference in the GitHub Release notes with:
+   ```markdown
+   ![Release vX.Y.Z](docs/assets/banners/release-vX.Y.Z.svg)
+   ```
+
+---
+
+## 5. Template Headers
+
+Issue and PR templates now include branded SVG headers from `.github/assets/`:
+
+| Template | Header File | Preview Text |
+|----------|-------------|-------------|
+| Bug Report | `bug-report-header.svg` | 🐛 Bug Report |
+| Feature Request | `feature-request-header.svg` | ✨ Feature Request |
+| Data / Schema Change | `data-schema-header.svg` | 🗄️ Data / Schema Change |
+| Pull Request | `pr-header.svg` | 🔀 Pull Request |
+
+Headers are referenced via `raw.githubusercontent.com` URLs so they render in GitHub's issue/PR creation UI.

--- a/.github/assets/bug-report-header.svg
+++ b/.github/assets/bug-report-header.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 100" width="800" height="100">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#0d7377"/>
+      <stop offset="100%" stop-color="#095456"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="100" rx="8" fill="url(#bg)"/>
+  <text x="40" y="42" font-family="system-ui,-apple-system,sans-serif" font-size="12" font-weight="500" fill="#5eead4" letter-spacing="2">POLAND FOOD DB</text>
+  <text x="40" y="72" font-family="system-ui,-apple-system,sans-serif" font-size="26" font-weight="700" fill="#ffffff">🐛 Bug Report</text>
+  <rect x="680" y="30" width="80" height="40" rx="6" fill="rgba(255,255,255,0.1)"/>
+  <text x="720" y="56" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="13" font-weight="600" fill="#2dd4bf">v3.2</text>
+</svg>

--- a/.github/assets/data-schema-header.svg
+++ b/.github/assets/data-schema-header.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 100" width="800" height="100">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#0d7377"/>
+      <stop offset="100%" stop-color="#095456"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="100" rx="8" fill="url(#bg)"/>
+  <text x="40" y="42" font-family="system-ui,-apple-system,sans-serif" font-size="12" font-weight="500" fill="#5eead4" letter-spacing="2">POLAND FOOD DB</text>
+  <text x="40" y="72" font-family="system-ui,-apple-system,sans-serif" font-size="26" font-weight="700" fill="#ffffff">🗄️ Data / Schema Change</text>
+  <rect x="680" y="30" width="80" height="40" rx="6" fill="rgba(255,255,255,0.1)"/>
+  <text x="720" y="56" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="13" font-weight="600" fill="#2dd4bf">v3.2</text>
+</svg>

--- a/.github/assets/feature-request-header.svg
+++ b/.github/assets/feature-request-header.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 100" width="800" height="100">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#0d7377"/>
+      <stop offset="100%" stop-color="#095456"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="100" rx="8" fill="url(#bg)"/>
+  <text x="40" y="42" font-family="system-ui,-apple-system,sans-serif" font-size="12" font-weight="500" fill="#5eead4" letter-spacing="2">POLAND FOOD DB</text>
+  <text x="40" y="72" font-family="system-ui,-apple-system,sans-serif" font-size="26" font-weight="700" fill="#ffffff">✨ Feature Request</text>
+  <rect x="680" y="30" width="80" height="40" rx="6" fill="rgba(255,255,255,0.1)"/>
+  <text x="720" y="56" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="13" font-weight="600" fill="#2dd4bf">v3.2</text>
+</svg>

--- a/.github/assets/pr-header.svg
+++ b/.github/assets/pr-header.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 100" width="800" height="100">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#0d7377"/>
+      <stop offset="100%" stop-color="#095456"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="100" rx="8" fill="url(#bg)"/>
+  <text x="40" y="42" font-family="system-ui,-apple-system,sans-serif" font-size="12" font-weight="500" fill="#5eead4" letter-spacing="2">POLAND FOOD DB</text>
+  <text x="40" y="72" font-family="system-ui,-apple-system,sans-serif" font-size="26" font-weight="700" fill="#ffffff">🔀 Pull Request</text>
+  <rect x="680" y="30" width="80" height="40" rx="6" fill="rgba(255,255,255,0.1)"/>
+  <text x="720" y="56" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="13" font-weight="600" fill="#2dd4bf">v3.2</text>
+</svg>

--- a/docs/assets/banners/release-template.svg
+++ b/docs/assets/banners/release-template.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 640" width="1280" height="640">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0d7377"/>
+      <stop offset="50%" stop-color="#095456"/>
+      <stop offset="100%" stop-color="#042f2e"/>
+    </linearGradient>
+    <linearGradient id="bandGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#22c55e"/>
+      <stop offset="20%" stop-color="#22c55e"/>
+      <stop offset="20%" stop-color="#eab308"/>
+      <stop offset="40%" stop-color="#eab308"/>
+      <stop offset="40%" stop-color="#f97316"/>
+      <stop offset="60%" stop-color="#f97316"/>
+      <stop offset="60%" stop-color="#ef4444"/>
+      <stop offset="80%" stop-color="#ef4444"/>
+      <stop offset="80%" stop-color="#991b1b"/>
+      <stop offset="100%" stop-color="#991b1b"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1280" height="640" fill="url(#bg)"/>
+
+  <!-- Subtle grid pattern -->
+  <g opacity="0.04">
+    <line x1="0" y1="80" x2="1280" y2="80" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="160" x2="1280" y2="160" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="240" x2="1280" y2="240" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="320" x2="1280" y2="320" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="400" x2="1280" y2="400" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="480" x2="1280" y2="480" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="560" x2="1280" y2="560" stroke="#fff" stroke-width="1"/>
+    <line x1="160" y1="0" x2="160" y2="640" stroke="#fff" stroke-width="1"/>
+    <line x1="320" y1="0" x2="320" y2="640" stroke="#fff" stroke-width="1"/>
+    <line x1="480" y1="0" x2="480" y2="640" stroke="#fff" stroke-width="1"/>
+    <line x1="640" y1="0" x2="640" y2="640" stroke="#fff" stroke-width="1"/>
+    <line x1="800" y1="0" x2="800" y2="640" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="640" stroke="#fff" stroke-width="1"/>
+    <line x1="1120" y1="0" x2="1120" y2="640" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Score band accent bar -->
+  <rect x="80" y="60" width="1120" height="6" rx="3" fill="url(#bandGrad)" opacity="0.8"/>
+
+  <!-- Project name -->
+  <text x="640" y="140" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="16" font-weight="500" fill="#5eead4" letter-spacing="4">POLAND FOOD QUALITY DATABASE</text>
+
+  <!-- Version placeholder (EDIT THIS) -->
+  <text x="640" y="220" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="72" font-weight="800" fill="#ffffff">v0.0.0</text>
+
+  <!-- Release title placeholder (EDIT THIS) -->
+  <text x="640" y="280" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="24" font-weight="500" fill="#d4a844">Release Title Goes Here</text>
+
+  <!-- Divider -->
+  <line x1="440" y1="310" x2="840" y2="310" stroke="#2dd4bf" stroke-width="2" opacity="0.5"/>
+
+  <!-- Highlights placeholders (EDIT THESE) -->
+  <text x="640" y="360" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="18" fill="#e2e8f0">✦ Highlight 1 — brief description</text>
+  <text x="640" y="400" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="18" fill="#e2e8f0">✦ Highlight 2 — brief description</text>
+  <text x="640" y="440" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="18" fill="#e2e8f0">✦ Highlight 3 — brief description</text>
+  <text x="640" y="480" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="18" fill="#e2e8f0">✦ Highlight 4 — brief description</text>
+  <text x="640" y="520" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="18" fill="#e2e8f0">✦ Highlight 5 — brief description</text>
+
+  <!-- Score band accent bar (bottom) -->
+  <rect x="80" y="574" width="1120" height="6" rx="3" fill="url(#bandGrad)" opacity="0.8"/>
+
+  <!-- Footer -->
+  <text x="640" y="610" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="14" fill="#64748b">PostgreSQL · Supabase · Next.js · TypeScript</text>
+</svg>


### PR DESCRIPTION
## Summary

Sets repository metadata (description, topics) and creates branded headers for issue/PR templates and a release banner template.

## Changes

### Repository Metadata (applied via `gh repo edit`)
- **Description:** 350-char summary with key metrics and tech stack
- **Topics (20):** food-database, food-quality, nutrition, health, nutri-score, nova-score, food-safety, allergens, ingredients, barcode-scanner, poland, germany, postgresql, supabase, nextjs, typescript, open-food-facts, efsa, food-science, health-tech

### Template Headers (4 × 800×100px SVGs)
- `.github/assets/bug-report-header.svg` — 🐛 Bug Report
- `.github/assets/feature-request-header.svg` — ✨ Feature Request
- `.github/assets/data-schema-header.svg` — 🗄️ Data / Schema Change
- `.github/assets/pr-header.svg` — 🔀 Pull Request

### Templates Updated
- `.github/ISSUE_TEMPLATE/bug_report.yml` — header image added
- `.github/ISSUE_TEMPLATE/feature_request.yml` — header image added
- `.github/ISSUE_TEMPLATE/data_schema.yml` — header image added
- `.github/PULL_REQUEST_TEMPLATE.md` — header image added

### Release Banner Template
- `docs/assets/banners/release-template.svg` — 1280×640px with placeholder fields (version, title, 5 highlights)

### Settings Guide
- `.github/REPOSITORY_SETTINGS.md` — step-by-step instructions for manual settings

**10 files changed, +214 lines**

Closes #414