### PR TITLE
test(vitest): fix flaky test timeouts by increasing testTimeout to 15s

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
+    testTimeout: 15_000,
+    hookTimeout: 15_000,
     setupFiles: ["./src/__tests__/setup.ts"],
     include: ["src/**/*.test.{ts,tsx}", "tests/**/*.test.{ts,tsx}"],
     coverage: {


### PR DESCRIPTION
## Problem

Tests fail non-deterministically during full-suite runs (253 files, ~4366 tests) due to the default 5000ms timeout. Under CPU contention, timing-sensitive tests exceed this limit:\n\n- **ScoreBadge tooltip hover** — depends on Radix UI tooltip delay (300ms) + jsdom rendering\n- **SubmitProductPage mutation callbacks** — react-query async mutation flow\n- **ErrorBoundary error recovery** — React error boundary re-render cycle\n\nAll tests pass consistently when run individually. Different tests fail on each full-suite run — classic flakiness pattern.\n\n## Fix\n\nSet `testTimeout: 15_000` and `hookTimeout: 15_000` in `vitest.config.ts`.\n\nThis gives timing-sensitive tests 3× more headroom while remaining reasonable (15s per test). The full suite completes in ~400s.\n\n## Verification\n\n**Before (default 5s):**\n- Run 1: 3 failures (ScoreBadge, SubmitProductPage ×2)\n- Run 2: 1 failure (ErrorBoundary) — different test each time\n\n**After (15s):**\n```\nTest Files  251 passed | 0 failed | 2 skipped (253)\n     Tests  4337 passed | 0 failed | 29 skipped (4366)\n  Duration  399.06s\n```\n\nTypeScript: `tsc --noEmit` clean.\n\n## File Impact\n\n**1 file changed, +2 lines:**\n- `frontend/vitest.config.ts` — added `testTimeout` and `hookTimeout`