### PR TITLE
security(rls): revoke v33 internal functions from anon + update QA allowlists

### DIFF
--- a/db/qa/QA__security_posture.sql
+++ b/db/qa/QA__security_posture.sql
@@ -135,7 +135,9 @@ WHERE n.nspname = 'public'
     'api_get_cross_country_links',     -- public cross-country links (#352)
     'api_get_recipes',                 -- public recipe browsing (#364)
     'api_get_recipe_detail',           -- public recipe detail (#364)
-    'api_get_recipe_nutrition'         -- public recipe nutrition (#364)
+    'api_get_recipe_nutrition',        -- public recipe nutrition (#364)
+    'api_better_alternatives_v2',      -- public alternatives v2 (#356)
+    'api_get_recipe_score'             -- public recipe score (#364)
   );
 
 -- 10. anon cannot EXECUTE internal computation functions
@@ -145,9 +147,12 @@ FROM pg_proc p
 JOIN pg_namespace n ON p.pronamespace = n.oid
 WHERE n.nspname = 'public'
   AND p.proname IN (
-    'compute_unhealthiness_v32',
-    'explain_score_v32','compute_data_confidence','compute_data_completeness',
-    'assign_confidence','find_similar_products','find_better_alternatives',
+    'compute_unhealthiness_v32','compute_unhealthiness_v33',
+    'explain_score_v32','explain_score_v33',
+    'compute_data_confidence','compute_data_completeness',
+    'assign_confidence','find_similar_products',
+    'find_better_alternatives','find_better_alternatives_v2',
+    'category_affinity',
     'refresh_all_materialized_views','mv_staleness_check',
     'check_product_preferences','resolve_effective_country',
     'compute_health_warnings',

--- a/supabase/migrations/20260316000200_revoke_v33_internal_from_anon.sql
+++ b/supabase/migrations/20260316000200_revoke_v33_internal_from_anon.sql
@@ -1,0 +1,20 @@
+-- Migration: Revoke anon access to internal v33 scoring functions + v2 helper functions
+-- These were accidentally granted to anon in their originating migrations.
+-- Internal scoring/helper functions should only be callable by authenticated + service_role.
+-- Rollback: GRANT EXECUTE ON FUNCTION <name> TO anon; (for each function)
+
+-- ── v3.3 scoring internals (granted in 20260315001910) ──────────────────────
+REVOKE EXECUTE ON FUNCTION public.compute_unhealthiness_v33(
+    numeric, numeric, numeric, numeric, numeric, numeric, text, text, numeric, numeric, numeric
+) FROM PUBLIC, anon;
+
+REVOKE EXECUTE ON FUNCTION public.explain_score_v33(
+    numeric, numeric, numeric, numeric, numeric, numeric, text, text, numeric, numeric, numeric
+) FROM PUBLIC, anon;
+
+-- ── v2 alternative-finding internals (granted in 20260315001800) ─────────────
+REVOKE EXECUTE ON FUNCTION public.find_better_alternatives_v2(
+    bigint, boolean, integer, text, text[], boolean, boolean, boolean, boolean, uuid, boolean, integer
+) FROM PUBLIC, anon;
+
+REVOKE EXECUTE ON FUNCTION public.category_affinity(text, text) FROM PUBLIC, anon;


### PR DESCRIPTION
## Problem

Pre-existing QA Suite 16 (Security Posture) had 2 failing checks:
- **Check 9:** \pi_better_alternatives_v2\ and \pi_get_recipe_score\ were granted to anon but missing from the public function allowlist
- **Check 10:** v33 scoring internals (\compute_unhealthiness_v33\, \xplain_score_v33\) and v2 helper functions (\ind_better_alternatives_v2\, \category_affinity\) were granted to anon in their origin migrations but never revoked — a genuine security gap

## Fix

### 1. New migration: \20260316000200_revoke_v33_internal_from_anon.sql\
Revokes EXECUTE from PUBLIC and anon on 4 internal functions:
- \compute_unhealthiness_v33()\ — internal scoring engine
- \xplain_score_v33()\ — internal score breakdown
- \ind_better_alternatives_v2()\ — internal helper (wrapped by \pi_better_alternatives_v2\)
- \category_affinity()\ — internal category similarity helper

### 2. QA check 9 allowlist update
Added 2 legitimately public functions:
- \pi_better_alternatives_v2\ — public alternatives endpoint (v1 was already in allowlist)
- \pi_get_recipe_score\ — public recipe score endpoint (other recipe functions already in allowlist)

### 3. QA check 10 blocklist update
Added 5 internal functions that should never be anon-accessible:
- \compute_unhealthiness_v33\, \xplain_score_v33\ (alongside existing v32 entries)
- \ind_better_alternatives_v2\ (alongside existing v1 entry)
- \category_affinity\ (new internal helper)

## Verification

- Migration is idempotent (REVOKE is always safe to re-run)
- QA check counts unchanged (41 checks) — existing checks now pass
- No API contract changes — public \pi_*\ functions unaffected