### PR TITLE
feat(frontend): complete brand meta tag integration (#416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,11 @@ Adheres to [Semantic Versioning](https://semver.org/).
   categories, 733 QA checks), tech stack pills, domain URL; dark teal gradient
   matching social-preview visual language; SVG source in `docs/assets/banners/`
   (#417)
+- Complete brand meta tag integration in `layout.tsx`: add dual theme-color
+  with `prefers-color-scheme` media queries (light=#0d7377, dark=#095456);
+  add OpenGraph image reference (og:image, og:image:width/height/alt) pointing
+  to `/og-image.png`; add Twitter card image; add `msapplication-TileColor` for
+  Windows tile branding (#416)
 - Redesign README.md as 15-section showcase-quality layout: hero banner, 9
   shields.io badges, elevator pitch, 4 feature highlight cards (HTML table),
   comparison table, 3-column quick start with collapsible command reference,

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,7 +6,10 @@ import { IS_QA_MODE } from "@/lib/qa-mode";
 import "@/styles/globals.css";
 
 export const viewport: Viewport = {
-  themeColor: "#0d7377",
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#0d7377" },
+    { media: "(prefers-color-scheme: dark)", color: "#095456" },
+  ],
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
@@ -50,16 +53,28 @@ export const metadata: Metadata = {
     description:
       "Compare health scores and nutritional data for food products in Poland and Germany.",
     url: "https://poland-food-db.vercel.app",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "Poland Food DB — Science-driven food quality intelligence for Poland and Germany",
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",
     title: "Poland Food DB",
     description:
       "Compare health scores and nutritional data for food products in Poland and Germany.",
+    images: ["/og-image.png"],
   },
   robots: {
     index: true,
     follow: true,
+  },
+  other: {
+    "msapplication-TileColor": "#0d7377",
   },
   metadataBase: new URL(
     process.env.NEXT_PUBLIC_APP_URL ?? "https://poland-food-db.vercel.app",


### PR DESCRIPTION
## Summary

Complete the remaining brand asset integration into `layout.tsx` meta tags. This builds on #409 (favicon suite) and #415 (PWA manifest/theme-color) to finalize all 5 meta tag categories.

Closes #416

## What Was Already Done (prior PRs)
- **Favicon Suite** — #409: ICO, SVG, Apple touch icon, PNG variants ✅
- **PWA/Android** — #415: manifest link, single theme-color, Apple web app meta ✅
- **OpenGraph** — Partially: type, siteName, title, description, url, locale ✅
- **Twitter/X** — Partially: card type, title, description ✅

## What This PR Adds

### 1. Dual Theme-Color (Dark Mode Support)
```tsx
themeColor: [
  { media: "(prefers-color-scheme: light)", color: "#0d7377" },
  { media: "(prefers-color-scheme: dark)", color: "#095456" },
],
```
Browser/PWA title bar adapts to OS dark mode preference.

### 2. OpenGraph Image
```tsx
images: [{
  url: "/og-image.png",
  width: 1200,
  height: 630,
  alt: "Poland Food DB — Science-driven food quality intelligence...",
}],
```
References the OG image created in #417 (PR #511).

### 3. Twitter Card Image
```tsx
images: ["/og-image.png"],
```

### 4. Microsoft Tile Color
```tsx
other: { "msapplication-TileColor": "#0d7377" },
```

## All 5 Categories — Final Status
| Category | Status | Source |
|----------|--------|--------|
| 1. Favicon Suite | ✅ Complete | #409 |
| 2. PWA / Android | ✅ Complete | #415 + this PR (dual theme-color) |
| 3. OpenGraph | ✅ Complete | Existing + this PR (image) |
| 4. Twitter / X Card | ✅ Complete | Existing + this PR (image) |
| 5. Microsoft / Windows | ✅ Complete | This PR (TileColor) |

## Testing
- [x] `npx tsc --noEmit` — TypeScript compiles clean
- [x] All meta tags use Next.js `metadata`/`viewport` export (no raw `<head>` tags)
- [x] Brand colors match established palette