### PR TITLE
security(api): add CAPTCHA + trust integration to API gateway (Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Security
 
+- Add CAPTCHA + trust integration to API gateway (Phase 3): Turnstile token
+  verification for `submit-product` when trust < 50 or velocity > 3/hour;
+  trust score lookup via service-role client against `user_trust_scores`;
+  high-trust users (score > 80) bypass CAPTCHA entirely; graceful degradation on
+  missing secret key, Turnstile API failure, or missing service-role key;
+  frontend `isGatewayCaptchaRequired` + `isGatewayCaptchaFailed` type guards;
+  `SubmitProductParams.turnstile_token` optional field; 11 new Vitest tests
+  (60 total) (#478)
 - Add Cloudflare Turnstile CAPTCHA integration for signup bot protection:
   `verify-turnstile` Edge Function (server-side token verification with graceful
   degradation), `TurnstileWidget` React component wrapper, `turnstile.ts` client

--- a/frontend/src/lib/api-gateway.ts
+++ b/frontend/src/lib/api-gateway.ts
@@ -7,7 +7,7 @@
 //   const gateway = createApiGateway(supabase);
 //   const result = await gateway.recordScan("5901234123457");
 //
-// Issue: #478 — Phase 1 + Phase 2 + Phase 4
+// Issue: #478 — Phase 1 + Phase 2 + Phase 3 + Phase 4
 // ─────────────────────────────────────────────────────────────────────────────
 
 import type { SupabaseClient } from "@supabase/supabase-js";
@@ -53,6 +53,18 @@ export function isGatewayValidationError(
       result.error === "invalid_ean" ||
       result.error === "invalid_ean_checksum")
   );
+}
+
+export function isGatewayCaptchaRequired(
+  result: GatewayResult,
+): result is GatewayError & { error: "captcha_required"; reason: string } {
+  return !result.ok && result.error === "captcha_required";
+}
+
+export function isGatewayCaptchaFailed(
+  result: GatewayResult,
+): result is GatewayError & { error: "captcha_failed" } {
+  return !result.ok && result.error === "captcha_failed";
 }
 
 // ─── Core invoke ────────────────────────────────────────────────────────────
@@ -143,6 +155,8 @@ export interface SubmitProductParams {
   category?: string | null;
   photo_url?: string | null;
   notes?: string | null;
+  /** Turnstile CAPTCHA token. Required when trust is low or velocity is high. */
+  turnstile_token?: string | null;
 }
 
 /**


### PR DESCRIPTION
# CAPTCHA + Trust Integration — API Gateway Phase 3

> **Issue:** #478 (Phase 3)
> **Dependencies:** #470 (Turnstile CAPTCHA — merged in PR #519)

## Summary

Adds CAPTCHA verification and trust score evaluation to the API gateway's `submit-product` action. This is Phase 3 of the gateway pipeline, completing the 7-step defense chain:

```
JWT → Parse → Route → Rate Limit → CAPTCHA+Trust → Client → Handler
```

## Changes

### Edge Function (`supabase/functions/api-gateway/index.ts`, +223 lines)

- **Trust score lookup** via service-role Supabase client against `user_trust_scores` table
- **Submission velocity check** from in-memory rate limit store (count in last 1 hour)
- **CAPTCHA decision logic:**
  - `trust > 80` → bypass CAPTCHA entirely (high-trust users)
  - `trust < 50` → always require CAPTCHA (low-trust users)
  - `velocity > 3/hour` → require CAPTCHA (suspicious velocity)
  - Otherwise → no CAPTCHA needed
- **Turnstile token verification** directly via Cloudflare `siteverify` API
- **Graceful degradation** (3 paths):
  - Missing `TURNSTILE_SECRET_KEY` → allow through (dev environments)
  - Turnstile API unreachable/error → allow through
  - Missing `SUPABASE_SERVICE_ROLE_KEY` → treat as new user (null trust)
- New error codes: `captcha_required` (403) and `captcha_failed` (403)

### Frontend (`frontend/src/lib/api-gateway.ts`, +16 lines)

- `isGatewayCaptchaRequired()` — type guard for `captcha_required` error
- `isGatewayCaptchaFailed()` — type guard for `captcha_failed` error
- `SubmitProductParams.turnstile_token` — optional field for CAPTCHA token

### Tests (`frontend/src/lib/api-gateway.test.ts`, +141 lines)

- 6 new type guard tests (`isGatewayCaptchaRequired`, `isGatewayCaptchaFailed`)
- 5 new CAPTCHA integration tests for `submitProductViaGateway`:
  - Low trust → captcha_required
  - High velocity → captcha_required
  - Invalid token → captcha_failed
  - Token passthrough to gateway
  - High-trust bypass

## Verification

- **TypeScript:** `npx tsc --noEmit` → 0 errors
- **Vitest:** 251 files, 4337 passed (60 in api-gateway suite), 0 failed
- **CI:** All required checks expected GREEN

## Decision Log

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Trust lookup method | Service-role client | `user_trust_scores` has service_role-only RLS; user JWT cannot read it |
| Turnstile verification | Direct API call | Reuse same Cloudflare API pattern from verify-turnstile Edge Function; avoids inter-function call overhead |
| Velocity window | 1 hour (3600s) | Matches issue spec; uses existing rate limit store data |
| CAPTCHA scope | `submit-product` only | Per spec; scans and events don't need CAPTCHA |
| Graceful degradation | Allow through on failure | Matches project pattern (§6 Core Principles) — unprotected but functional > broken |

## File Impact

**4 files changed, +383 / -5 lines:**
- 1 modified Edge Function (+223 lines)
- 1 modified frontend lib (+16 lines)
- 1 modified test file (+141 lines)
- 1 CHANGELOG entry (+8 lines)