### PR TITLE
fix(ci): fix quality-gate testDir and auth-route filtering

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -119,27 +119,46 @@ jobs:
           fi
           echo "Quality gate mode: $(cat "$GITHUB_OUTPUT" | grep mode | cut -d= -f2)"
 
+      # ── Check auth credentials ──────────────────────────────────────────
+      - name: Check auth credentials
+        id: auth
+        run: |
+          if [ -n "$QA_TEST_EMAIL" ] && [ -n "$QA_TEST_PASSWORD" ]; then
+            echo "has_auth=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_auth=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️  Missing QA_TEST_EMAIL and/or QA_TEST_PASSWORD — Lighthouse audits will be skipped"
+          fi
+        env:
+          QA_TEST_EMAIL: ${{ secrets.QA_TEST_EMAIL }}
+          QA_TEST_PASSWORD: ${{ secrets.QA_TEST_PASSWORD }}
+
       # ── Mobile Audit ─────────────────────────────────────────────────────
       - name: Run Mobile Audit
         working-directory: frontend
-        run: npx playwright test tests/quality/mobile.audit.spec.ts --reporter=html,list
+        run: npx playwright test --project=quality-mobile --reporter=html,list
         env:
           QA_MODE_LEVEL: ${{ steps.mode.outputs.mode }}
           BASE_URL: http://localhost:3000
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
 
       # ── Desktop Audit ────────────────────────────────────────────────────
       - name: Run Desktop Audit
+        if: always()
         working-directory: frontend
-        run: npx playwright test tests/quality/desktop.audit.spec.ts --reporter=html,list
+        run: npx playwright test --project=quality-desktop --reporter=html,list
         env:
           QA_MODE_LEVEL: ${{ steps.mode.outputs.mode }}
           BASE_URL: http://localhost:3000
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
 
       # ── Lighthouse CI (Mobile) ─────────────────────────────────────────
       - name: Run Lighthouse CI (Mobile)
         working-directory: frontend
+        if: always() && steps.auth.outputs.has_auth == 'true'
         run: npx lhci autorun --config=lighthouserc.mobile.js
-        if: always()
         env:
           QA_TEST_EMAIL: ${{ secrets.QA_TEST_EMAIL }}
           QA_TEST_PASSWORD: ${{ secrets.QA_TEST_PASSWORD }}
@@ -148,8 +167,8 @@ jobs:
       # ── Lighthouse CI (Desktop) ────────────────────────────────────────
       - name: Run Lighthouse CI (Desktop)
         working-directory: frontend
+        if: always() && steps.auth.outputs.has_auth == 'true'
         run: npx lhci autorun --config=lighthouserc.desktop.js
