### PR TITLE
security(auth): integrate Cloudflare Turnstile CAPTCHA on signup (#470)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,12 @@ UPSTASH_REDIS_REST_TOKEN=
 # Admin route protection (#186): comma-separated admin email addresses
 # Users not in this list get 403 on /app/admin/* routes.
 # ADMIN_EMAILS=admin@example.com
+
+# ── Cloudflare Turnstile — CAPTCHA (#470) ────────────────────────────────
+# Signup form bot protection. Get keys at: https://dash.cloudflare.com/turnstile
+# Test keys (always pass): Site=1x00000000000000000000AA  Secret=1x0000000000000000000000000000000AA
+# NEXT_PUBLIC_ prefix exposes the site key to the browser (required).
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=1x00000000000000000000AA
+# Secret key — set as Supabase Edge Function secret:
+#   supabase secrets set TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
+TURNSTILE_SECRET_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Security
 
+- Add Cloudflare Turnstile CAPTCHA integration for signup bot protection:
+  `verify-turnstile` Edge Function (server-side token verification with graceful
+  degradation), `TurnstileWidget` React component wrapper, `turnstile.ts` client
+  helper lib; SignupForm now requires Turnstile challenge before submission with
+  `captchaToken` passed to Supabase Auth; i18n keys for EN/PL/DE; `.env.example`
+  updated with Turnstile site/secret key config; 45 Vitest tests (19 lib +
+  12 component + 14 signup form) (#470)
 - Add API gateway Edge Function (`supabase/functions/api-gateway/`) for write-path
   defense: JWT validation, action-based routing, in-memory sliding-window rate
   limiting (100 scans/day/user), EAN format validation, structured error responses

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -668,7 +668,9 @@
     "signUpSubtitle": "Registrieren Sie sich, um auf Lebensmittelqualitätsdaten für Polen und Deutschland zuzugreifen.",
     "creatingAccount": "Konto wird erstellt…",
     "hasAccount": "Bereits ein Konto?",
-    "checkEmail": "Überprüfen Sie Ihre E-Mail, um Ihr Konto zu bestätigen."
+    "checkEmail": "Überprüfen Sie Ihre E-Mail, um Ihr Konto zu bestätigen.",
+    "captchaRequired": "Bitte schließen Sie die Sicherheitsüberprüfung vor der Registrierung ab.",
+    "captchaFailed": "Sicherheitsüberprüfung fehlgeschlagen. Bitte versuchen Sie es erneut."
   },
   "layout": {
     "appName": "FoodDB",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -668,7 +668,9 @@
     "signUpSubtitle": "Sign up to access food quality data for Poland and Germany.",
     "creatingAccount": "Creating account…",
     "hasAccount": "Already have an account?",
-    "checkEmail": "Check your email to confirm your account."
+    "checkEmail": "Check your email to confirm your account.",
+    "captchaRequired": "Please complete the security check before signing up.",
+    "captchaFailed": "Security verification failed. Please try again."
   },
   "layout": {
     "appName": "FoodDB",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -668,7 +668,9 @@
     "signUpSubtitle": "Zarejestruj się, aby uzyskać dostęp do danych o jakości żywności w Polsce i Niemczech.",
     "creatingAccount": "Tworzenie konta…",
     "hasAccount": "Masz już konto?",
-    "checkEmail": "Sprawdź e-mail, aby potwierdzić konto."
+    "checkEmail": "Sprawdź e-mail, aby potwierdzić konto.",
+    "captchaRequired": "Proszę przejść weryfikację bezpieczeństwa przed rejestracją.",
+    "captchaFailed": "Weryfikacja bezpieczeństwa nie powiodła się. Spróbuj ponownie."
   },
   "layout": {
     "appName": "FoodDB",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@marsidev/react-turnstile": "^1.4.2",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@sentry/nextjs": "^10.39.0",
         "@serwist/next": "^9.5.6",
@@ -2010,6 +2011,16 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@marsidev/react-turnstile": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@marsidev/react-turnstile/-/react-turnstile-1.4.2.tgz",
+      "integrity": "sha512-xs1qOuyeMOz6t9BXXCXWiukC0/0+48vR08B7uwNdG05wCMnbcNgxiFmdFKDOFbM76qFYFRYlGeRfhfq1U/iZmA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.0.0 || ^19.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@marsidev/react-turnstile": "^1.4.2",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@sentry/nextjs": "^10.39.0",
     "@serwist/next": "^9.5.6",

--- a/frontend/src/components/common/TurnstileWidget.test.tsx
+++ b/frontend/src/components/common/TurnstileWidget.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TurnstileWidget } from "./TurnstileWidget";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+// Mock the Turnstile widget from @marsidev/react-turnstile
+vi.mock("@marsidev/react-turnstile", () => ({
+  Turnstile: vi.fn(
+    ({
+      siteKey,
+      onSuccess,
+      onError,
+      onExpire,
+      options,
+    }: {
+      siteKey: string;
+      onSuccess?: (token: string) => void;
+      onError?: () => void;
+      onExpire?: () => void;
+      options?: Record<string, unknown>;
+    }) => (
+      <div
+        data-testid="mock-turnstile"
+        data-site-key={siteKey}
+        data-action={options?.action as string}
+        data-theme={options?.theme as string}
+        data-appearance={options?.appearance as string}
+      >
+        <button
+          data-testid="trigger-success"
+          onClick={() => onSuccess?.("mock-token-abc")}
+        >
+          Success
+        </button>
+        <button data-testid="trigger-error" onClick={() => onError?.()}>
+          Error
+        </button>
+        <button data-testid="trigger-expire" onClick={() => onExpire?.()}>
+          Expire
+        </button>
+      </div>
+    ),
+  ),
+}));
+
+// Mock turnstile lib to provide a known site key
+vi.mock("@/lib/turnstile", () => ({
+  getTurnstileSiteKey: () => "1x00000000000000000000AA",
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── Rendering ──────────────────────────────────────────────────────────────
+
+describe("TurnstileWidget", () => {
+  it("should render the widget wrapper", () => {
+    render(<TurnstileWidget onSuccess={vi.fn()} />);
+    expect(screen.getByTestId("turnstile-widget")).toBeInTheDocument();
+  });
+
+  it("should render the Turnstile component with site key", () => {
+    render(<TurnstileWidget onSuccess={vi.fn()} />);
+    const turnstile = screen.getByTestId("mock-turnstile");
+    expect(turnstile).toBeInTheDocument();
+    expect(turnstile.getAttribute("data-site-key")).toBe(
+      "1x00000000000000000000AA",
+    );
+  });
+
+  it("should pass action to Turnstile options", () => {
+    render(<TurnstileWidget onSuccess={vi.fn()} action="signup" />);
+    const turnstile = screen.getByTestId("mock-turnstile");
+    expect(turnstile.getAttribute("data-action")).toBe("signup");
+  });
+
+  it("should pass theme to Turnstile options", () => {
+    render(<TurnstileWidget onSuccess={vi.fn()} theme="dark" />);
+    const turnstile = screen.getByTestId("mock-turnstile");
+    expect(turnstile.getAttribute("data-theme")).toBe("dark");
+  });
+
+  it("should default to auto theme", () => {
+    render(<TurnstileWidget onSuccess={vi.fn()} />);
+    const turnstile = screen.getByTestId("mock-turnstile");
+    expect(turnstile.getAttribute("data-theme")).toBe("auto");
+  });
+
+  it("should default to interaction-only appearance", () => {
+    render(<TurnstileWidget onSuccess={vi.fn()} />);
+    const turnstile = screen.getByTestId("mock-turnstile");
+    expect(turnstile.getAttribute("data-appearance")).toBe("interaction-only");
+  });
+
+  it("should apply className to wrapper div", () => {
+    render(
+      <TurnstileWidget onSuccess={vi.fn()} className="flex justify-center" />,
+    );
+    const wrapper = screen.getByTestId("turnstile-widget");
+    expect(wrapper.className).toContain("flex justify-center");
+  });
+
+  // ─── Callbacks ──────────────────────────────────────────────────────────
+
+  it("should call onSuccess with token", async () => {
+    const onSuccess = vi.fn();
+    render(<TurnstileWidget onSuccess={onSuccess} />);
+    screen.getByTestId("trigger-success").click();
+    expect(onSuccess).toHaveBeenCalledWith("mock-token-abc");
+  });
+
+  it("should call onError when challenge fails", () => {
+    const onError = vi.fn();
+    render(<TurnstileWidget onSuccess={vi.fn()} onError={onError} />);
+    screen.getByTestId("trigger-error").click();
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
+  it("should call onExpire when token expires", () => {
+    const onExpire = vi.fn();
+    render(<TurnstileWidget onSuccess={vi.fn()} onExpire={onExpire} />);
+    screen.getByTestId("trigger-expire").click();
+    expect(onExpire).toHaveBeenCalledOnce();
+  });
+
+  it("should not throw when onError is undefined", () => {
+    render(<TurnstileWidget onSuccess={vi.fn()} />);
+    expect(() => screen.getByTestId("trigger-error").click()).not.toThrow();
+  });
+
+  it("should not throw when onExpire is undefined", () => {
+    render(<TurnstileWidget onSuccess={vi.fn()} />);
+    expect(() => screen.getByTestId("trigger-expire").click()).not.toThrow();
+  });
+});

--- a/frontend/src/components/common/TurnstileWidget.tsx
+++ b/frontend/src/components/common/TurnstileWidget.tsx
@@ -1,0 +1,92 @@
+/**
+ * TurnstileWidget — Cloudflare Turnstile CAPTCHA wrapper.
+ *
+ * Renders the invisible/managed Turnstile challenge widget. Provides
+ * callbacks for token success, error, and expiry. Gracefully renders
+ * nothing when the site key is not configured.
+ *
+ * @see https://developers.cloudflare.com/turnstile/
+ * Issue: #470
+ */
+
+"use client";
+
+import { useCallback, useRef } from "react";
+import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
+import { getTurnstileSiteKey } from "@/lib/turnstile";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface TurnstileWidgetProps {
+  /** Called with valid CAPTCHA token on success. */
+  readonly onSuccess: (token: string) => void;
+  /** Called when challenge encounters an error. */
+  readonly onError?: () => void;
+  /** Called when a previously valid token expires. */
+  readonly onExpire?: () => void;
+  /** Optional action name for analytics (e.g. "signup", "submit-product"). */
+  readonly action?: string;
+  /** Widget appearance. @default "interaction-only" */
+  readonly appearance?: "always" | "execute" | "interaction-only";
+  /** Widget theme. @default "auto" */
+  readonly theme?: "light" | "dark" | "auto";
+  /** Additional CSS classes on the wrapper div. */
+  readonly className?: string;
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+export function TurnstileWidget({
+  onSuccess,
+  onError,
+  onExpire,
+  action,
+  appearance = "interaction-only",
+  theme = "auto",
+  className,
+}: TurnstileWidgetProps) {
+  const ref = useRef<TurnstileInstance | null>(null);
+  const siteKey = getTurnstileSiteKey();
+
+  const handleSuccess = useCallback(
+    (token: string) => {
+      onSuccess(token);
+    },
+    [onSuccess],
+  );
+
+  const handleError = useCallback(() => {
+    onError?.();
+  }, [onError]);
+
+  const handleExpire = useCallback(() => {
+    onExpire?.();
+    // Auto-reset on expiry so user can re-verify
+    ref.current?.reset();
+  }, [onExpire]);
+
+  return (
+    <div className={className} data-testid="turnstile-widget">
+      <Turnstile
+        ref={ref}
+        siteKey={siteKey}
+        onSuccess={handleSuccess}
+        onError={handleError}
+        onExpire={handleExpire}
+        options={{
+          action,
+          appearance,
+          theme,
+        }}
+      />
+    </div>
+  );
+}
+
+// ─── Imperative Reset Helper ────────────────────────────────────────────────
+
+/**
+ * Hook-compatible ref type for external reset control.
+ * Usage: pass a ref to <Turnstile ref={ref} /> and call ref.current?.reset()
+ */
+export type { TurnstileInstance } from "@marsidev/react-turnstile";

--- a/frontend/src/lib/turnstile.test.ts
+++ b/frontend/src/lib/turnstile.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  getTurnstileSiteKey,
+  isTurnstileConfigured,
+  verifyTurnstileToken,
+  isTurnstileSuccess,
+  isTurnstileFailure,
+  TURNSTILE_TEST_SITE_KEY,
+  VERIFY_FUNCTION_NAME,
+} from "@/lib/turnstile";
+import type {
+  TurnstileVerifySuccess,
+  TurnstileVerifyFailure,
+} from "@/lib/turnstile";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockInvoke = vi.fn();
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const fakeSupabase = { functions: { invoke: mockInvoke } } as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Reset env var for each test
+  vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", "");
+});
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+describe("TURNSTILE_TEST_SITE_KEY", () => {
+  it("should be the Cloudflare always-pass test key", () => {
+    expect(TURNSTILE_TEST_SITE_KEY).toBe("1x00000000000000000000AA");
+  });
+});
+
+describe("VERIFY_FUNCTION_NAME", () => {
+  it("should be 'verify-turnstile'", () => {
+    expect(VERIFY_FUNCTION_NAME).toBe("verify-turnstile");
+  });
+});
+
+// ─── getTurnstileSiteKey ────────────────────────────────────────────────────
+
+describe("getTurnstileSiteKey", () => {
+  it("should return the test key when env var is not set", () => {
+    vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", "");
+    expect(getTurnstileSiteKey()).toBe(TURNSTILE_TEST_SITE_KEY);
+  });
+
+  it("should return the configured key when env var is set", () => {
+    vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", "0x_real_key");
+    expect(getTurnstileSiteKey()).toBe("0x_real_key");
+  });
+});
+
+// ─── isTurnstileConfigured ──────────────────────────────────────────────────
+
+describe("isTurnstileConfigured", () => {
+  it("should return false when env var is empty", () => {
+    vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", "");
+    expect(isTurnstileConfigured()).toBe(false);
+  });
+
+  it("should return false when env var is the test key", () => {
+    vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", TURNSTILE_TEST_SITE_KEY);
+    expect(isTurnstileConfigured()).toBe(false);
+  });
+
+  it("should return true when env var is a real key", () => {
+    vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", "0x_production_key");
+    expect(isTurnstileConfigured()).toBe(true);
+  });
+});
+
+// ─── verifyTurnstileToken ───────────────────────────────────────────────────
+
+describe("verifyTurnstileToken", () => {
+  it("should return failure for empty token", async () => {
+    const result = await verifyTurnstileToken(fakeSupabase, "");
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toBe("Missing Turnstile token.");
+    }
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it("should return failure for whitespace-only token", async () => {
+    const result = await verifyTurnstileToken(fakeSupabase, "   ");
+    expect(result.valid).toBe(false);
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it("should call Edge Function with correct params", async () => {
+    mockInvoke.mockResolvedValueOnce({
+      data: { valid: true, challenge_ts: "2026-01-01T00:00:00Z" },
+      error: null,
+    });
+
+    await verifyTurnstileToken(fakeSupabase, "test-token-123");
+
+    expect(mockInvoke).toHaveBeenCalledWith(VERIFY_FUNCTION_NAME, {
+      body: { token: "test-token-123" },
+    });
+  });
+
+  it("should return success when Edge Function returns valid", async () => {
+    mockInvoke.mockResolvedValueOnce({
+      data: {
+        valid: true,
+        challenge_ts: "2026-01-01T00:00:00Z",
+        hostname: "example.com",
+      },
+      error: null,
+    });
+
+    const result = await verifyTurnstileToken(fakeSupabase, "valid-token");
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.challenge_ts).toBe("2026-01-01T00:00:00Z");
+      expect(result.hostname).toBe("example.com");
+    }
+  });
+
+  it("should return failure when Edge Function returns invalid", async () => {
+    mockInvoke.mockResolvedValueOnce({
+      data: {
+        valid: false,
+        error: "Token already used.",
+        error_codes: ["timeout-or-duplicate"],
+      },
+      error: null,
+    });
+
+    const result = await verifyTurnstileToken(fakeSupabase, "bad-token");
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toBe("Token already used.");
+      expect(result.error_codes).toEqual(["timeout-or-duplicate"]);
+    }
+  });
+
+  it("should gracefully degrade when Edge Function is unreachable", async () => {
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockInvoke.mockResolvedValueOnce({
+      data: null,
+      error: { message: "Function not found" },
+    });
+
+    const result = await verifyTurnstileToken(fakeSupabase, "some-token");
+    expect(result.valid).toBe(true);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Turnstile verification unavailable:",
+      "Function not found",
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it("should gracefully degrade on unexpected response shape", async () => {
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockInvoke.mockResolvedValueOnce({
+      data: "unexpected string",
+      error: null,
+    });
+
+    const result = await verifyTurnstileToken(fakeSupabase, "some-token");
+    expect(result.valid).toBe(true);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Unexpected Turnstile response:",
+      "unexpected string",
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it("should gracefully degrade on network error", async () => {
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockInvoke.mockRejectedValueOnce(new Error("Network error"));
+
+    const result = await verifyTurnstileToken(fakeSupabase, "some-token");
+    expect(result.valid).toBe(true);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Turnstile verification network error",
+    );
+    consoleSpy.mockRestore();
+  });
+});
+
+// ─── Type Guards ────────────────────────────────────────────────────────────
+
+describe("isTurnstileSuccess", () => {
+  it("should return true for valid results", () => {
+    const result: TurnstileVerifySuccess = { valid: true };
+    expect(isTurnstileSuccess(result)).toBe(true);
+  });
+
+  it("should return false for invalid results", () => {
+    const result: TurnstileVerifyFailure = {
+      valid: false,
+      error: "Failed",
+    };
+    expect(isTurnstileSuccess(result)).toBe(false);
+  });
+});
+
+describe("isTurnstileFailure", () => {
+  it("should return true for invalid results", () => {
+    const result: TurnstileVerifyFailure = {
+      valid: false,
+      error: "Failed",
+    };
+    expect(isTurnstileFailure(result)).toBe(true);
+  });
+
+  it("should return false for valid results", () => {
+    const result: TurnstileVerifySuccess = { valid: true };
+    expect(isTurnstileFailure(result)).toBe(false);
+  });
+});

--- a/frontend/src/lib/turnstile.ts
+++ b/frontend/src/lib/turnstile.ts
@@ -1,0 +1,118 @@
+// ─── Turnstile CAPTCHA Client Utilities ─────────────────────────────────────
+// Client-side helpers for Cloudflare Turnstile integration.
+// Uses @marsidev/react-turnstile for the widget and Supabase Edge Function
+// for server-side token verification.
+//
+// Test keys (CI / local development):
+//   Site key:   1x00000000000000000000AA (always passes)
+//   Secret key: 1x0000000000000000000000000000000AA (always passes)
+//
+// Issue: #470
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/**
+ * Cloudflare Turnstile test site key — always passes verification.
+ * Used when NEXT_PUBLIC_TURNSTILE_SITE_KEY is not configured.
+ */
+export const TURNSTILE_TEST_SITE_KEY = "1x00000000000000000000AA";
+
+/**
+ * Edge Function name for server-side verification.
+ */
+export const VERIFY_FUNCTION_NAME = "verify-turnstile";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface TurnstileVerifySuccess {
+  valid: true;
+  challenge_ts?: string;
+  hostname?: string;
+}
+
+export interface TurnstileVerifyFailure {
+  valid: false;
+  error: string;
+  error_codes?: string[];
+}
+
+export type TurnstileVerifyResult =
+  | TurnstileVerifySuccess
+  | TurnstileVerifyFailure;
+
+// ─── Configuration ──────────────────────────────────────────────────────────
+
+/**
+ * Returns the configured Turnstile site key, falling back to the test key
+ * for local development when NEXT_PUBLIC_TURNSTILE_SITE_KEY is not set.
+ */
+export function getTurnstileSiteKey(): string {
+  const key = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+  return key || TURNSTILE_TEST_SITE_KEY;
+}
+
+/**
+ * Returns true if Turnstile is configured with a real (non-test) site key.
+ */
+export function isTurnstileConfigured(): boolean {
+  const key = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+  return !!key && key !== TURNSTILE_TEST_SITE_KEY;
+}
+
+// ─── Server-Side Verification ───────────────────────────────────────────────
+
+/**
+ * Verify a Turnstile token via the Edge Function.
+ * Returns { valid: true } on success or graceful degradation (Edge Function
+ * unavailable), { valid: false, error } on rejection.
+ */
+export async function verifyTurnstileToken(
+  supabase: SupabaseClient,
+  token: string,
+): Promise<TurnstileVerifyResult> {
+  if (!token || token.trim().length === 0) {
+    return { valid: false, error: "Missing Turnstile token." };
+  }
+
+  try {
+    const { data, error } = await supabase.functions.invoke(
+      VERIFY_FUNCTION_NAME,
+      { body: { token } },
+    );
+
+    if (error) {
+      // Graceful degradation: if Edge Function is unreachable, allow through
+      console.warn("Turnstile verification unavailable:", error.message);
+      return { valid: true };
+    }
+
+    if (data && typeof data === "object" && "valid" in data) {
+      return data as TurnstileVerifyResult;
+    }
+
+    // Unexpected response shape — graceful degradation
+    console.warn("Unexpected Turnstile response:", data);
+    return { valid: true };
+  } catch {
+    // Network error — graceful degradation
+    console.warn("Turnstile verification network error");
+    return { valid: true };
+  }
+}
+
+// ─── Type Guards ────────────────────────────────────────────────────────────
+
+export function isTurnstileSuccess(
+  result: TurnstileVerifyResult,
+): result is TurnstileVerifySuccess {
+  return result.valid === true;
+}
+
+export function isTurnstileFailure(
+  result: TurnstileVerifyResult,
+): result is TurnstileVerifyFailure {
+  return result.valid === false;
+}

--- a/supabase/functions/verify-turnstile/index.ts
+++ b/supabase/functions/verify-turnstile/index.ts
@@ -1,0 +1,158 @@
+// ─── Supabase Edge Function: verify-turnstile ───────────────────────────────
+// Server-side Cloudflare Turnstile token verification endpoint.
+// Called by the frontend before auth operations (signup, password reset)
+// and conditionally before product submissions (low trust / high velocity).
+//
+// Cloudflare Turnstile test keys (for CI/development):
+//   Site key:   1x00000000000000000000AA (always passes)
+//   Secret key: 1x0000000000000000000000000000000AA (always passes)
+//
+// Issue: #470
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TURNSTILE_VERIFY_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+interface TurnstileVerifyResponse {
+  success: boolean;
+  "error-codes"?: string[];
+  challenge_ts?: string;
+  hostname?: string;
+  action?: string;
+  cdata?: string;
+}
+
+interface VerifyRequest {
+  token: string;
+}
+
+interface VerifySuccess {
+  valid: true;
+  challenge_ts?: string;
+  hostname?: string;
+}
+
+interface VerifyFailure {
+  valid: false;
+  error: string;
+  error_codes?: string[];
+}
+
+type VerifyResponse = VerifySuccess | VerifyFailure;
+
+// ─── CORS Headers ───────────────────────────────────────────────────────────
+
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+function jsonResponse(body: VerifyResponse, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+  });
+}
+
+// ─── Main Handler ───────────────────────────────────────────────────────────
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  // Handle CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: CORS_HEADERS });
+  }
+
+  // Only accept POST
+  if (req.method !== "POST") {
+    return jsonResponse(
+      { valid: false, error: "Method not allowed. Use POST." },
+      405,
+    );
+  }
+
+  // Parse request body
+  let body: VerifyRequest;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse(
+      { valid: false, error: "Invalid JSON body." },
+      400,
+    );
+  }
+
+  // Validate token presence
+  const token = body?.token;
+  if (!token || typeof token !== "string" || token.trim().length === 0) {
+    return jsonResponse(
+      { valid: false, error: "Missing or empty Turnstile token." },
+      400,
+    );
+  }
+
+  // Get secret key from environment
+  const secretKey = Deno.env.get("TURNSTILE_SECRET_KEY");
+  if (!secretKey) {
+    // Graceful degradation: if no secret key configured, allow through
+    // This enables local development without Turnstile setup
+    console.warn(
+      "TURNSTILE_SECRET_KEY not set — allowing request (graceful degradation)",
+    );
+    return jsonResponse({ valid: true }, 200);
+  }
+
+  // Extract client IP for additional verification
+  const ip =
+    req.headers.get("cf-connecting-ip") ??
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    "";
+
+  // Verify token with Cloudflare
+  try {
+    const verifyResponse = await fetch(TURNSTILE_VERIFY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        secret: secretKey,
+        response: token,
+        remoteip: ip,
+      }),
+    });
+
+    if (!verifyResponse.ok) {
+      console.error(
+        `Turnstile API returned ${verifyResponse.status}: ${verifyResponse.statusText}`,
+      );
+      // Graceful degradation on Turnstile API failure
+      return jsonResponse({ valid: true }, 200);
+    }
+
+    const data: TurnstileVerifyResponse = await verifyResponse.json();
+
+    if (data.success) {
+      return jsonResponse(
+        {
+          valid: true,
+          challenge_ts: data.challenge_ts,
+          hostname: data.hostname,
+        },
+        200,
+      );
+    }
+
+    return jsonResponse(
+      {
+        valid: false,
+        error: "Turnstile verification failed.",
+        error_codes: data["error-codes"],
+      },
+      403,
+    );
+  } catch (err) {
+    // Graceful degradation: if Turnstile is unreachable, allow through
+    console.error("Turnstile verification error:", err);
+    return jsonResponse({ valid: true }, 200);
+  }
+});


