### PR TITLE
feat(docs): create stats infographic, tech stack visual, and before/after comparison (#433)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,15 @@ Adheres to [Semantic Versioning](https://semver.org/).
   product result card), smart search (search bar with pg_trgm + filter chips
   + fuzzy results); white card style with brand-colored border, dark mode
   via `prefers-color-scheme` media queries, all under 6 KB (#432)
+- Create 3 marketing infographics in `docs/marketing/`: stats infographic
+  (900×480, 12 key metrics in 3×4 grid on brand gradient — products, ingredients,
+  QA checks, migrations, EANs, API functions, categories, countries, tables,
+  ADRs, docs, allergen declarations); tech stack visual (900×520, 6-layer
+  horizontal architecture — Frontend, Backend/Database, Pipeline, Testing,
+  CI/CD, Governance — with technology pills); before/after comparison
+  (900×440, split-panel red/green with 6 value proposition rows — data
+  organization, health scoring, barcode scanning, ingredient transparency,
+  allergen safety, product comparison); all under 9 KB (#433)
 - Redesign README.md as 15-section showcase-quality layout: hero banner, 9
   shields.io badges, elevator pitch, 4 feature highlight cards (HTML table),
   comparison table, 3-column quick start with collapsible command reference,

--- a/docs/marketing/before-after.svg
+++ b/docs/marketing/before-after.svg
@@ -1,0 +1,137 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 440" fill="none">
+  <style>
+    .bg-left { fill: #fef2f2; }
+    .bg-right { fill: #f0fdf4; }
+    .border { stroke: #e2e8f0; stroke-width: 1; fill: none; }
+    .title { font-family: system-ui, -apple-system, sans-serif; font-size: 24px; font-weight: 800; text-anchor: middle; letter-spacing: 1px; }
+    .title-before { fill: #991b1b; }
+    .title-after { fill: #166534; }
+    .divider-line { stroke: #cbd5e1; stroke-width: 2; }
+    .vs-bg { fill: #0f172a; }
+    .vs-text { font-family: system-ui, -apple-system, sans-serif; font-size: 14px; font-weight: 800; fill: #ffffff; text-anchor: middle; }
+    .row-bg-left { fill: #ffffff; stroke: #fecaca; stroke-width: 1; }
+    .row-bg-right { fill: #ffffff; stroke: #bbf7d0; stroke-width: 1; }
+    .icon-circle-bad { fill: #fecaca; }
+    .icon-circle-good { fill: #bbf7d0; }
+    .row-title { font-family: system-ui, -apple-system, sans-serif; font-size: 13px; font-weight: 700; }
+    .row-title-bad { fill: #991b1b; }
+    .row-title-good { fill: #166534; }
+    .row-desc { font-family: system-ui, -apple-system, sans-serif; font-size: 11px; }
+    .row-desc-bad { fill: #7f1d1d; opacity: 0.7; }
+    .row-desc-good { fill: #14532d; opacity: 0.7; }
+    .icon-bad { fill: #dc2626; }
+    .icon-good { fill: #16a34a; }
+    .header-subtitle { font-family: system-ui, -apple-system, sans-serif; font-size: 11px; fill: #64748b; text-anchor: middle; }
+    .footer { font-family: system-ui, -apple-system, sans-serif; font-size: 10px; fill: #94a3b8; text-anchor: middle; }
+    .stat-badge { font-family: system-ui, -apple-system, sans-serif; font-size: 9px; font-weight: 700; }
+    .stat-badge-good { fill: #16a34a; }
+  </style>
+  <rect width="900" height="440" rx="16" fill="#ffffff"/>
+  <rect x="0.5" y="0.5" width="899" height="439" rx="16" class="border"/>
+  <!-- Left panel background -->
+  <rect x="1" y="1" width="448" height="438" rx="16" class="bg-left"/>
+  <!-- Right panel background -->
+  <rect x="451" y="1" width="448" height="438" rx="16" class="bg-right"/>
+  <!-- Center divider -->
+  <line class="divider-line" x1="450" y1="0" x2="450" y2="440"/>
+  <!-- VS badge -->
+  <circle class="vs-bg" cx="450" cy="48" r="20"/>
+  <text class="vs-text" x="450" y="53">VS</text>
+  <!-- Left header: Before -->
+  <text class="title title-before" x="225" y="44">WITHOUT</text>
+  <text class="header-subtitle" x="225" y="60">Manual approach</text>
+  <!-- Right header: After -->
+  <text class="title title-after" x="675" y="44">WITH PROJECT</text>
+  <text class="header-subtitle" x="675" y="60">Poland Food Quality Database</text>
+  <!-- Row 1: Data Organization -->
+  <g transform="translate(20, 78)">
+    <rect class="row-bg-left" x="0" y="0" width="410" height="48" rx="8"/>
+    <circle class="icon-circle-bad" cx="24" cy="24" r="14"/>
+    <path d="M18 20h4v4h-4v-4zm6 2h4v4h-4v-4zm-3 5h4v4h-4v-4z" class="icon-bad"/>
+    <text class="row-title row-title-bad" x="46" y="20">Scattered nutrition data</text>
+    <text class="row-desc row-desc-bad" x="46" y="36">Checking labels on every product manually</text>
+  </g>
+  <g transform="translate(470, 78)">
+    <rect class="row-bg-right" x="0" y="0" width="410" height="48" rx="8"/>
+    <circle class="icon-circle-good" cx="24" cy="24" r="14"/>
+    <path d="M19 24l4 4 8-8" stroke="#16a34a" stroke-width="2.5" fill="none"/>
+    <text class="row-title row-title-good" x="46" y="20">Unified 1,281-product database</text>
+    <text class="row-desc row-desc-good" x="46" y="36">Structured, searchable, country-scoped data</text>
+  </g>
+  <!-- Row 2: Scoring -->
+  <g transform="translate(20, 138)">
+    <rect class="row-bg-left" x="0" y="0" width="410" height="48" rx="8"/>
+    <circle class="icon-circle-bad" cx="24" cy="24" r="14"/>
+    <text class="icon-bad" x="20" y="29" style="font-size:16px">?</text>
+    <text class="row-title row-title-bad" x="46" y="20">No health scoring</text>
+    <text class="row-desc row-desc-bad" x="46" y="36">No way to compare healthiness objectively</text>
+  </g>
+  <g transform="translate(470, 138)">
+    <rect class="row-bg-right" x="0" y="0" width="410" height="48" rx="8"/>
+    <circle class="icon-circle-good" cx="24" cy="24" r="14"/>
+    <path d="M18 28a8 8 0 010-8" stroke="#16a34a" stroke-width="2" fill="none"/>
+    <circle cx="18" cy="20" r="2" class="icon-good"/>
+    <text class="row-title row-title-good" x="46" y="20">9-factor weighted scientific scoring</text>
+    <text class="row-desc row-desc-good" x="46" y="36">v3.2 engine with EFSA-based concern tiers</text>
+  </g>
+  <!-- Row 3: Barcode -->
+  <g transform="translate(20, 198)">
+    <rect class="row-bg-left" x="0" y="0" width="410" height="48" rx="8"/>
+    <circle class="icon-circle-bad" cx="24" cy="24" r="14"/>
+    <path d="M18 18v12m4-12v12m4-12v12m4-12v12" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+    <text class="row-title row-title-bad" x="46" y="20">Manual label reading</text>
+    <text class="row-desc row-desc-bad" x="46" y="36">Tiny print, inconsistent formats, time-consuming</text>
+  </g>
+  <g transform="translate(470, 198)">
+    <rect class="row-bg-right" x="0" y="0" width="410" height="48" rx="8"/>
+    <circle class="icon-circle-good" cx="24" cy="24" r="14"/>
+    <path d="M18 18v12m3-12v12m3-12v12m3-12v12" stroke="#16a34a" stroke-width="1.5"/>
+    <text class="row-title row-title-good" x="46" y="20">Instant barcode scan → full report</text>
+    <text class="row-desc row-desc-good" x="46" y="36">1,024 EANs with 99.8% coverage</text>
+  </g>
+  <!-- Row 4: Ingredients -->
+  <g transform="translate(20, 258)">
+    <rect class="row-bg-left" x="0" y="0" width="410" height="48" rx="8"/>
+    <circle class="icon-circle-bad" cx="24" cy="24" r="14"/>
+    <path d="M17 20h14v8H17v-8z" class="icon-bad" opacity="0.4"/>
+    <text class="row-title row-title-bad" x="46" y="20">No ingredient transparency</text>
+    <text class="row-desc row-desc-bad" x="46" y="36">E-numbers without context or safety info</text>
+  </g>
+  <g transform="translate(470, 258)">
+    <rect class="row-bg-right" x="0" y="0" width="410" height="48" rx="8"/>
+    <circle class="icon-circle-good" cx="24" cy="24" r="14"/>
+    <path d="M19 24l3 3 6-6" stroke="#16a34a" stroke-width="2" fill="none"/>
+    <text class="row-title row-title-good" x="46" y="20">2,995 ingredients with EFSA concern tiers</text>
+    <text class="row-desc row-desc-good" x="46" y="36">4-tier classification: none → low → moderate → high</text>
+  </g>
+  <!-- Row 5: Allergens -->
+  <g transform="translate(20, 318)">
+    <rect class="row-bg-left" x="0" y="0" width="410" height="48" rx="8"/>
+    <circle class="icon-circle-bad" cx="24" cy="24" r="14"/>
+    <path d="M19 19l10 10m0-10l-10 10" stroke="#dc2626" stroke-width="2"/>
+    <text class="row-title row-title-bad" x="46" y="20">Guessing allergens</text>
+    <text class="row-desc row-desc-bad" x="46" y="36">Risk of missing hidden allergens in products</text>
+  </g>
+  <g transform="translate(470, 318)">
+    <rect class="row-bg-right" x="0" y="0" width="410" height="48" rx="8"/>
+    <circle class="icon-circle-good" cx="24" cy="24" r="14"/>
+    <path d="M24 16v6l-4 2v8l4 2 4-2v-8l-4-2v-6z" class="icon-good" opacity="0.7"/>
+    <text class="row-title row-title-good" x="46" y="20">2,630 allergen declarations, auto-warnings</text>
+    <text class="row-desc row-desc-good" x="46" y="36">1,269 allergens + 1,361 traces with personal profiles</text>
+  </g>
+  <!-- Row 6: Comparison -->
+  <g transform="translate(20, 378)">
+    <rect class="row-bg-left" x="0" y="0" width="410" height="48" rx="8"/>
+    <circle class="icon-circle-bad" cx="24" cy="24" r="14"/>
+    <path d="M18 20h5v8h-5v-8zm7 2h5v6h-5v-6z" class="icon-bad" opacity="0.4"/>
+    <text class="row-title row-title-bad" x="46" y="20">No product comparison</text>
+    <text class="row-desc row-desc-bad" x="46" y="36">Mentally comparing nutrition labels side by side</text>
+  </g>
+  <g transform="translate(470, 378)">
+    <rect class="row-bg-right" x="0" y="0" width="410" height="48" rx="8"/>
+    <circle class="icon-circle-good" cx="24" cy="24" r="14"/>
+    <path d="M17 20h5v8h-5v-8zm3 0h1v8h-1v-8zm5 0h5v8h-5v-8zm3 0h1v8h-1v-8z" class="icon-good"/>
+    <text class="row-title row-title-good" x="46" y="20">Side-by-side comparison with sharing</text>
+    <text class="row-desc row-desc-good" x="46" y="36">Compare up to 4 products, save and share results</text>
+  </g>
+</svg>

--- a/docs/marketing/stats-infographic.svg
+++ b/docs/marketing/stats-infographic.svg
@@ -1,0 +1,113 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 480" fill="none">
+  <style>
+    .bg { fill: #0d7377; }
+    .title { font-family: system-ui, -apple-system, sans-serif; font-size: 28px; font-weight: 800; fill: #ffffff; text-anchor: middle; letter-spacing: 2px; }
+    .subtitle { font-family: system-ui, -apple-system, sans-serif; font-size: 13px; fill: #99f6e4; text-anchor: middle; letter-spacing: 1px; }
+    .card { fill: #ffffff; opacity: 0.12; }
+    .metric { font-family: system-ui, -apple-system, sans-serif; font-size: 32px; font-weight: 800; fill: #ffffff; text-anchor: middle; }
+    .label { font-family: system-ui, -apple-system, sans-serif; font-size: 12px; fill: #99f6e4; text-anchor: middle; font-weight: 500; }
+    .divider { stroke: #ffffff; stroke-width: 0.5; opacity: 0.2; }
+    .icon-circle { fill: #ffffff; opacity: 0.15; }
+    .footer { font-family: system-ui, -apple-system, sans-serif; font-size: 10px; fill: #5eead4; text-anchor: middle; letter-spacing: 0.5px; }
+    .accent { fill: #d4a844; }
+    .accent-text { font-family: system-ui, -apple-system, sans-serif; font-size: 32px; font-weight: 800; fill: #fbbf24; text-anchor: middle; }
+  </style>
+  <!-- Background -->
+  <defs>
+    <linearGradient id="bg-grad" x1="0" y1="0" x2="900" y2="480" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#0d7377"/>
+      <stop offset="100%" stop-color="#064e52"/>
+    </linearGradient>
+  </defs>
+  <rect width="900" height="480" rx="20" fill="url(#bg-grad)"/>
+  <!-- Decorative circles -->
+  <circle cx="50" cy="50" r="120" fill="#ffffff" opacity="0.03"/>
+  <circle cx="850" cy="430" r="150" fill="#ffffff" opacity="0.03"/>
+  <!-- Title -->
+  <text class="title" x="450" y="52">PROJECT BY THE NUMBERS</text>
+  <text class="subtitle" x="450" y="74">Poland Food Quality Database — Real-time metrics</text>
+  <line class="divider" x1="150" y1="88" x2="750" y2="88"/>
+  <!-- Row 1: Primary metrics (4 cards) -->
+  <g transform="translate(32, 104)">
+    <!-- Card 1: Products -->
+    <rect class="card" x="0" y="0" width="195" height="100" rx="12"/>
+    <circle class="icon-circle" cx="97" cy="28" r="14"/>
+    <path d="M91 24h12v2H91v-2zm0 4h12v2H91v-2zm0 4h8v2h-8v-2z" fill="#ffffff" opacity="0.8"/>
+    <text class="metric" x="97" y="68">1,281</text>
+    <text class="label" x="97" y="88">Active Products</text>
+    <!-- Card 2: Ingredients -->
+    <rect class="card" x="215" y="0" width="195" height="100" rx="12"/>
+    <circle class="icon-circle" cx="312" cy="28" r="14"/>
+    <path d="M308 20v16l4-4 4 4V20h-8z" fill="#ffffff" opacity="0.8"/>
+    <text class="metric" x="312" y="68">2,995</text>
+    <text class="label" x="312" y="88">Unique Ingredients</text>
+    <!-- Card 3: QA Checks -->
+    <rect class="card" x="430" y="0" width="195" height="100" rx="12"/>
+    <circle class="icon-circle" cx="527" cy="28" r="14"/>
+    <path d="M522 28l3 3 7-7" stroke="#ffffff" stroke-width="2" fill="none" opacity="0.8"/>
+    <text class="accent-text" x="527" y="68">733</text>
+    <text class="label" x="527" y="88">QA Checks</text>
+    <!-- Card 4: Migrations -->
+    <rect class="card" x="645" y="0" width="195" height="100" rx="12"/>
+    <circle class="icon-circle" cx="742" cy="28" r="14"/>
+    <path d="M737 22v12h10v-12h-10zm2 2h6v8h-6v-8z" fill="#ffffff" opacity="0.8"/>
+    <text class="metric" x="742" y="68">182</text>
+    <text class="label" x="742" y="88">DB Migrations</text>
+  </g>
+  <!-- Row 2: Secondary metrics (4 cards) -->
+  <g transform="translate(32, 222)">
+    <!-- Card 5: EANs -->
+    <rect class="card" x="0" y="0" width="195" height="100" rx="12"/>
+    <circle class="icon-circle" cx="97" cy="28" r="14"/>
+    <path d="M89 22v12h2v-12h-2zm4 0v12h1v-12h-1zm3 0v12h2v-12h-2zm4 0v12h1v-12h-1zm3 0v12h2v-12h-2z" fill="#ffffff" opacity="0.8"/>
+    <text class="metric" x="97" y="68">1,024</text>
+    <text class="label" x="97" y="88">EAN Barcodes (99.8%)</text>
+    <!-- Card 6: API Functions -->
+    <rect class="card" x="215" y="0" width="195" height="100" rx="12"/>
+    <circle class="icon-circle" cx="312" cy="28" r="14"/>
+    <path d="M306 26l-4 4 4 4m12-8l4 4-4 4" stroke="#ffffff" stroke-width="1.5" fill="none" opacity="0.8"/>
+    <text class="metric" x="312" y="68">191</text>
+    <text class="label" x="312" y="88">API Functions</text>
+    <!-- Card 7: Categories -->
+    <rect class="card" x="430" y="0" width="195" height="100" rx="12"/>
+    <circle class="icon-circle" cx="527" cy="28" r="14"/>
+    <path d="M521 24h4v4h-4v-4zm6 0h4v4h-4v-4zm-6 6h4v4h-4v-4zm6 0h4v4h-4v-4z" fill="#ffffff" opacity="0.8"/>
+    <text class="metric" x="527" y="68">25</text>
+    <text class="label" x="527" y="88">Categories</text>
+    <!-- Card 8: Countries -->
+    <rect class="card" x="645" y="0" width="195" height="100" rx="12"/>
+    <circle class="icon-circle" cx="742" cy="28" r="14"/>
+    <path d="M742 20a8 8 0 100 16 8 8 0 000-16zm0 2a6 6 0 110 12 6 6 0 010-12z" fill="#ffffff" opacity="0.8"/>
+    <text class="metric" x="742" y="68">2</text>
+    <text class="label" x="742" y="88">Countries (PL + DE)</text>
+  </g>
+  <!-- Row 3: Tertiary metrics (4 cards) -->
+  <g transform="translate(32, 340)">
+    <!-- Card 9: Tables -->
+    <rect class="card" x="0" y="0" width="195" height="100" rx="12"/>
+    <circle class="icon-circle" cx="97" cy="28" r="14"/>
+    <path d="M89 24h16v2H89v-2zm0 4h16v2H89v-2zm0 4h16v2H89v-2z" fill="#ffffff" opacity="0.8"/>
+    <text class="metric" x="97" y="68">35+</text>
+    <text class="label" x="97" y="88">Database Tables</text>
+    <!-- Card 10: ADRs -->
+    <rect class="card" x="215" y="0" width="195" height="100" rx="12"/>
+    <circle class="icon-circle" cx="312" cy="28" r="14"/>
+    <path d="M307 22h10l-3 3v9h-7v-12z" fill="#ffffff" opacity="0.8"/>
+    <text class="metric" x="312" y="68">7</text>
+    <text class="label" x="312" y="88">Architecture Decisions</text>
+    <!-- Card 11: Docs -->
+    <rect class="card" x="430" y="0" width="195" height="100" rx="12"/>
+    <circle class="icon-circle" cx="527" cy="28" r="14"/>
+    <path d="M521 22h6l4 4v8h-10v-12zm6 0v4h4" stroke="#ffffff" stroke-width="1" fill="none" opacity="0.8"/>
+    <text class="metric" x="527" y="68">45+</text>
+    <text class="label" x="527" y="88">Documentation Files</text>
+    <!-- Card 12: Allergens -->
+    <rect class="card" x="645" y="0" width="195" height="100" rx="12"/>
+    <circle class="icon-circle" cx="742" cy="28" r="14"/>
+    <path d="M742 22l5 6h-10l5-6zm-3 8h6v2h-6v-2z" fill="#ffffff" opacity="0.8"/>
+    <text class="metric" x="742" y="68">2,630</text>
+    <text class="label" x="742" y="88">Allergen Declarations</text>
+  </g>
+  <!-- Footer -->
+  <text class="footer" x="450" y="468">Scoring v3.2 · 9-factor weighted formula · EFSA-based concern tiers · Open Food Facts API v2</text>
+</svg>

--- a/docs/marketing/tech-stack.svg
+++ b/docs/marketing/tech-stack.svg
@@ -1,0 +1,143 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 520" fill="none">
+  <style>
+    .bg { fill: #f8fafc; }
+    .title { font-family: system-ui, -apple-system, sans-serif; font-size: 24px; font-weight: 800; fill: #0f172a; text-anchor: middle; letter-spacing: 1px; }
+    .subtitle { font-family: system-ui, -apple-system, sans-serif; font-size: 12px; fill: #64748b; text-anchor: middle; }
+    .layer-bg { rx: 10; }
+    .layer-label { font-family: system-ui, -apple-system, sans-serif; font-size: 13px; font-weight: 700; fill: #ffffff; }
+    .layer-label-dark { font-family: system-ui, -apple-system, sans-serif; font-size: 13px; font-weight: 700; fill: #0f172a; }
+    .tech-name { font-family: system-ui, -apple-system, sans-serif; font-size: 12px; font-weight: 600; fill: #0f172a; }
+    .tech-pill { rx: 10; fill: #ffffff; stroke: #e2e8f0; stroke-width: 1; }
+    .tech-pill-text { font-family: system-ui, -apple-system, sans-serif; font-size: 11px; fill: #334155; text-anchor: middle; }
+    .connector { stroke: #cbd5e1; stroke-width: 1; stroke-dasharray: 4 3; }
+    .badge { font-family: system-ui, -apple-system, sans-serif; font-size: 9px; font-weight: 700; fill: #ffffff; text-anchor: middle; }
+    .footer { font-family: system-ui, -apple-system, sans-serif; font-size: 10px; fill: #94a3b8; text-anchor: middle; }
+  </style>
+  <rect width="900" height="520" rx="16" class="bg"/>
+  <rect x="0.5" y="0.5" width="899" height="519" rx="16" stroke="#e2e8f0" stroke-width="1" fill="none"/>
+  <!-- Title -->
+  <text class="title" x="450" y="40">TECHNOLOGY STACK</text>
+  <text class="subtitle" x="450" y="58">Full-stack architecture — 6 layers, 20+ technologies</text>
+  <!-- Layer 1: Frontend (teal) -->
+  <g transform="translate(32, 76)">
+    <rect class="layer-bg" width="836" height="60" fill="#0d7377"/>
+    <text class="layer-label" x="16" y="20">FRONTEND</text>
+    <!-- Pills -->
+    <rect class="tech-pill" x="16" y="28" width="90" height="24"/>
+    <text class="tech-pill-text" x="61" y="44">Next.js 15</text>
+    <rect class="tech-pill" x="116" y="28" width="80" height="24"/>
+    <text class="tech-pill-text" x="156" y="44">React 19</text>
+    <rect class="tech-pill" x="206" y="28" width="96" height="24"/>
+    <text class="tech-pill-text" x="254" y="44">TypeScript</text>
+    <rect class="tech-pill" x="312" y="28" width="100" height="24"/>
+    <text class="tech-pill-text" x="362" y="44">Tailwind CSS</text>
+    <rect class="tech-pill" x="422" y="28" width="120" height="24"/>
+    <text class="tech-pill-text" x="482" y="44">TanStack Query</text>
+    <rect class="tech-pill" x="552" y="28" width="76" height="24"/>
+    <text class="tech-pill-text" x="590" y="44">Zustand</text>
+    <rect class="tech-pill" x="638" y="28" width="80" height="24"/>
+    <text class="tech-pill-text" x="678" y="44">next-intl</text>
+  </g>
+  <!-- Connector -->
+  <line class="connector" x1="450" y1="136" x2="450" y2="148"/>
+  <!-- Layer 2: Backend / Database (dark teal) -->
+  <g transform="translate(32, 148)">
+    <rect class="layer-bg" width="836" height="60" fill="#095456"/>
+    <text class="layer-label" x="16" y="20">BACKEND / DATABASE</text>
+    <rect class="tech-pill" x="16" y="28" width="110" height="24"/>
+    <text class="tech-pill-text" x="71" y="44">PostgreSQL 15</text>
+    <rect class="tech-pill" x="136" y="28" width="86" height="24"/>
+    <text class="tech-pill-text" x="179" y="44">Supabase</text>
+    <rect class="tech-pill" x="232" y="28" width="134" height="24"/>
+    <text class="tech-pill-text" x="299" y="44">Row-Level Security</text>
+    <rect class="tech-pill" x="376" y="28" width="76" height="24"/>
+    <text class="tech-pill-text" x="414" y="44">pg_trgm</text>
+    <rect class="tech-pill" x="462" y="28" width="78" height="24"/>
+    <text class="tech-pill-text" x="501" y="44">tsvector</text>
+    <rect class="tech-pill" x="550" y="28" width="140" height="24"/>
+    <text class="tech-pill-text" x="620" y="44">Materialized Views</text>
+    <rect class="tech-pill" x="700" y="28" width="120" height="24"/>
+    <text class="tech-pill-text" x="760" y="44">Edge Functions</text>
+  </g>
+  <!-- Connector -->
+  <line class="connector" x1="450" y1="208" x2="450" y2="220"/>
+  <!-- Layer 3: Pipeline (gold/accent) -->
+  <g transform="translate(32, 220)">
+    <rect class="layer-bg" width="836" height="60" fill="#d4a844"/>
+    <text class="layer-label-dark" x="16" y="20">DATA PIPELINE</text>
+    <rect class="tech-pill" x="16" y="28" width="96" height="24"/>
+    <text class="tech-pill-text" x="64" y="44">Python 3.12</text>
+    <rect class="tech-pill" x="122" y="28" width="166" height="24"/>
+    <text class="tech-pill-text" x="205" y="44">Open Food Facts API v2</text>
+    <rect class="tech-pill" x="298" y="28" width="116" height="24"/>
+    <text class="tech-pill-text" x="356" y="44">SQL Generator</text>
+    <rect class="tech-pill" x="424" y="28" width="100" height="24"/>
+    <text class="tech-pill-text" x="474" y="44">Data Validator</text>
+    <rect class="tech-pill" x="534" y="28" width="130" height="24"/>
+    <text class="tech-pill-text" x="599" y="44">Ingredient Enricher</text>
+  </g>
+  <!-- Connector -->
+  <line class="connector" x1="450" y1="280" x2="450" y2="292"/>
+  <!-- Layer 4: Testing (green) -->
+  <g transform="translate(32, 292)">
+    <rect class="layer-bg" width="836" height="60" fill="#15803d"/>
+    <text class="layer-label" x="16" y="20">TESTING</text>
+    <rect class="tech-pill" x="16" y="28" width="60" height="24"/>
+    <text class="tech-pill-text" x="46" y="44">Vitest</text>
+    <rect class="tech-pill" x="86" y="28" width="86" height="24"/>
+    <text class="tech-pill-text" x="129" y="44">Playwright</text>
+    <rect class="tech-pill" x="182" y="28" width="64" height="24"/>
+    <text class="tech-pill-text" x="214" y="44">pgTAP</text>
+    <rect class="tech-pill" x="256" y="28" width="110" height="24"/>
+    <text class="tech-pill-text" x="311" y="44">733 QA Checks</text>
+    <!-- Badge -->
+    <rect x="289" y="28" width="46" height="12" rx="6" fill="#fbbf24"/>
+    <text class="badge" x="312" y="37">PASS</text>
+    <rect class="tech-pill" x="376" y="28" width="120" height="24"/>
+    <text class="tech-pill-text" x="436" y="44">Testing Library</text>
+    <rect class="tech-pill" x="506" y="28" width="120" height="24"/>
+    <text class="tech-pill-text" x="566" y="44">23 Negative Tests</text>
+  </g>
+  <!-- Connector -->
+  <line class="connector" x1="450" y1="352" x2="450" y2="364"/>
+  <!-- Layer 5: CI/CD (slate) -->
+  <g transform="translate(32, 364)">
+    <rect class="layer-bg" width="836" height="60" fill="#334155"/>
+    <text class="layer-label" x="16" y="20">CI / CD</text>
+    <rect class="tech-pill" x="16" y="28" width="116" height="24"/>
+    <text class="tech-pill-text" x="74" y="44">GitHub Actions</text>
+    <rect class="tech-pill" x="142" y="28" width="96" height="24"/>
+    <text class="tech-pill-text" x="190" y="44">SonarCloud</text>
+    <rect class="tech-pill" x="248" y="28" width="68" height="24"/>
+    <text class="tech-pill-text" x="282" y="44">Sentry</text>
+    <rect class="tech-pill" x="326" y="28" width="66" height="24"/>
+    <text class="tech-pill-text" x="359" y="44">Vercel</text>
+    <rect class="tech-pill" x="402" y="28" width="54" height="24"/>
+    <text class="tech-pill-text" x="429" y="44">Ruff</text>
+    <rect class="tech-pill" x="466" y="28" width="80" height="24"/>
+    <text class="tech-pill-text" x="506" y="44">CodeQL</text>
+    <rect class="tech-pill" x="556" y="28" width="96" height="24"/>
+    <text class="tech-pill-text" x="604" y="44">Dependabot</text>
+  </g>
+  <!-- Connector -->
+  <line class="connector" x1="450" y1="424" x2="450" y2="436"/>
+  <!-- Layer 6: Governance (light) -->
+  <g transform="translate(32, 436)">
+    <rect class="layer-bg" width="836" height="52" fill="#e2e8f0" stroke="#cbd5e1" stroke-width="1"/>
+    <text class="layer-label-dark" x="16" y="18">GOVERNANCE</text>
+    <rect class="tech-pill" x="16" y="26" width="70" height="20" style="stroke:#94a3b8"/>
+    <text class="tech-pill-text" x="51" y="40">45+ Docs</text>
+    <rect class="tech-pill" x="96" y="26" width="64" height="20" style="stroke:#94a3b8"/>
+    <text class="tech-pill-text" x="128" y="40">7 ADRs</text>
+    <rect class="tech-pill" x="170" y="26" width="140" height="20" style="stroke:#94a3b8"/>
+    <text class="tech-pill-text" x="240" y="40">Conventional Commits</text>
+    <rect class="tech-pill" x="320" y="26" width="86" height="20" style="stroke:#94a3b8"/>
+    <text class="tech-pill-text" x="363" y="40">MADR 3.0</text>
+    <rect class="tech-pill" x="416" y="26" width="100" height="20" style="stroke:#94a3b8"/>
+    <text class="tech-pill-text" x="466" y="40">DR Drills</text>
+    <rect class="tech-pill" x="526" y="26" width="114" height="20" style="stroke:#94a3b8"/>
+    <text class="tech-pill-text" x="583" y="40">GDPR / RODO</text>
+  </g>
+  <!-- Footer -->
+  <text class="footer" x="450" y="510">poland-food-db · Science-driven food quality database for Poland + Germany</text>
+</svg>


### PR DESCRIPTION
## Summary

Creates 3 high-impact marketing infographics for README, presentations, and portfolio showcase.

## Deliverables

### 1. Statistics Infographic (`stats-infographic.svg` — 6.63 KB)
- 900×480 viewBox, brand teal gradient background
- 12 metrics in 3×4 grid with micro-icons:

| Metric | Value | Metric | Value |
|--------|-------|--------|-------|
| Active Products | 1,281 | EAN Barcodes | 1,024 (99.8%) |
| Unique Ingredients | 2,995 | API Functions | 191 |
| QA Checks | 733 | Categories | 25 |
| DB Migrations | 182 | Countries | 2 (PL + DE) |
| Database Tables | 35+ | Architecture Decisions | 7 |
| Documentation Files | 45+ | Allergen Declarations | 2,630 |

### 2. Tech Stack Visual (`tech-stack.svg` — 8.80 KB)
- 900×520 viewBox, layered horizontal architecture
- 6 layers with technology pills: Frontend (Next.js 15, React 19, TypeScript, Tailwind, TanStack Query, Zustand, next-intl), Backend/Database (PostgreSQL 15, Supabase, RLS, pg_trgm, tsvector, MVs, Edge Functions), Pipeline (Python 3.12, OFF API v2, SQL Generator, Validator, Enricher), Testing (Vitest, Playwright, pgTAP, 733 QA, Testing Library, 23 Negative Tests), CI/CD (GitHub Actions, SonarCloud, Sentry, Vercel, Ruff, CodeQL, Dependabot), Governance (45+ Docs, 7 ADRs, Conventional Commits, MADR 3.0, DR Drills, GDPR/RODO)

### 3. Before/After Comparison (`before-after.svg` — 8.22 KB)
- 900×440 viewBox, split-panel design (red left / green right)
- 6 compelling value proposition rows with icons:
  - Scattered data → Unified 1,281-product database
  - No health scoring → 9-factor weighted scientific scoring
  - Manual label reading → Instant barcode scan → full report
  - No ingredient transparency → 2,995 ingredients with EFSA tiers
  - Guessing allergens → 2,630 declarations with auto-warnings
  - No comparison → Side-by-side with sharing

## Checklist

- [x] 12 accurate metrics matching current project state
- [x] 6 tech stack layers with correct technology names
- [x] 6 before/after value propositions
- [x] All under 30 KB (largest: 8.80 KB)
- [x] Brand palette used throughout
- [x] CHANGELOG updated
- [x] No components or tests needed (documentation/marketing assets only)

Closes #433