-        if: always()
         env:
           QA_TEST_EMAIL: ${{ secrets.QA_TEST_EMAIL }}
           QA_TEST_PASSWORD: ${{ secrets.QA_TEST_PASSWORD }}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -53,7 +53,7 @@ const HAS_QUALITY = !!process.env.QA_MODE_LEVEL;
 
 const qualityMobileProject = {
   name: "quality-mobile",
-  testDir: "../tests/quality",
+  testDir: "./tests/quality",
   testMatch: /mobile\.audit\.spec\.ts/,
   dependencies: HAS_AUTH ? ["auth-setup"] : [],
   use: {
@@ -64,7 +64,7 @@ const qualityMobileProject = {
 
 const qualityDesktopProject = {
   name: "quality-desktop",
-  testDir: "../tests/quality",
+  testDir: "./tests/quality",
   testMatch: /desktop\.audit\.spec\.ts/,
   dependencies: HAS_AUTH ? ["auth-setup"] : [],
   use: {

--- a/frontend/tests/quality/desktop.audit.spec.ts
+++ b/frontend/tests/quality/desktop.audit.spec.ts
@@ -30,6 +30,14 @@ import { waitForStable } from "./helpers/network";
 /** Audit mode: `smoke` visits ~9 routes, `full` visits all ~40. */
 const MODE = (process.env.QA_MODE_LEVEL ?? "smoke") as "smoke" | "full";
 
+/**
+ * Auth-protected routes require both SUPABASE_SERVICE_ROLE_KEY (for test user
+ * provisioning) and NEXT_PUBLIC_SUPABASE_URL (for Supabase client setup).
+ */
+const HAS_AUTH =
+  !!process.env.SUPABASE_SERVICE_ROLE_KEY &&
+  !!process.env.NEXT_PUBLIC_SUPABASE_URL;
+
 /* ── Setup ───────────────────────────────────────────────────────────────── */
 
 test.beforeAll(async () => {
@@ -38,7 +46,9 @@ test.beforeAll(async () => {
 
 /* ── Route tests ─────────────────────────────────────────────────────────── */
 
-const routes = getRoutes(MODE).filter((r) => !r.mobileOnly);
+const routes = getRoutes(MODE)
+  .filter((r) => !r.mobileOnly)
+  .filter((r) => HAS_AUTH || !r.requiresAuth);
 
 for (const route of routes) {
   test(`desktop audit — ${route.label}`, async ({ page }) => {

--- a/frontend/tests/quality/mobile.audit.spec.ts
+++ b/frontend/tests/quality/mobile.audit.spec.ts
@@ -29,6 +29,14 @@ import { waitForStable } from "./helpers/network";
 /** Audit mode: `smoke` visits ~9 routes, `full` visits all ~40. */
 const MODE = (process.env.QA_MODE_LEVEL ?? "smoke") as "smoke" | "full";
 
+/**
+ * Auth-protected routes require both SUPABASE_SERVICE_ROLE_KEY (for test user
+ * provisioning) and NEXT_PUBLIC_SUPABASE_URL (for Supabase client setup).
+ */
+const HAS_AUTH =
+  !!process.env.SUPABASE_SERVICE_ROLE_KEY &&
+  !!process.env.NEXT_PUBLIC_SUPABASE_URL;
+
 /* ── Setup ───────────────────────────────────────────────────────────────── */
 
 test.beforeAll(async () => {
@@ -37,7 +45,9 @@ test.beforeAll(async () => {
 
 /* ── Route tests ─────────────────────────────────────────────────────────── */
 
-const routes = getRoutes(MODE).filter((r) => !r.desktopOnly);
+const routes = getRoutes(MODE)
+  .filter((r) => !r.desktopOnly)
+  .filter((r) => HAS_AUTH || !r.requiresAuth);
 
 for (const route of routes) {
   test(`mobile audit — ${route.label}`, async ({ page }) => {


### PR DESCRIPTION
## Problem

The Quality Gate workflow has **never passed** — all 355 runs failed. After PR #532 fixed the YAML parse error, the underlying test execution failures became visible.

## Root Causes (5 issues)

### 1. Wrong `testDir` path in `playwright.config.ts`
Both quality projects used `testDir: "../tests/quality"` which resolves to `<repo_root>/tests/quality/` (nonexistent). The actual files are at `frontend/tests/quality/`.

**Fix:** Changed to `./tests/quality` → resolves to `frontend/tests/quality/` ✓

### 2. Auth-protected routes without credentials
Smoke routes include auth-required pages (`/app`, `/app/search`, `/app/categories`, etc.) but `SUPABASE_SERVICE_ROLE_KEY` is not set in the workflow. Tests would navigate to protected routes without auth → failures.

**Fix:** Added `HAS_AUTH` filter in both audit specs — skips `requiresAuth` routes when no service role key. Non-auth routes (`/`, `/auth/login`, `/privacy`) still run.

### 3. Desktop Audit never ran
No `if: always()` on Desktop Audit step → when Mobile failed, Desktop was skipped (0s).

**Fix:** Added `if: always()` so both viewports run independently.

### 4. Lighthouse ran without credentials
Lighthouse CI steps ran unconditionally via `if: always()`, but `QA_TEST_EMAIL`/`QA_TEST_PASSWORD` secrets are needed for the puppeteer auth script.

**Fix:** Added auth credential check step; Lighthouse now gated on `steps.auth.outputs.has_auth == 'true'`.

### 5. Missing `--project` flag
Audit steps used `npx playwright test tests/quality/...` (file path) instead of `--project=quality-mobile`/`--project=quality-desktop`, preventing proper project matching after testDir was resolved.

**Fix:** Use `--project=quality-mobile`/`--project=quality-desktop` flags.

## Behavior After Fix

| Scenario | Playwright Audits | Lighthouse |
|---|---|---|
| No auth secrets | ✅ Non-auth routes only (3 smoke) | ⏭️ Skipped |
| Auth secrets set | ✅ All routes (9 smoke / ~40 full) | ✅ Runs |

## Files Changed

| File | Change |
|---|---|
| `frontend/playwright.config.ts` | Fix testDir: `../tests/quality` → `./tests/quality` |
| `frontend/tests/quality/mobile.audit.spec.ts` | Add `HAS_AUTH` filter for auth routes |
| `frontend/tests/quality/desktop.audit.spec.ts` | Add `HAS_AUTH` filter for auth routes |
| `.github/workflows/quality-gate.yml` | `--project` flags, `if: always()`, auth check, conditional Lighthouse |

## Verification

- [x] `npx tsc --noEmit` — clean
- [x] 4 files changed, +34 / -8 lines