### PR TITLE
feat(docs): create 6 feature showcase card SVGs (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,13 @@ Adheres to [Semantic Versioning](https://semver.org/).
   component (5 steps, custom dimensions, priority loading) with 32 Vitest tests;
   `ErrorIllustration` component (3 error types, HTTP status metadata) with
   30 Vitest tests; LoadingSpinner and Skeleton components already exist (#424)
+- Create 6 feature showcase card SVGs in `docs/marketing/` (400×300 viewBox):
+  scoring engine (gauge + 5 factor bars), ingredient analysis (concern tier
+  badges), product comparison (side-by-side grid with VS badge), allergen
+  filtering (8-allergen status matrix), barcode scanner (phone mockup with
+  product result card), smart search (search bar with pg_trgm + filter chips
+  + fuzzy results); white card style with brand-colored border, dark mode
+  via `prefers-color-scheme` media queries, all under 6 KB (#432)
 - Redesign README.md as 15-section showcase-quality layout: hero banner, 9
   shields.io badges, elevator pitch, 4 feature highlight cards (HTML table),
   comparison table, 3-column quick start with collapsible command reference,

--- a/docs/marketing/feature-allergens.svg
+++ b/docs/marketing/feature-allergens.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" fill="none">
+  <style>
+    .card-bg { fill: #ffffff; }
+    .card-border { stroke: #0d7377; stroke-width: 1.5; fill: none; }
+    .icon-bg { fill: #0d7377; opacity: 0.1; }
+    .icon-fill { fill: #0d7377; }
+    .title { font-family: system-ui, -apple-system, sans-serif; font-size: 18px; font-weight: 700; fill: #0f172a; }
+    .desc { font-family: system-ui, -apple-system, sans-serif; font-size: 13px; fill: #475569; }
+    .stat { font-family: system-ui, -apple-system, sans-serif; font-size: 11px; font-weight: 600; fill: #0d7377; }
+    .shield-bg { fill: #f0fdfa; stroke: #0d7377; stroke-width: 1.5; }
+    .check-icon { fill: #16a34a; }
+    .warn-icon { fill: #dc2626; }
+    .maybe-icon { fill: #d4a844; }
+    .allergen-name { font-family: system-ui, sans-serif; font-size: 11px; fill: #334155; }
+    .allergen-type { font-family: system-ui, sans-serif; font-size: 8px; fill: #94a3b8; }
+    .safe-bg { fill: #dcfce7; rx: 4; }
+    .warn-bg { fill: #fee2e2; rx: 4; }
+    .trace-bg { fill: #fef9c3; rx: 4; }
+    .safe-text { font-family: system-ui, sans-serif; font-size: 9px; font-weight: 600; fill: #166534; }
+    .warn-text { font-family: system-ui, sans-serif; font-size: 9px; font-weight: 600; fill: #991b1b; }
+    .trace-text { font-family: system-ui, sans-serif; font-size: 9px; font-weight: 600; fill: #854d0e; }
+    @media (prefers-color-scheme: dark) {
+      .card-bg { fill: #1e293b; }
+      .card-border { stroke: #2dd4bf; }
+      .icon-bg { fill: #2dd4bf; opacity: 0.15; }
+      .icon-fill { fill: #2dd4bf; }
+      .title { fill: #f1f5f9; }
+      .desc { fill: #94a3b8; }
+      .stat { fill: #2dd4bf; }
+      .shield-bg { fill: #134e4a; stroke: #2dd4bf; }
+      .allergen-name { fill: #e2e8f0; }
+      .allergen-type { fill: #64748b; }
+      .safe-bg { fill: #052e16; }
+      .warn-bg { fill: #450a0a; }
+      .trace-bg { fill: #422006; }
+      .safe-text { fill: #4ade80; }
+      .warn-text { fill: #fca5a5; }
+      .trace-text { fill: #fbbf24; }
+    }
+  </style>
+  <rect class="card-bg" x="0.75" y="0.75" width="398.5" height="298.5" rx="16"/>
+  <rect class="card-border" x="0.75" y="0.75" width="398.5" height="298.5" rx="16"/>
+  <!-- Icon: shield -->
+  <circle class="icon-bg" cx="40" cy="40" r="24"/>
+  <path class="icon-fill" d="M40 22 l12 5v8c0 7-5 13-12 16-7-3-12-9-12-16v-8z"/>
+  <path d="M36 37l3 3 6-6" stroke="#ffffff" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Title -->
+  <text class="title" x="72" y="44">Allergen Safety</text>
+  <!-- Description -->
+  <text class="desc" x="24" y="76">2,630 allergen &amp; trace declarations. Personal filters</text>
+  <text class="desc" x="24" y="92">flag unsafe products automatically for your profile.</text>
+  <!-- Mini visual: allergen status list -->
+  <g transform="translate(24,110)">
+    <!-- Shield mini -->
+    <path class="shield-bg" d="M22 0 l20 6v12c0 10-8 18-20 22C10 36 2 28 2 18V6z"/>
+    <text style="font-size:18px;text-anchor:middle" x="22" y="24">🛡️</text>
+    <!-- Allergen rows -->
+    <g transform="translate(60,0)">
+      <text class="allergen-name" x="0" y="14">🌾 Gluten</text>
+      <rect class="safe-bg" x="130" y="3" width="56" height="16" rx="8"/>
+      <text class="safe-text" x="142" y="15">✓ Safe</text>
+      <text class="allergen-name" x="210" y="14">🥛 Milk</text>
+      <rect class="warn-bg" x="260" y="3" width="72" height="16" rx="8"/>
+      <text class="warn-text" x="269" y="15">✗ Contains</text>
+    </g>
+    <g transform="translate(60,28)">
+      <text class="allergen-name" x="0" y="14">🥜 Peanuts</text>
+      <rect class="trace-bg" x="130" y="3" width="56" height="16" rx="8"/>
+      <text class="trace-text" x="139" y="15">⚠ Traces</text>
+      <text class="allergen-name" x="210" y="14">🥚 Eggs</text>
+      <rect class="safe-bg" x="260" y="3" width="56" height="16" rx="8"/>
+      <text class="safe-text" x="272" y="15">✓ Safe</text>
+    </g>
+    <g transform="translate(60,56)">
+      <text class="allergen-name" x="0" y="14">🐟 Fish</text>
+      <rect class="safe-bg" x="130" y="3" width="56" height="16" rx="8"/>
+      <text class="safe-text" x="142" y="15">✓ Safe</text>
+      <text class="allergen-name" x="210" y="14">🫘 Soy</text>
+      <rect class="warn-bg" x="260" y="3" width="72" height="16" rx="8"/>
+      <text class="warn-text" x="269" y="15">✗ Contains</text>
+    </g>
+    <g transform="translate(60,84)">
+      <text class="allergen-name" x="0" y="14">🌰 Nuts</text>
+      <rect class="trace-bg" x="130" y="3" width="56" height="16" rx="8"/>
+      <text class="trace-text" x="139" y="15">⚠ Traces</text>
+      <text class="allergen-name" x="210" y="14">🌱 Celery</text>
+      <rect class="safe-bg" x="260" y="3" width="56" height="16" rx="8"/>
+      <text class="safe-text" x="272" y="15">✓ Safe</text>
+    </g>
+  </g>
+  <text class="stat" x="24" y="282">1,269 allergens · 1,361 traces · personal profiles</text>
+</svg>

--- a/docs/marketing/feature-comparisons.svg
+++ b/docs/marketing/feature-comparisons.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" fill="none">
+  <style>
+    .card-bg { fill: #ffffff; }
+    .card-border { stroke: #0d7377; stroke-width: 1.5; fill: none; }
+    .icon-bg { fill: #0d7377; opacity: 0.1; }
+    .icon-fill { fill: #0d7377; }
+    .title { font-family: system-ui, -apple-system, sans-serif; font-size: 18px; font-weight: 700; fill: #0f172a; }
+    .desc { font-family: system-ui, -apple-system, sans-serif; font-size: 13px; fill: #475569; }
+    .stat { font-family: system-ui, -apple-system, sans-serif; font-size: 11px; font-weight: 600; fill: #0d7377; }
+    .col-header { font-family: system-ui, sans-serif; font-size: 10px; font-weight: 600; fill: #64748b; text-anchor: middle; }
+    .col-name { font-family: system-ui, sans-serif; font-size: 10px; font-weight: 600; fill: #0f172a; text-anchor: middle; }
+    .col-val { font-family: system-ui, sans-serif; font-size: 9px; fill: #475569; text-anchor: middle; }
+    .col-score { font-family: system-ui, sans-serif; font-size: 14px; font-weight: 700; text-anchor: middle; }
+    .score-good { fill: #16a34a; }
+    .score-mid { fill: #d4a844; }
+    .col-bg-a { fill: #f0fdfa; }
+    .col-bg-b { fill: #fefce8; }
+    .vs-badge { fill: #0d7377; }
+    .vs-text { font-family: system-ui, sans-serif; font-size: 10px; font-weight: 700; fill: #ffffff; text-anchor: middle; }
+    .divider { stroke: #e2e8f0; stroke-width: 1; stroke-dasharray: 4 3; }
+    .row-label { font-family: system-ui, sans-serif; font-size: 9px; fill: #94a3b8; }
+    .better { fill: #dcfce7; stroke: #16a34a; stroke-width: 0.6; }
+    .better-text { font-family: system-ui, sans-serif; font-size: 7px; font-weight: 600; fill: #166534; }
+    @media (prefers-color-scheme: dark) {
+      .card-bg { fill: #1e293b; }
+      .card-border { stroke: #2dd4bf; }
+      .icon-bg { fill: #2dd4bf; opacity: 0.15; }
+      .icon-fill { fill: #2dd4bf; }
+      .title { fill: #f1f5f9; }
+      .desc { fill: #94a3b8; }
+      .stat { fill: #2dd4bf; }
+      .col-header { fill: #94a3b8; }
+      .col-name { fill: #e2e8f0; }
+      .col-val { fill: #94a3b8; }
+      .score-good { fill: #4ade80; }
+      .score-mid { fill: #fbbf24; }
+      .col-bg-a { fill: #134e4a; opacity: 0.4; }
+      .col-bg-b { fill: #422006; opacity: 0.3; }
+      .vs-badge { fill: #2dd4bf; }
+      .vs-text { fill: #0f172a; }
+      .divider { stroke: #475569; }
+      .row-label { fill: #64748b; }
+      .better { fill: #052e16; stroke: #22c55e; }
+      .better-text { fill: #4ade80; }
+    }
+  </style>
+  <rect class="card-bg" x="0.75" y="0.75" width="398.5" height="298.5" rx="16"/>
+  <rect class="card-border" x="0.75" y="0.75" width="398.5" height="298.5" rx="16"/>
+  <!-- Icon: split screen -->
+  <circle class="icon-bg" cx="40" cy="40" r="24"/>
+  <rect class="icon-fill" x="28" y="28" width="10" height="24" rx="2"/>
+  <rect class="icon-fill" x="42" y="28" width="10" height="24" rx="2"/>
+  <line stroke="#0d7377" stroke-width="2" stroke-dasharray="2 2" x1="40" y1="30" x2="40" y2="50"/>
+  <!-- Title -->
+  <text class="title" x="72" y="44">Side-by-Side Compare</text>
+  <!-- Description -->
+  <text class="desc" x="24" y="76">Compare 2–4 products at a glance. Nutrition,</text>
+  <text class="desc" x="24" y="92">scores, and ingredients highlighted instantly.</text>
+  <!-- Mini visual: comparison grid -->
+  <g transform="translate(24,108)">
+    <!-- Column backgrounds -->
+    <rect class="col-bg-a" x="80" y="0" width="120" height="150" rx="8"/>
+    <rect class="col-bg-b" x="220" y="0" width="120" height="150" rx="8"/>
+    <!-- VS badge -->
+    <circle class="vs-badge" cx="200" cy="24" r="12"/>
+    <text class="vs-text" x="200" y="28">VS</text>
+    <!-- Headers -->
+    <text class="col-name" x="140" y="18">Skyr Natural</text>
+    <text class="col-name" x="280" y="18">Jogurt Pitny</text>
+    <!-- Rows -->
+    <text class="row-label" x="0" y="50">Score</text>
+    <text class="col-score score-good" x="140" y="52">8</text>
+    <text class="col-score score-mid" x="280" y="52">34</text>
+    <rect class="better" x="112" y="56" width="56" height="13" rx="6"/>
+    <text class="better-text" x="125" y="65">26 pts better</text>
+    <line class="divider" x1="80" y1="72" x2="340" y2="72"/>
+    <text class="row-label" x="0" y="88">Sugars</text>
+    <text class="col-val" x="140" y="88">3.6 g</text>
+    <text class="col-val" x="280" y="88">12.1 g</text>
+    <line class="divider" x1="80" y1="96" x2="340" y2="96"/>
+    <text class="row-label" x="0" y="112">Sat Fat</text>
+    <text class="col-val" x="140" y="112">0.1 g</text>
+    <text class="col-val" x="280" y="112">1.8 g</text>
+    <line class="divider" x1="80" y1="120" x2="340" y2="120"/>
+    <text class="row-label" x="0" y="136">Additives</text>
+    <text class="col-val" x="140" y="136">0</text>
+    <text class="col-val" x="280" y="136">3</text>
+  </g>
+  <text class="stat" x="24" y="282">Compare up to 4 products · Save &amp; share results</text>
+</svg>

--- a/docs/marketing/feature-ingredients.svg
+++ b/docs/marketing/feature-ingredients.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" fill="none">
+  <style>
+    .card-bg { fill: #ffffff; }
+    .card-border { stroke: #0d7377; stroke-width: 1.5; fill: none; }
+    .icon-bg { fill: #0d7377; opacity: 0.1; }
+    .icon-fill { fill: #0d7377; }
+    .title { font-family: system-ui, -apple-system, sans-serif; font-size: 18px; font-weight: 700; fill: #0f172a; }
+    .desc { font-family: system-ui, -apple-system, sans-serif; font-size: 13px; fill: #475569; }
+    .stat { font-family: system-ui, -apple-system, sans-serif; font-size: 11px; font-weight: 600; fill: #0d7377; }
+    .pill-bg { fill: #f0fdfa; stroke: #0d7377; stroke-width: 0.8; }
+    .pill-text { font-family: system-ui, sans-serif; font-size: 9px; fill: #0d7377; }
+    .badge-warn { fill: #fef3c7; stroke: #d4a844; stroke-width: 0.8; }
+    .badge-ok { fill: #dcfce7; stroke: #16a34a; stroke-width: 0.8; }
+    .badge-text-warn { font-family: system-ui, sans-serif; font-size: 8px; font-weight: 600; fill: #92400e; }
+    .badge-text-ok { font-family: system-ui, sans-serif; font-size: 8px; font-weight: 600; fill: #166534; }
+    .line-sep { stroke: #e2e8f0; stroke-width: 0.5; }
+    .ingr-name { font-family: system-ui, sans-serif; font-size: 10px; fill: #334155; }
+    .ingr-flag { font-family: system-ui, sans-serif; font-size: 8px; fill: #94a3b8; }
+    @media (prefers-color-scheme: dark) {
+      .card-bg { fill: #1e293b; }
+      .card-border { stroke: #2dd4bf; }
+      .icon-bg { fill: #2dd4bf; opacity: 0.15; }
+      .icon-fill { fill: #2dd4bf; }
+      .title { fill: #f1f5f9; }
+      .desc { fill: #94a3b8; }
+      .stat { fill: #2dd4bf; }
+      .pill-bg { fill: #134e4a; stroke: #2dd4bf; }
+      .pill-text { fill: #2dd4bf; }
+      .badge-warn { fill: #451a03; stroke: #fbbf24; }
+      .badge-ok { fill: #052e16; stroke: #22c55e; }
+      .badge-text-warn { fill: #fbbf24; }
+      .badge-text-ok { fill: #4ade80; }
+      .line-sep { stroke: #334155; }
+      .ingr-name { fill: #cbd5e1; }
+      .ingr-flag { fill: #64748b; }
+    }
+  </style>
+  <rect class="card-bg" x="0.75" y="0.75" width="398.5" height="298.5" rx="16"/>
+  <rect class="card-border" x="0.75" y="0.75" width="398.5" height="298.5" rx="16"/>
+  <!-- Icon: flask -->
+  <circle class="icon-bg" cx="40" cy="40" r="24"/>
+  <path class="icon-fill" d="M36 28h8v8l6 10a2 2 0 0 1-1.7 3H31.7a2 2 0 0 1-1.7-3l6-10zm2 2v6.5l-5 8.5h14l-5-8.5V30z" transform="translate(0,2)"/>
+  <!-- Title -->
+  <text class="title" x="72" y="44">Ingredient Intelligence</text>
+  <!-- Description -->
+  <text class="desc" x="24" y="76">2,995 unique ingredients analyzed. EFSA 4-tier</text>
+  <text class="desc" x="24" y="92">additive classification with concern scoring.</text>
+  <!-- Mini visual: ingredient list with badges -->
+  <g transform="translate(24,112)">
+    <!-- Row 1 -->
+    <text class="ingr-name" x="0" y="12">Citric acid (E330)</text>
+    <rect class="badge-ok" x="130" y="2" width="56" height="15" rx="7"/>
+    <text class="badge-text-ok" x="140" y="13">No concern</text>
+    <rect class="pill-bg" x="195" y="2" width="50" height="15" rx="7"/>
+    <text class="pill-text" x="204" y="13">Tier 0</text>
+    <line class="line-sep" x1="0" y1="22" x2="350" y2="22"/>
+    <!-- Row 2 -->
+    <text class="ingr-name" x="0" y="38">Sodium nitrite (E250)</text>
+    <rect class="badge-warn" x="130" y="28" width="68" height="15" rx="7"/>
+    <text class="badge-text-warn" x="138" y="39">High concern</text>
+    <rect class="pill-bg" x="207" y="28" width="50" height="15" rx="7"/>
+    <text class="pill-text" x="216" y="39">Tier 3</text>
+    <line class="line-sep" x1="0" y1="48" x2="350" y2="48"/>
+    <!-- Row 3 -->
+    <text class="ingr-name" x="0" y="64">Lecithins (E322)</text>
+    <rect class="badge-ok" x="130" y="54" width="56" height="15" rx="7"/>
+    <text class="badge-text-ok" x="140" y="65">No concern</text>
+    <rect class="pill-bg" x="195" y="54" width="50" height="15" rx="7"/>
+    <text class="pill-text" x="204" y="65">Tier 0</text>
+    <line class="line-sep" x1="0" y1="74" x2="350" y2="74"/>
+    <!-- Row 4 -->
+    <text class="ingr-name" x="0" y="90">Caramel color (E150d)</text>
+    <rect class="badge-warn" x="130" y="80" width="80" height="15" rx="7"/>
+    <text class="badge-text-warn" x="136" y="91">Moderate concern</text>
+    <rect class="pill-bg" x="219" y="80" width="50" height="15" rx="7"/>
+    <text class="pill-text" x="228" y="91">Tier 2</text>
+    <line class="line-sep" x1="0" y1="100" x2="350" y2="100"/>
+    <!-- Row 5 -->
+    <text class="ingr-name" x="0" y="116">Palm oil</text>
+    <rect class="badge-warn" x="130" y="106" width="62" height="15" rx="7"/>
+    <text class="badge-text-warn" x="137" y="117">Controversy</text>
+    <text class="ingr-flag" x="200" y="117">🌴 environmental</text>
+  </g>
+  <text class="stat" x="24" y="282">2,995 ingredients · 4 concern tiers · EFSA-based</text>
+</svg>

--- a/docs/marketing/feature-scanner.svg
+++ b/docs/marketing/feature-scanner.svg
@@ -1,0 +1,107 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" fill="none">
+  <style>
+    .card-bg { fill: #ffffff; }
+    .card-border { stroke: #0d7377; stroke-width: 1.5; fill: none; }
+    .icon-bg { fill: #0d7377; opacity: 0.1; }
+    .icon-fill { fill: #0d7377; }
+    .title { font-family: system-ui, -apple-system, sans-serif; font-size: 18px; font-weight: 700; fill: #0f172a; }
+    .desc { font-family: system-ui, -apple-system, sans-serif; font-size: 13px; fill: #475569; }
+    .stat { font-family: system-ui, -apple-system, sans-serif; font-size: 11px; font-weight: 600; fill: #0d7377; }
+    .phone-shell { fill: #f8fafc; stroke: #cbd5e1; stroke-width: 2; }
+    .phone-screen { fill: #ffffff; }
+    .phone-notch { fill: #e2e8f0; }
+    .barcode-line { stroke: #0f172a; stroke-width: 1.5; }
+    .barcode-thin { stroke: #0f172a; stroke-width: 0.8; }
+    .scan-line { stroke: #0d7377; stroke-width: 2; opacity: 0.7; }
+    .product-card { fill: #f0fdfa; stroke: #0d7377; stroke-width: 1; }
+    .product-name { font-family: system-ui, sans-serif; font-size: 9px; font-weight: 600; fill: #0f172a; }
+    .product-brand { font-family: system-ui, sans-serif; font-size: 8px; fill: #64748b; }
+    .score-circle { fill: #16a34a; }
+    .score-num { font-family: system-ui, sans-serif; font-size: 10px; font-weight: 700; fill: #ffffff; text-anchor: middle; }
+    .ean-text { font-family: 'Courier New', monospace; font-size: 8px; fill: #94a3b8; text-anchor: middle; }
+    .arrow { fill: #0d7377; }
+    .flash { fill: #d4a844; opacity: 0.4; }
+    @media (prefers-color-scheme: dark) {
+      .card-bg { fill: #1e293b; }
+      .card-border { stroke: #2dd4bf; }
+      .icon-bg { fill: #2dd4bf; opacity: 0.15; }
+      .icon-fill { fill: #2dd4bf; }
+      .title { fill: #f1f5f9; }
+      .desc { fill: #94a3b8; }
+      .stat { fill: #2dd4bf; }
+      .phone-shell { fill: #0f172a; stroke: #475569; }
+      .phone-screen { fill: #1e293b; }
+      .phone-notch { fill: #334155; }
+      .barcode-line { stroke: #e2e8f0; }
+      .barcode-thin { stroke: #e2e8f0; }
+      .scan-line { stroke: #2dd4bf; }
+      .product-card { fill: #134e4a; stroke: #2dd4bf; }
+      .product-name { fill: #f1f5f9; }
+      .product-brand { fill: #94a3b8; }
+      .score-circle { fill: #22c55e; }
+      .ean-text { fill: #64748b; }
+      .arrow { fill: #2dd4bf; }
+      .flash { fill: #fbbf24; opacity: 0.3; }
+    }
+  </style>
+  <rect class="card-bg" x="0.75" y="0.75" width="398.5" height="298.5" rx="16"/>
+  <rect class="card-border" x="0.75" y="0.75" width="398.5" height="298.5" rx="16"/>
+  <!-- Icon: barcode -->
+  <circle class="icon-bg" cx="40" cy="40" r="24"/>
+  <g transform="translate(28,28)">
+    <rect class="icon-fill" x="0" y="0" width="2.5" height="20"/>
+    <rect class="icon-fill" x="4" y="0" width="1.5" height="20"/>
+    <rect class="icon-fill" x="7" y="0" width="3" height="20"/>
+    <rect class="icon-fill" x="12" y="0" width="1.5" height="20"/>
+    <rect class="icon-fill" x="15" y="0" width="2.5" height="20"/>
+    <rect class="icon-fill" x="19" y="0" width="1" height="20"/>
+    <rect class="icon-fill" x="22" y="0" width="2" height="20"/>
+  </g>
+  <!-- Title -->
+  <text class="title" x="72" y="44">Instant Barcode Scan</text>
+  <!-- Description -->
+  <text class="desc" x="24" y="76">Scan any barcode in store for instant product details,</text>
+  <text class="desc" x="24" y="92">health score, and better alternatives. 99.8% EAN coverage.</text>
+  <!-- Mini visual: phone with barcode scan -->
+  <g transform="translate(50,108)">
+    <!-- Phone outline -->
+    <rect class="phone-shell" x="0" y="0" width="100" height="155" rx="14"/>
+    <rect class="phone-screen" x="6" y="18" width="88" height="120" rx="2"/>
+    <rect class="phone-notch" x="32" y="4" width="36" height="8" rx="4"/>
+    <!-- Barcode on screen -->
+    <g transform="translate(20,40)">
+      <rect class="barcode-line" x="0" y="0" width="3" height="45" rx="0" fill="#0f172a" stroke="none"/>
+      <rect fill="#0f172a" x="5" y="0" width="2" height="45"/>
+      <rect fill="#0f172a" x="9" y="0" width="4" height="45"/>
+      <rect fill="#0f172a" x="15" y="0" width="2" height="45"/>
+      <rect fill="#0f172a" x="19" y="0" width="3" height="45"/>
+      <rect fill="#0f172a" x="24" y="0" width="1.5" height="45"/>
+      <rect fill="#0f172a" x="28" y="0" width="3" height="45"/>
+      <rect fill="#0f172a" x="33" y="0" width="2" height="45"/>
+      <rect fill="#0f172a" x="37" y="0" width="4" height="45"/>
+      <rect fill="#0f172a" x="43" y="0" width="2" height="45"/>
+      <rect fill="#0f172a" x="47" y="0" width="3" height="45"/>
+      <rect fill="#0f172a" x="52" y="0" width="1.5" height="45"/>
+      <rect fill="#0f172a" x="56" y="0" width="3" height="45"/>
+    </g>
+    <!-- Scan line -->
+    <line class="scan-line" x1="12" y1="62" x2="88" y2="62"/>
+    <!-- EAN text -->
+    <text class="ean-text" x="50" y="100">5900617002478</text>
+    <!-- Flash burst -->
+    <circle class="flash" cx="50" cy="62" r="30"/>
+  </g>
+  <!-- Arrow -->
+  <polygon class="arrow" points="170,180 185,174 185,186"/>
+  <!-- Product result card -->
+  <g transform="translate(200,140)">
+    <rect class="product-card" x="0" y="0" width="160" height="80" rx="10"/>
+    <circle class="score-circle" cx="28" cy="26" r="16"/>
+    <text class="score-num" x="28" y="30">8</text>
+    <text class="product-name" x="52" y="20">Piątnica Skyr</text>
+    <text class="product-brand" x="52" y="32">Naturalny · Dairy</text>
+    <text class="product-brand" x="12" y="55">Sugars: 3.6g · Sat Fat: 0.1g</text>
+    <text class="product-brand" x="12" y="67">Nutri-Score: A · NOVA: 1</text>
+  </g>
+  <text class="stat" x="24" y="282">1,024 EANs · scan history · instant lookup</text>
+</svg>

--- a/docs/marketing/feature-scoring.svg
+++ b/docs/marketing/feature-scoring.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" fill="none">
+  <style>
+    .card-bg { fill: #ffffff; }
+    .card-border { stroke: #0d7377; stroke-width: 1.5; fill: none; rx: 16; }
+    .icon-bg { fill: #0d7377; opacity: 0.1; }
+    .icon-fill { fill: #0d7377; }
+    .title { font-family: system-ui, -apple-system, sans-serif; font-size: 18px; font-weight: 700; fill: #0f172a; }
+    .desc { font-family: system-ui, -apple-system, sans-serif; font-size: 13px; fill: #475569; }
+    .stat { font-family: system-ui, -apple-system, sans-serif; font-size: 11px; font-weight: 600; fill: #0d7377; }
+    .bar-track { fill: #e2e8f0; rx: 3; }
+    .bar-green { fill: #16a34a; rx: 3; }
+    .bar-yellow { fill: #d4a844; rx: 3; }
+    .bar-orange { fill: #ea580c; rx: 3; }
+    .bar-red { fill: #dc2626; rx: 3; }
+    .gauge-ring { stroke: #e2e8f0; stroke-width: 8; fill: none; }
+    .gauge-value { stroke: #0d7377; stroke-width: 8; fill: none; stroke-linecap: round; }
+    .gauge-text { font-family: system-ui, sans-serif; font-size: 20px; font-weight: 700; fill: #0d7377; text-anchor: middle; }
+    .gauge-label { font-family: system-ui, sans-serif; font-size: 9px; fill: #94a3b8; text-anchor: middle; }
+    .factor { font-family: system-ui, sans-serif; font-size: 9px; fill: #64748b; }
+    @media (prefers-color-scheme: dark) {
+      .card-bg { fill: #1e293b; }
+      .card-border { stroke: #2dd4bf; }
+      .icon-bg { fill: #2dd4bf; opacity: 0.15; }
+      .icon-fill { fill: #2dd4bf; }
+      .title { fill: #f1f5f9; }
+      .desc { fill: #94a3b8; }
+      .stat { fill: #2dd4bf; }
+      .bar-track { fill: #334155; }
+      .gauge-ring { stroke: #334155; }
+      .gauge-value { stroke: #2dd4bf; }
+      .gauge-text { fill: #2dd4bf; }
+      .gauge-label { fill: #64748b; }
+      .factor { fill: #94a3b8; }
+    }
+  </style>
+  <!-- Card background -->
+  <rect class="card-bg" x="0.75" y="0.75" width="398.5" height="298.5" rx="16"/>
+  <rect class="card-border" x="0.75" y="0.75" width="398.5" height="298.5" rx="16"/>
+  <!-- Icon -->
+  <circle class="icon-bg" cx="40" cy="40" r="24"/>
+  <path class="icon-fill" d="M33 32 a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v2h-14zm0 4h14v8a2 2 0 0 1-2 2h-10a2 2 0 0 1-2-2zm3 2v4h2v-4zm4 0v4h2v-4z" transform="translate(0,2)"/>
+  <!-- Title -->
+  <text class="title" x="72" y="44">9-Factor Health Score</text>
+  <!-- Description -->
+  <text class="desc" x="24" y="76">Every product scored 1–100 using 9 weighted nutrition</text>
+  <text class="desc" x="24" y="92">and ingredient factors. Science-driven, transparent.</text>
+  <!-- Mini visual: gauge + factor bars -->
+  <g transform="translate(60,120)">
+    <!-- Gauge -->
+    <circle class="gauge-ring" cx="55" cy="55" r="40"/>
+    <circle class="gauge-value" cx="55" cy="55" r="40"
+      stroke-dasharray="188 252" stroke-dashoffset="63"
+      transform="rotate(-90 55 55)"/>
+    <text class="gauge-text" x="55" y="60">27</text>
+    <text class="gauge-label" x="55" y="73">/ 100</text>
+  </g>
+  <g transform="translate(190,130)">
+    <!-- Factor bars -->
+    <text class="factor" x="0" y="8">Sat Fat</text>
+    <rect class="bar-track" x="55" y="0" width="120" height="10"/>
+    <rect class="bar-green" x="55" y="0" width="36" height="10"/>
+    <text class="factor" x="0" y="26">Sugars</text>
+    <rect class="bar-track" x="55" y="18" width="120" height="10"/>
+    <rect class="bar-yellow" x="55" y="18" width="72" height="10"/>
+    <text class="factor" x="0" y="44">Salt</text>
+    <rect class="bar-track" x="55" y="36" width="120" height="10"/>
+    <rect class="bar-orange" x="55" y="36" width="48" height="10"/>
+    <text class="factor" x="0" y="62">Calories</text>
+    <rect class="bar-track" x="55" y="54" width="120" height="10"/>
+    <rect class="bar-green" x="55" y="54" width="24" height="10"/>
+    <text class="factor" x="0" y="80">Additives</text>
+    <rect class="bar-track" x="55" y="72" width="120" height="10"/>
+    <rect class="bar-red" x="55" y="72" width="96" height="10"/>
+  </g>
+  <!-- Bottom stat -->
+  <text class="stat" x="24" y="282">1,281 products · 25 categories · PL + DE</text>
+</svg>

--- a/docs/marketing/feature-search.svg
+++ b/docs/marketing/feature-search.svg
@@ -1,0 +1,99 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" fill="none">
+  <style>
+    .card-bg { fill: #ffffff; }
+    .card-border { stroke: #0d7377; stroke-width: 1.5; fill: none; }
+    .icon-bg { fill: #0d7377; opacity: 0.1; }
+    .icon-fill { fill: #0d7377; }
+    .title { font-family: system-ui, -apple-system, sans-serif; font-size: 18px; font-weight: 700; fill: #0f172a; }
+    .desc { font-family: system-ui, -apple-system, sans-serif; font-size: 13px; fill: #475569; }
+    .stat { font-family: system-ui, -apple-system, sans-serif; font-size: 11px; font-weight: 600; fill: #0d7377; }
+    .search-bg { fill: #f8fafc; stroke: #cbd5e1; stroke-width: 1.5; }
+    .search-text { font-family: system-ui, sans-serif; font-size: 12px; fill: #94a3b8; }
+    .search-query { font-family: system-ui, sans-serif; font-size: 12px; fill: #0f172a; }
+    .result-bg { fill: #f0fdfa; stroke: #0d7377; stroke-width: 0.8; }
+    .result-name { font-family: system-ui, sans-serif; font-size: 10px; font-weight: 600; fill: #0f172a; }
+    .result-meta { font-family: system-ui, sans-serif; font-size: 8px; fill: #64748b; }
+    .highlight { fill: #d4a844; opacity: 0.3; }
+    .filter-bg { fill: #f1f5f9; stroke: #cbd5e1; stroke-width: 0.8; }
+    .filter-text { font-family: system-ui, sans-serif; font-size: 8px; fill: #475569; }
+    .filter-active { fill: #0d7377; }
+    .filter-active-text { font-family: system-ui, sans-serif; font-size: 8px; font-weight: 600; fill: #ffffff; }
+    .trgm-badge { fill: #e0f2fe; stroke: #0284c7; stroke-width: 0.6; }
+    .trgm-text { font-family: system-ui, sans-serif; font-size: 7px; fill: #0369a1; }
+    .score-dot { r: 6; }
+    .score-dot-good { fill: #16a34a; }
+    .score-dot-mid { fill: #d4a844; }
+    .score-dot-bad { fill: #ea580c; }
+    .score-text { font-family: system-ui, sans-serif; font-size: 8px; font-weight: 700; fill: #ffffff; text-anchor: middle; }
+    @media (prefers-color-scheme: dark) {
+      .card-bg { fill: #1e293b; }
+      .card-border { stroke: #2dd4bf; }
+      .icon-bg { fill: #2dd4bf; opacity: 0.15; }
+      .icon-fill { fill: #2dd4bf; }
+      .title { fill: #f1f5f9; }
+      .desc { fill: #94a3b8; }
+      .stat { fill: #2dd4bf; }
+      .search-bg { fill: #0f172a; stroke: #475569; }
+      .search-text { fill: #64748b; }
+      .search-query { fill: #f1f5f9; }
+      .result-bg { fill: #134e4a; stroke: #2dd4bf; }
+      .result-name { fill: #e2e8f0; }
+      .result-meta { fill: #94a3b8; }
+      .highlight { fill: #fbbf24; opacity: 0.2; }
+      .filter-bg { fill: #334155; stroke: #475569; }
+      .filter-text { fill: #94a3b8; }
+      .filter-active { fill: #2dd4bf; }
+      .filter-active-text { fill: #0f172a; }
+      .trgm-badge { fill: #0c4a6e; stroke: #38bdf8; }
+      .trgm-text { fill: #7dd3fc; }
+    }
+  </style>
+  <rect class="card-bg" x="0.75" y="0.75" width="398.5" height="298.5" rx="16"/>
+  <rect class="card-border" x="0.75" y="0.75" width="398.5" height="298.5" rx="16"/>
+  <!-- Icon: magnifying glass -->
+  <circle class="icon-bg" cx="40" cy="40" r="24"/>
+  <circle cx="37" cy="37" r="8" stroke="#0d7377" stroke-width="2.5" fill="none"/>
+  <line x1="43" y1="43" x2="50" y2="50" stroke="#0d7377" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- Title -->
+  <text class="title" x="72" y="44">Smart Search</text>
+  <!-- Description -->
+  <text class="desc" x="24" y="76">Find products by name, brand, or category. Fuzzy</text>
+  <text class="desc" x="24" y="92">matching, autocomplete, and saved search filters.</text>
+  <!-- Mini visual: search box + filters + results -->
+  <g transform="translate(24,108)">
+    <!-- Search bar -->
+    <rect class="search-bg" x="0" y="0" width="350" height="32" rx="8"/>
+    <circle cx="18" cy="16" r="6" stroke="#94a3b8" stroke-width="1.5" fill="none"/>
+    <line x1="22" y1="20" x2="26" y2="24" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/>
+    <text class="search-query" x="34" y="20">piatni</text>
+    <text class="search-text" x="76" y="20">ca skyr…</text>
+    <rect class="trgm-badge" x="280" y="8" width="55" height="14" rx="7"/>
+    <text class="trgm-text" x="290" y="18">pg_trgm</text>
+    <!-- Filter chips -->
+    <rect class="filter-active" x="0" y="40" width="48" height="18" rx="9"/>
+    <text class="filter-active-text" x="10" y="52">Dairy</text>
+    <rect class="filter-bg" x="54" y="40" width="62" height="18" rx="9"/>
+    <text class="filter-text" x="63" y="52">Score ≤ 20</text>
+    <rect class="filter-bg" x="122" y="40" width="55" height="18" rx="9"/>
+    <text class="filter-text" x="130" y="52">Vegan ✓</text>
+    <rect class="filter-bg" x="183" y="40" width="72" height="18" rx="9"/>
+    <text class="filter-text" x="191" y="52">Nutri A or B</text>
+    <!-- Results -->
+    <rect class="result-bg" x="0" y="68" width="350" height="26" rx="6"/>
+    <circle class="score-dot score-dot-good" cx="16" cy="81" r="8"/>
+    <text class="score-text" x="16" y="84">8</text>
+    <text class="result-name" x="30" y="78">Piątnica Skyr Naturalny</text>
+    <text class="result-meta" x="30" y="89">Dairy · 57 kcal · Score 8 · Nutri-Score A</text>
+    <rect class="result-bg" x="0" y="100" width="350" height="26" rx="6"/>
+    <circle class="score-dot score-dot-mid" cx="16" cy="113" r="8"/>
+    <text class="score-text" x="16" y="116">22</text>
+    <text class="result-name" x="30" y="110">Piątnica Twaróg Półtłusty</text>
+    <text class="result-meta" x="30" y="121">Dairy · 135 kcal · Score 22 · Nutri-Score B</text>
+    <rect class="result-bg" x="0" y="132" width="350" height="26" rx="6"/>
+    <circle class="score-dot score-dot-bad" cx="16" cy="145" r="8"/>
+    <text class="score-text" x="16" y="148">38</text>
+    <text class="result-name" x="30" y="142">Piątnica Maślanka Truskawk.</text>
+    <text class="result-meta" x="30" y="153">Dairy · 54 kcal · Score 38 · Nutri-Score C</text>
+  </g>
+  <text class="stat" x="24" y="282">pg_trgm + tsvector · autocomplete · saved filters</text>
+</svg>


### PR DESCRIPTION
## Summary

Creates 6 feature showcase card SVGs in `docs/marketing/` for use in README, landing page, and promotional materials.

## Cards Created

| Card | File | Key Visual | Size |
|------|------|------------|------|
| Scoring Engine | `feature-scoring.svg` | Gauge circle (27/100) + 5 factor bars | 3.99 KB |
| Ingredient Analysis | `feature-ingredients.svg` | 5 ingredient rows with concern tier badges | 4.76 KB |
| Product Comparison | `feature-comparisons.svg` | Side-by-side grid with VS badge | 4.81 KB |
| Allergen Filtering | `feature-allergens.svg` | 8-allergen status matrix (safe/contains/traces) | 4.87 KB |
| Barcode Scanner | `feature-scanner.svg` | Phone mockup with scan line + product result card | 5.58 KB |
| Smart Search | `feature-search.svg` | Search bar + filter chips + fuzzy results | 5.81 KB |

## Design Specs

- **ViewBox:** 400×300 (consistent across all 6)
- **Style:** White card with brand-colored (#0d7377) 1.5px border, rounded corners (rx=16)
- **Layout:** Icon circle → title (18px bold) → description (13px) → mini visual → stat line
- **Dark mode:** Full `prefers-color-scheme` media query support with dark palette (#1e293b bg, #2dd4bf accent)
- **All under 6 KB** — no external dependencies, pure SVG with inline styles

## Checklist

- [x] 6 SVGs created with consistent card design
- [x] Dark mode support via CSS media queries
- [x] All under 10 KB size limit (largest: 5.81 KB)
- [x] Brand palette used (primary #0d7377, accent #d4a844, action #16a34a)
- [x] CHANGELOG updated
- [x] No components or tests needed (documentation/marketing assets only)

Closes #432