### PR TITLE
feat(frontend): add 8 empty-state illustrations + EmptyStateIllustration component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,15 @@ Adheres to [Semantic Versioning](https://semver.org/).
   `data-achievement` and `data-unlocked` attributes; 29 Vitest tests covering
   all 5 types × 2 states, accessibility, sizing, label display, and
   utilities (#425)
+- Create 8 empty-state SVG illustrations in
+  `frontend/public/illustrations/empty-states/` (no-results, no-favorites,
+  no-scan-history, no-comparisons, no-lists, no-products-category,
+  no-submissions, no-saved-searches); flat/semi-flat style with brand palette,
+  dark mode via `prefers-color-scheme` media queries, all under 2.1 KB;
+  `EmptyStateIllustration` React component wrapping existing `EmptyState`
+  with context-specific SVG illustrations, typed to 8 states, i18n-ready;
+  39 Vitest tests covering all 8 types, alt text, actions, image dimensions,
+  className passthrough, and utility functions (#423)
 - Redesign README.md as 15-section showcase-quality layout: hero banner, 9
   shields.io badges, elevator pitch, 4 feature highlight cards (HTML table),
   comparison table, 3-column quick start with collapsible command reference,

--- a/frontend/public/illustrations/empty-states/no-comparisons.svg
+++ b/frontend/public/illustrations/empty-states/no-comparisons.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 200" fill="none">
+  <style>
+    .es-plate { fill: #e2e8f0; }
+    .es-plate-rim { fill: #cbd5e1; }
+    .es-shadow { fill: #94a3b8; opacity: 0.18; }
+    .es-arrows { stroke: #0d7377; stroke-width: 2.5; stroke-linecap: round; stroke-linejoin: round; fill: none; }
+    .es-dash { stroke: #d4a844; stroke-width: 1.5; stroke-dasharray: 3 5; fill: none; }
+    @media (prefers-color-scheme: dark) {
+      .es-plate { fill: #334155; }
+      .es-plate-rim { fill: #475569; }
+      .es-shadow { fill: #1e293b; opacity: 0.3; }
+      .es-arrows { stroke: #2dd4bf; }
+      .es-dash { stroke: #fbbf24; }
+    }
+  </style>
+  <!-- Shadows -->
+  <ellipse class="es-shadow" cx="76" cy="168" rx="46" ry="8"/>
+  <ellipse class="es-shadow" cx="164" cy="168" rx="46" ry="8"/>
+  <!-- Left plate -->
+  <ellipse class="es-plate-rim" cx="76" cy="136" rx="46" ry="22"/>
+  <ellipse class="es-plate" cx="76" cy="132" rx="40" ry="18"/>
+  <!-- Right plate -->
+  <ellipse class="es-plate-rim" cx="164" cy="136" rx="46" ry="22"/>
+  <ellipse class="es-plate" cx="164" cy="132" rx="40" ry="18"/>
+  <!-- Dashed circles inside plates (empty indicator) -->
+  <circle class="es-dash" cx="76" cy="130" r="16"/>
+  <circle class="es-dash" cx="164" cy="130" r="16"/>
+  <!-- Double-headed arrows between plates -->
+  <polyline class="es-arrows" points="108,98 120,88 132,98"/>
+  <line class="es-arrows" x1="120" y1="88" x2="120" y2="112"/>
+  <polyline class="es-arrows" points="108,112 120,122 132,112"/>
+  <!-- Small compare dots above -->
+  <circle fill="#0d7377" cx="96" cy="60" r="4" opacity="0.25"/>
+  <circle fill="#0d7377" cx="120" cy="50" r="5" opacity="0.15"/>
+  <circle fill="#0d7377" cx="144" cy="58" r="3.5" opacity="0.2"/>
+</svg>

--- a/frontend/public/illustrations/empty-states/no-favorites.svg
+++ b/frontend/public/illustrations/empty-states/no-favorites.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 200" fill="none">
+  <style>
+    .es-plate { fill: #e2e8f0; }
+    .es-plate-rim { fill: #cbd5e1; }
+    .es-heart { fill: #0d7377; opacity: 0.2; }
+    .es-heart-outline { stroke: #0d7377; stroke-width: 2; fill: none; }
+    .es-shadow { fill: #94a3b8; opacity: 0.18; }
+    .es-dash { stroke: #d4a844; stroke-width: 2; stroke-linecap: round; stroke-dasharray: 4 6; fill: none; }
+    @media (prefers-color-scheme: dark) {
+      .es-plate { fill: #334155; }
+      .es-plate-rim { fill: #475569; }
+      .es-heart { fill: #2dd4bf; opacity: 0.22; }
+      .es-heart-outline { stroke: #2dd4bf; }
+      .es-shadow { fill: #1e293b; opacity: 0.3; }
+      .es-dash { stroke: #fbbf24; }
+    }
+  </style>
+  <!-- Shadow -->
+  <ellipse class="es-shadow" cx="120" cy="170" rx="65" ry="10"/>
+  <!-- Heart-shaped plate rim -->
+  <path class="es-plate-rim" d="M120 162 C60 162 50 130 50 118 C50 90 80 72 120 100 C160 72 190 90 190 118 C190 130 180 162 120 162Z"/>
+  <!-- Heart-shaped plate surface -->
+  <path class="es-plate" d="M120 155 C68 155 58 128 58 118 C58 94 84 80 120 104 C156 80 182 94 182 118 C182 128 172 155 120 155Z"/>
+  <!-- Dashed circle inside (empty indicator) -->
+  <circle class="es-dash" cx="120" cy="118" r="22"/>
+  <!-- Small hearts floating above -->
+  <path class="es-heart-outline" d="M80 60 C76 54 66 54 66 62 C66 68 80 78 80 78 C80 78 94 68 94 62 C94 54 84 54 80 60Z" transform="scale(0.5) translate(100 60)"/>
+  <path class="es-heart-outline" d="M80 60 C76 54 66 54 66 62 C66 68 80 78 80 78 C80 78 94 68 94 62 C94 54 84 54 80 60Z" transform="scale(0.4) translate(340 80)"/>
+</svg>

--- a/frontend/public/illustrations/empty-states/no-lists.svg
+++ b/frontend/public/illustrations/empty-states/no-lists.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 200" fill="none">
+  <style>
+    .es-basket { fill: #e2e8f0; }
+    .es-basket-rim { stroke: #cbd5e1; stroke-width: 3; fill: none; }
+    .es-handle { stroke: #0d7377; stroke-width: 3; fill: none; stroke-linecap: round; }
+    .es-weave { stroke: #cbd5e1; stroke-width: 1.5; }
+    .es-shadow { fill: #94a3b8; opacity: 0.18; }
+    .es-sparkle { fill: #d4a844; }
+    @media (prefers-color-scheme: dark) {
+      .es-basket { fill: #334155; }
+      .es-basket-rim { stroke: #475569; }
+      .es-handle { stroke: #2dd4bf; }
+      .es-weave { stroke: #475569; }
+      .es-shadow { fill: #1e293b; opacity: 0.3; }
+      .es-sparkle { fill: #fbbf24; }
+    }
+  </style>
+  <!-- Shadow -->
+  <ellipse class="es-shadow" cx="120" cy="172" rx="58" ry="9"/>
+  <!-- Basket body -->
+  <path class="es-basket" d="M68 100 L76 160 L164 160 L172 100Z"/>
+  <line class="es-basket-rim" x1="64" y1="100" x2="176" y2="100"/>
+  <!-- Basket weave lines -->
+  <line class="es-weave" x1="72" y1="115" x2="168" y2="115"/>
+  <line class="es-weave" x1="74" y1="130" x2="166" y2="130"/>
+  <line class="es-weave" x1="76" y1="145" x2="164" y2="145"/>
+  <!-- Handle -->
+  <path class="es-handle" d="M92 100 Q92 58 120 58 Q148 58 148 100"/>
+  <!-- Sparkles around basket -->
+  <path class="es-sparkle" d="M58 72 L60 66 L62 72 L68 74 L62 76 L60 82 L58 76 L52 74Z"/>
+  <path class="es-sparkle" d="M174 62 L175.5 57.5 L177 62 L181.5 63.5 L177 65 L175.5 69.5 L174 65 L169.5 63.5Z"/>
+  <path class="es-sparkle" d="M182 90 L183 86.5 L184 90 L187.5 91 L184 92 L183 95.5 L182 92 L178.5 91Z"/>
+  <!-- Plus sign inside basket -->
+  <line class="es-handle" x1="120" y1="118" x2="120" y2="142"/>
+  <line class="es-handle" x1="108" y1="130" x2="132" y2="130"/>
+</svg>

--- a/frontend/public/illustrations/empty-states/no-products-category.svg
+++ b/frontend/public/illustrations/empty-states/no-products-category.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 200" fill="none">
+  <style>
+    .es-shelf { fill: #cbd5e1; }
+    .es-shelf-edge { fill: #94a3b8; }
+    .es-bracket { stroke: #0d7377; stroke-width: 2.5; fill: none; stroke-linecap: round; }
+    .es-shadow { fill: #94a3b8; opacity: 0.18; }
+    .es-dash { stroke: #d4a844; stroke-width: 1.5; stroke-dasharray: 5 5; fill: none; }
+    .es-dot { fill: #e2e8f0; }
+    @media (prefers-color-scheme: dark) {
+      .es-shelf { fill: #475569; }
+      .es-shelf-edge { fill: #334155; }
+      .es-bracket { stroke: #2dd4bf; }
+      .es-shadow { fill: #1e293b; opacity: 0.3; }
+      .es-dash { stroke: #fbbf24; }
+      .es-dot { fill: #334155; }
+    }
+  </style>
+  <!-- Shadow -->
+  <ellipse class="es-shadow" cx="120" cy="176" rx="80" ry="8"/>
+  <!-- Top shelf -->
+  <rect class="es-shelf" x="36" y="68" width="168" height="8" rx="2"/>
+  <rect class="es-shelf-edge" x="36" y="74" width="168" height="4" rx="1"/>
+  <!-- Middle shelf -->
+  <rect class="es-shelf" x="36" y="110" width="168" height="8" rx="2"/>
+  <rect class="es-shelf-edge" x="36" y="116" width="168" height="4" rx="1"/>
+  <!-- Bottom shelf -->
+  <rect class="es-shelf" x="36" y="152" width="168" height="8" rx="2"/>
+  <rect class="es-shelf-edge" x="36" y="158" width="168" height="4" rx="1"/>
+  <!-- Shelf supports -->
+  <rect class="es-shelf" x="38" y="68" width="5" height="100" rx="1"/>
+  <rect class="es-shelf" x="197" y="68" width="5" height="100" rx="1"/>
+  <!-- Ghost product outlines (dashed rectangles) -->
+  <rect class="es-dash" x="60" y="80" width="24" height="28" rx="3"/>
+  <rect class="es-dash" x="108" y="80" width="24" height="28" rx="3"/>
+  <rect class="es-dash" x="156" y="80" width="24" height="28" rx="3"/>
+  <!-- Ghost products row 2 -->
+  <rect class="es-dash" x="84" y="122" width="24" height="28" rx="3"/>
+  <rect class="es-dash" x="132" y="122" width="24" height="28" rx="3"/>
+  <!-- Filter bracket icon -->
+  <path class="es-bracket" d="M102 40 L120 32 L138 40"/>
+  <line class="es-bracket" x1="120" y1="32" x2="120" y2="50"/>
+  <line class="es-bracket" x1="110" y1="50" x2="130" y2="50"/>
+</svg>

--- a/frontend/public/illustrations/empty-states/no-results.svg
+++ b/frontend/public/illustrations/empty-states/no-results.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 200" fill="none">
+  <style>
+    .es-plate { fill: #e2e8f0; }
+    .es-plate-rim { fill: #cbd5e1; }
+    .es-glass { fill: #0d7377; opacity: 0.15; }
+    .es-glass-rim { stroke: #0d7377; stroke-width: 2.5; fill: none; }
+    .es-handle { stroke: #0d7377; stroke-width: 3; stroke-linecap: round; fill: none; }
+    .es-shadow { fill: #94a3b8; opacity: 0.18; }
+    .es-accent { fill: #d4a844; }
+    @media (prefers-color-scheme: dark) {
+      .es-plate { fill: #334155; }
+      .es-plate-rim { fill: #475569; }
+      .es-glass { fill: #2dd4bf; opacity: 0.18; }
+      .es-glass-rim { stroke: #2dd4bf; }
+      .es-handle { stroke: #2dd4bf; }
+      .es-shadow { fill: #1e293b; opacity: 0.3; }
+      .es-accent { fill: #fbbf24; }
+    }
+  </style>
+  <!-- Shadow -->
+  <ellipse class="es-shadow" cx="120" cy="170" rx="70" ry="10"/>
+  <!-- Plate -->
+  <ellipse class="es-plate-rim" cx="120" cy="138" rx="58" ry="28"/>
+  <ellipse class="es-plate" cx="120" cy="134" rx="52" ry="24"/>
+  <!-- Magnifying glass -->
+  <circle class="es-glass" cx="110" cy="90" r="32"/>
+  <circle class="es-glass-rim" cx="110" cy="90" r="32"/>
+  <!-- Handle -->
+  <line class="es-handle" x1="134" y1="114" x2="158" y2="138"/>
+  <!-- Question mark accent -->
+  <text class="es-accent" x="104" y="98" font-family="Arial, sans-serif" font-size="28" font-weight="700">?</text>
+</svg>

--- a/frontend/public/illustrations/empty-states/no-saved-searches.svg
+++ b/frontend/public/illustrations/empty-states/no-saved-searches.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 200" fill="none">
+  <style>
+    .es-bookmark { fill: #e2e8f0; }
+    .es-bookmark-fold { fill: #cbd5e1; }
+    .es-glass { fill: #0d7377; opacity: 0.15; }
+    .es-glass-rim { stroke: #0d7377; stroke-width: 2.5; fill: none; }
+    .es-handle { stroke: #0d7377; stroke-width: 3; stroke-linecap: round; fill: none; }
+    .es-shadow { fill: #94a3b8; opacity: 0.18; }
+    .es-line { stroke: #cbd5e1; stroke-width: 2; stroke-linecap: round; }
+    .es-accent { fill: #d4a844; }
+    @media (prefers-color-scheme: dark) {
+      .es-bookmark { fill: #334155; }
+      .es-bookmark-fold { fill: #475569; }
+      .es-glass { fill: #2dd4bf; opacity: 0.18; }
+      .es-glass-rim { stroke: #2dd4bf; }
+      .es-handle { stroke: #2dd4bf; }
+      .es-shadow { fill: #1e293b; opacity: 0.3; }
+      .es-line { stroke: #475569; }
+      .es-accent { fill: #fbbf24; }
+    }
+  </style>
+  <!-- Shadow -->
+  <ellipse class="es-shadow" cx="120" cy="176" rx="56" ry="8"/>
+  <!-- Bookmark shape -->
+  <path class="es-bookmark" d="M82 36 L82 168 L120 148 L158 168 L158 36 Q158 30 152 30 L88 30 Q82 30 82 36Z"/>
+  <path class="es-bookmark-fold" d="M82 168 L120 148 L120 140 L82 158Z"/>
+  <path class="es-bookmark-fold" d="M158 168 L120 148 L120 140 L158 158Z"/>
+  <!-- Text lines on bookmark -->
+  <line class="es-line" x1="96" y1="52" x2="144" y2="52"/>
+  <line class="es-line" x1="96" y1="66" x2="138" y2="66"/>
+  <line class="es-line" x1="96" y1="80" x2="142" y2="80"/>
+  <!-- Magnifying glass overlapping bookmark -->
+  <circle class="es-glass" cx="140" cy="112" r="22"/>
+  <circle class="es-glass-rim" cx="140" cy="112" r="22"/>
+  <line class="es-handle" x1="156" y1="128" x2="172" y2="144"/>
+  <!-- Bell/notification accent -->
+  <path class="es-accent" d="M60 56 L62 50 L64 56 L70 58 L64 60 L62 66 L60 60 L54 58Z"/>
+  <circle class="es-accent" cx="180" cy="48" r="3"/>
+</svg>

--- a/frontend/public/illustrations/empty-states/no-scan-history.svg
+++ b/frontend/public/illustrations/empty-states/no-scan-history.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 200" fill="none">
+  <style>
+    .es-shelf { fill: #cbd5e1; }
+    .es-shelf-edge { fill: #94a3b8; }
+    .es-scanner { fill: #0d7377; }
+    .es-scanner-light { fill: #d4a844; opacity: 0.35; }
+    .es-beam { stroke: #d4a844; stroke-width: 2; stroke-dasharray: 6 4; }
+    .es-shadow { fill: #94a3b8; opacity: 0.18; }
+    .es-barcode { stroke: #64748b; stroke-width: 2; stroke-linecap: round; }
+    @media (prefers-color-scheme: dark) {
+      .es-shelf { fill: #475569; }
+      .es-shelf-edge { fill: #334155; }
+      .es-scanner { fill: #2dd4bf; }
+      .es-scanner-light { fill: #fbbf24; opacity: 0.3; }
+      .es-beam { stroke: #fbbf24; }
+      .es-shadow { fill: #1e293b; opacity: 0.3; }
+      .es-barcode { stroke: #94a3b8; }
+    }
+  </style>
+  <!-- Shadow -->
+  <ellipse class="es-shadow" cx="120" cy="172" rx="75" ry="9"/>
+  <!-- Empty shelf -->
+  <rect class="es-shelf" x="40" y="130" width="160" height="10" rx="2"/>
+  <rect class="es-shelf-edge" x="40" y="138" width="160" height="6" rx="1"/>
+  <!-- Shelf supports -->
+  <rect class="es-shelf" x="52" y="144" width="6" height="24" rx="1"/>
+  <rect class="es-shelf" x="182" y="144" width="6" height="24" rx="1"/>
+  <!-- Scanner device -->
+  <rect class="es-scanner" x="96" y="50" width="48" height="32" rx="6"/>
+  <rect class="es-scanner" x="112" y="82" width="16" height="20" rx="2"/>
+  <!-- Scanner beam (dashed line pointing at shelf) -->
+  <line class="es-beam" x1="120" y1="102" x2="120" y2="128"/>
+  <!-- Scan light glow -->
+  <path class="es-scanner-light" d="M110 102 L120 128 L130 102Z"/>
+  <!-- Small barcode lines on scanner screen -->
+  <line class="es-barcode" x1="106" y1="60" x2="106" y2="72"/>
+  <line class="es-barcode" x1="112" y1="58" x2="112" y2="72"/>
+  <line class="es-barcode" x1="117" y1="60" x2="117" y2="72"/>
+  <line class="es-barcode" x1="123" y1="58" x2="123" y2="72"/>
+  <line class="es-barcode" x1="128" y1="60" x2="128" y2="72"/>
+  <line class="es-barcode" x1="134" y1="58" x2="134" y2="72"/>
+</svg>

--- a/frontend/public/illustrations/empty-states/no-submissions.svg
+++ b/frontend/public/illustrations/empty-states/no-submissions.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 200" fill="none">
+  <style>
+    .es-board { fill: #e2e8f0; }
+    .es-board-edge { fill: #cbd5e1; }
+    .es-clip { fill: #0d7377; }
+    .es-check { stroke: #0d7377; stroke-width: 3; stroke-linecap: round; stroke-linejoin: round; fill: none; }
+    .es-line { stroke: #cbd5e1; stroke-width: 2; stroke-linecap: round; }
+    .es-shadow { fill: #94a3b8; opacity: 0.18; }
+    .es-star { fill: #d4a844; }
+    @media (prefers-color-scheme: dark) {
+      .es-board { fill: #334155; }
+      .es-board-edge { fill: #475569; }
+      .es-clip { fill: #2dd4bf; }
+      .es-check { stroke: #2dd4bf; }
+      .es-line { stroke: #475569; }
+      .es-shadow { fill: #1e293b; opacity: 0.3; }
+      .es-star { fill: #fbbf24; }
+    }
+  </style>
+  <!-- Shadow -->
+  <ellipse class="es-shadow" cx="120" cy="176" rx="52" ry="8"/>
+  <!-- Clipboard body -->
+  <rect class="es-board-edge" x="72" y="46" width="96" height="126" rx="6"/>
+  <rect class="es-board" x="76" y="50" width="88" height="118" rx="4"/>
+  <!-- Clip at top -->
+  <rect class="es-clip" x="104" y="38" width="32" height="16" rx="4"/>
+  <rect class="es-board" x="108" y="42" width="24" height="8" rx="2"/>
+  <!-- Checked list items -->
+  <polyline class="es-check" points="90,78 96,84 108,72"/>
+  <line class="es-line" x1="116" y1="78" x2="152" y2="78"/>
+  <polyline class="es-check" points="90,100 96,106 108,94"/>
+  <line class="es-line" x1="116" y1="100" x2="148" y2="100"/>
+  <polyline class="es-check" points="90,122 96,128 108,116"/>
+  <line class="es-line" x1="116" y1="122" x2="144" y2="122"/>
+  <polyline class="es-check" points="90,144 96,150 108,138"/>
+  <line class="es-line" x1="116" y1="144" x2="150" y2="144"/>
+  <!-- Star accent -->
+  <path class="es-star" d="M178 56 L181 50 L184 56 L190 58 L184 60 L181 66 L178 60 L172 58Z"/>
+  <path class="es-star" d="M56 88 L58 84 L60 88 L64 89.5 L60 91 L58 95 L56 91 L52 89.5Z"/>
+</svg>

--- a/frontend/src/components/common/EmptyStateIllustration.test.tsx
+++ b/frontend/src/components/common/EmptyStateIllustration.test.tsx
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  EmptyStateIllustration,
+  getIllustrationTypes,
+  getIllustrationMeta,
+} from "./EmptyStateIllustration";
+import type { EmptyStateIllustrationType } from "./EmptyStateIllustration";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("next/image", () => ({
+  default: (props: Record<string, unknown>) => (
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    <img {...props} />
+  ),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// ─── Illustration Types ─────────────────────────────────────────────────────
+
+const ALL_TYPES: EmptyStateIllustrationType[] = [
+  "no-results",
+  "no-favorites",
+  "no-scan-history",
+  "no-comparisons",
+  "no-lists",
+  "no-products-category",
+  "no-submissions",
+  "no-saved-searches",
+];
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("EmptyStateIllustration", () => {
+  // ── Rendering per type ──────────────────────────────────────────────────
+
+  describe("renders correct illustration for each type", () => {
+    it.each(ALL_TYPES)("renders %s illustration", (type) => {
+      const { container } = render(
+        <EmptyStateIllustration type={type} titleKey="common.noResults" />,
+      );
+
+      const img = container.querySelector(
+        `img[data-illustration="${type}"]`,
+      ) as HTMLImageElement;
+      expect(img).toBeInTheDocument();
+      expect(img.getAttribute("src")).toBe(
+        `/illustrations/empty-states/${type}.svg`,
+      );
+    });
+  });
+
+  // ── Alt text ──────────────────────────────────────────────────────────
+
+  describe("sets descriptive alt text per type", () => {
+    it("no-results has magnifying glass alt text", () => {
+      const { container } = render(
+        <EmptyStateIllustration type="no-results" titleKey="common.noResults" />,
+      );
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("no results found");
+    });
+
+    it("no-favorites has heart-shaped plate alt text", () => {
+      const { container } = render(
+        <EmptyStateIllustration
+          type="no-favorites"
+          titleKey="common.noResults"
+        />,
+      );
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("no favorites saved");
+    });
+
+    it("no-scan-history has barcode scanner alt text", () => {
+      const { container } = render(
+        <EmptyStateIllustration
+          type="no-scan-history"
+          titleKey="common.noResults"
+        />,
+      );
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("no scans recorded");
+    });
+
+    it("no-comparisons has two plates alt text", () => {
+      const { container } = render(
+        <EmptyStateIllustration
+          type="no-comparisons"
+          titleKey="common.noResults"
+        />,
+      );
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("no comparisons saved");
+    });
+
+    it("no-lists has shopping basket alt text", () => {
+      const { container } = render(
+        <EmptyStateIllustration type="no-lists" titleKey="common.noResults" />,
+      );
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("no lists created");
+    });
+
+    it("no-products-category has empty shelf alt text", () => {
+      const { container } = render(
+        <EmptyStateIllustration
+          type="no-products-category"
+          titleKey="common.noResults"
+        />,
+      );
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("no products match");
+    });
+
+    it("no-submissions has clipboard alt text", () => {
+      const { container } = render(
+        <EmptyStateIllustration
+          type="no-submissions"
+          titleKey="common.noResults"
+        />,
+      );
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("submissions reviewed");
+    });
+
+    it("no-saved-searches has bookmark alt text", () => {
+      const { container } = render(
+        <EmptyStateIllustration
+          type="no-saved-searches"
+          titleKey="common.noResults"
+        />,
+      );
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("no saved searches");
+    });
+  });
+
+  // ── Title rendering ───────────────────────────────────────────────────
+
+  it("renders title from i18n key", () => {
+    render(
+      <EmptyStateIllustration type="no-results" titleKey="common.noResults" />,
+    );
+    expect(screen.getByText("No results found")).toBeInTheDocument();
+  });
+
+  // ── Description rendering ─────────────────────────────────────────────
+
+  it("renders description when descriptionKey is provided", () => {
+    render(
+      <EmptyStateIllustration
+        type="no-favorites"
+        titleKey="common.noResults"
+        descriptionKey="common.errorDescription"
+      />,
+    );
+    expect(
+      screen.getByText("An unexpected error occurred. Please try again."),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render description when descriptionKey is omitted", () => {
+    const { container } = render(
+      <EmptyStateIllustration type="no-results" titleKey="common.noResults" />,
+    );
+    const descriptions = container.querySelectorAll("p");
+    expect(descriptions).toHaveLength(0);
+  });
+
+  // ── Action button ─────────────────────────────────────────────────────
+
+  it("renders action button when onClick is provided", () => {
+    const onClick = vi.fn();
+    render(
+      <EmptyStateIllustration
+        type="no-favorites"
+        titleKey="common.noResults"
+        action={{ labelKey: "common.tryAgain", onClick }}
+      />,
+    );
+    const button = screen.getByRole("button", { name: "Try again" });
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("renders action link when href is provided", () => {
+    render(
+      <EmptyStateIllustration
+        type="no-scan-history"
+        titleKey="common.noResults"
+        action={{ labelKey: "common.retry", href: "/app/scan" }}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "Retry" });
+    expect(link).toHaveAttribute("href", "/app/scan");
+  });
+
+  it("does not render action when none provided", () => {
+    render(
+      <EmptyStateIllustration type="no-lists" titleKey="common.noResults" />,
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  // ── Secondary action ──────────────────────────────────────────────────
+
+  it("renders secondary action when provided", () => {
+    render(
+      <EmptyStateIllustration
+        type="no-comparisons"
+        titleKey="common.noResults"
+        action={{ labelKey: "common.clear", href: "/app/search" }}
+        secondaryAction={{ labelKey: "common.back", href: "/app" }}
+      />,
+    );
+    expect(screen.getByRole("link", { name: "Clear" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back" })).toBeInTheDocument();
+  });
+
+  // ── Data attribute ────────────────────────────────────────────────────
+
+  it("passes variant to underlying EmptyState data-variant", () => {
+    render(
+      <EmptyStateIllustration type="no-results" titleKey="common.noResults" />,
+    );
+    expect(screen.getByTestId("empty-state")).toHaveAttribute(
+      "data-variant",
+      "no-results",
+    );
+  });
+
+  it("maps no-data types to no-data variant", () => {
+    render(
+      <EmptyStateIllustration
+        type="no-favorites"
+        titleKey="common.noResults"
+      />,
+    );
+    expect(screen.getByTestId("empty-state")).toHaveAttribute(
+      "data-variant",
+      "no-data",
+    );
+  });
+
+  // ── data-illustration attribute ───────────────────────────────────────
+
+  it.each(ALL_TYPES)("sets data-illustration=%s on the image", (type) => {
+    const { container } = render(
+      <EmptyStateIllustration type={type} titleKey="common.noResults" />,
+    );
+    const img = container.querySelector(`[data-illustration="${type}"]`);
+    expect(img).toBeInTheDocument();
+  });
+
+  // ── Image dimensions ──────────────────────────────────────────────────
+
+  it("renders illustration at 240×200", () => {
+    const { container } = render(
+      <EmptyStateIllustration type="no-results" titleKey="common.noResults" />,
+    );
+    const img = container.querySelector("img") as HTMLImageElement;
+    expect(img.getAttribute("width")).toBe("240");
+    expect(img.getAttribute("height")).toBe("200");
+  });
+
+  // ── className passthrough ─────────────────────────────────────────────
+
+  it("passes className to underlying EmptyState", () => {
+    render(
+      <EmptyStateIllustration
+        type="no-submissions"
+        titleKey="common.noResults"
+        className="mt-8"
+      />,
+    );
+    expect(screen.getByTestId("empty-state").className).toContain("mt-8");
+  });
+
+  // ── Title params interpolation ────────────────────────────────────────
+
+  it("passes titleParams for i18n interpolation", () => {
+    render(
+      <EmptyStateIllustration
+        type="no-results"
+        titleKey="common.items"
+        titleParams={{ count: 0 }}
+      />,
+    );
+    expect(screen.getByText("0 items")).toBeInTheDocument();
+  });
+});
+
+// ─── Utility Functions ──────────────────────────────────────────────────────
+
+describe("getIllustrationTypes", () => {
+  it("returns all 8 illustration types", () => {
+    const types = getIllustrationTypes();
+    expect(types).toHaveLength(8);
+    expect(types).toEqual(expect.arrayContaining(ALL_TYPES));
+  });
+});
+
+describe("getIllustrationMeta", () => {
+  it("returns metadata with alt, src, and variant for each type", () => {
+    for (const type of ALL_TYPES) {
+      const meta = getIllustrationMeta(type);
+      expect(meta.alt).toBeTruthy();
+      expect(meta.src).toContain(type);
+      expect(["no-data", "no-results", "error", "offline"]).toContain(
+        meta.variant,
+      );
+    }
+  });
+
+  it("returns correct src path for no-favorites", () => {
+    const meta = getIllustrationMeta("no-favorites");
+    expect(meta.src).toBe("/illustrations/empty-states/no-favorites.svg");
+  });
+});

--- a/frontend/src/components/common/EmptyStateIllustration.tsx
+++ b/frontend/src/components/common/EmptyStateIllustration.tsx
@@ -1,0 +1,166 @@
+// ─── EmptyStateIllustration ─────────────────────────────────────────
+// Maps 8 page-specific empty-state types to branded SVG illustrations
+// and wraps the existing EmptyState component. Each type provides the
+// correct illustration, alt text, and default variant mapping.
+// ─────────────────────────────────────────────────────────────────────
+
+import Image from "next/image";
+import { EmptyState } from "./EmptyState";
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+/**
+ * Context-specific empty-state illustration types.
+ * Each maps to a dedicated SVG in public/illustrations/empty-states/.
+ */
+export type EmptyStateIllustrationType =
+  | "no-results"
+  | "no-favorites"
+  | "no-scan-history"
+  | "no-comparisons"
+  | "no-lists"
+  | "no-products-category"
+  | "no-submissions"
+  | "no-saved-searches";
+
+export interface EmptyStateIllustrationProps {
+  /** Which illustration to display */
+  readonly type: EmptyStateIllustrationType;
+  /** i18n key resolved to the title heading */
+  readonly titleKey: string;
+  /** i18n key resolved to the description paragraph */
+  readonly descriptionKey?: string;
+  /** i18n interpolation params for titleKey */
+  readonly titleParams?: Record<string, string | number>;
+  /** i18n interpolation params for descriptionKey */
+  readonly descriptionParams?: Record<string, string | number>;
+  /** Primary call-to-action */
+  readonly action?: {
+    labelKey: string;
+    href?: string;
+    onClick?: () => void;
+  };
+  /** Optional secondary call-to-action */
+  readonly secondaryAction?: {
+    labelKey: string;
+    href?: string;
+    onClick?: () => void;
+  };
+  /** Additional CSS classes on the root container */
+  readonly className?: string;
+}
+
+// ─── Illustration Metadata ───────────────────────────────────────────
+
+interface IllustrationMeta {
+  /** Alt text for the illustration image */
+  alt: string;
+  /** Path to the SVG file in public/ */
+  src: string;
+  /** Which EmptyState variant this maps to */
+  variant: "no-data" | "no-results" | "error" | "offline";
+}
+
+const ILLUSTRATION_META: Record<EmptyStateIllustrationType, IllustrationMeta> = {
+  "no-results": {
+    alt: "Magnifying glass over an empty plate — no results found",
+    src: "/illustrations/empty-states/no-results.svg",
+    variant: "no-results",
+  },
+  "no-favorites": {
+    alt: "Heart-shaped empty plate — no favorites saved",
+    src: "/illustrations/empty-states/no-favorites.svg",
+    variant: "no-data",
+  },
+  "no-scan-history": {
+    alt: "Barcode scanner pointing at an empty shelf — no scans recorded",
+    src: "/illustrations/empty-states/no-scan-history.svg",
+    variant: "no-data",
+  },
+  "no-comparisons": {
+    alt: "Two empty plates side by side — no comparisons saved",
+    src: "/illustrations/empty-states/no-comparisons.svg",
+    variant: "no-data",
+  },
+  "no-lists": {
+    alt: "Empty shopping basket with sparkles — no lists created",
+    src: "/illustrations/empty-states/no-lists.svg",
+    variant: "no-data",
+  },
+  "no-products-category": {
+    alt: "Empty category shelf — no products match filters",
+    src: "/illustrations/empty-states/no-products-category.svg",
+    variant: "no-results",
+  },
+  "no-submissions": {
+    alt: "Clipboard with checkmarks — all submissions reviewed",
+    src: "/illustrations/empty-states/no-submissions.svg",
+    variant: "no-data",
+  },
+  "no-saved-searches": {
+    alt: "Bookmark with magnifying glass — no saved searches",
+    src: "/illustrations/empty-states/no-saved-searches.svg",
+    variant: "no-data",
+  },
+};
+
+// ─── Utilities ───────────────────────────────────────────────────────
+
+/** Returns all available illustration type strings. */
+export function getIllustrationTypes(): EmptyStateIllustrationType[] {
+  return Object.keys(ILLUSTRATION_META) as EmptyStateIllustrationType[];
+}
+
+/** Returns metadata for a given illustration type. */
+export function getIllustrationMeta(
+  type: EmptyStateIllustrationType,
+): IllustrationMeta {
+  return ILLUSTRATION_META[type];
+}
+
+// ─── Component ───────────────────────────────────────────────────────
+
+/**
+ * Empty-state with branded SVG illustration. Wraps the base EmptyState
+ * component, injecting the type-specific illustration as a custom icon.
+ *
+ * Used on: search, favorites, scan history, comparisons, lists,
+ * category detail, admin submissions, and saved searches pages.
+ */
+export function EmptyStateIllustration({
+  type,
+  titleKey,
+  descriptionKey,
+  titleParams,
+  descriptionParams,
+  action,
+  secondaryAction,
+  className,
+}: EmptyStateIllustrationProps) {
+  const meta = ILLUSTRATION_META[type];
+
+  const illustration = (
+    <Image
+      src={meta.src}
+      alt={meta.alt}
+      width={240}
+      height={200}
+      priority={false}
+      data-illustration={type}
+    />
+  );
+
+  return (
+    <EmptyState
+      variant={meta.variant}
+      icon={illustration}
+      titleKey={titleKey}
+      descriptionKey={descriptionKey}
+      titleParams={titleParams}
+      descriptionParams={descriptionParams}
+      action={action}
+      secondaryAction={secondaryAction}
+      className={className}
+    />
+  );
+}


### PR DESCRIPTION
## Summary\n\nCreate 8 empty-state SVG illustrations and an `EmptyStateIllustration` React component that wraps the existing `EmptyState` component with context-specific branded illustrations.\n\nPart of epic #402 — UX Illustrations.\n\n## Deliverables\n\n### 8 SVG Illustrations\n\nAll in `frontend/public/illustrations/empty-states/`:\n\n| File | Visual Concept | Size |\n|------|---------------|------|\n| `no-results.svg` | Magnifying glass over empty plate | 1.4 KB |\n| `no-favorites.svg` | Heart-shaped empty plate | 1.6 KB |\n| `no-scan-history.svg` | Barcode scanner pointing at empty shelf | 2.0 KB |\n| `no-comparisons.svg` | Two empty plates side by side | 1.7 KB |\n| `no-lists.svg` | Empty shopping basket with sparkles | 1.7 KB |\n| `no-products-category.svg` | Empty category shelf with ghost products | 2.1 KB |\n| `no-submissions.svg` | Clipboard with checkmarks | 1.9 KB |\n| `no-saved-searches.svg` | Bookmark with magnifying glass | 1.9 KB |\n\n### Design\n- 240x200 viewBox (landscape)\n- Flat/semi-flat style with brand palette (primary #0d7377, accent #d4a844)\n- Dark mode via `prefers-color-scheme` media queries in each SVG\n- All under 2.1 KB (well below 5KB spec)\n\n### EmptyStateIllustration Component\n- Wraps existing `EmptyState` component (no breaking changes)\n- Maps 8 context-specific types to SVG illustrations via `next/image`\n- Full i18n support (inherits titleKey/descriptionKey pattern)\n- Typed to 8 states with `EmptyStateIllustrationType`\n- Exports utility functions: `getIllustrationTypes()`, `getIllustrationMeta()`\n\n## Testing\n- **39 new tests** in `EmptyStateIllustration.test.tsx`\n- **16 existing tests** in `EmptyState.test.tsx` - all still passing\n- Coverage: all 8 types, alt text per type, actions, image dimensions, className passthrough, variant mapping, utility functions\n- TypeScript: 0 errors\n\nCloses #423