### PR TITLE
chore(config): disable isort, add Tailwind config path, update CURRENT_STATE

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -427,8 +427,13 @@
     "typescript": "javascript",
     "typescriptreact": "javascript"
   },
+  "tailwindCSS.configPath": "frontend/tailwind.config.ts",
   "css.customData": [],
   "scss.validate": false,
+  // ═══════════════════════════════════════════════════════════════════════
+  // isort — DISABLED (Ruff handles import sorting via ruff.organizeImports)
+  // ═══════════════════════════════════════════════════════════════════════
+  "isort.check": false,
   // ═══════════════════════════════════════════════════════════════════════
   // Ruff (Python linter / formatter)
   // ═══════════════════════════════════════════════════════════════════════

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -1,63 +1,75 @@
 # CURRENT_STATE.md
 
-> **Last updated:** 2026-03-04 by GitHub Copilot (session 10)
+> **Last updated:** 2026-03-02 by GitHub Copilot (session 11)
 > **Purpose:** Volatile project status for AI agent context recovery. Read this FIRST at session start.
 
 ---
 
 ## Active Branch & PR
 
-- **Branch:** `fix/qa-fixture-data` (implementing #553)
-- **Latest SHA:** `97c9959` (chore(state): update CURRENT_STATE.md after PR #546 merge (#557))
-- **Open PRs:** 4 dependabot PRs (#547, #549, #551, #552) — major version bumps needing review
+- **Branch:** `main` (clean)
+- **Latest SHA:** `2e31184` (deps(actions): bump github-official actions group (#556))
+- **Open PRs:** 0
 
 ## Recently Shipped (This Session)
 
-| SHA       | Summary                                                                                   |
-| --------- | ----------------------------------------------------------------------------------------- |
-| `f3b1746` | chore: rename poland-food-db → TryVit + full audit cleanup (#546) — squash-merged to main |
+| SHA       | Summary                                                                      |
+| --------- | ---------------------------------------------------------------------------- |
+| `2e31184` | deps(actions): bump github-official actions group — upload-artifact v7 (#556) |
 
 ## Recently Shipped (Last 7 Days)
 
 | Date       | PR   | Summary                                                                                  |
 | ---------- | ---- | ---------------------------------------------------------------------------------------- |
+| 2026-03-02 | #556 | **MERGED** — GitHub Actions bumps (upload-artifact v7, download-artifact, codeql-action) |
+| 2026-03-04 | #558 | **MERGED** — QA fixture seeding for quality gate + nightly CI (closes #553)              |
 | 2026-03-04 | #546 | **MERGED** — rename poland-food-db → TryVit + 59 ruff fixes + ESLint cleanup + doc fixes |
 | 2026-03-01 | #540 | fix(deps): resolve 6 high-severity npm audit vulnerabilities                             |
 
+## Closed PRs (This Session)
+
+| PR   | Action    | Reason                                                                |
+| ---- | --------- | --------------------------------------------------------------------- |
+| #556 | Merged    | GitHub Actions bumps — clean CI, squash-merged                        |
+| #547 | Closed    | Next.js 15→16 — major migration, 8 CI failures, needs dedicated work |
+| #551 | Closed    | Tailwind CSS 3→4 — complete rewrite needed                            |
+| #552 | Closed    | sonner 1→2, tesseract.js 5→7, @types/node 22→25 — multiple breaking  |
+
 ## Known Issues & Broken Items
 
-- [ ] **#553** (P1): Quality Gate workflow fails — CI lacks fixture data for product detail page tests
+- [x] **#553** (P1): ~~Quality Gate workflow fails~~ — CLOSED, fixed in PR #558
 - [ ] **#554** (P2): Nightly data integrity audit exits with critical findings
 - [ ] **#555** (P3): 11 ESLint non-null assertion warnings across 8 frontend files
-- [ ] 4 dependabot PRs with **major version bumps** need review: #547, #549, #551, #552
+- [ ] Quality Gate dashboard test still fails — staging DB missing API functions (schema sync needed)
 
 ## CI Gate Status (main branch)
 
-| Gate         | Status | Notes                                                          |
-| ------------ | ------ | -------------------------------------------------------------- |
-| pr-gate      | ✅      | Typecheck, lint, unit tests, build, Playwright smoke           |
-| main-gate    | ✅      | Last runs all success                                          |
-| qa.yml       | ✅      | 733/733 checks passing                                         |
-| dep-audit    | ✅      | 0 high/critical vulnerabilities                                |
-| python-lint  | ✅      | 0 ruff errors (59 fixed in #546)                               |
-| quality-gate | ⚠️      | 7 failures — CI env data gaps (issue #553)                     |
-| nightly      | ⚠️      | Intermittent timeout + data audit failures (issues #553, #554) |
+| Gate         | Status | Notes                                                              |
+| ------------ | ------ | ------------------------------------------------------------------ |
+| pr-gate      | ✅      | Typecheck, lint, unit tests, build, Playwright smoke               |
+| main-gate    | ✅      | Last runs all success                                              |
+| qa.yml       | ✅      | 733/733 checks passing                                             |
+| dep-audit    | ✅      | 0 high/critical vulnerabilities                                    |
+| python-lint  | ✅      | 0 ruff errors (59 fixed in #546)                                   |
+| quality-gate | ⚠️      | 18/20 pass; dashboard 400s from staging DB schema gap              |
+| nightly      | ⚠️      | Fixture seeding fixed; dashboard + data audit still pending (#554) |
 
-## Open Issues (4 total)
+## Open Issues (3 total)
 
 | Issue | Priority | Effort | Summary                                                         |
 | ----- | -------- | ------ | --------------------------------------------------------------- |
-| #553  | P1       | M      | fix(ci): provision QA fixture data for quality gate and nightly |
 | #554  | P2       | S      | fix(ci): resolve nightly data integrity audit critical findings |
 | #555  | P3       | S      | fix(frontend): resolve 11 ESLint non-null assertion warnings    |
 | #212  | Deferred | —      | Infrastructure Cost Attribution Framework                       |
 
 ## Next Planned Work
 
-- [x] Implement #553 — QA fixture data for CI (P1, in PR)
+- [x] Implement #553 — QA fixture data for CI (P1, merged in #558)
+- [x] Clean up open PRs — merged #556, closed #547/#551/#552
+- [x] Profile README rebrand — Poland Food DB → TryVit
+- [x] Fix VS Code extension errors — isort disabled, Tailwind path, reopened correct folder
 - [ ] Implement #554 — nightly data audit findings (P2)
 - [ ] Implement #555 — ESLint non-null assertions (P3)
-- [ ] Review 4 dependabot major-bump PRs (#547, #549, #551, #552)
 
 ## Key Metrics Snapshot
 
@@ -65,11 +77,11 @@
 - **QA checks:** 733/733 passing
 - **EAN coverage:** 1,277/1,279 with EAN (99.8%)
 - **Frontend test coverage:** ~88% lines (SonarCloud Quality Gate passing)
-- **Open issues:** 4 | **Open PRs:** 4 (dependabot)
+- **Open issues:** 3 | **Open PRs:** 0
 - **Vitest:** 4,420 tests passing (29 skipped), 259 test files
 - **DB migrations:** 184 append-only
 - **Ruff lint:** 0 errors
-- **Local branches:** 1 (main only — all stale branches cleaned)
+- **Local branches:** 1 (main only)
 
 ---
 


### PR DESCRIPTION
## Summary

Session 11 housekeeping — fixes VS Code extension errors and updates volatile state.

### Changes

**`.vscode/settings.json`:**
- Added `isort.check: false` — disables isort extension (redundant; Ruff handles import sorting via `ruff.organizeImports`)
- Added `tailwindCSS.configPath: "frontend/tailwind.config.ts"` — explicit path so Tailwind IntelliSense finds the config regardless of workspace root

**`CURRENT_STATE.md`:**
- Updated to session 11 state: merged PR #556, closed #547/#551/#552, 0 open PRs
- Added profile README rebrand and VS Code fix to completed work
- Corrected metrics (3 open issues, 0 open PRs)

### Context

The root cause of isort/Ruff/Tailwind extension crashes was VS Code referencing the old `poland-food-db` folder path after the rename to `tryvit`. Reopening from the correct path + these config changes resolve all three errors.