### PR TITLE
fix(deps): resolve 6 high-severity npm audit vulnerabilities

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11420,9 +11420,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -12719,15 +12719,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -13181,6 +13172,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13378,12 +13370,12 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-static": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,8 @@
     "zustand": "^5.0.11"
   },
   "overrides": {
-    "minimatch": ">=10.0.1"
+    "minimatch": ">=10.2.4",
+    "serialize-javascript": ">=7.0.3"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",


### PR DESCRIPTION
## Summary

Resolves all 6 high-severity npm audit vulnerabilities in production dependencies by adding/updating npm overrides in `package.json`.

## Vulnerabilities Fixed

| Package | Advisory | Severity | Fix |
|---|---|---|---|
| minimatch 10.0.0–10.2.2 | [GHSA-7r86-cg39-jmmj](https://github.com/advisories/GHSA-7r86-cg39-jmmj) | High | Override `>=10.2.4` |
| minimatch 10.0.0–10.2.2 | [GHSA-23c5-xmqv-rm74](https://github.com/advisories/GHSA-23c5-xmqv-rm74) | High | Override `>=10.2.4` |
| serialize-javascript ≤7.0.2 | [GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq) | High (RCE) | Override `>=7.0.3` |

The serialize-javascript vulnerability was transitive via `@sentry/nextjs` → `@sentry/webpack-plugin` → `webpack` → `terser-webpack-plugin` → `serialize-javascript`.

## Changes

- **`frontend/package.json`**: Updated `minimatch` override from `>=10.0.1` to `>=10.2.4`, added `serialize-javascript` override `>=7.0.3`
- **`frontend/package-lock.json`**: Regenerated lockfile

## Before / After

```
# Before
npm audit --omit=dev --audit-level=high
6 high severity vulnerabilities

# After
npm audit --omit=dev --audit-level=high
found 0 vulnerabilities
```

## Verification

- [x] `npm audit --omit=dev --audit-level=high` → 0 vulnerabilities
- [x] `npx tsc --noEmit` → clean
- [x] `npx vitest run` → 259 files, 4420 tests passed
- [x] No production dependency changes (overrides only affect transitive resolution)

## Notes

- Supersedes #483 (minimatch-only bump via Dependabot). This PR additionally fixes the serialize-javascript RCE vulnerability.
- The `dependency-audit.yml` CI workflow (`npm Audit` check) has been **failing on main** due to these exact vulnerabilities. This PR will fix it.