### PR DESCRIPTION
## Summary

Integrates Cloudflare Turnstile CAPTCHA into the signup form to prevent bot account creation. This is the foundational CAPTCHA infrastructure that unblocks #478 Phase 3 (CAPTCHA + trust scoring in the API gateway).

Closes #470

## Changes

### New Files (5)
- **`supabase/functions/verify-turnstile/index.ts`** (158 lines) — Deno Edge Function for server-side Turnstile token verification. Validates POST requests, calls Cloudflare `siteverify` API, returns `{valid: true/false}`. **Graceful degradation**: if secret key is not configured or Cloudflare API is unreachable, requests are allowed through with console warnings.
- **`frontend/src/lib/turnstile.ts`** (118 lines) — Client helper: `getTurnstileSiteKey()` (falls back to test key), `verifyTurnstileToken()` (calls Edge Function), `isTurnstileConfigured()`, type exports, type guards.
- **`frontend/src/components/common/TurnstileWidget.tsx`** (92 lines) — React component wrapping `@marsidev/react-turnstile`. Props: `onSuccess`, `onError`, `onExpire`, `action`, `theme`, `appearance`. Auto-resets on token expiry.
- **`frontend/src/lib/turnstile.test.ts`** (218 lines) — 19 tests covering constants, site key resolution, Edge Function calls, graceful degradation (3 paths), type guards
- **`frontend/src/components/common/TurnstileWidget.test.tsx`** (137 lines) — 12 tests covering rendering, props, callbacks, default values

