### PR TITLE
test(vitest): add tests for LearnCard, SourceCitation, typography

### DIFF
--- a/frontend/src/components/learn/LearnCard.test.tsx
+++ b/frontend/src/components/learn/LearnCard.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LearnCard } from "./LearnCard";
+import { Book, GraduationCap } from "lucide-react";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("LearnCard", () => {
+  it("renders title and description", () => {
+    render(
+      <LearnCard
+        icon={Book}
+        title="Nutri-Score"
+        description="Learn about the European nutrition label"
+        href="/learn/nutri-score"
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { name: "Nutri-Score" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Learn about the European nutrition label"),
+    ).toBeInTheDocument();
+  });
+
+  it("links to the topic page", () => {
+    render(
+      <LearnCard
+        icon={Book}
+        title="NOVA"
+        description="Food processing classification"
+        href="/learn/nova"
+      />,
+    );
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/learn/nova");
+  });
+
+  it("renders a Lucide icon component", () => {
+    const { container } = render(
+      <LearnCard
+        icon={GraduationCap}
+        title="Score"
+        description="How scores work"
+        href="/learn/score"
+      />,
+    );
+    // Lucide renders as SVG
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("renders a ReactNode icon", () => {
+    render(
+      <LearnCard
+        icon={<span data-testid="custom-icon">🍎</span>}
+        title="Additives"
+        description="E-number guide"
+        href="/learn/additives"
+      />,
+    );
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+    expect(screen.getByText("🍎")).toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <LearnCard
+        icon={Book}
+        title="Test"
+        description="Desc"
+        href="/learn/test"
+        className="my-custom-class"
+      />,
+    );
+    const link = container.querySelector("a");
+    expect(link?.classList.contains("my-custom-class")).toBe(true);
+  });
+
+  it("icon container has aria-hidden for accessibility", () => {
+    const { container } = render(
+      <LearnCard
+        icon={Book}
+        title="Accessible"
+        description="Desc"
+        href="/learn/a11y"
+      />,
+    );
+    const iconWrapper = container.querySelector("[aria-hidden='true']");
+    expect(iconWrapper).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/learn/SourceCitation.test.tsx
+++ b/frontend/src/components/learn/SourceCitation.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SourceCitation } from "./SourceCitation";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+// No mocks needed — pure presentational component
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("SourceCitation", () => {
+  it("renders author and title", () => {
+    render(<SourceCitation author="WHO" title="Nutrition Guidelines" />);
+    expect(screen.getByText("WHO")).toBeInTheDocument();
+    expect(screen.getByText("Nutrition Guidelines")).toBeInTheDocument();
+  });
+
+  it("renders as a <cite> element", () => {
+    const { container } = render(
+      <SourceCitation author="EFSA" title="Food Additives Report" />,
+    );
+    expect(container.querySelector("cite")).toBeInTheDocument();
+  });
+
+  it("includes year when provided", () => {
+    render(
+      <SourceCitation author="EFSA" title="Additive Safety" year={2023} />,
+    );
+    expect(screen.getByText(/2023/)).toBeInTheDocument();
+  });
+
+  it("accepts string year", () => {
+    render(<SourceCitation author="EFSA" title="Report" year="2024" />);
+    expect(screen.getByText(/2024/)).toBeInTheDocument();
+  });
+
+  it("omits year text when not provided", () => {
+    const { container } = render(
+      <SourceCitation author="EFSA" title="Report" />,
+    );
+    expect(container.textContent).not.toMatch(/\(\d{4}\)/);
+  });
+
+  it("renders link when URL is provided", () => {
+    render(
+      <SourceCitation
+        author="EFSA"
+        title="Report"
+        url="https://efsa.europa.eu/report"
+      />,
+    );
+    const link = screen.getByRole("link", { name: /Link/ });
+    expect(link).toHaveAttribute("href", "https://efsa.europa.eu/report");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("does not render link when URL is absent", () => {
+    render(<SourceCitation author="EFSA" title="Report" />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <SourceCitation author="EFSA" title="Report" className="mt-4" />,
+    );
+    const cite = container.querySelector("cite");
+    expect(cite?.classList.contains("mt-4")).toBe(true);
+  });
+
+  it("renders all props together", () => {
+    render(
+      <SourceCitation
+        author="World Health Organization"
+        title="Guideline: Sugars intake for adults and children"
+        url="https://who.int/sugars"
+        year={2015}
+        className="mb-2"
+      />,
+    );
+    expect(screen.getByText("World Health Organization")).toBeInTheDocument();
+    expect(
+      screen.getByText("Guideline: Sugars intake for adults and children"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/2015/)).toBeInTheDocument();
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "https://who.int/sugars",
+    );
+  });
+});

--- a/frontend/src/lib/typography.test.ts
+++ b/frontend/src/lib/typography.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { typography, spacing } from "./typography";
+
+// ─── Typography ─────────────────────────────────────────────────────────────
+
+describe("typography", () => {
+  it("exports all semantic roles", () => {
+    const expectedKeys = [
+      "pageTitle",
+      "greeting",
+      "sectionHeading",
+      "cardHeading",
+      "statValue",
+      "body",
+      "bodySecondary",
+      "caption",
+      "muted",
+      "label",
+      "sectionLink",
+    ];
+    expect(Object.keys(typography)).toEqual(
+      expect.arrayContaining(expectedKeys),
+    );
+    expect(Object.keys(typography).length).toBe(expectedKeys.length);
+  });
+
+  it("each value is a non-empty string", () => {
+    for (const [, value] of Object.entries(typography)) {
+      expect(typeof value).toBe("string");
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("desktop entries include lg: responsive prefix", () => {
+    const desktopScaled = [
+      "pageTitle",
+      "greeting",
+      "sectionHeading",
+      "cardHeading",
+      "statValue",
+      "body",
+      "caption",
+    ];
+    for (const key of desktopScaled) {
+      expect(typography[key as keyof typeof typography]).toContain("lg:");
+    }
+  });
+
+  it("non-scaling entries omit lg: prefix", () => {
+    const staticEntries = ["bodySecondary", "muted", "label"];
+    for (const key of staticEntries) {
+      expect(typography[key as keyof typeof typography]).not.toContain("lg:");
+    }
+  });
+});
+
+// ─── Spacing ────────────────────────────────────────────────────────────────
+
+describe("spacing", () => {
+  it("exports all spacing keys", () => {
+    const expectedKeys = [
+      "pageStack",
+      "sectionStack",
+      "gridGap",
+      "sectionHeadingMargin",
+    ];
+    expect(Object.keys(spacing)).toEqual(
+      expect.arrayContaining(expectedKeys),
+    );
+    expect(Object.keys(spacing).length).toBe(expectedKeys.length);
+  });
+
+  it("each value is a non-empty string", () => {
+    for (const [, value] of Object.entries(spacing)) {
+      expect(typeof value).toBe("string");
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("all spacing values include desktop lg: responsive prefix", () => {
+    for (const [, value] of Object.entries(spacing)) {
+      expect(value).toContain("lg:");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds 22 new unit/component tests across 3 previously untested modules, pushing lines coverage from 88.10% → 88.17%.

## New Test Files

| File | Tests | Coverage |
|------|-------|----------|
| `frontend/src/components/learn/LearnCard.test.tsx` | 6 | Render, link, Lucide icon, ReactNode icon, className, a11y |
| `frontend/src/components/learn/SourceCitation.test.tsx` | 9 | Render, cite element, year, URL, className, full props |
| `frontend/src/lib/typography.test.ts` | 7 | Semantic roles, responsive prefixes, spacing keys |

## Verification

- **Vitest**: 254 files passed, 4359 tests, 0 failures
- **Coverage**: 88.17% lines (above 88% baseline)
- **No regressions** — full suite green