### PR TITLE
docs(scoring): overhaul scoring docs for TryVit Score (#591)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- Overhaul scoring docs for TryVit Score consumer display layer: add §2.8
+  Consumer Display Layer (TryVit Score = 100 − unhealthiness, band table with
+  consumer labels Excellent/Good/Moderate/Poor/Bad, rationale for higher=healthier
+  inversion) and §2.9 Category Percentile to SCORING_METHODOLOGY.md; add
+  consumer-facing columns to §2.6 band table; add §10.1 TryVit Score and
+  regression anchor notes to SCORING_ENGINE.md; update copilot-instructions §14
+  with consumer display note and dual-column band table (#591)
+
 ### Fixed
 
 - Remove 11 ESLint `@typescript-eslint/no-non-null-assertion` warnings across 8

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1109,13 +1109,15 @@ unhealthiness_score (1-100) =
 
 **Ceilings** (per 100g): sat fat 10g, sugars 27g, salt 3g, trans fat 2g, calories 600 kcal, additives 10, ingredient concern 100.
 
-| Band     | Score  | Meaning        |
-| -------- | ------ | -------------- |
-| Green    | 1–20   | Low risk       |
-| Yellow   | 21–40  | Moderate risk  |
-| Orange   | 41–60  | Elevated risk  |
-| Red      | 61–80  | High risk      |
-| Dark red | 81–100 | Very high risk |
+**Consumer display (TryVit Score):** `TryVit Score = 100 − unhealthiness_score` (higher = healthier). This is a presentation-layer inversion only — the database, formula, and regression anchors (§8.19) all use unhealthiness values.
+
+| Band     | Unhealthiness | TryVit Score | Consumer Label | Meaning        |
+| -------- | ------------- | ------------ | -------------- | -------------- |
+| Green    | 1–20          | 80–100       | Excellent      | Low risk       |
+| Yellow   | 21–40         | 60–79        | Good           | Moderate risk  |
+| Orange   | 41–60         | 40–59        | Moderate       | Elevated risk  |
+| Red      | 61–80         | 20–39        | Poor           | High risk      |
+| Dark red | 81–100        | 1–19         | Bad            | Very high risk |
 
 Full documentation: `docs/SCORING_METHODOLOGY.md`
 

--- a/docs/SCORING_ENGINE.md
+++ b/docs/SCORING_ENGINE.md
@@ -2,7 +2,7 @@
 
 > **Issue:** #189 — Canonical Scoring Engine  
 > **Status:** Active  
-> **Last updated:** 2026-02-25
+> **Last updated:** 2026-03-15
 
 ---
 
@@ -234,6 +234,20 @@ The score explanation API (`api_score_explanation`) now includes:
 
 The `ScoreBreakdownPanel` displays a model version badge and freshness timestamp when available.
 
+### 10.1 TryVit Score (Consumer Display Layer)
+
+The frontend presents the **TryVit Score** — an inverted view of the internal unhealthiness score:
+
+```
+TryVit Score = 100 − unhealthiness_score
+```
+
+This is a **display-only transformation**. The scoring engine, database columns, audit trail, drift detection, and all regression anchors continue to operate on the unhealthiness scale (1–100, lower = better). The TryVit Score (1–100, higher = healthier) is computed at render time by `toTryVitScore()` in the frontend.
+
+**Key invariant:** A scoring engine change (new weights, new factor, new version) affects `unhealthiness_score` directly. The TryVit Score changes are an automatic consequence of the inversion — no separate calibration or version tracking is needed for the display layer.
+
+See `SCORING_METHODOLOGY.md` §2.8 for the full consumer band table and scientific rationale.
+
 ---
 
 ## 11. Performance
@@ -279,6 +293,12 @@ The v3.2 fast path ensures zero performance regression for pipeline scoring.
 | T15 | `detect_score_drift` is callable |
 | T16 | Audit trigger is installed |
 | T17 | Grants are correct |
+
+### Regression Anchors
+
+All regression anchor products in `copilot-instructions.md` §8.19 use **unhealthiness scores** (1–100, lower = better). These anchors validate the scoring formula and must remain stable (±2 tolerance) across scoring engine changes.
+
+Consumer display tests (TryVit Score bands, percentile badges) are **separate** from formula regression tests. Frontend tests in `frontend/src/lib/score-utils.test.ts` validate the band mapping and inversion logic independently.
 
 ---
 

--- a/docs/SCORING_METHODOLOGY.md
+++ b/docs/SCORING_METHODOLOGY.md
@@ -1,7 +1,7 @@
 # Scoring Methodology
 
 > **Version:** 3.2
-> **Last updated:** 2026-02-10
+> **Last updated:** 2026-03-15
 > **Scope:** TryVit
 
 ---
@@ -169,17 +169,59 @@ The `score_category()` procedure handles: ingredient concern defaults,
 
 ### 2.6 Score Bands
 
-| Range  | Interpretation                              | Typical products                   |
-| ------ | ------------------------------------------- | ---------------------------------- |
-| 1–20   | Low concern                                 | Plain oats, raw vegetables         |
-| 21–40  | Moderate — acceptable for regular use       | Whole-grain bread, basic yogurt    |
-| 41–60  | Elevated — occasional consumption advised   | Baked chips, sweetened cereal      |
-| 61–80  | High — frequent use is a health risk        | Fried chips, sugary drinks         |
-| 81–100 | Very high — minimal consumption recommended | Deep-fried + high-salt + additives |
+| Unhealthiness | Interpretation                              | TryVit Score | Consumer Band | Typical products                   |
+| ------------- | ------------------------------------------- | ------------ | ------------- | ---------------------------------- |
+| 1–20          | Low concern                                 | 80–100       | Excellent     | Plain oats, raw vegetables         |
+| 21–40         | Moderate — acceptable for regular use       | 60–79        | Good          | Whole-grain bread, basic yogurt    |
+| 41–60         | Elevated — occasional consumption advised   | 40–59        | Moderate      | Baked chips, sweetened cereal      |
+| 61–80         | High — frequent use is a health risk        | 20–39        | Poor          | Fried chips, sugary drinks         |
+| 81–100        | Very high — minimal consumption recommended | 1–19         | Bad           | Deep-fried + high-salt + additives |
 
 ### ~~2.7 Scoring Version~~ (removed — column dropped in migration 20260211000500)
 
 > The `scoring_version` column was dropped because all rows were `'v3.2'`. The version is now tracked only in `score_breakdown->>'version'` (JSONB). When methodology changes, update the function and this document.
+
+### 2.8 Consumer Display Layer (TryVit Score)
+
+The user-facing app presents health scores as the **TryVit Score** — a simple inversion of the internal unhealthiness score so that **higher values mean healthier products**.
+
+```
+TryVit Score = 100 − unhealthiness_score
+```
+
+Clamped to `[0, 100]`. A product with `unhealthiness_score = 25` displays as **TryVit Score 75**.
+
+**Rationale:** Consumer research consistently shows that "higher = better" scales are easier to understand and act on. The internal unhealthiness scale (lower = better) is retained in the database and scoring formula because it directly models harm accumulation — "how much risk does this product carry?" The display inversion is a **presentation-layer transformation only**; no formula, weight, or ceiling values change.
+
+**Important:** The underlying `compute_unhealthiness_v32()` function, all database columns (`unhealthiness_score`), and all regression anchors (§8.19 in `copilot-instructions.md`) continue to use the unhealthiness scale. The TryVit Score is computed at display time in the frontend.
+
+#### Consumer Band Table
+
+| TryVit Score | Consumer Label | Color   | Internal Unhealthiness | Internal Band |
+| ------------ | -------------- | ------- | ---------------------- | ------------- |
+| 80–100       | Excellent      | Green   | 1–20                   | Low concern   |
+| 60–79        | Good           | Yellow  | 21–40                  | Moderate      |
+| 40–59        | Moderate       | Orange  | 41–60                  | Elevated      |
+| 20–39        | Poor           | Red     | 61–80                  | High          |
+| 1–19         | Bad            | Darkred | 81–100                 | Very high     |
+
+#### Frontend Implementation
+
+The TryVit Score is computed by `toTryVitScore(unhealthinessScore)` in `frontend/src/lib/score-utils.ts`. Band resolution uses `getScoreBand()` which maps the **unhealthiness** value to its color/label configuration. The consumer-facing labels (Excellent, Good, Moderate, Poor, Bad) are resolved via i18n dictionary keys.
+
+### 2.9 Category Percentile
+
+Each product receives a **category percentile** indicating its relative ranking within its category. The percentile answers: *"This product is healthier than X% of products in its category."*
+
+```
+percentile = ((total_in_category − rank) / total_in_category) × 100
+```
+
+Where `rank` is the product's position when sorted by `unhealthiness_score` ascending (healthiest first). A product ranked 3rd out of 50 in its category has percentile = `((50 − 3) / 50) × 100 = 94%`.
+
+**Data source:** The `api_score_explanation()` function returns `category_rank`, `category_total`, and `category_avg_score` in its response, enabling the frontend to compute and display the percentile badge.
+
+**Display:** The frontend shows a "Top X%" badge when the product is in the top 25% of its category (percentile ≥ 75).
 
 ---
 


### PR DESCRIPTION
## Summary

Overhaul scoring documentation to document the TryVit Score consumer display layer — the `100 - unhealthiness` inversion, consumer band labels, and category percentile.

Closes #591

## Changes

### docs/SCORING_METHODOLOGY.md
- Expanded §2.6 Score Bands table with TryVit Score and Consumer Band columns
- Added §2.8 Consumer Display Layer (TryVit Score): formula, rationale, band table, frontend implementation note
- Added §2.9 Category Percentile: formula, data source, display rule
- Updated last-updated date

### docs/SCORING_ENGINE.md
- Added §10.1 TryVit Score (Consumer Display Layer) under Frontend Integration
- Added Regression Anchors subsection under §13 QA Tests
- Updated last-updated date

### copilot-instructions.md §14
- Added Consumer display (TryVit Score) note explaining the inversion
- Replaced 3-column band table with 5-column table (Band / Unhealthiness / TryVit Score / Consumer Label / Meaning)

### CHANGELOG.md
- Added documentation entry under [Unreleased]

## Verification

Docs-only change — no code, schema, or test modifications. 4 files changed, +90 / -16 lines.