### PR TITLE
ci(config): enforce Unix LF line endings for SQL files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,11 @@
 *.ttf binary
 *.otf binary
 
+# SQL files — force Unix LF line endings to prevent \r in PostgreSQL
+# function bodies (core.autocrlf=true on Windows causes CRLF which
+# breaks dynamic patching via pg_get_functiondef + regexp_replace)
+*.sql text eol=lf
+
 # Design source files (if ever added)
 *.fig binary
 *.sketch binary


### PR DESCRIPTION
## Problem

On Windows with `core.autocrlf=true`, SQL migration files are checked out with CRLF line endings. PostgreSQL stores `\r` characters in function bodies, causing migrations that use `pg_get_functiondef()` + `regexp_replace()` with `chr(10)` (LF only) to fail — the regex can't match `\r\n` line endings.

**Specific failure:** `20260315000400_api_rate_limiting.sql` fails with:
```
Failed to patch api_search_products — rate limit check not found in output
```

This makes `supabase db reset` impossible on Windows without manual intervention, while CI (Linux) works fine because files are LF natively.

## Fix

Add `*.sql text eol=lf` to `.gitattributes`, forcing Unix LF line endings for all SQL files regardless of `core.autocrlf` setting.

## Verification

- `supabase db reset` — all 181 migrations applied successfully
- `.\RUN_LOCAL.ps1` — 108/108 pipeline files succeeded
- `.\RUN_QA.ps1` — 724/725 checks passing (1 non-blocking)
- `.\RUN_NEGATIVE_TESTS.ps1` — 23/23 caught
- Repo blobs already stored as LF; this rule prevents CRLF in working directory

## File Impact

**1 file changed, +4 lines:**
- `.gitattributes` — added `*.sql text eol=lf` rule with explanatory comment