### PR TITLE
fix(ci): add secret validation step to deploy.yml preflight

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,27 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Validate required secrets
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          SUPABASE_STAGING_PROJECT_REF: ${{ secrets.SUPABASE_STAGING_PROJECT_REF }}
+        run: |
+          missing=""
+          if [ -z "$SUPABASE_ACCESS_TOKEN" ]; then missing="$missing SUPABASE_ACCESS_TOKEN"; fi
+
+          if [ "${{ github.event.inputs.environment }}" = "production" ]; then
+            if [ -z "$SUPABASE_PROJECT_REF" ]; then missing="$missing SUPABASE_PROJECT_REF"; fi
+          else
+            if [ -z "$SUPABASE_STAGING_PROJECT_REF" ]; then missing="$missing SUPABASE_STAGING_PROJECT_REF"; fi
+          fi
+
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required secrets:$missing — configure them in GitHub Settings > Secrets"
+            exit 1
+          fi
+          echo "✅ All required secrets are configured"
+
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1
         with:


### PR DESCRIPTION
## Summary

Fixes #444 — Deploy dry-run verification and secret validation.

## Problem

`deploy.yml` preflight job failed with a cryptic "Cannot find project ref. Have you run supabase link?" error when the `SUPABASE_PROJECT_REF` / `SUPABASE_STAGING_PROJECT_REF` secrets were not configured. This was the project's only production deployment path and had never been successfully executed end-to-end.

## Root Cause

Two issues:
1. **Missing secrets:** `SUPABASE_PROJECT_REF` was not set in GitHub repository settings (now set to `uskvezwftkkudvksmken`)
2. **Poor error messaging:** The workflow didn't validate that required secrets were configured before attempting to use them

## Changes

### Secret Configuration
- Set `SUPABASE_PROJECT_REF` secret to the known production project ref

### Workflow Improvement (`deploy.yml`)
- Added "Validate required secrets" step in the `preflight` job (before Setup Supabase CLI)
- Checks for `SUPABASE_ACCESS_TOKEN` (always required)
- Checks for `SUPABASE_PROJECT_REF` (when targeting production) or `SUPABASE_STAGING_PROJECT_REF` (when targeting staging)
- Fails early with a clear `::error` message listing which secrets need to be configured

## Verification

### Dry-Run Results

| Run | Environment | Status | URL |
|-----|------------|--------|-----|
| 22533687446 | staging | ❌ Failed (missing `SUPABASE_STAGING_PROJECT_REF`) | [Link](https://github.com/ericsocrat/poland-food-db/actions/runs/22533687446) |
| 22533725343 | production | ✅ Success | [Link](https://github.com/ericsocrat/poland-food-db/actions/runs/22533725343) |

- **Preflight job:** ✅ Completed successfully (link, schema diff, dry-run abort)
- **Deploy job:** ✅ Skipped (as expected for `dry_run=true`)
- **Schema diff:** Executed against production (~3 min), output written to step summary
- **Dry-run exit:** Clean notice: "Dry run — schema diff shown above. No deployment performed."

### Outstanding Items
- `SUPABASE_STAGING_PROJECT_REF` remains unconfigured (staging Supabase project not yet provisioned)
- `SUPABASE_DB_PASSWORD`, `PRODUCTION_URL`, `STAGING_URL` not yet configured (only needed for actual deploys, not dry-runs)

## File Impact
**1 file changed, +21 lines:**
- `.github/workflows/deploy.yml` — added secret validation step