### PR TITLE
fix(ci): move secrets out of quality-gate.yml step if condition

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -200,9 +200,13 @@ jobs:
 
       # ── Optional: Nightly failure notification ───────────────────────────
       - name: Notify on nightly failure
-        if: failure() && github.event_name == 'schedule' && secrets.ALERT_WEBHOOK_URL != ''
+        if: failure() && github.event_name == 'schedule'
+        env:
+          ALERT_WEBHOOK_URL: ${{ secrets.ALERT_WEBHOOK_URL }}
         run: |
-          curl -sS -X POST "${{ secrets.ALERT_WEBHOOK_URL }}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\": \"Quality Gate nightly FAILED — https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
-            || true
+          if [ -n "$ALERT_WEBHOOK_URL" ]; then
+            curl -sS -X POST "$ALERT_WEBHOOK_URL" \
+              -H 'Content-Type: application/json' \
+              -d "{\"text\": \"Quality Gate nightly FAILED — https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
+              || true
+          fi


### PR DESCRIPTION
## Summary

Fixes the `quality-gate.yml` workflow parse error that has been failing on every push to `main`.

**Error:** `Unrecognized named-value: 'secrets'. Located at position 49 within expression: failure() && github.event_name == 'schedule' && secrets.ALERT_WEBHOOK_URL != ''`

**Cause:** GitHub Actions does not support the `secrets` context in step `if` expressions.

**Fix:** Move `ALERT_WEBHOOK_URL` to an `env` block and check it inside the shell script with `if [ -n "$ALERT_WEBHOOK_URL" ]`. This matches the pattern already used in `nightly.yml` (line 121–130).

## Changes

- `.github/workflows/quality-gate.yml` — Replace `secrets.ALERT_WEBHOOK_URL` in `if` condition with env variable + shell check

## Verification

- No local verification needed — this is a workflow YAML syntax fix
- The fix matches the working pattern in `nightly.yml`
- CI on this PR will validate the workflow file parses correctly

**Files changed:** 1 file, +9 / -5 lines