### PR TITLE
feat(frontend): add 5 achievement badges with unlocked/locked states (#425)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,15 @@ Adheres to [Semantic Versioning](https://semver.org/).
   add `variant` prop (`'outline' | 'filled'`); add slug aliasing for country
   variants (chips-pl/chips-de → chips); expand test suite from 22 to 65 tests
   covering variants, aliases, viewBox, and accessibility (#419)
+- Design 5 achievement badge illustrations (first-scan, list-builder,
+  health-explorer, comparison-pro, profile-complete) in
+  `frontend/public/illustrations/achievements/`; circular medal/badge style with
+  gold ring, ribbon, and brand-colored thematic center icons; CSS-driven
+  locked/unlocked states (grayscale + opacity); `AchievementBadge` React component
+  with `unlocked` prop, 3 size presets (32/48/96px), optional label,
+  `data-achievement` and `data-unlocked` attributes; 29 Vitest tests covering
+  all 5 types × 2 states, accessibility, sizing, label display, and
+  utilities (#425)
 - Redesign README.md as 15-section showcase-quality layout: hero banner, 9
   shields.io badges, elevator pitch, 4 feature highlight cards (HTML table),
   comparison table, 3-column quick start with collapsible command reference,

--- a/frontend/public/illustrations/achievements/comparison-pro.svg
+++ b/frontend/public/illustrations/achievements/comparison-pro.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" width="96" height="96" aria-hidden="true">
+  <title>Comparison Pro</title>
+  <!-- Ribbon -->
+  <path d="M38 78l-8 16v-20h8z" fill="#d4a844" opacity=".8"/>
+  <path d="M58 78l8 16v-20h-8z" fill="#c09030" opacity=".8"/>
+  <!-- Medal ring -->
+  <circle cx="48" cy="44" r="32" fill="#FFD700"/>
+  <circle cx="48" cy="44" r="28" fill="#FFF8DC"/>
+  <circle cx="48" cy="44" r="26" fill="#FFFBF0"/>
+  <circle cx="48" cy="44" r="26" fill="url(#cp-g)" opacity=".15"/>
+  <!-- Scale / balance icon -->
+  <rect x="46.5" y="30" width="3" height="20" rx="1" fill="#0d7377"/>
+  <circle cx="48" cy="30" r="3" fill="#0d7377"/>
+  <!-- Balance beam -->
+  <line x1="33" y1="38" x2="63" y2="38" stroke="#0d7377" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- Left pan -->
+  <path d="M30 38l-2 10h10l-2-10" fill="none" stroke="#0d7377" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M28 48q3 3 10 0" fill="none" stroke="#0d7377" stroke-width="2" stroke-linecap="round"/>
+  <!-- Right pan -->
+  <path d="M56 38l-2 10h10l-2-10" fill="none" stroke="#0d7377" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M54 48q3 3 10 0" fill="none" stroke="#0d7377" stroke-width="2" stroke-linecap="round"/>
+  <!-- Base -->
+  <rect x="42" y="50" width="12" height="3" rx="1.5" fill="#0d7377"/>
+  <defs><radialGradient id="cp-g"><stop offset="0" stop-color="#FFD700" stop-opacity=".3"/><stop offset="1" stop-color="#FFD700" stop-opacity="0"/></radialGradient></defs>
+</svg>

--- a/frontend/public/illustrations/achievements/first-scan.svg
+++ b/frontend/public/illustrations/achievements/first-scan.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" width="96" height="96" aria-hidden="true">
+  <title>First Scan</title>
+  <!-- Ribbon -->
+  <path d="M38 78l-8 16v-20h8z" fill="#d4a844" opacity=".8"/>
+  <path d="M58 78l8 16v-20h-8z" fill="#c09030" opacity=".8"/>
+  <!-- Medal ring -->
+  <circle cx="48" cy="44" r="32" fill="#FFD700"/>
+  <circle cx="48" cy="44" r="28" fill="#FFF8DC"/>
+  <circle cx="48" cy="44" r="26" fill="#FFFBF0"/>
+  <!-- Inner shadow -->
+  <circle cx="48" cy="44" r="26" fill="url(#fs-g)" opacity=".15"/>
+  <!-- Barcode icon -->
+  <rect x="33" y="32" width="3" height="24" rx="1" fill="#0d7377"/>
+  <rect x="38" y="32" width="2" height="24" rx=".5" fill="#0d7377"/>
+  <rect x="42" y="32" width="4" height="24" rx="1" fill="#0d7377"/>
+  <rect x="48" y="32" width="2" height="24" rx=".5" fill="#0d7377"/>
+  <rect x="52" y="32" width="3" height="24" rx="1" fill="#0d7377"/>
+  <rect x="57" y="32" width="2" height="24" rx=".5" fill="#0d7377"/>
+  <rect x="61" y="32" width="3" height="24" rx="1" fill="#0d7377"/>
+  <!-- Glow -->
+  <defs><radialGradient id="fs-g"><stop offset="0" stop-color="#FFD700" stop-opacity=".3"/><stop offset="1" stop-color="#FFD700" stop-opacity="0"/></radialGradient></defs>
+</svg>

--- a/frontend/public/illustrations/achievements/health-explorer.svg
+++ b/frontend/public/illustrations/achievements/health-explorer.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" width="96" height="96" aria-hidden="true">
+  <title>Health Explorer</title>
+  <!-- Ribbon -->
+  <path d="M38 78l-8 16v-20h8z" fill="#d4a844" opacity=".8"/>
+  <path d="M58 78l8 16v-20h-8z" fill="#c09030" opacity=".8"/>
+  <!-- Medal ring -->
+  <circle cx="48" cy="44" r="32" fill="#FFD700"/>
+  <circle cx="48" cy="44" r="28" fill="#FFF8DC"/>
+  <circle cx="48" cy="44" r="26" fill="#FFFBF0"/>
+  <circle cx="48" cy="44" r="26" fill="url(#he-g)" opacity=".15"/>
+  <!-- Magnifying glass -->
+  <circle cx="44" cy="40" r="10" fill="none" stroke="#0d7377" stroke-width="2.5"/>
+  <line x1="51" y1="47" x2="60" y2="56" stroke="#0d7377" stroke-width="3" stroke-linecap="round"/>
+  <!-- Magnifying glass lens highlight -->
+  <path d="M39 36a6 6 0 0 1 8-2" fill="none" stroke="#0d7377" stroke-width="1.5" stroke-linecap="round" opacity=".4"/>
+  <!-- Small heart inside lens -->
+  <path d="M44 37c-1-2-4-2-4 0s4 5 4 5 4-3 4-5-3-2-4 0z" fill="#22c55e" opacity=".7"/>
+  <defs><radialGradient id="he-g"><stop offset="0" stop-color="#FFD700" stop-opacity=".3"/><stop offset="1" stop-color="#FFD700" stop-opacity="0"/></radialGradient></defs>
+</svg>

--- a/frontend/public/illustrations/achievements/list-builder.svg
+++ b/frontend/public/illustrations/achievements/list-builder.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" width="96" height="96" aria-hidden="true">
+  <title>List Builder</title>
+  <!-- Ribbon -->
+  <path d="M38 78l-8 16v-20h8z" fill="#d4a844" opacity=".8"/>
+  <path d="M58 78l8 16v-20h-8z" fill="#c09030" opacity=".8"/>
+  <!-- Medal ring -->
+  <circle cx="48" cy="44" r="32" fill="#FFD700"/>
+  <circle cx="48" cy="44" r="28" fill="#FFF8DC"/>
+  <circle cx="48" cy="44" r="26" fill="#FFFBF0"/>
+  <circle cx="48" cy="44" r="26" fill="url(#lb-g)" opacity=".15"/>
+  <!-- List/clipboard icon -->
+  <rect x="37" y="28" width="22" height="30" rx="3" fill="none" stroke="#0d7377" stroke-width="2.5"/>
+  <rect x="42" y="25" width="12" height="6" rx="2" fill="#0d7377"/>
+  <!-- Checkmarks -->
+  <path d="M41 38l2.5 2.5L48 36" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M41 45l2.5 2.5L48 43" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M41 52l2.5 2.5L48 50" fill="none" stroke="#0d7377" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Lines -->
+  <line x1="51" y1="38" x2="56" y2="38" stroke="#0d7377" stroke-width="2" stroke-linecap="round"/>
+  <line x1="51" y1="45" x2="56" y2="45" stroke="#0d7377" stroke-width="2" stroke-linecap="round"/>
+  <line x1="51" y1="52" x2="56" y2="52" stroke="#0d7377" stroke-width="2" stroke-linecap="round"/>
+  <defs><radialGradient id="lb-g"><stop offset="0" stop-color="#FFD700" stop-opacity=".3"/><stop offset="1" stop-color="#FFD700" stop-opacity="0"/></radialGradient></defs>
+</svg>

--- a/frontend/public/illustrations/achievements/profile-complete.svg
+++ b/frontend/public/illustrations/achievements/profile-complete.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" width="96" height="96" aria-hidden="true">
+  <title>Profile Complete</title>
+  <!-- Ribbon -->
+  <path d="M38 78l-8 16v-20h8z" fill="#d4a844" opacity=".8"/>
+  <path d="M58 78l8 16v-20h-8z" fill="#c09030" opacity=".8"/>
+  <!-- Medal ring -->
+  <circle cx="48" cy="44" r="32" fill="#FFD700"/>
+  <circle cx="48" cy="44" r="28" fill="#FFF8DC"/>
+  <circle cx="48" cy="44" r="26" fill="#FFFBF0"/>
+  <circle cx="48" cy="44" r="26" fill="url(#pc-g)" opacity=".15"/>
+  <!-- Heart icon (health profile) -->
+  <path d="M48 54c-12-8-18-14-18-20a9 9 0 0 1 18 0 9 9 0 0 1 18 0c0 6-6 12-18 20z" fill="#0d7377"/>
+  <!-- Heartbeat line -->
+  <path d="M37 42h5l2-4 3 8 2-4h5" fill="none" stroke="#FFFBF0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Checkmark circle overlay -->
+  <circle cx="58" cy="54" r="7" fill="#22c55e"/>
+  <path d="M54.5 54l2 2 4.5-4" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <defs><radialGradient id="pc-g"><stop offset="0" stop-color="#FFD700" stop-opacity=".3"/><stop offset="1" stop-color="#FFD700" stop-opacity="0"/></radialGradient></defs>
+</svg>

--- a/frontend/src/components/common/AchievementBadge.test.tsx
+++ b/frontend/src/components/common/AchievementBadge.test.tsx
@@ -1,0 +1,215 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  AchievementBadge,
+  getAchievementTypes,
+  getAchievementMeta,
+} from "./AchievementBadge";
+import type { AchievementType } from "./AchievementBadge";
+
+describe("AchievementBadge", () => {
+  // ── Rendering ─────────────────────────────────────────────────────────────
+
+  it("renders an image for a known achievement type", () => {
+    render(<AchievementBadge type="first-scan" unlocked={true} />);
+    const img = screen.getByRole("img");
+    expect(img).toBeTruthy();
+  });
+
+  it("uses the correct SVG source path", () => {
+    render(<AchievementBadge type="list-builder" unlocked={true} />);
+    const img = screen.getByRole("img");
+    expect(img.getAttribute("src")).toContain("list-builder");
+  });
+
+  // ── All 5 types render ────────────────────────────────────────────────────
+
+  const TYPES: AchievementType[] = [
+    "first-scan",
+    "list-builder",
+    "health-explorer",
+    "comparison-pro",
+    "profile-complete",
+  ];
+
+  it.each(TYPES)("renders unlocked badge for type: %s", (type) => {
+    const { container } = render(
+      <AchievementBadge type={type} unlocked={true} />,
+    );
+    expect(container.querySelector("img")).toBeTruthy();
+  });
+
+  it.each(TYPES)("renders locked badge for type: %s", (type) => {
+    const { container } = render(
+      <AchievementBadge type={type} unlocked={false} />,
+    );
+    expect(container.querySelector("img")).toBeTruthy();
+  });
+
+  // ── Unlocked vs Locked states ─────────────────────────────────────────────
+
+  it("applies achievement-unlocked class when unlocked", () => {
+    render(<AchievementBadge type="first-scan" unlocked={true} />);
+    const img = screen.getByRole("img");
+    expect(img.className).toContain("achievement-unlocked");
+    expect(img.className).not.toContain("grayscale");
+  });
+
+  it("applies grayscale + opacity classes when locked", () => {
+    render(<AchievementBadge type="first-scan" unlocked={false} />);
+    const img = screen.getByRole("img");
+    expect(img.className).toContain("achievement-locked");
+    expect(img.className).toContain("grayscale");
+    expect(img.className).toContain("opacity-50");
+  });
+
+  it("sets data-unlocked attribute based on state", () => {
+    const { container: unlockedContainer } = render(
+      <AchievementBadge type="first-scan" unlocked={true} />,
+    );
+    expect(
+      unlockedContainer
+        .querySelector("[data-achievement]")
+        ?.getAttribute("data-unlocked"),
+    ).toBe("true");
+
+    const { container: lockedContainer } = render(
+      <AchievementBadge type="first-scan" unlocked={false} />,
+    );
+    expect(
+      lockedContainer
+        .querySelector("[data-achievement]")
+        ?.getAttribute("data-unlocked"),
+    ).toBe("false");
+  });
+
+  // ── Size variants ─────────────────────────────────────────────────────────
+
+  it("renders sm size (32px)", () => {
+    render(<AchievementBadge type="first-scan" unlocked={true} size="sm" />);
+    const img = screen.getByRole("img");
+    expect(img.getAttribute("width")).toBe("32");
+    expect(img.getAttribute("height")).toBe("32");
+  });
+
+  it("defaults to md size (48px)", () => {
+    render(<AchievementBadge type="first-scan" unlocked={true} />);
+    const img = screen.getByRole("img");
+    expect(img.getAttribute("width")).toBe("48");
+    expect(img.getAttribute("height")).toBe("48");
+  });
+
+  it("renders lg size (96px)", () => {
+    render(<AchievementBadge type="first-scan" unlocked={true} size="lg" />);
+    const img = screen.getByRole("img");
+    expect(img.getAttribute("width")).toBe("96");
+    expect(img.getAttribute("height")).toBe("96");
+  });
+
+  // ── Accessibility ─────────────────────────────────────────────────────────
+
+  it("includes achievement name and state in alt text (unlocked)", () => {
+    render(<AchievementBadge type="first-scan" unlocked={true} />);
+    const img = screen.getByRole("img");
+    const alt = img.getAttribute("alt") ?? "";
+    expect(alt).toContain("First Scan");
+    expect(alt).toContain("Unlocked");
+  });
+
+  it("includes achievement name and state in alt text (locked)", () => {
+    render(<AchievementBadge type="first-scan" unlocked={false} />);
+    const img = screen.getByRole("img");
+    const alt = img.getAttribute("alt") ?? "";
+    expect(alt).toContain("First Scan");
+    expect(alt).toContain("Locked");
+  });
+
+  it("includes achievement description in alt text", () => {
+    render(<AchievementBadge type="health-explorer" unlocked={true} />);
+    const img = screen.getByRole("img");
+    const alt = img.getAttribute("alt") ?? "";
+    expect(alt).toContain("Viewed 50 or more product details");
+  });
+
+  // ── Label display ─────────────────────────────────────────────────────────
+
+  it("shows label text when showLabel is true", () => {
+    render(
+      <AchievementBadge type="first-scan" unlocked={true} showLabel={true} />,
+    );
+    expect(screen.getByText("First Scan")).toBeTruthy();
+  });
+
+  it("does not show label text when showLabel is false", () => {
+    render(
+      <AchievementBadge
+        type="first-scan"
+        unlocked={true}
+        showLabel={false}
+      />,
+    );
+    expect(screen.queryByText("First Scan")).toBeNull();
+  });
+
+  it("does not show label by default", () => {
+    render(<AchievementBadge type="first-scan" unlocked={true} />);
+    expect(screen.queryByText("First Scan")).toBeNull();
+  });
+
+  // ── CSS className passthrough ─────────────────────────────────────────────
+
+  it("applies custom className to wrapper", () => {
+    const { container } = render(
+      <AchievementBadge
+        type="first-scan"
+        unlocked={true}
+        className="my-custom-class"
+      />,
+    );
+    const wrapper = container.querySelector("[data-achievement]")!;
+    expect(wrapper.className).toContain("my-custom-class");
+  });
+
+  // ── data-achievement attribute ────────────────────────────────────────────
+
+  it("sets data-achievement attribute to the type", () => {
+    const { container } = render(
+      <AchievementBadge type="comparison-pro" unlocked={true} />,
+    );
+    expect(
+      container
+        .querySelector("[data-achievement]")
+        ?.getAttribute("data-achievement"),
+    ).toBe("comparison-pro");
+  });
+
+  // ── Utility: getAchievementTypes ──────────────────────────────────────────
+
+  it("getAchievementTypes returns all 5 types", () => {
+    const types = getAchievementTypes();
+    expect(types).toHaveLength(5);
+    expect(types).toContain("first-scan");
+    expect(types).toContain("list-builder");
+    expect(types).toContain("health-explorer");
+    expect(types).toContain("comparison-pro");
+    expect(types).toContain("profile-complete");
+  });
+
+  // ── Utility: getAchievementMeta ───────────────────────────────────────────
+
+  it("getAchievementMeta returns label and description", () => {
+    const meta = getAchievementMeta("first-scan");
+    expect(meta.label).toBe("First Scan");
+    expect(meta.description).toBe("Scanned your first product barcode");
+    expect(meta.src).toContain("first-scan.svg");
+  });
+
+  it("getAchievementMeta returns correct data for all types", () => {
+    for (const type of getAchievementTypes()) {
+      const meta = getAchievementMeta(type);
+      expect(meta.label).toBeTruthy();
+      expect(meta.description).toBeTruthy();
+      expect(meta.src).toContain(".svg");
+    }
+  });
+});

--- a/frontend/src/components/common/AchievementBadge.tsx
+++ b/frontend/src/components/common/AchievementBadge.tsx
@@ -1,0 +1,145 @@
+// ─── AchievementBadge — Gamification achievement badge component ────────────
+// 5 achievement types with unlocked (full color) and locked (grayscale) states.
+// SVG illustrations stored in public/illustrations/achievements/.
+// CSS-driven locked/unlocked display — no duplicate SVG files needed.
+//
+// Issue #425 — Design 5 achievement badges (unlocked + locked states)
+
+import Image from "next/image";
+
+/* ── Achievement definitions ─────────────────────────────────────────────── */
+
+export type AchievementType =
+  | "first-scan"
+  | "list-builder"
+  | "health-explorer"
+  | "comparison-pro"
+  | "profile-complete";
+
+interface AchievementMeta {
+  readonly label: string;
+  readonly description: string;
+  readonly src: string;
+}
+
+const ACHIEVEMENT_META: Record<AchievementType, AchievementMeta> = {
+  "first-scan": {
+    label: "First Scan",
+    description: "Scanned your first product barcode",
+    src: "/illustrations/achievements/first-scan.svg",
+  },
+  "list-builder": {
+    label: "List Builder",
+    description: "Created 5 or more product lists",
+    src: "/illustrations/achievements/list-builder.svg",
+  },
+  "health-explorer": {
+    label: "Health Explorer",
+    description: "Viewed 50 or more product details",
+    src: "/illustrations/achievements/health-explorer.svg",
+  },
+  "comparison-pro": {
+    label: "Comparison Pro",
+    description: "Saved 10 or more product comparisons",
+    src: "/illustrations/achievements/comparison-pro.svg",
+  },
+  "profile-complete": {
+    label: "Profile Complete",
+    description: "Fully configured your health profile",
+    src: "/illustrations/achievements/profile-complete.svg",
+  },
+};
+
+/* ── Size scale ──────────────────────────────────────────────────────────── */
+
+const SIZE_MAP = {
+  sm: 32,
+  md: 48,
+  lg: 96,
+} as const;
+
+export type AchievementBadgeSize = keyof typeof SIZE_MAP;
+
+/* ── Props ───────────────────────────────────────────────────────────────── */
+
+export interface AchievementBadgeProps {
+  /** Achievement type identifier. */
+  readonly type: AchievementType;
+  /** Whether the achievement is unlocked (full color) or locked (grayscale). */
+  readonly unlocked: boolean;
+  /** Badge size preset. @default "md" (48px) */
+  readonly size?: AchievementBadgeSize;
+  /** Show text label below the badge. @default false */
+  readonly showLabel?: boolean;
+  /** Additional CSS classes on the wrapper. */
+  readonly className?: string;
+}
+
+/* ── Component ───────────────────────────────────────────────────────────── */
+
+/**
+ * Renders an achievement badge with unlocked (full color) or locked (grayscale)
+ * visual state. CSS-driven — same SVG file, different filter classes.
+ *
+ * @example
+ * // Unlocked achievement
+ * <AchievementBadge type="first-scan" unlocked={true} size="lg" showLabel />
+ *
+ * // Locked achievement (grayscale + 50% opacity)
+ * <AchievementBadge type="first-scan" unlocked={false} />
+ */
+export function AchievementBadge({
+  type,
+  unlocked,
+  size = "md",
+  showLabel = false,
+  className = "",
+}: AchievementBadgeProps) {
+  const meta = ACHIEVEMENT_META[type];
+  const px = SIZE_MAP[size];
+  const stateLabel = unlocked ? "Unlocked" : "Locked";
+  const ariaLabel = `${meta.label} — ${stateLabel}: ${meta.description}`;
+
+  return (
+    <div
+      className={`inline-flex flex-col items-center gap-1 ${className}`}
+      data-achievement={type}
+      data-unlocked={unlocked}
+    >
+      <Image
+        src={meta.src}
+        alt={ariaLabel}
+        width={px}
+        height={px}
+        className={
+          unlocked
+            ? "achievement-unlocked"
+            : "achievement-locked grayscale opacity-50"
+        }
+        draggable={false}
+      />
+      {showLabel && (
+        <span
+          className={`text-xs font-medium text-center leading-tight ${
+            unlocked ? "text-gray-900 dark:text-gray-100" : "text-gray-400 dark:text-gray-500"
+          }`}
+          style={{ maxWidth: px }}
+        >
+          {meta.label}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/* ── Utilities ───────────────────────────────────────────────────────────── */
+
+/** All supported achievement type identifiers. */
+export function getAchievementTypes(): AchievementType[] {
+  return Object.keys(ACHIEVEMENT_META) as AchievementType[];
+}
+
+/** Returns display metadata for an achievement type. */
+export function getAchievementMeta(type: AchievementType): AchievementMeta {
+  return ACHIEVEMENT_META[type];
+}


### PR DESCRIPTION
## Summary

Closes #425 — Design 5 achievement badges (unlocked + locked states).

## Changes

### 5 Achievement Badge SVGs (`frontend/public/illustrations/achievements/`)
| Badge | File | Size | Center Icon |
|-------|------|------|-------------|
| First Scan | `first-scan.svg` | 1.2 KB | Barcode |
| List Builder | `list-builder.svg` | 1.6 KB | Clipboard with checkmarks |
| Health Explorer | `health-explorer.svg` | 1.2 KB | Magnifying glass + heart |
| Comparison Pro | `comparison-pro.svg` | 1.6 KB | Balance scale |
| Profile Complete | `profile-complete.svg` | 1.2 KB | Heart + heartbeat + checkmark |

**Design:** Circular medal/badge with gold (#FFD700) ring, accent (#d4a844) ribbon tails, cream inner circle, brand teal (#0d7377) center icons. All < 3KB.

### AchievementBadge Component
- `type`: 5 achievement identifiers
- `unlocked`: boolean — controls CSS state (full color vs grayscale + 50% opacity)
- `size`: `'sm'` (32px) / `'md'` (48px, default) / `'lg'` (96px)
- `showLabel`: optional text label below badge
- `data-achievement` + `data-unlocked` attributes for test/styling hooks
- Alt text includes achievement name, state, and description
- Utilities: `getAchievementTypes()`, `getAchievementMeta()`

### 29 Tests
- All 5 types × unlocked/locked rendering
- CSS class application (achievement-unlocked vs grayscale+opacity)
- data-attribute correctness
- Size variants (sm/md/lg)
- Accessibility (alt text with name + state + description)
- Label display (showLabel = true/false/default)
- className passthrough
- Utility functions

## Verification
- `npx tsc --noEmit` — 0 errors
- `npx vitest run AchievementBadge` — 29/29 pass
- All SVGs < 3KB