### Modified Files (9)
- **`frontend/src/app/auth/signup/SignupForm.tsx`** — Added Turnstile challenge: token state, verification before `signUp()`, `captchaToken` passed in auth options, submit disabled until token received
- **`frontend/src/app/auth/signup/SignupForm.test.tsx`** — Updated all existing tests for Turnstile flow; added 7 new tests (Turnstile widget rendering, token state, captchaToken pass-through, verification failure, error callback). 14 total tests.
- **`frontend/messages/en.json`** — `auth.captchaRequired`, `auth.captchaFailed`
- **`frontend/messages/pl.json`** — Polish translations for CAPTCHA messages
- **`frontend/messages/de.json`** — German translations for CAPTCHA messages
- **`frontend/package.json`** — Added `@marsidev/react-turnstile`
- **`.env.example`** — Added Turnstile section with `NEXT_PUBLIC_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY`
- **`CHANGELOG.md`** — Added entry under Security

## Test Results

- **TypeScript**: `npx tsc --noEmit` — 0 errors
- **Vitest**: 251 files, **4326 passed**, 29 skipped, 0 failed
- **New tests**: 45 (19 lib + 12 component + 14 signup form)

## Architecture Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| CAPTCHA provider | Cloudflare Turnstile | Free, privacy-respecting (no tracking), invisible/managed mode |
| Verification location | Dedicated Edge Function | Separation of concerns, reusable by future forms (password reset, etc.) |
| Graceful degradation | Allow through on failure | Availability > absolute bot blocking; prevents lockout if Cloudflare is down |
| Test key fallback | `1x00000000000000000000AA` | Always-passes key for local dev and CI without Cloudflare account |

## Deployment Notes

After merge, set Turnstile secrets on the Supabase project:
```bash
supabase secrets set TURNSTILE_SECRET_KEY=<real-secret-key>
```

Set the site key in Vercel environment variables:
```
NEXT_PUBLIC_TURNSTILE_SITE_KEY=<real-site-key>
```

## File Impact

**14 files changed, +927 / -7 lines**
- 1 new Edge Function (158 lines)
- 2 new frontend modules (210 lines)
- 2 new test files (355 lines)
- 1 form integration (42 lines added)
- 1 test file updated (129 lines added)
- 3 i18n files (2 keys each)
- 1 package dependency
- 1 env config