### PR TITLE
fix(pipeline): add defensive WHERE guard for orphan sub-ingredients

### DIFF
--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -1,15 +1,15 @@
 # CURRENT_STATE.md
 
-> **Last updated:** 2026-03-07 by GitHub Copilot (session 30)
+> **Last updated:** 2026-03-07 by GitHub Copilot (session 31)
 > **Purpose:** Volatile project status for AI agent context recovery. Read this FIRST at session start.
 
 ---
 
 ## Active Branch & PR
 
-- **Branch:** `fix/portable-enrichment-sql` (from main at `5a49d40`)
-- **Latest SHA (main):** `5a49d40` (includes merged PR #674)
-- **Open PRs:** PR for portable enrichment fix (pending creation)
+- **Branch:** `main` at `41d2929` (PR #675 squash merge)
+- **Latest SHA (main):** `41d2929`
+- **Open PRs:** None
 
 ## Production Deployment (2026-03-06)
 
@@ -19,39 +19,41 @@
 - #614 — Deploy v3.3 scoring ✅ CLOSED
 
 **Production stats:**
-- 73/73 migrations applied (4 enrichment migrations skipped — hardcoded IDs)
+- 73/73 migrations applied + 1 enrichment migration (portable name-based JOINs)
 - 236/236 pipelines executed successfully
 - Pre-deploy backup: `backups/cloud_backup_20260306_172023.dump`
 
 ## Recently Shipped (This Session)
 
-| SHA       | Summary                                                                                |
-| --------- | -------------------------------------------------------------------------------------- |
-| 5a49d40   | fix(pipeline): collision on oils-vinegars + spreads-dips categories (#674)              |
+| SHA     | Summary                                                                           |
+| ------- | --------------------------------------------------------------------------------- |
+| 41d2929 | fix(pipeline): portable enrichment SQL + check_enrichment_identity fix (#675)     |
+| 5a49d40 | fix(pipeline): collision on oils-vinegars + spreads-dips categories (#674)        |
+| —       | data(production): enrichment migration — 1,836 products enriched (90.5% coverage) |
 
 ## Recently Shipped (Last 7 Days)
 
-| Date       | PR/SHA    | Summary                                                                           |
-| ---------- | --------- | --------------------------------------------------------------------------------- |
-| 2026-03-06 | Deploy    | **PRODUCTION DEPLOY** — 73 migrations + 236 pipelines → 2,434 active products |
-| 2026-03-06 | #672      | test(coverage): dashboard + WatchButton component tests — 55 tests |
-| 2026-03-06 | #670      | test(coverage): flags evaluator, PWA install prompt, score history — 78 tests |
-| 2026-03-06 | #668      | test(coverage): hook unit tests for alternatives-v2 + cross-country-links (7 tests) |
-| 2026-03-06 | #666      | test(coverage): product layout 0→covered (14 tests), export functions +5 tests |
-| 2026-03-06 | #664      | test(coverage): api.ts 70→99%, flags/server.ts 0→covered, service.ts 0→covered, fix flaky E2E |
-| 2026-03-06 | #662      | security(rls): revoke v33 internal functions from anon + QA allowlists             |
-| 2026-03-06 | #661      | fix(ci): rename colliding migration timestamps for repo_verify                     |
-| 2026-03-06 | #660      | chore(state): update CURRENT_STATE.md after PR merges                              |
-| 2026-03-06 | #657      | test(e2e): comprehensive Playwright E2E for M18-M22 features (#622)               |
-| 2026-03-06 | #658      | feat(pipeline): Oils & Vinegars + Spreads & Dips for PL (~150 products) (#594)    |
-| 2026-03-06 | #659      | fix(schema): api_get_score_history CASE fix + pgTAP tests (#620)                  |
-| 2026-03-05 | #655      | test(qa): DE validation suite — anchors, multi-country fixes (#602)               |
-| 2026-03-05 | #654      | data(ingredients): enrich DE products (#603)                                      |
-| 2026-03-05 | #652      | test(qa): PL validation gate (#595)                                               |
-| 2026-03-05 | #651      | data(ingredients): enrich PL products — 14,392 product_ingredients, 2,872 allergens/traces |
-| 2026-03-05 | #650      | fix(frontend): a11y contrast ratio on scoring learn page (#589)                   |
-| 2026-03-04 | #649      | chore(docs): copilot-instructions §8, §13 — merge marathon lessons learned       |
-| 2026-03-03 | #583      | **MERGED** — Milestone #17: 17 UX issues, 134 files, 4,504 tests                 |
+| Date       | PR/SHA | Summary                                                                                       |
+| ---------- | ------ | --------------------------------------------------------------------------------------------- |
+| 2026-03-06 | Deploy | **PRODUCTION DEPLOY** — 73 migrations + 236 pipelines → 2,434 active products                 |
+| 2026-03-06 | #672   | test(coverage): dashboard + WatchButton component tests — 55 tests                            |
+| 2026-03-06 | #670   | test(coverage): flags evaluator, PWA install prompt, score history — 78 tests                 |
+| 2026-03-06 | #668   | test(coverage): hook unit tests for alternatives-v2 + cross-country-links (7 tests)           |
+| 2026-03-06 | #666   | test(coverage): product layout 0→covered (14 tests), export functions +5 tests                |
+| 2026-03-06 | #664   | test(coverage): api.ts 70→99%, flags/server.ts 0→covered, service.ts 0→covered, fix flaky E2E |
+| 2026-03-06 | #662   | security(rls): revoke v33 internal functions from anon + QA allowlists                        |
+| 2026-03-06 | #661   | fix(ci): rename colliding migration timestamps for repo_verify                                |
+| 2026-03-06 | #660   | chore(state): update CURRENT_STATE.md after PR merges                                         |
+| 2026-03-06 | #657   | test(e2e): comprehensive Playwright E2E for M18-M22 features (#622)                           |
+| 2026-03-06 | #658   | feat(pipeline): Oils & Vinegars + Spreads & Dips for PL (~150 products) (#594)                |
+| 2026-03-06 | #659   | fix(schema): api_get_score_history CASE fix + pgTAP tests (#620)                              |
+| 2026-03-05 | #655   | test(qa): DE validation suite — anchors, multi-country fixes (#602)                           |
+| 2026-03-05 | #654   | data(ingredients): enrich DE products (#603)                                                  |
+| 2026-03-05 | #652   | test(qa): PL validation gate (#595)                                                           |
+| 2026-03-05 | #651   | data(ingredients): enrich PL products — 14,392 product_ingredients, 2,872 allergens/traces    |
+| 2026-03-05 | #650   | fix(frontend): a11y contrast ratio on scoring learn page (#589)                               |
+| 2026-03-04 | #649   | chore(docs): copilot-instructions §8, §13 — merge marathon lessons learned                    |
+| 2026-03-03 | #583   | **MERGED** — Milestone #17: 17 UX issues, 134 files, 4,504 tests                              |
 
 ## Known Issues & Broken Items
 
@@ -61,7 +63,6 @@
 - [x] QA Suite 16 (Security): 2 anon-accessible non-public api_* functions — **FIXED in #662**
 - [ ] QA Suite 35 (StoreArch): 48 orphan junction rows + 2 backfill coverage gaps
 - [ ] QA Suite 41 (IdxVerify): 1 FK column missing supporting index
-- [ ] Production enrichment gap: 784/2,434 products have ingredient data (4 enrichment migrations skipped — hardcoded IDs from local dev DB)
 
 ## CI Gate Status (main branch)
 
@@ -77,10 +78,10 @@
 
 ## Open Issues (2 total — all deferred)
 
-| Issue | Priority | Effort | Summary                                                          |
-| ----- | -------- | ------ | ---------------------------------------------------------------- |
-| #563  | Deferred | S      | Sync staging DB schema for quality-gate                          |
-| #212  | Deferred | —      | Infrastructure Cost Attribution Framework                        |
+| Issue | Priority | Effort | Summary                                   |
+| ----- | -------- | ------ | ----------------------------------------- |
+| #563  | Deferred | S      | Sync staging DB schema for quality-gate   |
+| #212  | Deferred | —      | Infrastructure Cost Attribution Framework |
 
 ## Milestones Completed
 
@@ -88,22 +89,23 @@
 
 ## Next Planned Work
 
-- [x] Fix enrichment SQL generator portability (hardcoded ingredient_id → name-based JOINs) — PR pending
-- [ ] Re-run ingredient enrichment against production DB with fixed generator (resolve 1,650/2,434 coverage gap)
+- [x] Fix enrichment SQL generator portability (hardcoded ingredient_id → name-based JOINs) — **MERGED in #675**
+- [x] Re-run ingredient enrichment against production DB — **DONE** (2,206/2,438 = 90.5% coverage)
 - [ ] Sync staging DB schema for quality-gate (#563)
 
 ## Key Metrics Snapshot
 
-- **Products (production):** 2,434 active (1,332 PL + 1,102 DE across 22 PL + 19 DE categories)
+- **Products (production):** 2,438 active (1,332 PL + 1,102 DE across 22 PL + 19 DE categories)
 - **Deprecated products:** 286 (229 PL + 57 DE)
 - **QA checks:** 743/743 passing (48 suites) — local DB
 - **Negative tests:** 23/23 caught
 - **EAN coverage:** 2,261/2,264 with EAN (99.9%) — local DB
-- **Ingredient refs:** 2,673 (production) / 2,898 (local)
-- **Product-ingredient links:** 12,580 (production) / 14,392 (local)
-- **Allergen declarations:** 2,330 (production) / 2,872 (local)
-- **Production ingredient coverage:** 784/2,434 products (32%) — enrichment gap
-- **Nutrition coverage (production):** 2,434/2,434 (100%)
+- **Ingredient refs:** 5,761 (production) / 2,898 (local)
+- **Product-ingredient links:** 30,789 (production) / 14,392 (local)
+- **Allergen declarations:** 5,787 (production) / 2,872 (local)
+- **Production ingredient coverage:** 2,206/2,438 products (90.5%) — enrichment complete
+- **Production allergen coverage:** 1,652/2,438 products (67.8%)
+- **Nutrition coverage (production):** 2,438/2,438 (100%)
 - **Frontend test coverage:** ~88% lines (SonarCloud Quality Gate passing)
 - **ESLint warnings:** 0
 - **Open issues:** 2 (both deferred) | **Open PRs:** 0
@@ -119,41 +121,41 @@
 
 ### Validation Results
 
-| Check                      | Result                    | Status |
-| -------------------------- | ------------------------- | ------ |
-| QA suites (48)             | 43 pass / 5 known issues  | ✅      |
-| Negative tests             | 23/23 caught              | ✅      |
-| EAN checksums              | 2,261/2,261 valid (100%)  | ✅      |
-| Pipeline structure         | 39 categories verified    | ✅      |
-| Enrichment identity        | PASSED                    | ✅      |
-| Scoring anchor regression  | 9/9 verified within ±2    | ✅      |
-| Data completeness avg (PL) | 97.5%                     | ✅      |
-| Min completeness (PL)      | 73% (Instant & Frozen)    | ✅      |
+| Check                      | Result                   | Status |
+| -------------------------- | ------------------------ | ------ |
+| QA suites (48)             | 43 pass / 5 known issues | ✅      |
+| Negative tests             | 23/23 caught             | ✅      |
+| EAN checksums              | 2,261/2,261 valid (100%) | ✅      |
+| Pipeline structure         | 39 categories verified   | ✅      |
+| Enrichment identity        | PASSED                   | ✅      |
+| Scoring anchor regression  | 9/9 verified within ±2   | ✅      |
+| Data completeness avg (PL) | 97.5%                    | ✅      |
+| Min completeness (PL)      | 73% (Instant & Frozen)   | ✅      |
 
 ### Scoring Anchor Verification
 
-| Product                      | Expected | Actual | Delta | Status |
-| ---------------------------- | -------- | ------ | ----- | ------ |
-| Piątnica Skyr Naturalny      | ≈5       | 5      | 0     | ✅      |
-| Melvit Płatki owsiane        | ≈7       | 7      | 0     | ✅      |
-| Tarczyński Kabanosy           | ≈27      | 27     | 0     | ✅      |
-| Auchan Tortilla               | ≈29      | 29     | 0     | ✅      |
-| Dr. Oetker Pizza 4 sery       | ≈30      | 30     | 0     | ✅      |
-| Pudliszki Ketchup łagodny    | ≈18      | 33     | +15   | ⚠️ *   |
-| Doritos Sweet Chili           | ≈41      | 41     | 0     | ✅      |
-| Indomie Noodles Chicken       | ≈43      | 43     | 0     | ✅      |
-| E. Wedel Czekolada Tiramisu   | ≈52      | 52     | 0     | ✅      |
+| Product                     | Expected | Actual | Delta | Status |
+| --------------------------- | -------- | ------ | ----- | ------ |
+| Piątnica Skyr Naturalny     | ≈5       | 5      | 0     | ✅      |
+| Melvit Płatki owsiane       | ≈7       | 7      | 0     | ✅      |
+| Tarczyński Kabanosy         | ≈27      | 27     | 0     | ✅      |
+| Auchan Tortilla             | ≈29      | 29     | 0     | ✅      |
+| Dr. Oetker Pizza 4 sery     | ≈30      | 30     | 0     | ✅      |
+| Pudliszki Ketchup łagodny   | ≈18      | 33     | +15   | ⚠️ *    |
+| Doritos Sweet Chili         | ≈41      | 41     | 0     | ✅      |
+| Indomie Noodles Chicken     | ≈43      | 43     | 0     | ✅      |
+| E. Wedel Czekolada Tiramisu | ≈52      | 52     | 0     | ✅      |
 
 \* Pudliszki Ketchup: score shifted from 18→33 after enrichment (new ingredients/allergens added from OFF API). Needs anchor update in copilot-instructions.md §8.19.
 
 ### Known QA Failures (Pre-existing, Non-blocking)
 
-| Suite                   | Failures | Cause                                    |
-| ----------------------- | -------- | ---------------------------------------- |
-| Suite 11 (NutriRange)   | 9        | OFF calorie back-calculation outliers    |
-| Suite 16 (Security)     | 2        | Anon-accessible non-public functions     |
-| Suite 35 (StoreArch)    | 48+2     | Orphan junction rows + backfill gaps     |
-| Suite 41 (IdxVerify)    | 1        | FK column missing index                  |
+| Suite                 | Failures | Cause                                 |
+| --------------------- | -------- | ------------------------------------- |
+| Suite 11 (NutriRange) | 9        | OFF calorie back-calculation outliers |
+| Suite 16 (Security)   | 2        | Anon-accessible non-public functions  |
+| Suite 35 (StoreArch)  | 48+2     | Orphan junction rows + backfill gaps  |
+| Suite 41 (IdxVerify)  | 1        | FK column missing index               |
 
 ---
 
@@ -174,20 +176,20 @@
 
 ### Bugs Fixed
 
-| Check                            | Bug                                                          | Fix                                                  |
-| -------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------- |
-| Multi-country check 1            | Called stale `compute_unhealthiness_v32()` with old params   | Upgraded to v33 with `_g` suffix + protein/fibre     |
-| Multi-country check 10           | Stale v32 + wrong column names + non-existent `p.additive_count` | v33 + `_g` columns + LATERAL subquery for additives |
+| Check                  | Bug                                                              | Fix                                                 |
+| ---------------------- | ---------------------------------------------------------------- | --------------------------------------------------- |
+| Multi-country check 1  | Called stale `compute_unhealthiness_v32()` with old params       | Upgraded to v33 with `_g` suffix + protein/fibre    |
+| Multi-country check 10 | Stale v32 + wrong column names + non-existent `p.additive_count` | v33 + `_g` columns + LATERAL subquery for additives |
 
 ### DE Anchor Products Added (Tests 36-40)
 
-| Product                           | Category         | Score | Range  | Status |
-| --------------------------------- | ---------------- | ----- | ------ | ------ |
-| Ritter Sport Edel-Vollmilch       | Sweets (DE)      | 48    | 46-50  | ✅      |
-| Alpro Sojadrink, Ungesüßt        | Drinks (DE)      | 8     | 6-10   | ✅      |
-| Chipsfrisch ungarisch             | Chips (DE)       | 25    | 23-27  | ✅      |
-| Wildlachsfilet / Golden Seafood  | Seafood (DE)     | 3     | 1-5    | ✅      |
-| Instant-Nudeln Beef              | Instant (DE)     | 55    | 53-57  | ✅      |
+| Product                         | Category     | Score | Range | Status |
+| ------------------------------- | ------------ | ----- | ----- | ------ |
+| Ritter Sport Edel-Vollmilch     | Sweets (DE)  | 48    | 46-50 | ✅      |
+| Alpro Sojadrink, Ungesüßt       | Drinks (DE)  | 8     | 6-10  | ✅      |
+| Chipsfrisch ungarisch           | Chips (DE)   | 25    | 23-27 | ✅      |
+| Wildlachsfilet / Golden Seafood | Seafood (DE) | 3     | 1-5   | ✅      |
+| Instant-Nudeln Beef             | Instant (DE) | 55    | 53-57 | ✅      |
 
 ---
 

--- a/enrich_ingredients.py
+++ b/enrich_ingredients.py
@@ -662,6 +662,7 @@ def _gen_ingredient_batch(batch: list[dict]) -> list[str]:
     lines.append("JOIN ingredient_ref ir ON lower(ir.name_en) = lower(v.ingredient_name)")
     lines.append("LEFT JOIN ingredient_ref ir_parent ON lower(ir_parent.name_en) = lower(v.parent_ingredient_name)")
     lines.append(SQL_WHERE_ACTIVE)
+    lines.append("  AND NOT (v.is_sub_ingredient AND ir_parent.ingredient_id IS NULL)")
     lines.append("ON CONFLICT (product_id, ingredient_id, position) DO NOTHING;")
     lines.append("")
     return lines


### PR DESCRIPTION
## Problem

During production enrichment execution, the `chk_sub_has_parent` CHECK constraint was violated when a sub-ingredient's parent name (from OFF API) didn't exist in `ingredient_ref`. The CASE WHEN guard in the generated SQL wasn't sufficient alone.

**Root cause:** Parent ingredient name `'Roggenvollkorn'` (standalone) was not in the Section 1 `ingredient_ref INSERT` — only compound variants existed. The `LEFT JOIN ingredient_ref ir_parent` correctly returned NULL, but the row still attempted to insert with `is_sub_ingredient=true`.

## Fix

Added a defensive WHERE filter to `_gen_ingredient_batch()` in `enrich_ingredients.py`:

```sql
AND NOT (v.is_sub_ingredient AND ir_parent.ingredient_id IS NULL)
```

This skips rows where `is_sub_ingredient=true` but the parent can't be resolved. Belt-and-suspenders with the existing CASE WHEN guard.

## Production Enrichment Results (Applied)

The enrichment migration was successfully applied to production after this fix:

| Metric | Before | After | Delta |
|---|---|---|---|
| `ingredient_ref` | 2,673 | 5,761 | +3,088 |
| `product_ingredient` | 12,580 | 30,789 | +18,209 |
| `product_allergen_info` | 2,330 | 5,787 | +3,457 |
| Ingredient coverage | 784 (32%) | **2,206 (90.5%)** | +1,422 products |
| Allergen coverage | 602 (24.7%) | **1,652 (67.8%)** | +1,050 products |

## Verification

- `python -c "import py_compile; py_compile.compile('enrich_ingredients.py', doraise=True)"` → OK
- Zero orphan sub-ingredients on production: `SELECT count(*) FROM product_ingredient WHERE is_sub_ingredient = true AND parent_ingredient_id IS NULL` → 0
- All materialized views refreshed successfully