### PR TITLE
fix(ci): add workflow paths to CodeQL trigger — resolve 12 stale alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,7 @@ on:
     branches: [main]
     paths:
       - "frontend/**"
+      - ".github/workflows/**"
       - "**.js"
       - "**.ts"
       - "**.tsx"


### PR DESCRIPTION
## Problem

12 CodeQL medium alerts ("Workflow does not contain permissions") are **stale**:

| Alert # | File | Line | Created |
|---------|------|------|---------|
| #1, #4, #6, #16 | `pr-gate.yml` | 35, 88, 138, 199 | 2026-02-22/23 |
| #14 | `main-gate.yml` | 27 | 2026-02-23 |
| #3, #15 | `nightly.yml` | 31, 127 | 2026-02-22/23 |
| #12 | `qa.yml` | 46 | 2026-02-22 |
| #5, #9 | `deploy.yml` | 44, 104 | 2026-02-22 |
| #10, #11 | `sync-cloud-db.yml` | 15, 39 | 2026-02-22 |

All 12 alerts were created on commit `48d32db` (Feb 23, 03:58). Permissions were added **9 hours later** in PR #244 (`aa17783`, Feb 23, 13:17). All 6 workflow files now have both workflow-level and job-level `permissions: contents: read` blocks.

## Root Cause

CodeQL never re-scanned the YAML files because `codeql.yml`'s push trigger `paths:` only included `frontend/**`, `**.js`, `**.ts`, `**.tsx` — not `.github/workflows/**`. So merging workflow YAML changes to main didn't trigger CodeQL re-analysis.

## Fix

Add `.github/workflows/**` to the CodeQL push trigger paths. This:

1. **Ensures future workflow YAML changes trigger CodeQL re-analysis** — proper security coverage
2. **This PR's CodeQL run** (PR trigger has no paths filter) will re-scan the current YAML files and auto-close the 12 stale alerts

## Change

```diff
  push:
    branches: [main]
    paths:
      - "frontend/**"
+     - ".github/workflows/**"
      - "**.js"
      - "**.ts"
      - "**.tsx"
```

**1 file changed, 1 insertion.**

## Verification

- All 6 workflow files already have `permissions:` blocks (confirmed via grep)
- No functional change to any workflow behavior
- CodeQL will re-scan on this PR and should auto-close all 12 alerts