### PR TITLE
feat(frontend): add onboarding & error page illustrations (#424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,14 @@ Adheres to [Semantic Versioning](https://semver.org/).
   with context-specific SVG illustrations, typed to 8 states, i18n-ready;
   39 Vitest tests covering all 8 types, alt text, actions, image dimensions,
   className passthrough, and utility functions (#423)
+- Create 5 onboarding step SVG illustrations (280×280) in
+  `frontend/public/illustrations/onboarding/` (welcome, country, diet,
+  allergens, ready) and 3 error page SVG illustrations (240×200) in
+  `frontend/public/illustrations/errors/` (404, 500, offline); brand palette
+  with `prefers-color-scheme` dark mode, all under 3 KB; `OnboardingIllustration`
+  component (5 steps, custom dimensions, priority loading) with 32 Vitest tests;
+  `ErrorIllustration` component (3 error types, HTTP status metadata) with
+  30 Vitest tests; LoadingSpinner and Skeleton components already exist (#424)
 - Redesign README.md as 15-section showcase-quality layout: hero banner, 9
   shields.io badges, elevator pitch, 4 feature highlight cards (HTML table),
   comparison table, 3-column quick start with collapsible command reference,

--- a/frontend/public/illustrations/errors/404-not-found.svg
+++ b/frontend/public/illustrations/errors/404-not-found.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 200" fill="none">
+  <style>
+    .er-plate { fill: #e2e8f0; }
+    .er-plate-rim { fill: #cbd5e1; }
+    .er-primary { fill: #0d7377; }
+    .er-primary-stroke { stroke: #0d7377; stroke-width: 3; fill: none; stroke-linecap: round; }
+    .er-accent { fill: #d4a844; }
+    .er-shadow { fill: #94a3b8; opacity: 0.18; }
+    .er-text { fill: #64748b; font-family: Arial, sans-serif; font-weight: 700; }
+    @media (prefers-color-scheme: dark) {
+      .er-plate { fill: #334155; }
+      .er-plate-rim { fill: #475569; }
+      .er-primary { fill: #2dd4bf; }
+      .er-primary-stroke { stroke: #2dd4bf; }
+      .er-accent { fill: #fbbf24; }
+      .er-shadow { fill: #1e293b; opacity: 0.3; }
+      .er-text { fill: #94a3b8; }
+    }
+  </style>
+  <!-- Shadow -->
+  <ellipse class="er-shadow" cx="120" cy="172" rx="68" ry="9"/>
+  <!-- Plate -->
+  <ellipse class="er-plate-rim" cx="120" cy="140" rx="60" ry="28"/>
+  <ellipse class="er-plate" cx="120" cy="136" rx="54" ry="24"/>
+  <!-- 404 text on plate -->
+  <text class="er-text" x="90" y="144" font-size="28" opacity="0.35">404</text>
+  <!-- Fork pointing off-screen left -->
+  <rect class="er-primary" x="18" y="85" width="5" height="65" rx="2.5" transform="rotate(-20 20 85)"/>
+  <rect class="er-primary" x="12" y="72" width="3" height="18" rx="1.5" transform="rotate(-20 13 72)"/>
+  <rect class="er-primary" x="18" y="72" width="3" height="18" rx="1.5" transform="rotate(-20 19 72)"/>
+  <rect class="er-primary" x="24" y="72" width="3" height="18" rx="1.5" transform="rotate(-20 25 72)"/>
+  <!-- Knife pointing off-screen right -->
+  <rect class="er-primary" x="210" y="80" width="5" height="65" rx="2.5" transform="rotate(18 212 80)"/>
+  <path class="er-primary" d="M210 68 L210 86 L220 80 L220 68Z" transform="rotate(18 215 77)"/>
+  <!-- Question marks floating -->
+  <text class="er-accent" x="80" y="50" font-family="Arial" font-size="20" font-weight="700" opacity="0.6">?</text>
+  <text class="er-accent" x="155" y="42" font-family="Arial" font-size="16" font-weight="700" opacity="0.4">?</text>
+  <text class="er-accent" x="168" y="68" font-family="Arial" font-size="12" font-weight="700" opacity="0.3">?</text>
+</svg>

--- a/frontend/public/illustrations/errors/500-server-error.svg
+++ b/frontend/public/illustrations/errors/500-server-error.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 200" fill="none">
+  <style>
+    .er-primary { fill: #0d7377; }
+    .er-primary-light { fill: #0d7377; opacity: 0.15; }
+    .er-accent { fill: #d4a844; }
+    .er-neutral { fill: #e2e8f0; }
+    .er-neutral-dark { fill: #cbd5e1; }
+    .er-shadow { fill: #94a3b8; opacity: 0.18; }
+    .er-spill { fill: #0d7377; opacity: 0.12; }
+    @media (prefers-color-scheme: dark) {
+      .er-primary { fill: #2dd4bf; }
+      .er-primary-light { fill: #2dd4bf; opacity: 0.15; }
+      .er-accent { fill: #fbbf24; }
+      .er-neutral { fill: #334155; }
+      .er-neutral-dark { fill: #475569; }
+      .er-shadow { fill: #1e293b; opacity: 0.3; }
+      .er-spill { fill: #2dd4bf; opacity: 0.12; }
+    }
+  </style>
+  <!-- Shadow -->
+  <ellipse class="er-shadow" cx="120" cy="175" rx="80" ry="8"/>
+  <!-- Spill puddle -->
+  <ellipse class="er-spill" cx="130" cy="168" rx="55" ry="12"/>
+  <!-- Tipped-over bowl -->
+  <ellipse class="er-neutral-dark" cx="100" cy="140" rx="45" ry="20" transform="rotate(18 100 140)"/>
+  <ellipse class="er-neutral" cx="100" cy="137" rx="39" ry="16" transform="rotate(18 100 137)"/>
+  <!-- Scattered ingredients -->
+  <!-- Tomato -->
+  <circle class="er-accent" cx="160" cy="150" r="10"/>
+  <path stroke="#d4a844" stroke-width="1.5" fill="none" d="M156 146 Q160 140 164 146"/>
+  <!-- Carrot piece -->
+  <path class="er-accent" d="M175 160 L172 175 L180 175Z" opacity="0.7"/>
+  <!-- Leaf -->
+  <path class="er-primary" d="M145 170 C145 170 155 165 158 172 C158 172 148 178 145 170Z" opacity="0.5"/>
+  <!-- Small dots (crumbs) -->
+  <circle class="er-neutral-dark" cx="130" cy="162" r="3"/>
+  <circle class="er-neutral-dark" cx="140" cy="155" r="2"/>
+  <circle class="er-neutral-dark" cx="185" cy="165" r="2.5"/>
+  <!-- Alert triangle above -->
+  <path class="er-accent" d="M120 38 L136 68 L104 68Z"/>
+  <text fill="white" x="116" y="64" font-family="Arial" font-size="20" font-weight="700">!</text>
+  <!-- Steam/error wisps -->
+  <path stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round" d="M85 100 Q80 88 88 78"/>
+  <path stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round" d="M95 95 Q92 84 98 74"/>
+  <path stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round" d="M105 98 Q100 86 108 76" opacity="0.6"/>
+</svg>

--- a/frontend/public/illustrations/errors/offline.svg
+++ b/frontend/public/illustrations/errors/offline.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 200" fill="none">
+  <style>
+    .er-primary { fill: #0d7377; }
+    .er-primary-stroke { stroke: #0d7377; stroke-width: 2.5; fill: none; stroke-linecap: round; }
+    .er-accent { fill: #d4a844; }
+    .er-neutral { fill: #e2e8f0; }
+    .er-neutral-dark { fill: #cbd5e1; }
+    .er-shadow { fill: #94a3b8; opacity: 0.18; }
+    .er-x { stroke: #dc2626; stroke-width: 3; stroke-linecap: round; }
+    @media (prefers-color-scheme: dark) {
+      .er-primary { fill: #2dd4bf; }
+      .er-primary-stroke { stroke: #2dd4bf; }
+      .er-accent { fill: #fbbf24; }
+      .er-neutral { fill: #334155; }
+      .er-neutral-dark { fill: #475569; }
+      .er-shadow { fill: #1e293b; opacity: 0.3; }
+      .er-x { stroke: #f87171; }
+    }
+  </style>
+  <!-- Shadow -->
+  <ellipse class="er-shadow" cx="120" cy="172" rx="50" ry="7"/>
+  <!-- Cloud shape -->
+  <circle class="er-neutral" cx="100" cy="95" r="35"/>
+  <circle class="er-neutral" cx="140" cy="85" r="40"/>
+  <circle class="er-neutral" cx="170" cy="100" r="30"/>
+  <rect class="er-neutral" x="72" y="95" width="128" height="40" rx="0"/>
+  <ellipse class="er-neutral" cx="120" cy="135" rx="55" ry="8"/>
+  <!-- Cloud outline highlights -->
+  <path class="er-primary-stroke" d="M72 120 Q65 95 100 80 Q100 55 140 60 Q165 55 175 78 Q202 82 200 110 Q200 130 170 135" opacity="0.5"/>
+  <!-- X mark on cloud -->
+  <line class="er-x" x1="108" y1="90" x2="132" y2="114"/>
+  <line class="er-x" x1="132" y1="90" x2="108" y2="114"/>
+  <!-- Disconnected signal waves below -->
+  <path class="er-primary-stroke" d="M90 155 Q95 148 100 155" opacity="0.4"/>
+  <path class="er-primary-stroke" d="M82 160 Q95 145 108 160" opacity="0.3"/>
+  <path class="er-primary-stroke" d="M130 155 Q135 148 140 155" opacity="0.4"/>
+  <path class="er-primary-stroke" d="M122 160 Q135 145 148 160" opacity="0.3"/>
+  <!-- Broken connection dots -->
+  <circle class="er-accent" cx="115" cy="158" r="3"/>
+  <line stroke="#d4a844" stroke-width="1.5" stroke-dasharray="3 4" stroke-linecap="round" x1="105" y1="155" x2="125" y2="155"/>
+</svg>

--- a/frontend/public/illustrations/onboarding/step-1-welcome.svg
+++ b/frontend/public/illustrations/onboarding/step-1-welcome.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 280" fill="none">
+  <style>
+    .ob-primary { fill: #0d7377; }
+    .ob-primary-light { fill: #0d7377; opacity: 0.12; }
+    .ob-accent { fill: #d4a844; }
+    .ob-neutral { fill: #e2e8f0; }
+    .ob-neutral-dark { fill: #cbd5e1; }
+    .ob-shadow { fill: #94a3b8; opacity: 0.15; }
+    @media (prefers-color-scheme: dark) {
+      .ob-primary { fill: #2dd4bf; }
+      .ob-primary-light { fill: #2dd4bf; opacity: 0.12; }
+      .ob-accent { fill: #fbbf24; }
+      .ob-neutral { fill: #334155; }
+      .ob-neutral-dark { fill: #475569; }
+      .ob-shadow { fill: #1e293b; opacity: 0.25; }
+    }
+  </style>
+  <!-- Background circle -->
+  <circle class="ob-primary-light" cx="140" cy="140" r="120"/>
+  <!-- Shield shape (logo motif) -->
+  <path class="ob-primary" d="M140 50 L200 80 L200 150 C200 190 170 220 140 235 C110 220 80 190 80 150 L80 80Z"/>
+  <!-- Leaf accent on shield -->
+  <path class="ob-accent" d="M140 100 C140 100 165 115 165 140 C165 155 155 165 140 165 C140 165 140 130 140 100Z"/>
+  <path class="ob-accent" d="M140 100 C140 100 115 115 115 140 C115 155 125 165 140 165 C140 165 140 130 140 100Z" opacity="0.6"/>
+  <!-- Food motifs around shield -->
+  <!-- Apple -->
+  <circle class="ob-neutral" cx="60" cy="90" r="14"/>
+  <path class="ob-primary" d="M60 76 Q64 68 68 76" fill="none" stroke="#0d7377" stroke-width="2"/>
+  <!-- Carrot -->
+  <path class="ob-neutral" d="M220 160 L210 200 L230 200Z"/>
+  <line stroke="#cbd5e1" stroke-width="1.5" x1="218" y1="175" x2="222" y2="172"/>
+  <line stroke="#cbd5e1" stroke-width="1.5" x1="216" y1="185" x2="220" y2="182"/>
+  <!-- Wheat -->
+  <ellipse class="ob-accent" cx="68" cy="195" rx="6" ry="12" transform="rotate(-20 68 195)"/>
+  <ellipse class="ob-accent" cx="78" cy="188" rx="5" ry="10" transform="rotate(-20 78 188)" opacity="0.6"/>
+  <!-- Sparkle dots -->
+  <circle class="ob-accent" cx="210" cy="80" r="4"/>
+  <circle class="ob-accent" cx="225" cy="100" r="2.5" opacity="0.5"/>
+  <circle class="ob-accent" cx="50" cy="160" r="3" opacity="0.7"/>
+</svg>

--- a/frontend/public/illustrations/onboarding/step-2-country.svg
+++ b/frontend/public/illustrations/onboarding/step-2-country.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 280" fill="none">
+  <style>
+    .ob-primary { fill: #0d7377; }
+    .ob-primary-light { fill: #0d7377; opacity: 0.12; }
+    .ob-primary-stroke { stroke: #0d7377; stroke-width: 2; fill: none; }
+    .ob-accent { fill: #d4a844; }
+    .ob-neutral { fill: #e2e8f0; }
+    .ob-neutral-dark { fill: #cbd5e1; }
+    @media (prefers-color-scheme: dark) {
+      .ob-primary { fill: #2dd4bf; }
+      .ob-primary-light { fill: #2dd4bf; opacity: 0.12; }
+      .ob-primary-stroke { stroke: #2dd4bf; }
+      .ob-accent { fill: #fbbf24; }
+      .ob-neutral { fill: #334155; }
+      .ob-neutral-dark { fill: #475569; }
+    }
+  </style>
+  <!-- Background circle -->
+  <circle class="ob-primary-light" cx="140" cy="140" r="120"/>
+  <!-- Globe base -->
+  <circle class="ob-neutral" cx="140" cy="140" r="80"/>
+  <circle class="ob-primary-stroke" cx="140" cy="140" r="80"/>
+  <!-- Longitude lines -->
+  <ellipse class="ob-primary-stroke" cx="140" cy="140" rx="40" ry="80"/>
+  <ellipse class="ob-primary-stroke" cx="140" cy="140" rx="65" ry="80"/>
+  <!-- Latitude lines -->
+  <line class="ob-primary-stroke" x1="60" y1="140" x2="220" y2="140"/>
+  <line class="ob-primary-stroke" x1="68" y1="110" x2="212" y2="110"/>
+  <line class="ob-primary-stroke" x1="68" y1="170" x2="212" y2="170"/>
+  <!-- Poland pin (left) -->
+  <circle class="ob-primary" cx="105" cy="115" r="12"/>
+  <path class="ob-primary" d="M105 127 L100 140 L110 140Z"/>
+  <text fill="white" x="99" y="120" font-family="Arial" font-size="12" font-weight="700">PL</text>
+  <!-- Germany pin (right) -->
+  <circle class="ob-accent" cx="170" cy="108" r="12"/>
+  <path class="ob-accent" d="M170 120 L165 133 L175 133Z"/>
+  <text fill="white" x="162" y="113" font-family="Arial" font-size="11" font-weight="700">DE</text>
+  <!-- Selection indicator (checkmark on PL) -->
+  <circle class="ob-primary" cx="105" cy="85" r="8" opacity="0.3"/>
+  <polyline stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" points="100,85 104,89 112,81" fill="none"/>
+</svg>

--- a/frontend/public/illustrations/onboarding/step-3-diet.svg
+++ b/frontend/public/illustrations/onboarding/step-3-diet.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 280" fill="none">
+  <style>
+    .ob-primary { fill: #0d7377; }
+    .ob-primary-light { fill: #0d7377; opacity: 0.12; }
+    .ob-accent { fill: #d4a844; }
+    .ob-neutral { fill: #e2e8f0; }
+    .ob-neutral-dark { fill: #cbd5e1; }
+    .ob-green { fill: #15803d; }
+    .ob-red { fill: #dc2626; opacity: 0.7; }
+    @media (prefers-color-scheme: dark) {
+      .ob-primary { fill: #2dd4bf; }
+      .ob-primary-light { fill: #2dd4bf; opacity: 0.12; }
+      .ob-accent { fill: #fbbf24; }
+      .ob-neutral { fill: #334155; }
+      .ob-neutral-dark { fill: #475569; }
+      .ob-green { fill: #22c55e; }
+      .ob-red { fill: #f87171; opacity: 0.7; }
+    }
+  </style>
+  <!-- Background circle -->
+  <circle class="ob-primary-light" cx="140" cy="140" r="120"/>
+  <!-- Plate -->
+  <ellipse class="ob-neutral-dark" cx="140" cy="155" rx="85" ry="40"/>
+  <ellipse class="ob-neutral" cx="140" cy="150" rx="78" ry="36"/>
+  <!-- Food group sections (pie-chart style on plate) -->
+  <!-- Vegetables (green) -->
+  <path class="ob-green" d="M140 118 L140 150 L105 130Z" opacity="0.7"/>
+  <path class="ob-green" d="M140 150 L105 130 L95 155Z" opacity="0.5"/>
+  <!-- Protein (primary teal) -->
+  <path class="ob-primary" d="M140 118 L140 150 L175 130Z" opacity="0.7"/>
+  <path class="ob-primary" d="M140 150 L175 130 L185 155Z" opacity="0.5"/>
+  <!-- Grains (accent gold) -->
+  <path class="ob-accent" d="M140 150 L95 155 L105 172Z" opacity="0.7"/>
+  <path class="ob-accent" d="M140 150 L105 172 L140 178Z" opacity="0.5"/>
+  <!-- Dairy (lighter) -->
+  <path class="ob-neutral-dark" d="M140 150 L185 155 L175 172Z"/>
+  <path class="ob-neutral-dark" d="M140 150 L175 172 L140 178Z" opacity="0.7"/>
+  <!-- Divider lines on plate -->
+  <line stroke="white" stroke-width="1.5" x1="140" y1="118" x2="140" y2="178" opacity="0.5"/>
+  <line stroke="white" stroke-width="1.5" x1="95" y1="155" x2="185" y2="155" opacity="0.5"/>
+  <!-- Fork (left) -->
+  <rect class="ob-primary" x="42" y="100" width="4" height="80" rx="2"/>
+  <rect class="ob-primary" x="38" y="90" width="3" height="18" rx="1"/>
+  <rect class="ob-primary" x="44" y="90" width="3" height="18" rx="1"/>
+  <rect class="ob-primary" x="50" y="90" width="3" height="18" rx="1"/>
+  <!-- Knife (right) -->
+  <rect class="ob-primary" x="228" y="100" width="5" height="80" rx="2"/>
+  <path class="ob-primary" d="M228 90 L228 108 L238 102 L238 90Z" rx="1"/>
+  <!-- Toggle/checkmark indicators above plate -->
+  <circle class="ob-green" cx="100" cy="70" r="10" opacity="0.8"/>
+  <polyline stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" points="95,70 99,74 106,66" fill="none"/>
+  <circle class="ob-green" cx="140" cy="65" r="10" opacity="0.8"/>
+  <polyline stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" points="135,65 139,69 146,61" fill="none"/>
+  <circle class="ob-red" cx="180" cy="70" r="10"/>
+  <line stroke="white" stroke-width="2.5" stroke-linecap="round" x1="175" y1="70" x2="185" y2="70"/>
+</svg>

--- a/frontend/public/illustrations/onboarding/step-4-allergens.svg
+++ b/frontend/public/illustrations/onboarding/step-4-allergens.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 280" fill="none">
+  <style>
+    .ob-primary { fill: #0d7377; }
+    .ob-primary-light { fill: #0d7377; opacity: 0.12; }
+    .ob-primary-stroke { stroke: #0d7377; stroke-width: 2.5; fill: none; }
+    .ob-accent { fill: #d4a844; }
+    .ob-neutral { fill: #e2e8f0; }
+    .ob-neutral-dark { fill: #cbd5e1; }
+    .ob-warn { fill: #f59e0b; }
+    @media (prefers-color-scheme: dark) {
+      .ob-primary { fill: #2dd4bf; }
+      .ob-primary-light { fill: #2dd4bf; opacity: 0.12; }
+      .ob-primary-stroke { stroke: #2dd4bf; }
+      .ob-accent { fill: #fbbf24; }
+      .ob-neutral { fill: #334155; }
+      .ob-neutral-dark { fill: #475569; }
+      .ob-warn { fill: #fbbf24; }
+    }
+  </style>
+  <!-- Background circle -->
+  <circle class="ob-primary-light" cx="140" cy="140" r="120"/>
+  <!-- Shield shape -->
+  <path class="ob-neutral" d="M140 45 L210 80 L210 160 C210 200 175 230 140 245 C105 230 70 200 70 160 L70 80Z"/>
+  <path class="ob-primary-stroke" d="M140 45 L210 80 L210 160 C210 200 175 230 140 245 C105 230 70 200 70 160 L70 80Z"/>
+  <!-- Shield inner glow -->
+  <path class="ob-primary" d="M140 60 L200 90 L200 155 C200 190 170 215 140 228 C110 215 80 190 80 155 L80 90Z" opacity="0.08"/>
+  <!-- Allergen icon grid (3×2) -->
+  <!-- Gluten/Wheat -->
+  <circle class="ob-neutral-dark" cx="110" cy="110" r="18"/>
+  <text class="ob-primary" x="103" y="116" font-family="Arial" font-size="18">🌾</text>
+  <!-- Milk -->
+  <circle class="ob-neutral-dark" cx="170" cy="110" r="18"/>
+  <text class="ob-primary" x="163" y="116" font-family="Arial" font-size="18">🥛</text>
+  <!-- Egg -->
+  <circle class="ob-neutral-dark" cx="110" cy="155" r="18"/>
+  <text class="ob-primary" x="103" y="161" font-family="Arial" font-size="18">🥚</text>
+  <!-- Peanut -->
+  <circle class="ob-neutral-dark" cx="170" cy="155" r="18"/>
+  <text class="ob-primary" x="163" y="161" font-family="Arial" font-size="18">🥜</text>
+  <!-- Fish -->
+  <circle class="ob-neutral-dark" cx="110" cy="200" r="18"/>
+  <text class="ob-primary" x="103" y="206" font-family="Arial" font-size="18">🐟</text>
+  <!-- Soy -->
+  <circle class="ob-neutral-dark" cx="170" cy="200" r="18"/>
+  <text class="ob-primary" x="163" y="206" font-family="Arial" font-size="18">🫘</text>
+  <!-- Warning badge -->
+  <circle class="ob-warn" cx="210" cy="70" r="14"/>
+  <text fill="white" x="205" y="77" font-family="Arial" font-size="18" font-weight="700">!</text>
+</svg>

--- a/frontend/public/illustrations/onboarding/step-5-ready.svg
+++ b/frontend/public/illustrations/onboarding/step-5-ready.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 280" fill="none">
+  <style>
+    .ob-primary { fill: #0d7377; }
+    .ob-primary-light { fill: #0d7377; opacity: 0.12; }
+    .ob-accent { fill: #d4a844; }
+    .ob-green { fill: #15803d; }
+    .ob-neutral { fill: #e2e8f0; }
+    @media (prefers-color-scheme: dark) {
+      .ob-primary { fill: #2dd4bf; }
+      .ob-primary-light { fill: #2dd4bf; opacity: 0.12; }
+      .ob-accent { fill: #fbbf24; }
+      .ob-green { fill: #22c55e; }
+      .ob-neutral { fill: #334155; }
+    }
+  </style>
+  <!-- Background circle -->
+  <circle class="ob-primary-light" cx="140" cy="140" r="120"/>
+  <!-- Large checkmark circle -->
+  <circle class="ob-green" cx="140" cy="130" r="52"/>
+  <polyline stroke="white" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none" points="115,130 133,148 168,113"/>
+  <!-- Confetti particles -->
+  <rect class="ob-accent" x="62" y="68" width="8" height="4" rx="2" transform="rotate(-30 66 70)"/>
+  <rect class="ob-primary" x="202" y="72" width="8" height="4" rx="2" transform="rotate(25 206 74)"/>
+  <rect class="ob-accent" x="55" y="170" width="6" height="3" rx="1.5" transform="rotate(15 58 171)"/>
+  <rect class="ob-primary" x="215" y="165" width="7" height="3.5" rx="1.5" transform="rotate(-20 218 167)"/>
+  <rect class="ob-accent" x="90" y="50" width="7" height="3.5" rx="1.5" transform="rotate(45 93 52)"/>
+  <rect class="ob-primary" x="185" y="48" width="6" height="3" rx="1.5" transform="rotate(-45 188 50)"/>
+  <!-- Confetti circles -->
+  <circle class="ob-accent" cx="72" cy="120" r="4"/>
+  <circle class="ob-primary" cx="210" cy="125" r="3.5" opacity="0.6"/>
+  <circle class="ob-accent" cx="80" cy="200" r="3" opacity="0.7"/>
+  <circle class="ob-primary" cx="195" cy="205" r="4" opacity="0.5"/>
+  <circle class="ob-accent" cx="140" cy="50" r="3.5"/>
+  <!-- Star bursts -->
+  <path class="ob-accent" d="M230 90 L232 84 L234 90 L240 92 L234 94 L232 100 L230 94 L224 92Z"/>
+  <path class="ob-accent" d="M50 140 L51.5 135.5 L53 140 L57.5 141.5 L53 143 L51.5 147.5 L50 143 L45.5 141.5Z" opacity="0.7"/>
+  <!-- Celebration rays -->
+  <line stroke="#d4a844" stroke-width="1.5" stroke-linecap="round" x1="140" y1="60" x2="140" y2="45" opacity="0.5"/>
+  <line stroke="#d4a844" stroke-width="1.5" stroke-linecap="round" x1="100" y1="80" x2="88" y2="68" opacity="0.4"/>
+  <line stroke="#d4a844" stroke-width="1.5" stroke-linecap="round" x1="180" y1="80" x2="192" y2="68" opacity="0.4"/>
+  <!-- Bottom tagline area (text rendered by React, just subtle accent line) -->
+  <line stroke="#0d7377" stroke-width="2" stroke-linecap="round" x1="100" y1="210" x2="180" y2="210" opacity="0.3"/>
+</svg>

--- a/frontend/src/components/common/ErrorIllustration.test.tsx
+++ b/frontend/src/components/common/ErrorIllustration.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import {
+  ErrorIllustration,
+  getErrorTypes,
+  getErrorMeta,
+} from "./ErrorIllustration";
+import type { ErrorType } from "./ErrorIllustration";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("next/image", () => ({
+  default: ({ priority, ...props }: Record<string, unknown>) => (
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    <img {...props} data-priority={priority ? "true" : "false"} />
+  ),
+}));
+
+// ─── Error Types ────────────────────────────────────────────────────────────
+
+const ALL_TYPES: ErrorType[] = ["not-found", "server-error", "offline"];
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("ErrorIllustration", () => {
+  // ── Rendering per type ────────────────────────────────────────────────
+
+  describe("renders correct illustration for each type", () => {
+    it.each(ALL_TYPES)("renders %s illustration", (type) => {
+      const { container } = render(<ErrorIllustration type={type} />);
+
+      const img = container.querySelector(
+        `img[data-illustration="${type}"]`,
+      ) as HTMLImageElement;
+      expect(img).toBeInTheDocument();
+    });
+  });
+
+  // ── SVG source paths ─────────────────────────────────────────────────
+
+  describe("uses correct SVG source paths", () => {
+    it.each([
+      ["not-found", "/illustrations/errors/404-not-found.svg"],
+      ["server-error", "/illustrations/errors/500-server-error.svg"],
+      ["offline", "/illustrations/errors/offline.svg"],
+    ] as [ErrorType, string][])(
+      "%s uses %s",
+      (type, expectedSrc) => {
+        const { container } = render(<ErrorIllustration type={type} />);
+        const img = container.querySelector("img") as HTMLImageElement;
+        expect(img.getAttribute("src")).toBe(expectedSrc);
+      },
+    );
+  });
+
+  // ── Alt text ──────────────────────────────────────────────────────────
+
+  describe("sets descriptive alt text per type", () => {
+    it("not-found mentions page not found", () => {
+      const { container } = render(<ErrorIllustration type="not-found" />);
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("not found");
+    });
+
+    it("server-error mentions server error", () => {
+      const { container } = render(<ErrorIllustration type="server-error" />);
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("server error");
+    });
+
+    it("offline mentions no internet", () => {
+      const { container } = render(<ErrorIllustration type="offline" />);
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("no internet");
+    });
+  });
+
+  // ── Default dimensions ────────────────────────────────────────────────
+
+  it("renders at default 240×200 dimensions", () => {
+    const { container } = render(<ErrorIllustration type="not-found" />);
+    const img = container.querySelector("img") as HTMLImageElement;
+    expect(img.getAttribute("width")).toBe("240");
+    expect(img.getAttribute("height")).toBe("200");
+  });
+
+  // ── Custom dimensions ─────────────────────────────────────────────────
+
+  it("accepts custom width and height", () => {
+    const { container } = render(
+      <ErrorIllustration type="server-error" width={320} height={260} />,
+    );
+    const img = container.querySelector("img") as HTMLImageElement;
+    expect(img.getAttribute("width")).toBe("320");
+    expect(img.getAttribute("height")).toBe("260");
+  });
+
+  // ── data-testid ───────────────────────────────────────────────────────
+
+  it("renders with data-testid error-illustration", () => {
+    const { container } = render(<ErrorIllustration type="offline" />);
+    const wrapper = container.querySelector(
+      '[data-testid="error-illustration"]',
+    );
+    expect(wrapper).toBeInTheDocument();
+  });
+
+  // ── data-error-type attribute ─────────────────────────────────────────
+
+  it.each(ALL_TYPES)("sets data-error-type=%s on wrapper", (type) => {
+    const { container } = render(<ErrorIllustration type={type} />);
+    const wrapper = container.querySelector(`[data-error-type="${type}"]`);
+    expect(wrapper).toBeInTheDocument();
+  });
+
+  // ── data-illustration attribute ───────────────────────────────────────
+
+  it.each(ALL_TYPES)("sets data-illustration=%s on the image", (type) => {
+    const { container } = render(<ErrorIllustration type={type} />);
+    const img = container.querySelector(`[data-illustration="${type}"]`);
+    expect(img).toBeInTheDocument();
+  });
+
+  // ── className passthrough ─────────────────────────────────────────────
+
+  it("passes className to wrapper div", () => {
+    const { container } = render(
+      <ErrorIllustration type="not-found" className="my-8 text-center" />,
+    );
+    const wrapper = container.querySelector(
+      '[data-testid="error-illustration"]',
+    );
+    expect(wrapper?.className).toContain("my-8 text-center");
+  });
+
+  // ── priority loading ──────────────────────────────────────────────────
+
+  it("sets priority=false by default", () => {
+    const { container } = render(<ErrorIllustration type="not-found" />);
+    const img = container.querySelector("img") as HTMLImageElement;
+    expect(img.getAttribute("data-priority")).toBe("false");
+  });
+
+  it("passes priority=true when specified", () => {
+    const { container } = render(
+      <ErrorIllustration type="server-error" priority />,
+    );
+    const img = container.querySelector("img") as HTMLImageElement;
+    expect(img.getAttribute("data-priority")).toBe("true");
+  });
+});
+
+// ─── Utility Functions ──────────────────────────────────────────────────────
+
+describe("getErrorTypes", () => {
+  it("returns all 3 error types", () => {
+    const types = getErrorTypes();
+    expect(types).toHaveLength(3);
+    expect(types).toEqual(expect.arrayContaining(ALL_TYPES));
+  });
+});
+
+describe("getErrorMeta", () => {
+  it("returns metadata with alt, src, and statusCode for each type", () => {
+    for (const type of ALL_TYPES) {
+      const meta = getErrorMeta(type);
+      expect(meta.alt).toBeTruthy();
+      expect(meta.src).toContain("errors");
+      expect(meta.src).toMatch(/\.svg$/);
+    }
+  });
+
+  it("not-found has status code 404", () => {
+    const meta = getErrorMeta("not-found");
+    expect(meta.statusCode).toBe(404);
+  });
+
+  it("server-error has status code 500", () => {
+    const meta = getErrorMeta("server-error");
+    expect(meta.statusCode).toBe(500);
+  });
+
+  it("offline has null status code", () => {
+    const meta = getErrorMeta("offline");
+    expect(meta.statusCode).toBeNull();
+  });
+
+  it("returns correct src path for not-found", () => {
+    const meta = getErrorMeta("not-found");
+    expect(meta.src).toBe("/illustrations/errors/404-not-found.svg");
+  });
+});

--- a/frontend/src/components/common/ErrorIllustration.tsx
+++ b/frontend/src/components/common/ErrorIllustration.tsx
@@ -1,0 +1,106 @@
+// ─── ErrorIllustration ───────────────────────────────────────────────
+// Maps 3 error page types to branded SVG illustrations (240×200).
+// Each error type has a food-themed illustration that maintains visual
+// consistency with the empty-state illustration family.
+// ─────────────────────────────────────────────────────────────────────
+
+import Image from "next/image";
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+/**
+ * Error page illustration types.
+ * Each maps to a dedicated SVG in public/illustrations/errors/.
+ */
+export type ErrorType = "not-found" | "server-error" | "offline";
+
+export interface ErrorIllustrationProps {
+  /** Which error illustration to display */
+  readonly type: ErrorType;
+  /** Override the default width (240) */
+  readonly width?: number;
+  /** Override the default height (200) */
+  readonly height?: number;
+  /** Additional CSS classes on the wrapper */
+  readonly className?: string;
+  /** Whether to use priority loading (above the fold) */
+  readonly priority?: boolean;
+}
+
+// ─── Illustration Metadata ───────────────────────────────────────────
+
+interface ErrorMeta {
+  /** Alt text for the illustration image */
+  alt: string;
+  /** Path to the SVG file in public/ */
+  src: string;
+  /** HTTP status code associated with this error (informational) */
+  statusCode: number | null;
+}
+
+const ERROR_META: Record<ErrorType, ErrorMeta> = {
+  "not-found": {
+    alt: "Plate with 404 text, fork and knife — page not found",
+    src: "/illustrations/errors/404-not-found.svg",
+    statusCode: 404,
+  },
+  "server-error": {
+    alt: "Tipped-over bowl with spilled ingredients — server error",
+    src: "/illustrations/errors/500-server-error.svg",
+    statusCode: 500,
+  },
+  offline: {
+    alt: "Cloud with X mark — no internet connection",
+    src: "/illustrations/errors/offline.svg",
+    statusCode: null,
+  },
+};
+
+// ─── Utilities ───────────────────────────────────────────────────────
+
+/** Returns all available error type strings. */
+export function getErrorTypes(): ErrorType[] {
+  return Object.keys(ERROR_META) as ErrorType[];
+}
+
+/** Returns metadata for a given error type. */
+export function getErrorMeta(type: ErrorType): ErrorMeta {
+  return ERROR_META[type];
+}
+
+// ─── Component ───────────────────────────────────────────────────────
+
+/**
+ * Branded SVG illustration for error pages.
+ *
+ * All illustrations are 240×200 with dark mode support via
+ * `prefers-color-scheme` media queries embedded in the SVGs.
+ * These share the same visual language as the empty-state
+ * illustrations (flat/semi-flat, brand palette, dark mode).
+ */
+export function ErrorIllustration({
+  type,
+  width = 240,
+  height = 200,
+  className,
+  priority = false,
+}: ErrorIllustrationProps) {
+  const meta = ERROR_META[type];
+
+  return (
+    <div
+      className={className}
+      data-testid="error-illustration"
+      data-error-type={type}
+    >
+      <Image
+        src={meta.src}
+        alt={meta.alt}
+        width={width}
+        height={height}
+        priority={priority}
+        data-illustration={type}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/common/OnboardingIllustration.test.tsx
+++ b/frontend/src/components/common/OnboardingIllustration.test.tsx
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import {
+  OnboardingIllustration,
+  getOnboardingSteps,
+  getOnboardingStepMeta,
+} from "./OnboardingIllustration";
+import type { OnboardingStep } from "./OnboardingIllustration";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("next/image", () => ({
+  default: ({ priority, ...props }: Record<string, unknown>) => (
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    <img {...props} data-priority={priority ? "true" : "false"} />
+  ),
+}));
+
+// ─── Step Types ─────────────────────────────────────────────────────────────
+
+const ALL_STEPS: OnboardingStep[] = [
+  "welcome",
+  "country",
+  "diet",
+  "allergens",
+  "ready",
+];
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("OnboardingIllustration", () => {
+  // ── Rendering per step ────────────────────────────────────────────────
+
+  describe("renders correct illustration for each step", () => {
+    it.each(ALL_STEPS)("renders %s illustration", (step) => {
+      const { container } = render(<OnboardingIllustration step={step} />);
+
+      const img = container.querySelector(
+        `img[data-illustration="${step}"]`,
+      ) as HTMLImageElement;
+      expect(img).toBeInTheDocument();
+    });
+  });
+
+  // ── SVG source paths ─────────────────────────────────────────────────
+
+  describe("uses correct SVG source paths", () => {
+    it.each([
+      ["welcome", "/illustrations/onboarding/step-1-welcome.svg"],
+      ["country", "/illustrations/onboarding/step-2-country.svg"],
+      ["diet", "/illustrations/onboarding/step-3-diet.svg"],
+      ["allergens", "/illustrations/onboarding/step-4-allergens.svg"],
+      ["ready", "/illustrations/onboarding/step-5-ready.svg"],
+    ] as [OnboardingStep, string][])(
+      "%s uses %s",
+      (step, expectedSrc) => {
+        const { container } = render(<OnboardingIllustration step={step} />);
+        const img = container.querySelector("img") as HTMLImageElement;
+        expect(img.getAttribute("src")).toBe(expectedSrc);
+      },
+    );
+  });
+
+  // ── Alt text ──────────────────────────────────────────────────────────
+
+  describe("sets descriptive alt text per step", () => {
+    it("welcome mentions the app", () => {
+      const { container } = render(<OnboardingIllustration step="welcome" />);
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("welcome");
+    });
+
+    it("country mentions region selection", () => {
+      const { container } = render(<OnboardingIllustration step="country" />);
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("region");
+    });
+
+    it("diet mentions diet preferences", () => {
+      const { container } = render(<OnboardingIllustration step="diet" />);
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("diet");
+    });
+
+    it("allergens mentions allergen alerts", () => {
+      const { container } = render(
+        <OnboardingIllustration step="allergens" />,
+      );
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("allergen");
+    });
+
+    it("ready mentions setup complete", () => {
+      const { container } = render(<OnboardingIllustration step="ready" />);
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img.getAttribute("alt")).toContain("complete");
+    });
+  });
+
+  // ── Default dimensions ────────────────────────────────────────────────
+
+  it("renders at default 280×280 dimensions", () => {
+    const { container } = render(<OnboardingIllustration step="welcome" />);
+    const img = container.querySelector("img") as HTMLImageElement;
+    expect(img.getAttribute("width")).toBe("280");
+    expect(img.getAttribute("height")).toBe("280");
+  });
+
+  // ── Custom dimensions ─────────────────────────────────────────────────
+
+  it("accepts custom width and height", () => {
+    const { container } = render(
+      <OnboardingIllustration step="country" width={200} height={200} />,
+    );
+    const img = container.querySelector("img") as HTMLImageElement;
+    expect(img.getAttribute("width")).toBe("200");
+    expect(img.getAttribute("height")).toBe("200");
+  });
+
+  // ── data-testid ───────────────────────────────────────────────────────
+
+  it("renders with data-testid onboarding-illustration", () => {
+    const { container } = render(<OnboardingIllustration step="diet" />);
+    const wrapper = container.querySelector(
+      '[data-testid="onboarding-illustration"]',
+    );
+    expect(wrapper).toBeInTheDocument();
+  });
+
+  // ── data-step attribute ───────────────────────────────────────────────
+
+  it.each(ALL_STEPS)("sets data-step=%s on wrapper", (step) => {
+    const { container } = render(<OnboardingIllustration step={step} />);
+    const wrapper = container.querySelector(`[data-step="${step}"]`);
+    expect(wrapper).toBeInTheDocument();
+  });
+
+  // ── data-illustration attribute ───────────────────────────────────────
+
+  it.each(ALL_STEPS)("sets data-illustration=%s on the image", (step) => {
+    const { container } = render(<OnboardingIllustration step={step} />);
+    const img = container.querySelector(`[data-illustration="${step}"]`);
+    expect(img).toBeInTheDocument();
+  });
+
+  // ── className passthrough ─────────────────────────────────────────────
+
+  it("passes className to wrapper div", () => {
+    const { container } = render(
+      <OnboardingIllustration step="ready" className="mx-auto mt-4" />,
+    );
+    const wrapper = container.querySelector(
+      '[data-testid="onboarding-illustration"]',
+    );
+    expect(wrapper?.className).toContain("mx-auto mt-4");
+  });
+
+  // ── priority loading ──────────────────────────────────────────────────
+
+  it("sets priority=false by default", () => {
+    const { container } = render(<OnboardingIllustration step="welcome" />);
+    const img = container.querySelector("img") as HTMLImageElement;
+    expect(img.getAttribute("data-priority")).toBe("false");
+  });
+
+  it("passes priority=true when specified", () => {
+    const { container } = render(
+      <OnboardingIllustration step="welcome" priority />,
+    );
+    const img = container.querySelector("img") as HTMLImageElement;
+    expect(img.getAttribute("data-priority")).toBe("true");
+  });
+});
+
+// ─── Utility Functions ──────────────────────────────────────────────────────
+
+describe("getOnboardingSteps", () => {
+  it("returns all 5 onboarding steps", () => {
+    const steps = getOnboardingSteps();
+    expect(steps).toHaveLength(5);
+    expect(steps).toEqual(expect.arrayContaining(ALL_STEPS));
+  });
+});
+
+describe("getOnboardingStepMeta", () => {
+  it("returns metadata with alt and src for each step", () => {
+    for (const step of ALL_STEPS) {
+      const meta = getOnboardingStepMeta(step);
+      expect(meta.alt).toBeTruthy();
+      expect(meta.src).toContain("onboarding");
+      expect(meta.src).toMatch(/\.svg$/);
+    }
+  });
+
+  it("returns correct src path for welcome", () => {
+    const meta = getOnboardingStepMeta("welcome");
+    expect(meta.src).toBe("/illustrations/onboarding/step-1-welcome.svg");
+  });
+
+  it("returns correct src path for ready", () => {
+    const meta = getOnboardingStepMeta("ready");
+    expect(meta.src).toBe("/illustrations/onboarding/step-5-ready.svg");
+  });
+});

--- a/frontend/src/components/common/OnboardingIllustration.tsx
+++ b/frontend/src/components/common/OnboardingIllustration.tsx
@@ -1,0 +1,112 @@
+// ─── OnboardingIllustration ──────────────────────────────────────────
+// Maps 5 onboarding step types to branded SVG illustrations (280×280).
+// Each step has a contextual illustration that visually reinforces the
+// wizard step's purpose. Drop-in for any onboarding step layout.
+// ─────────────────────────────────────────────────────────────────────
+
+import Image from "next/image";
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+/**
+ * Onboarding step illustration types.
+ * Each maps to a dedicated SVG in public/illustrations/onboarding/.
+ */
+export type OnboardingStep =
+  | "welcome"
+  | "country"
+  | "diet"
+  | "allergens"
+  | "ready";
+
+export interface OnboardingIllustrationProps {
+  /** Which onboarding step illustration to display */
+  readonly step: OnboardingStep;
+  /** Override the default width (280) */
+  readonly width?: number;
+  /** Override the default height (280) */
+  readonly height?: number;
+  /** Additional CSS classes on the wrapper */
+  readonly className?: string;
+  /** Whether to use priority loading (above the fold) */
+  readonly priority?: boolean;
+}
+
+// ─── Illustration Metadata ───────────────────────────────────────────
+
+interface StepMeta {
+  /** Alt text for the illustration image */
+  alt: string;
+  /** Path to the SVG file in public/ */
+  src: string;
+}
+
+const STEP_META: Record<OnboardingStep, StepMeta> = {
+  welcome: {
+    alt: "Shield-leaf logo with food motifs — welcome to the app",
+    src: "/illustrations/onboarding/step-1-welcome.svg",
+  },
+  country: {
+    alt: "Globe with country selection pins — choose your region",
+    src: "/illustrations/onboarding/step-2-country.svg",
+  },
+  diet: {
+    alt: "Plate with food group sections — select your diet preferences",
+    src: "/illustrations/onboarding/step-3-diet.svg",
+  },
+  allergens: {
+    alt: "Shield with allergen icons — set your allergen alerts",
+    src: "/illustrations/onboarding/step-4-allergens.svg",
+  },
+  ready: {
+    alt: "Checkmark with confetti — setup complete, ready to explore",
+    src: "/illustrations/onboarding/step-5-ready.svg",
+  },
+};
+
+// ─── Utilities ───────────────────────────────────────────────────────
+
+/** Returns all available onboarding step strings. */
+export function getOnboardingSteps(): OnboardingStep[] {
+  return Object.keys(STEP_META) as OnboardingStep[];
+}
+
+/** Returns metadata for a given onboarding step. */
+export function getOnboardingStepMeta(step: OnboardingStep): StepMeta {
+  return STEP_META[step];
+}
+
+// ─── Component ───────────────────────────────────────────────────────
+
+/**
+ * Branded SVG illustration for onboarding wizard steps.
+ *
+ * All illustrations are 280×280 with dark mode support via
+ * `prefers-color-scheme` media queries embedded in the SVGs.
+ */
+export function OnboardingIllustration({
+  step,
+  width = 280,
+  height = 280,
+  className,
+  priority = false,
+}: OnboardingIllustrationProps) {
+  const meta = STEP_META[step];
+
+  return (
+    <div
+      className={className}
+      data-testid="onboarding-illustration"
+      data-step={step}
+    >
+      <Image
+        src={meta.src}
+        alt={meta.alt}
+        width={width}
+        height={height}
+        priority={priority}
+        data-illustration={step}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements #424 — onboarding and error page SVG illustrations with React component wrappers.

## Deliverables

### 5 Onboarding SVGs (280×280)
| Step | File | Description |
|------|------|-------------|
| 1 | `step-1-welcome.svg` | Shield-leaf logomark with food motifs (apple, carrot, wheat) |
| 2 | `step-2-country.svg` | Globe with PL/DE map pins, selection checkmark |
| 3 | `step-3-diet.svg` | Plate with food group sections, fork/knife, toggle indicators |
| 4 | `step-4-allergens.svg` | Shield with 6 allergen emoji icons, warning badge |
| 5 | `step-5-ready.svg` | Green checkmark circle with confetti particles |

### 3 Error SVGs (240×200)
| Type | File | Description |
|------|------|-------------|
| 404 | `404-not-found.svg` | Plate with "404" text, fork and knife, question marks |
| 500 | `500-server-error.svg` | Tipped-over bowl with spilled ingredients, alert triangle |
| Offline | `offline.svg` | Cloud with X mark, disconnected signal waves |

### React Components
- **`OnboardingIllustration`** — 5 step types, custom dimensions, priority loading, `data-step` attribute
- **`ErrorIllustration`** — 3 error types, HTTP status metadata, `data-error-type` attribute
- **LoadingSpinner** and **Skeleton** — already exist with tests, no changes needed

### Tests
- 32 Vitest tests for `OnboardingIllustration` (all steps, alt text, dimensions, data attributes, className, priority)
- 30 Vitest tests for `ErrorIllustration` (all types, alt text, dimensions, data attributes, className, priority, status codes)

## Design Specs
- Brand palette: primary=#0d7377, accent=#d4a844, dark mode via `prefers-color-scheme`
- All SVGs under 3 KB
- Consistent visual language with empty-state illustrations

## Verification
- 62/62 Vitest tests passing
- 0 TypeScript errors
- 13 files changed, +977 lines

Closes #424