### PR TITLE
feat(branding): create wordmark + lockup variants — 6 SVGs + brand guidelines update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@ Adheres to [Semantic Versioning](https://semver.org/).
   teal gradient, dark veins, brighter gold), monochrome (`currentColor` silhouette);
   8 PNG exports (16–512px) for favicons, app icons, and social media; add Brand
   Assets section to `docs/INDEX.md` (#407)
+- Create wordmark + lockup variants (`docs/assets/logo/`): 2 wordmark SVGs
+  (placeholder styled text, light + dark), 4 lockup SVGs — horizontal and
+  stacked compositions embedding the logomark with clear-space-governed text
+  placement (light + dark variants each); complete §2 Logo Usage in
+  `docs/BRAND_GUIDELINES.md` with variant table, clear space rules, minimum
+  size rules, and do's/don'ts; add Logo & Brand Mark subsection to asset
+  inventory (#408)
 - Harden copilot-instructions.md: rewrite §16 as discovery-driven (script-first),
   extract 240-line issue template to `.github/ISSUE_TEMPLATE/feature.md`,
   reduce from 1,668 to 1,418 lines (under 1,500 cap) (#334)

--- a/docs/BRAND_GUIDELINES.md
+++ b/docs/BRAND_GUIDELINES.md
@@ -66,32 +66,51 @@ Empower consumers in Poland (and expanding to Europe) to make healthier food cho
 
 ## 2. Logo Usage
 
-> **Status:** Pending — depends on [#407](https://github.com/ericsocrat/poland-food-db/issues/407) (logomark design) and [#408](https://github.com/ericsocrat/poland-food-db/issues/408) (lockup variations). This section will be completed when those assets are finalized.
+> **Status:** Active — logomark (#407) and lockups (#408) finalized.
 
-### Planned Variants
+### Logo Variants
 
-| Variant          | Use Case                                   | Issue |
-| ---------------- | ------------------------------------------ | ----- |
-| Icon-only        | Favicons, app icons, small badges          | #407  |
-| Horizontal lockup | Navigation bar, email headers             | #408  |
-| Stacked lockup   | Marketing materials, splash screens        | #408  |
-| Monochrome       | Single-color contexts (print, watermarks)  | #408  |
+| Variant                | File                         | Use Case                                  |
+| ---------------------- | ---------------------------- | ----------------------------------------- |
+| Icon-only (full color) | `logomark.svg`               | App icons, favicons (32px+), badges       |
+| Icon-only (dark mode)  | `logomark-dark.svg`          | App icons on dark backgrounds             |
+| Icon-only (mono)       | `logomark-mono.svg`          | Single-color contexts, watermarks, print  |
+| Horizontal lockup      | `lockup-horizontal.svg`      | Navigation bar, email headers, banners    |
+| Horizontal lockup (dark) | `lockup-horizontal-dark.svg` | Nav bar on dark backgrounds            |
+| Stacked lockup         | `lockup-stacked.svg`         | Marketing materials, splash screens       |
+| Stacked lockup (dark)  | `lockup-stacked-dark.svg`    | Splash screens on dark backgrounds        |
+| Wordmark               | `wordmark.svg`               | Text-only contexts (placeholder name)     |
+| Wordmark (dark)        | `wordmark-dark.svg`          | Text-only on dark backgrounds             |
 
-### Clear Space Rules (to be defined with #408)
+> **Wordmark note:** The wordmark is a deliberate placeholder. When the project name changes, regenerate `wordmark.svg` and `wordmark-dark.svg`. The lockup architecture makes this swap trivial — only the `<text>` element changes.
 
-- Minimum clear space: 1× the icon height on all sides.
-- Minimum icon size: 24×24px (digital), 10mm (print).
-- Never rotate, skew, distort, or apply effects to the logo.
-- Never place the logo on busy backgrounds without a container.
+### Clear Space Rules
 
-### Do's and Don'ts (Preliminary)
+- **Minimum clear space around logomark:** icon height × 0.5 on all sides.
+- **Minimum clear space in horizontal lockup:** icon height × 0.5 between icon and wordmark.
+- **Minimum clear space in stacked lockup:** icon height × 0.3 between icon and wordmark.
+- **Minimum padding around entire lockup:** icon height × 0.25 on all sides.
 
-| Do                                              | Don't                                           |
-| ------------------------------------------------ | ------------------------------------------------ |
-| Use the correct variant for the theme (light/dark) | Stretch or distort the logo                     |
-| Maintain minimum clear space                      | Change logo colors outside approved palette      |
-| Use the monochrome variant on photos              | Add drop shadows or outlines to the logo         |
-| Center-align when used as a standalone mark       | Place logo smaller than minimum size             |
+### Minimum Size Rules
+
+| Context                | Minimum Size | Action                            |
+| ---------------------- | ------------ | --------------------------------- |
+| Digital icon-only      | 16×16px      | Use monochrome variant (`logomark-mono.svg`) |
+| Digital icon-only      | 32×32px+     | Use full-color variant            |
+| Horizontal lockup      | 120px width  | Below this, switch to icon-only   |
+| Stacked lockup         | 80px width   | Below this, switch to icon-only   |
+| Print icon-only        | 10mm         | Use monochrome variant            |
+
+### Do's and Don'ts
+
+| Do                                                  | Don't                                            |
+| --------------------------------------------------- | ------------------------------------------------ |
+| Use the correct variant for the theme (light/dark)  | Stretch or distort the logo                      |
+| Maintain minimum clear space                        | Change logo colors outside approved palette      |
+| Use the monochrome variant on photos                | Add drop shadows or outlines to the logo         |
+| Center-align when used as a standalone mark         | Place logo smaller than minimum size             |
+| Use lockup SVGs as-is (they embed the logomark)     | Recompose icon + text manually                   |
+| Switch to icon-only below lockup minimum width      | Crop or partially obscure the logomark           |
 
 ---
 
@@ -834,6 +853,21 @@ As per the [Open Food Facts Terms of Use](https://world.openfoodfacts.org/terms-
 | `data-schema-header.svg`    | 800×100    | SVG    | Data/schema template     | 2026-03-13   | #414  |
 | `pr-header.svg`             | 800×100    | SVG    | Pull request template    | 2026-03-13   | #414  |
 
+### Logo & Brand Mark (`docs/assets/logo/`)
+
+| File                         | Dimensions | Format | Dark Variant            | Last Updated | Issue |
+| ---------------------------- | ---------- | ------ | ----------------------- | ------------ | ----- |
+| `logomark.svg`               | 512×512    | SVG    | `logomark-dark.svg`     | 2026-03-14   | #407  |
+| `logomark-dark.svg`          | 512×512    | SVG    | (is dark)               | 2026-03-14   | #407  |
+| `logomark-mono.svg`          | 512×512    | SVG    | N/A (currentColor)      | 2026-03-14   | #407  |
+| `logomark-{16–512}.png`      | 16–512px   | PNG    | N/A                     | 2026-03-14   | #407  |
+| `wordmark.svg`               | 480×72     | SVG    | `wordmark-dark.svg`     | 2026-03-14   | #408  |
+| `wordmark-dark.svg`          | 480×72     | SVG    | (is dark)               | 2026-03-14   | #408  |
+| `lockup-horizontal.svg`      | 660×120    | SVG    | `lockup-horizontal-dark.svg` | 2026-03-14 | #408 |
+| `lockup-horizontal-dark.svg` | 660×120    | SVG    | (is dark)               | 2026-03-14   | #408  |
+| `lockup-stacked.svg`         | 320×380    | SVG    | `lockup-stacked-dark.svg` | 2026-03-14 | #408  |
+| `lockup-stacked-dark.svg`    | 320×380    | SVG    | (is dark)               | 2026-03-14   | #408  |
+
 ### Banners (`docs/assets/banners/`)
 
 | File                    | Dimensions | Format | Purpose                     | Last Updated | Issue |
@@ -850,8 +884,6 @@ As per the [Open Food Facts Terms of Use](https://world.openfoodfacts.org/terms-
 
 | Asset              | Issue | Status                     |
 | ------------------ | ----- | -------------------------- |
-| Logomark (icon)    | #407  | Open — design pending      |
-| Lockup variations  | #408  | Open — blocked by #407     |
 | Social preview     | #409  | Open — blocked by #407     |
 | Favicon set        | #413  | Open — blocked by #407     |
 | OG images          | #416  | Open — blocked by #407     |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,7 +2,7 @@
 
 > **Last updated:** 2026-03-14
 > **Status:** Active — update when adding, renaming, or archiving docs
-> **Total documents:** 49 in `docs/` + 8 in `docs/decisions/` + 11 in `docs/assets/logo/` + 5 elsewhere in repo
+> **Total documents:** 49 in `docs/` + 8 in `docs/decisions/` + 17 in `docs/assets/logo/` + 5 elsewhere in repo
 > **Reference:** Issue [#200](https://github.com/ericsocrat/poland-food-db/issues/200), [#201](https://github.com/ericsocrat/poland-food-db/issues/201)
 
 ---
@@ -13,7 +13,7 @@
 | -------------------------------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | [Architecture & Design](#architecture--design)           | 6     | Governance blueprint, domain boundaries, feature flags, scoring engine, search architecture, CI proposal                           |
 | [Diagrams](#diagrams)                                    | 13    | Architecture, ERDs, pipeline flow, QA overview, CI/CD, confidence, concern tiers, country expansion, scoring infographic + headers |
-| [Brand Assets](#brand-assets)                            | 11    | Logomark SVG variants (full color, dark, mono) + 8 PNG exports (16–512px)                                                         |
+| [Brand Assets](#brand-assets)                            | 17    | Logomark SVG variants + PNG exports, wordmark, lockup variants (horizontal + stacked, light + dark) |
 | [API](#api)                                              | 6     | Contracts, conventions, versioning, frontend mapping, contract testing, registry                                                   |
 | [Scoring](#scoring)                                      | 2     | Methodology (formula), engine (architecture)                                                                                       |
 | [Data & Provenance](#data--provenance)                   | 5     | Sources, provenance, integrity audits, EAN validation, production data                                                             |
@@ -98,6 +98,12 @@
 | [logomark-64.png](assets/logo/logomark-64.png)                 | PNG export 64×64                                                            | [#407](https://github.com/ericsocrat/poland-food-db/issues/407) | 2026-03-14   |
 | [logomark-32.png](assets/logo/logomark-32.png)                 | PNG export 32×32 (favicon candidate)                                        | [#407](https://github.com/ericsocrat/poland-food-db/issues/407) | 2026-03-14   |
 | [logomark-16.png](assets/logo/logomark-16.png)                 | PNG export 16×16 (smallest favicon)                                         | [#407](https://github.com/ericsocrat/poland-food-db/issues/407) | 2026-03-14   |
+| [wordmark.svg](assets/logo/wordmark.svg)                       | Placeholder wordmark — styled project name (brand teal, system sans-serif)  | [#408](https://github.com/ericsocrat/poland-food-db/issues/408) | 2026-03-14   |
+| [wordmark-dark.svg](assets/logo/wordmark-dark.svg)             | Dark-mode wordmark — white text for dark backgrounds                        | [#408](https://github.com/ericsocrat/poland-food-db/issues/408) | 2026-03-14   |
+| [lockup-horizontal.svg](assets/logo/lockup-horizontal.svg)     | Horizontal lockup — logomark left + wordmark right (light bg)               | [#408](https://github.com/ericsocrat/poland-food-db/issues/408) | 2026-03-14   |
+| [lockup-horizontal-dark.svg](assets/logo/lockup-horizontal-dark.svg) | Horizontal lockup — dark mode variant                                 | [#408](https://github.com/ericsocrat/poland-food-db/issues/408) | 2026-03-14   |
+| [lockup-stacked.svg](assets/logo/lockup-stacked.svg)           | Stacked lockup — logomark above + wordmark below (light bg)                 | [#408](https://github.com/ericsocrat/poland-food-db/issues/408) | 2026-03-14   |
+| [lockup-stacked-dark.svg](assets/logo/lockup-stacked-dark.svg) | Stacked lockup — dark mode variant                                          | [#408](https://github.com/ericsocrat/poland-food-db/issues/408) | 2026-03-14   |
 
 ## API
 

--- a/docs/assets/logo/lockup-horizontal-dark.svg
+++ b/docs/assets/logo/lockup-horizontal-dark.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 660 120" role="img" aria-label="Poland Food DB">
+  <title>Poland Food DB — Horizontal Lockup (Dark Mode)</title>
+  <desc>Dark-mode horizontal brand lockup for dark backgrounds (#0f172a). Logomark uses lighter teal gradient; wordmark is white.</desc>
+
+  <defs>
+    <linearGradient id="brand-fill-dark" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3ee0d0"/>
+      <stop offset="100%" stop-color="#1aafab"/>
+    </linearGradient>
+  </defs>
+
+  <!-- ═══ Logomark (dark mode variant, 100×100) ═══ -->
+  <svg x="10" y="10" width="100" height="100" viewBox="0 0 512 512">
+    <path d="M 256 28 C 364 64, 444 168, 444 272 C 444 376, 336 456, 256 488 C 176 456, 68 376, 68 272 C 68 168, 148 64, 256 28 Z" fill="url(#brand-fill-dark)"/>
+    <!-- Veins — dark strokes for contrast on light fills -->
+    <line x1="256" y1="84" x2="256" y2="440" stroke="#0f172a" stroke-width="3.5" opacity="0.25" stroke-linecap="round"/>
+    <line x1="256" y1="176" x2="172" y2="236" stroke="#0f172a" stroke-width="2.5" opacity="0.18" stroke-linecap="round"/>
+    <line x1="256" y1="176" x2="340" y2="236" stroke="#0f172a" stroke-width="2.5" opacity="0.18" stroke-linecap="round"/>
+    <line x1="256" y1="256" x2="180" y2="312" stroke="#0f172a" stroke-width="2.5" opacity="0.18" stroke-linecap="round"/>
+    <line x1="256" y1="256" x2="332" y2="312" stroke="#0f172a" stroke-width="2.5" opacity="0.18" stroke-linecap="round"/>
+    <line x1="256" y1="336" x2="200" y2="380" stroke="#0f172a" stroke-width="2.5" opacity="0.18" stroke-linecap="round"/>
+    <line x1="256" y1="336" x2="312" y2="380" stroke="#0f172a" stroke-width="2.5" opacity="0.18" stroke-linecap="round"/>
+    <circle cx="256" cy="64" r="10" fill="#fbbf24" opacity="0.90"/>
+  </svg>
+
+  <!-- ═══ Wordmark (white for dark backgrounds) ═══ -->
+  <text
+    x="160" y="72"
+    font-family="'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif"
+    font-size="40"
+    font-weight="700"
+    fill="#ffffff"
+    letter-spacing="0.02em"
+    dominant-baseline="middle"
+  >Poland Food DB</text>
+</svg>

--- a/docs/assets/logo/lockup-horizontal.svg
+++ b/docs/assets/logo/lockup-horizontal.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 660 120" role="img" aria-label="Poland Food DB">
+  <title>Poland Food DB — Horizontal Lockup</title>
+  <desc>Horizontal brand lockup: logomark left, wordmark right. Clear space between icon and text equals icon height × 0.5. Switch to icon-only below 120px total width.</desc>
+
+  <defs>
+    <linearGradient id="brand-fill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0e8a8e"/>
+      <stop offset="100%" stop-color="#074a4c"/>
+    </linearGradient>
+  </defs>
+
+  <!-- ═══ Logomark (scaled to 100×100, centered in 120×120 area) ═══ -->
+  <svg x="10" y="10" width="100" height="100" viewBox="0 0 512 512">
+    <!-- Shield-leaf silhouette -->
+    <path d="M 256 28 C 364 64, 444 168, 444 272 C 444 376, 336 456, 256 488 C 176 456, 68 376, 68 272 C 68 168, 148 64, 256 28 Z" fill="url(#brand-fill)"/>
+    <!-- Central vein -->
+    <line x1="256" y1="84" x2="256" y2="440" stroke="#ffffff" stroke-width="3.5" opacity="0.30" stroke-linecap="round"/>
+    <!-- Side veins — 3 pairs -->
+    <line x1="256" y1="176" x2="172" y2="236" stroke="#ffffff" stroke-width="2.5" opacity="0.22" stroke-linecap="round"/>
+    <line x1="256" y1="176" x2="340" y2="236" stroke="#ffffff" stroke-width="2.5" opacity="0.22" stroke-linecap="round"/>
+    <line x1="256" y1="256" x2="180" y2="312" stroke="#ffffff" stroke-width="2.5" opacity="0.22" stroke-linecap="round"/>
+    <line x1="256" y1="256" x2="332" y2="312" stroke="#ffffff" stroke-width="2.5" opacity="0.22" stroke-linecap="round"/>
+    <line x1="256" y1="336" x2="200" y2="380" stroke="#ffffff" stroke-width="2.5" opacity="0.22" stroke-linecap="round"/>
+    <line x1="256" y1="336" x2="312" y2="380" stroke="#ffffff" stroke-width="2.5" opacity="0.22" stroke-linecap="round"/>
+    <!-- Gold accent dot -->
+    <circle cx="256" cy="64" r="10" fill="#d4a844" opacity="0.85"/>
+  </svg>
+
+  <!-- ═══ Wordmark (clear space = icon height × 0.5 = 50px from icon edge) ═══ -->
+  <text
+    x="160" y="72"
+    font-family="'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif"
+    font-size="40"
+    font-weight="700"
+    fill="#0d7377"
+    letter-spacing="0.02em"
+    dominant-baseline="middle"
+  >Poland Food DB</text>
+</svg>

--- a/docs/assets/logo/lockup-stacked-dark.svg
+++ b/docs/assets/logo/lockup-stacked-dark.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 380" role="img" aria-label="Poland Food DB">
+  <title>Poland Food DB — Stacked Lockup (Dark Mode)</title>
+  <desc>Dark-mode stacked lockup for dark backgrounds (#0f172a). Lighter teal logomark, white wordmark.</desc>
+
+  <defs>
+    <linearGradient id="brand-fill-dark" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3ee0d0"/>
+      <stop offset="100%" stop-color="#1aafab"/>
+    </linearGradient>
+  </defs>
+
+  <!-- ═══ Logomark (dark mode, centered, 200×200) ═══ -->
+  <svg x="60" y="20" width="200" height="200" viewBox="0 0 512 512">
+    <path d="M 256 28 C 364 64, 444 168, 444 272 C 444 376, 336 456, 256 488 C 176 456, 68 376, 68 272 C 68 168, 148 64, 256 28 Z" fill="url(#brand-fill-dark)"/>
+    <line x1="256" y1="84" x2="256" y2="440" stroke="#0f172a" stroke-width="3.5" opacity="0.25" stroke-linecap="round"/>
+    <line x1="256" y1="176" x2="172" y2="236" stroke="#0f172a" stroke-width="2.5" opacity="0.18" stroke-linecap="round"/>
+    <line x1="256" y1="176" x2="340" y2="236" stroke="#0f172a" stroke-width="2.5" opacity="0.18" stroke-linecap="round"/>
+    <line x1="256" y1="256" x2="180" y2="312" stroke="#0f172a" stroke-width="2.5" opacity="0.18" stroke-linecap="round"/>
+    <line x1="256" y1="256" x2="332" y2="312" stroke="#0f172a" stroke-width="2.5" opacity="0.18" stroke-linecap="round"/>
+    <line x1="256" y1="336" x2="200" y2="380" stroke="#0f172a" stroke-width="2.5" opacity="0.18" stroke-linecap="round"/>
+    <line x1="256" y1="336" x2="312" y2="380" stroke="#0f172a" stroke-width="2.5" opacity="0.18" stroke-linecap="round"/>
+    <circle cx="256" cy="64" r="10" fill="#fbbf24" opacity="0.90"/>
+  </svg>
+
+  <!-- ═══ Wordmark (white, centered below) ═══ -->
+  <text
+    x="160" y="310"
+    text-anchor="middle"
+    font-family="'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif"
+    font-size="34"
+    font-weight="700"
+    fill="#ffffff"
+    letter-spacing="0.02em"
+  >Poland Food DB</text>
+</svg>

--- a/docs/assets/logo/lockup-stacked.svg
+++ b/docs/assets/logo/lockup-stacked.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 380" role="img" aria-label="Poland Food DB">
+  <title>Poland Food DB — Stacked Lockup</title>
+  <desc>Stacked brand lockup: logomark centered above, wordmark centered below. Clear space between icon and text equals icon height × 0.3. Preferred for square placements and compact layouts.</desc>
+
+  <defs>
+    <linearGradient id="brand-fill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0e8a8e"/>
+      <stop offset="100%" stop-color="#074a4c"/>
+    </linearGradient>
+  </defs>
+
+  <!-- ═══ Logomark (centered, 200×200) ═══ -->
+  <svg x="60" y="20" width="200" height="200" viewBox="0 0 512 512">
+    <path d="M 256 28 C 364 64, 444 168, 444 272 C 444 376, 336 456, 256 488 C 176 456, 68 376, 68 272 C 68 168, 148 64, 256 28 Z" fill="url(#brand-fill)"/>
+    <line x1="256" y1="84" x2="256" y2="440" stroke="#ffffff" stroke-width="3.5" opacity="0.30" stroke-linecap="round"/>
+    <line x1="256" y1="176" x2="172" y2="236" stroke="#ffffff" stroke-width="2.5" opacity="0.22" stroke-linecap="round"/>
+    <line x1="256" y1="176" x2="340" y2="236" stroke="#ffffff" stroke-width="2.5" opacity="0.22" stroke-linecap="round"/>
+    <line x1="256" y1="256" x2="180" y2="312" stroke="#ffffff" stroke-width="2.5" opacity="0.22" stroke-linecap="round"/>
+    <line x1="256" y1="256" x2="332" y2="312" stroke="#ffffff" stroke-width="2.5" opacity="0.22" stroke-linecap="round"/>
+    <line x1="256" y1="336" x2="200" y2="380" stroke="#ffffff" stroke-width="2.5" opacity="0.22" stroke-linecap="round"/>
+    <line x1="256" y1="336" x2="312" y2="380" stroke="#ffffff" stroke-width="2.5" opacity="0.22" stroke-linecap="round"/>
+    <circle cx="256" cy="64" r="10" fill="#d4a844" opacity="0.85"/>
+  </svg>
+
+  <!-- ═══ Wordmark (centered below, clear space = 200 × 0.3 = 60px gap) ═══ -->
+  <text
+    x="160" y="310"
+    text-anchor="middle"
+    font-family="'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif"
+    font-size="34"
+    font-weight="700"
+    fill="#0d7377"
+    letter-spacing="0.02em"
+  >Poland Food DB</text>
+</svg>

--- a/docs/assets/logo/wordmark-dark.svg
+++ b/docs/assets/logo/wordmark-dark.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 72" role="img" aria-label="Poland Food DB wordmark">
+  <title>Poland Food DB</title>
+  <desc>Dark-mode wordmark — white text for dark backgrounds. Placeholder that will be regenerated when the project name changes.</desc>
+
+  <!-- ═══ Wordmark text (dark mode) ═══ -->
+  <!-- Fill: white for dark backgrounds (#0f172a / slate-900) -->
+  <text
+    x="0" y="52"
+    font-family="'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif"
+    font-size="44"
+    font-weight="700"
+    fill="#ffffff"
+    letter-spacing="0.02em"
+  >Poland Food DB</text>
+</svg>

--- a/docs/assets/logo/wordmark.svg
+++ b/docs/assets/logo/wordmark.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 72" role="img" aria-label="Poland Food DB wordmark">
+  <title>Poland Food DB</title>
+  <desc>Placeholder wordmark — styled project name in brand typography. This text will be regenerated when the project name changes. The lockup architecture is designed to make this swap trivial.</desc>
+
+  <!-- ═══ Wordmark text ═══ -->
+  <!-- Font: system sans-serif stack matching brand guidelines §4 -->
+  <!-- Weight: 700 (bold) — Display level per type scale -->
+  <!-- Color: brand primary teal #0d7377 -->
+  <!-- Letter spacing: 0.02em for refined tracking -->
+  <text
+    x="0" y="52"
+    font-family="'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif"
+    font-size="44"
+    font-weight="700"
+    fill="#0d7377"
+    letter-spacing="0.02em"
+  >Poland Food DB</text>
+</svg>


### PR DESCRIPTION
# Create Wordmark & Lockup Variants

Closes #408

## Summary

Creates the wordmark (styled project name) and composes it with the logomark (#407) into 4 lockup variants. The wordmark is a **deliberate placeholder** — when the project name changes, only the `<text>` element needs updating.

## Deliverables

### 2 Wordmark SVGs
| File | Variant | Properties |
|------|---------|------------|
| `wordmark.svg` | Light background | Brand teal (#0d7377), 44px bold, system sans-serif, 0.02em tracking |
| `wordmark-dark.svg` | Dark background | White text, same typography |

### 4 Lockup SVGs
| File | Layout | Properties |
|------|--------|------------|
| `lockup-horizontal.svg` | Icon left + text right | 660×120 viewBox, 100px icon, clear space 50px |
| `lockup-horizontal-dark.svg` | Same (dark mode) | Lighter teal icon, white text |
| `lockup-stacked.svg` | Icon above + text below | 320×380 viewBox, 200px icon, centered |
| `lockup-stacked-dark.svg` | Same (dark mode) | Lighter teal icon, white text |

### Brand Guidelines Update
- Complete §2 **Logo Usage**: variant table, clear space rules, minimum size rules, do's/don'ts
- Add §14 **Logo & Brand Mark** subsection to Asset Inventory (10 files catalogued)
- Remove completed items (#407, #408) from Pending Assets table

### Documentation
- **docs/INDEX.md** — Brand Assets count: 11 → 17 files
- **CHANGELOG.md** — Entry under `[Unreleased] > Documentation`

## Architecture Notes
- Lockup SVGs embed the logomark path directly (self-contained, no external refs)
- Wordmark uses SVG `<text>` with system font stack — rendering adapts to viewer's system
- Clear space governance: icon height × 0.5 (horizontal), × 0.3 (stacked)

## File Impact
**9 files changed, +253 / -30 lines:**
- 6 new SVG files
- 1 updated doc (BRAND_GUIDELINES.md)
- 1 updated index (INDEX.md)
- 1 updated changelog