### PR TITLE
fix(schema): clean orphan store rows + add parent_ingredient_id index

### DIFF
--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -1,15 +1,15 @@
 # CURRENT_STATE.md
 
-> **Last updated:** 2026-03-07 by GitHub Copilot (session 31)
+> **Last updated:** 2026-03-07 by GitHub Copilot (session 32)
 > **Purpose:** Volatile project status for AI agent context recovery. Read this FIRST at session start.
 
 ---
 
 ## Active Branch & PR
 
-- **Branch:** `main` at `41d2929` (PR #675 squash merge)
-- **Latest SHA (main):** `41d2929`
-- **Open PRs:** None
+- **Branch:** `fix/qa-orphan-rows-and-missing-index` off `main` at `084fad7`
+- **Latest SHA (main):** `084fad7` (PR #676 squash merge)
+- **Open PRs:** TBD (this branch)
 
 ## Production Deployment (2026-03-06)
 
@@ -27,9 +27,8 @@
 
 | SHA     | Summary                                                                           |
 | ------- | --------------------------------------------------------------------------------- |
-| 41d2929 | fix(pipeline): portable enrichment SQL + check_enrichment_identity fix (#675)     |
-| 5a49d40 | fix(pipeline): collision on oils-vinegars + spreads-dips categories (#674)        |
-| —       | data(production): enrichment migration — 1,836 products enriched (90.5% coverage) |
+| 084fad7 | fix(pipeline): add defensive WHERE guard for orphan sub-ingredients (#676)        |
+| —       | schema(production): fix orphan junction rows + add parent_ingredient_id index     |
 
 ## Recently Shipped (Last 7 Days)
 
@@ -61,8 +60,8 @@
 - [ ] QA Suite 2 (Scoring): Coca-Cola Zero test 12 — score 13 vs expected 2-6 (pre-existing after DE enrichment)
 - [ ] QA Suite 11 (NutriRange): 9 calorie back-calculation outliers — OFF source data quality
 - [x] QA Suite 16 (Security): 2 anon-accessible non-public api_* functions — **FIXED in #662**
-- [ ] QA Suite 35 (StoreArch): 48 orphan junction rows + 2 backfill coverage gaps
-- [ ] QA Suite 41 (IdxVerify): 1 FK column missing supporting index
+- [x] QA Suite 35 (StoreArch): 48 orphan junction rows + 2 backfill coverage gaps — **FIXED in migration 20260316000300**
+- [x] QA Suite 41 (IdxVerify): 1 FK column missing supporting index — **FIXED in migration 20260316000300**
 
 ## CI Gate Status (main branch)
 
@@ -91,6 +90,7 @@
 
 - [x] Fix enrichment SQL generator portability (hardcoded ingredient_id → name-based JOINs) — **MERGED in #675**
 - [x] Re-run ingredient enrichment against production DB — **DONE** (2,206/2,438 = 90.5% coverage)
+- [x] Fix QA Suite 35 orphan rows + Suite 41 missing FK index — **migration 20260316000300 applied to production**
 - [ ] Sync staging DB schema for quality-gate (#563)
 
 ## Key Metrics Snapshot
@@ -110,7 +110,7 @@
 - **ESLint warnings:** 0
 - **Open issues:** 2 (both deferred) | **Open PRs:** 0
 - **Vitest:** 5,117 tests passing (29 skipped)
-- **DB migrations:** 198 append-only (73 applied to production, 4 skipped)
+- **DB migrations:** 199 append-only (74 applied to production, 4 skipped)
 - **Ruff lint:** 0 errors
 
 ---

--- a/supabase/migrations/20260316000300_fix_orphan_rows_and_missing_index.sql
+++ b/supabase/migrations/20260316000300_fix_orphan_rows_and_missing_index.sql
@@ -1,0 +1,48 @@
+-- Migration: Fix QA Suite 35 orphan junction rows + Suite 41 missing FK index
+-- Rollback: DROP INDEX IF EXISTS idx_prod_ingr_parent;
+--           (orphan deletions are not reversible but are semantically correct)
+-- Idempotency: DELETE is conditional; CREATE INDEX IF NOT EXISTS
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 1. Clean up orphan product_store_availability rows for deprecated products
+--    QA Suite 35 (StoreArch) Check #5: products that are deleted or deprecated
+--    but still have junction rows in product_store_availability.
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+DELETE FROM public.product_store_availability psa
+WHERE NOT EXISTS (
+    SELECT 1 FROM public.products p
+    WHERE p.product_id = psa.product_id
+      AND p.is_deprecated IS NOT TRUE
+);
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 2. Backfill missing product_store_availability rows
+--    QA Suite 35 (StoreArch) Check #12: products with store_availability set
+--    but no matching junction row in product_store_availability.
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+INSERT INTO public.product_store_availability (product_id, store_id, source)
+SELECT p.product_id, sr.store_id, 'pipeline'
+FROM public.products p
+JOIN public.store_ref sr
+    ON sr.country = p.country
+    AND sr.store_name = p.store_availability
+WHERE p.store_availability IS NOT NULL
+  AND p.is_deprecated IS NOT TRUE
+  AND NOT EXISTS (
+      SELECT 1 FROM public.product_store_availability psa
+      WHERE psa.product_id = p.product_id
+        AND psa.store_id = sr.store_id
+  )
+ON CONFLICT (product_id, store_id) DO NOTHING;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 3. Add missing index on product_ingredient.parent_ingredient_id
+--    QA Suite 41 (IdxVerify) Check #13: FK column without supporting index.
+--    Used in sub-ingredient lookups and ON DELETE/UPDATE cascade operations.
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+CREATE INDEX IF NOT EXISTS idx_prod_ingr_parent
+    ON public.product_ingredient (parent_ingredient_id)
+    WHERE parent_ingredient_id IS NOT NULL;


### PR DESCRIPTION
## Problem

Two QA suites report violations on production:

1. **Suite 35 (StoreArch) Check #5** — 1 orphan junction row in `product_store_availability` for deprecated product `Brzoskwinie w syropie` (product_id 2352)
2. **Suite 41 (IdxVerify) Check #13** — FK column `product_ingredient.parent_ingredient_id` has no supporting index, causing sequential scans on JOIN/cascade operations

## Changes

**Migration `20260316000300_fix_orphan_rows_and_missing_index.sql`:**

1. **DELETE** orphan `product_store_availability` rows where the product is deleted or deprecated
2. **INSERT** backfill for products with `store_availability` set but no matching junction row (ON CONFLICT DO NOTHING)
3. **CREATE INDEX** `idx_prod_ingr_parent` on `product_ingredient(parent_ingredient_id)` WHERE NOT NULL — partial index for sub-ingredient FK lookups

## Production Verification

Migration already applied to production:
```
DELETE 1
INSERT 0 0
CREATE INDEX
```

Post-migration verification — all 3 checks pass:
```
Suite35-Check5: orphan junction rows  → 0 violations ✅
Suite35-Check12: backfill gaps        → 0 violations ✅
Suite41-Check13: FK without index     → 0 violations ✅
```

## Verification

```powershell
# Production DB verification (all 3 checks = 0 violations)
psql ... -c "SELECT ... FROM product_store_availability ... WHERE deprecated"  → 0 rows
psql ... -c "SELECT ... FROM pg_constraint ... EXCEPT ... pg_index"            → 0 rows
```

### Documentation Updated
- `CURRENT_STATE.md` — marked Suite 35 and Suite 41 as fixed, updated migration count (198→199, 73→74 production)