### PR TITLE
data(pipeline): add DE Oils & Vinegars + Spreads & Dips pipelines

### DIFF
--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -112,7 +112,7 @@ All 26 open PRs merged into main in a single session:
 
 ## Key Metrics Snapshot
 
-- **Products (production):** 2,438 active (1,332 PL + 1,102 DE across 22 PL + 19 DE categories)
+- **Products (production):** 2,438 active (1,332 PL + 1,102 DE across 22 PL + 21 DE categories)
 - **Deprecated products:** 286 (229 PL + 57 DE)
 - **QA checks:** 743/743 passing (48 suites) — local DB
 - **Negative tests:** 23/23 caught
@@ -144,7 +144,7 @@ All 26 open PRs merged into main in a single session:
 | QA suites (48)             | 43 pass / 5 known issues | ✅      |
 | Negative tests             | 23/23 caught             | ✅      |
 | EAN checksums              | 2,261/2,261 valid (100%) | ✅      |
-| Pipeline structure         | 39 categories verified   | ✅      |
+| Pipeline structure         | 43 categories verified   | ✅      |
 | Enrichment identity        | PASSED                   | ✅      |
 | Scoring anchor regression  | 9/9 verified within ±2   | ✅      |
 | Data completeness avg (PL) | 97.5%                    | ✅      |

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,8 +1,8 @@
 # Copilot Instructions — TryVit
 
 > **Last updated:** 2026-03-05
-> **Scope:** Poland (`PL`) primary + Germany (`DE`) full parity (1,066 products across 19 categories)
-> **Products:** ~2,264 active (20 PL categories + 19 DE categories), 273 deprecated
+> **Scope:** Poland (`PL`) primary + Germany (`DE`) full parity (1,168 products across 21 categories)
+> **Products:** ~2,366 active (22 PL categories + 21 DE categories), 273 deprecated
 > **EAN coverage:** 2,261/2,264 (99.9%)
 > **Scoring:** v3.3 — 9-factor weighted penalty + nutrient density bonus via `compute_unhealthiness_v33()` (protein & fibre credit)
 > **Servings:** removed as separate table — all nutrition data is per-100g on nutrition_facts
@@ -78,7 +78,7 @@ tryvit/
 │   ├── image_importer.py            # Product image import utility
 │   └── categories.py               # 20 category definitions + OFF tag mappings
 ├── db/
-│   ├── pipelines/                   # 39 category folders (20 PL + 19 DE), 4-5 SQL files each
+│   ├── pipelines/                   # 43 category folders (22 PL + 21 DE), 4-5 SQL files each
 │   │   ├── chips-pl/                # Reference PL implementation (copy for new categories)
 │   │   ├── chips-de/                # DE Chips (~56 products)
 │   │   ├── bread-de/                # DE Bread (51 products)
@@ -505,11 +505,11 @@ tryvit/
 
 ---
 
-## 5. Categories (20 PL + 19 DE)
+## 5. Categories (22 PL + 21 DE)
 
-All categories have **variable product counts** (28–95 active products). Categories are expanded by running the pipeline with `--max-products N`. DE categories target ~51 products each. All 19 PL categories (except Żabka) have a DE counterpart.
+All categories have **variable product counts** (28–95 active products). Categories are expanded by running the pipeline with `--max-products N`. DE categories target ~51 products each. All 21 PL categories (except Żabka) have a DE counterpart.
 
-### PL Categories (20)
+### PL Categories (22)
 
 | Category                   | Folder slug                 |
 | -------------------------- | --------------------------- |
@@ -527,14 +527,16 @@ All categories have **variable product counts** (28–95 active products). Categ
 | Instant & Frozen           | `instant-frozen/`           |
 | Meat                       | `meat/`                     |
 | Nuts, Seeds & Legumes      | `nuts-seeds-legumes/`       |
+| Oils & Vinegars            | `oils-vinegars/`            |
 | Plant-Based & Alternatives | `plant-based-alternatives/` |
 | Sauces                     | `sauces/`                   |
 | Seafood & Fish             | `seafood-fish/`             |
 | Snacks                     | `snacks/`                   |
+| Spreads & Dips             | `spreads-dips/`             |
 | Sweets                     | `sweets/`                   |
 | Żabka                      | `zabka/`                    |
 
-### DE Categories (19)
+### DE Categories (21)
 
 | Category                   | Folder slug                       |
 | -------------------------- | --------------------------------- |
@@ -552,13 +554,15 @@ All categories have **variable product counts** (28–95 active products). Categ
 | Instant & Frozen (DE)      | `instant-frozen-de/`              |
 | Meat (DE)                  | `meat-de/`                        |
 | Nuts, Seeds & Legumes (DE) | `nuts-seeds-legumes-de/`          |
+| Oils & Vinegars (DE)       | `oils-vinegars-de/`               |
 | Plant-Based & Alternatives (DE) | `plant-based-alternatives-de/` |
 | Sauces (DE)                | `sauces-de/`                      |
 | Seafood & Fish (DE)        | `seafood-fish-de/`                |
 | Snacks (DE)                | `snacks-de/`                      |
+| Spreads & Dips (DE)        | `spreads-dips-de/`                |
 | Sweets (DE)                | `sweets-de/`                      |
 
-**39 pipeline folders** (20 PL + 19 DE). Category-to-OFF tag mappings live in `pipeline/categories.py`. Each category has multiple OFF tags and search terms for comprehensive coverage.
+**43 pipeline folders** (22 PL + 21 DE). Category-to-OFF tag mappings live in `pipeline/categories.py`. Each category has multiple OFF tags and search terms for comprehensive coverage.
 
 ---
 
@@ -2163,7 +2167,7 @@ Then execute §19 (Canonical Execution Discipline Protocol v2) in full.
 | Document                          | Purpose                                                                   | Load When                        |
 | --------------------------------- | ------------------------------------------------------------------------- | -------------------------------- |
 | `docs/COUNTRY_EXPANSION_GUIDE.md` | Multi-country protocol — adding countries, activating DE, language matrix | Country/language expansion       |
-| `copilot-instructions.md §5`      | Active categories — 20 PL + 19 DE, pipeline folder mappings               | Category additions, DE expansion |
+| `copilot-instructions.md §5`      | Active categories — 22 PL + 21 DE, pipeline folder mappings               | Category additions, DE expansion |
 | `copilot-instructions.md §15.15`  | i18n impact checklist — dictionary keys, translations, search synonyms    | Any translated string change     |
 
 ### 18.9 Architecture Decision Records

--- a/db/pipelines/oils-vinegars-de/PIPELINE__oils-vinegars-de__01_insert_products.sql
+++ b/db/pipelines/oils-vinegars-de/PIPELINE__oils-vinegars-de__01_insert_products.sql
@@ -1,0 +1,95 @@
+-- PIPELINE (Oils & Vinegars): insert products
+-- Source: Open Food Facts API (automated pipeline)
+-- Generated: 2026-03-08
+
+-- 0a. DEPRECATE old products in this category & release their EANs
+update products
+set is_deprecated = true, deprecated_reason = 'Replaced by pipeline refresh', ean = null
+where country = 'DE'
+  and category = 'Oils & Vinegars'
+  and is_deprecated is not true;
+
+-- 0b. Release EANs across ALL categories to prevent unique constraint conflicts
+update products set ean = null
+where ean in ('4061462150685', '4056489017479', '4067796070255', '4061462626883', '4066447258936', '4028856014978', '4061458029650', '4069365106273', '4056489017493', '4056489957652', '4061458063074', '4047247949293', '4028856015272', '4056489412472', '4058172777400', '4061458063470', '4047247949286', '4099200023526', '4061459138856', '4056489166856', '4006040002062', '4068134060273', '4056489798552', '4063367000614', '4006040196518', '4006040205548', '4006040112327', '4005009103048', '4056489639817', '4021851585139', '4006040205111', '8002470031944', '4337256414371', '4311501635773', '4104420248823', '4311596421626', '4337256021654', '8002470031937', '4316268576161', '4311501311943', '4337256079792', '4337256625784', '8410660101153', '4316268510738', '21596278', '8002802103288', '4335619110694', '4316268393478', '8008460004332', '4337256876872', '4311501490884')
+  and ean is not null;
+
+-- 0c. Deprecate cross-category products whose identity_key collides with this batch
+update products
+set is_deprecated = true,
+    deprecated_reason = 'Reassigned to Oils & Vinegars by pipeline',
+    ean = null
+where country = 'DE'
+  and category != 'Oils & Vinegars'
+  and identity_key in ('02db529a31a8588afcd0f39af2d07773', '02ecc09af0ddf85bc9f35967fa86adc7', '07706810b3f31245ccb711e816ff7fe1', '0a17e63aaaa56c1b160b89261c9857db', '0edf681169e3f57c90d6cf5e09e9a4f3', '11b5f7dddedb89ccc52ac4d0e63a8548', '15db5343ed005f4645cdca82396be692', '18ac0321bc4cb47212f6e565ece90286', '23698db11dd155ccb7df6882c9d1b764', '257511595cfe00a7d5f48373d633f532', '2a1960bcd003f48a1055b05e5a27f8e8', '2c97126dcb3fab479dd3fd1fbcbdfac6', '343e06d9e33d1a4fc40ff296b400e714', '36a4ffb00c48c72e14176b4a9842cf03', '3ebb2ef7b53ab4111f96ab51f293af21', '43eeb59aa1999a00e66b2c89cdff4ce6', '44022517b8bcc2e28679e7dbf7c981b4', '443507371e1e518e148fa657fddd51f4', '4621eb4a7da5851492c903e86d97c192', '4d7548eee762d998322eefaa3ddf0762', '569a6a49995eb6e5a8e94c322ccd96be', '5a0b466b4c7681c8d1fdf50909f671ac', '5d00394b2e1ea8d10774ed74b48aca84', '606786b716d3ef3c025fd70ad93596aa', '7c501ab1d647be07ffd51ec4c76da979', '82d188285e1c8ea424a9efc21330f28a', '90d7f8a81b870f4421eefd9b5dcd41b4', '9d412218a7c2f407f4b4dae2ad419a00', '9d9d30435c3b91777ffe31742b0dedc4', 'a5cf5b5cb5297d640bfda2e66f8bae20', 'a8756d1050d13f3f2280738065e2021f', 'aee180c959e9253d262c751661e62821', 'b0d2546f897b38a453dbe5d0a69a85af', 'b41131193bc78b047111464e58d04964', 'b4790bcebed8e415674cbcdd71effe41', 'b68ff8ae43a93f133f8287ff77053d00', 'bc6b4b6e2c32d81a03e95d5aa3710bb6', 'c32e8bc018709006a47e95204c310181', 'c479a62b43a6b3256ad141cf150fe8a2', 'c75447452484a74e896d4889e84de853', 'c7e1a8f517719b4aebc5103e0236dc18', 'de58419f08cea91d0be350a5e05f3fa3', 'e0918890b45840008c8a4502606f47d8', 'e37ff6a099e021ea86641d019637d1e3', 'e557cfe94186f4bb78db416437ea8b7b', 'e7c31ff80ff62c5c1f1dc03b4d9ee273', 'e9d3daf22a974eab9e2adb65f895b59b', 'f572ac7a9db435e009c833b644baf290', 'f7ede849cde51bf20af8044032b89540', 'fdd0f876c6443700cd8fa81b49059df9', 'ff15a80bfe2ee5498168a04efddb708c')
+  and is_deprecated is not true;
+
+-- 1. INSERT products
+insert into products (country, brand, product_type, category, product_name, prep_method, store_availability, controversies, ean)
+values
+  ('DE', 'Bellasan', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl Extra', 'not-applicable', 'Aldi', 'none', '4061462150685'),
+  ('DE', 'Primadonna', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl Extra', 'not-applicable', 'Lidl', 'none', '4056489017479'),
+  ('DE', 'DmBio', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl extra', 'not-applicable', null, 'none', '4067796070255'),
+  ('DE', 'Lyttos', 'Grocery', 'Oils & Vinegars', 'Olivenöl', 'not-applicable', 'Aldi', 'none', '4061462626883'),
+  ('DE', 'DmBio', 'Grocery', 'Oils & Vinegars', 'Bratolivenöl', 'not-applicable', null, 'none', '4066447258936'),
+  ('DE', 'Camaletti', 'Grocery', 'Oils & Vinegars', 'Camaletti Olivenöl', 'not-applicable', 'Penny', 'none', '4028856014978'),
+  ('DE', 'Gut Bio', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl Extra', 'not-applicable', 'Aldi', 'none', '4061458029650'),
+  ('DE', 'Lyttos', 'Grocery', 'Oils & Vinegars', 'Griechisches natives Olivenöl extra', 'not-applicable', 'Aldi', 'none', '4069365106273'),
+  ('DE', 'Primadonna', 'Grocery', 'Oils & Vinegars', 'Brat Olivenöl', 'not-applicable', 'Lidl', 'none', '4056489017493'),
+  ('DE', 'Primadonna', 'Grocery', 'Oils & Vinegars', 'Olivenöl (nativ, extra)', 'not-applicable', 'Lidl', 'none', '4056489957652'),
+  ('DE', 'Aldi', 'Grocery', 'Oils & Vinegars', 'Griechisches natives Olivenöl Extra', 'not-applicable', 'Aldi', 'none', '4061458063074'),
+  ('DE', 'Bellasan', 'Grocery', 'Oils & Vinegars', 'Oliven Öl', 'not-applicable', 'Aldi', 'none', '4047247949293'),
+  ('DE', 'K-Classic', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl extra', 'not-applicable', 'Kaufland', 'none', '4028856015272'),
+  ('DE', 'Lidl', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl extra aus Griechenland', 'not-applicable', 'Lidl', 'none', '4056489412472'),
+  ('DE', 'DmBio', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl extra naturtrüb', 'not-applicable', null, 'none', '4058172777400'),
+  ('DE', 'Cucina Nobile', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl', 'not-applicable', 'Aldi', 'none', '4061458063470'),
+  ('DE', 'Aldi Bellasan', 'Grocery', 'Oils & Vinegars', 'ALDI BELLASAN Natives Olivenöl extra für kalte Zubereitungen wie Salate und Vinaigretten geeignet, in PET-Flasche 1l 8.99€', 'not-applicable', 'Aldi', 'none', '4047247949286'),
+  ('DE', 'Bellasan', 'Grocery', 'Oils & Vinegars', 'Olivenöl', 'not-applicable', 'Aldi', 'none', '4099200023526'),
+  ('DE', 'Aldi', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl Extra', 'not-applicable', 'Aldi', 'none', '4061459138856'),
+  ('DE', 'Primadonna', 'Grocery', 'Oils & Vinegars', 'Olivenöl', 'not-applicable', null, 'none', '4056489166856'),
+  ('DE', 'Rapunzel', 'Grocery', 'Oils & Vinegars', 'Ö-Kreta Olivenöl nativ extra-10,48€/29.6.22', 'not-applicable', null, 'none', '4006040002062'),
+  ('DE', 'Ener Bio', 'Grocery', 'Oils & Vinegars', 'Griechisches natives Olivenöl e', 'not-applicable', null, 'none', '4068134060273'),
+  ('DE', 'Deluxe', 'Grocery', 'Oils & Vinegars', 'Olivenöl', 'not-applicable', null, 'none', '4056489798552'),
+  ('DE', 'K Favorites', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl Extra', 'not-applicable', null, 'none', '4063367000614'),
+  ('DE', 'Rapunzel', 'Grocery', 'Oils & Vinegars', 'Olivenöl fruchtig', 'not-applicable', null, 'none', '4006040196518'),
+  ('DE', 'Rapunzel', 'Grocery', 'Oils & Vinegars', 'Olivenöl nativ extra mild', 'not-applicable', null, 'none', '4006040205548'),
+  ('DE', 'Rapunzel', 'Grocery', 'Oils & Vinegars', 'Ölivenöl Finca la Torre', 'not-applicable', null, 'none', '4006040112327'),
+  ('DE', 'Biozentrsle', 'Grocery', 'Oils & Vinegars', 'Olivenöl', 'not-applicable', null, 'none', '4005009103048'),
+  ('DE', 'Deluxe', 'Grocery', 'Oils & Vinegars', 'Öl - Olivenöl Extra G.G.A. Chania Kritis', 'not-applicable', null, 'none', '4056489639817'),
+  ('DE', 'Dennree', 'Grocery', 'Oils & Vinegars', 'Olivenöl nativ extra', 'not-applicable', null, 'none', '4021851585139'),
+  ('DE', 'Rapunzel', 'Grocery', 'Oils & Vinegars', 'Rapunzel Olivenöl Fruchtig, Nativ Extra, 0,5 LTR Flasche', 'not-applicable', null, 'none', '4006040205111'),
+  ('DE', 'Bertolli', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl Originale', 'not-applicable', null, 'none', '8002470031944'),
+  ('DE', 'Rewe', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl Extra', 'not-applicable', null, 'none', '4337256414371'),
+  ('DE', 'Edeka Bio', 'Grocery', 'Oils & Vinegars', 'EDEKA Bio Natives Olivenöl extra 750ml 6.65€ 1l 9.27€', 'not-applicable', null, 'none', '4311501635773'),
+  ('DE', 'Alnatura', 'Grocery', 'Oils & Vinegars', 'Olivenöl', 'not-applicable', null, 'none', '4104420248823'),
+  ('DE', 'Gut & Günstig', 'Grocery', 'Oils & Vinegars', 'Olivenöl Extra Natives', 'not-applicable', null, 'none', '4311596421626'),
+  ('DE', 'D.O.P. Terra Di Bari Castel Del Monte', 'Grocery', 'Oils & Vinegars', 'Italienisches natives Olivenöl extra', 'not-applicable', null, 'none', '4337256021654'),
+  ('DE', 'Bertolli', 'Grocery', 'Oils & Vinegars', 'Olivenöl Natives Extra Gentile SANFT', 'not-applicable', null, 'none', '8002470031937'),
+  ('DE', 'BioBio', 'Grocery', 'Oils & Vinegars', 'Natives Bio-Olivenöl Extra', 'not-applicable', 'Netto', 'none', '4316268576161'),
+  ('DE', 'EDEKA Bio', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl extra', 'not-applicable', null, 'none', '4311501311943'),
+  ('DE', 'Rewe beste Wahl', 'Grocery', 'Oils & Vinegars', 'Olivenöl ideal für warme Speisen', 'not-applicable', null, 'none', '4337256079792'),
+  ('DE', 'Ja!', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl Extra', 'not-applicable', null, 'none', '4337256625784'),
+  ('DE', 'La Espaniola', 'Grocery', 'Oils & Vinegars', 'Natives Ölivenöl extra', 'not-applicable', 'Kaufland', 'none', '8410660101153'),
+  ('DE', 'Las Cuarenta', 'Grocery', 'Oils & Vinegars', 'Spanisches Natives Olivenöl extra', 'not-applicable', 'Netto', 'none', '4316268510738'),
+  ('DE', 'Natur Gut', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl Extra', 'not-applicable', 'Penny', 'none', '21596278'),
+  ('DE', 'Bio', 'Grocery', 'Oils & Vinegars', 'Bio natives Olivenöl', 'not-applicable', 'Kaufland', 'none', '8002802103288'),
+  ('DE', 'Primadonna', 'Grocery', 'Oils & Vinegars', 'Bio natives Olivenöl extra', 'not-applicable', 'Lidl', 'none', '4335619110694'),
+  ('DE', 'Vegola', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl extra', 'not-applicable', 'Netto', 'none', '4316268393478'),
+  ('DE', 'Fiore', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl Extra', 'not-applicable', null, 'none', '8008460004332'),
+  ('DE', 'REWE Feine Welt', 'Grocery', 'Oils & Vinegars', 'Natives Olivenöl Extra Lesvos g.g.A.', 'not-applicable', null, 'none', '4337256876872'),
+  ('DE', 'Edeka', 'Grocery', 'Oils & Vinegars', 'Griechisches Natives Olivenöl Extra', 'not-applicable', null, 'none', '4311501490884')
+on conflict (country, brand, product_name) do update set
+  category = excluded.category,
+  ean = excluded.ean,
+  product_type = excluded.product_type,
+  store_availability = excluded.store_availability,
+  controversies = excluded.controversies,
+  prep_method = excluded.prep_method,
+  is_deprecated = false;
+
+-- 2. DEPRECATE removed products
+update products
+set is_deprecated = true, deprecated_reason = 'Removed from pipeline batch'
+where country = 'DE' and category = 'Oils & Vinegars'
+  and is_deprecated is not true
+  and product_name not in ('Natives Olivenöl Extra', 'Natives Olivenöl Extra', 'Natives Olivenöl extra', 'Olivenöl', 'Bratolivenöl', 'Camaletti Olivenöl', 'Natives Olivenöl Extra', 'Griechisches natives Olivenöl extra', 'Brat Olivenöl', 'Olivenöl (nativ, extra)', 'Griechisches natives Olivenöl Extra', 'Oliven Öl', 'Natives Olivenöl extra', 'Natives Olivenöl extra aus Griechenland', 'Natives Olivenöl extra naturtrüb', 'Natives Olivenöl', 'ALDI BELLASAN Natives Olivenöl extra für kalte Zubereitungen wie Salate und Vinaigretten geeignet, in PET-Flasche 1l 8.99€', 'Olivenöl', 'Natives Olivenöl Extra', 'Olivenöl', 'Ö-Kreta Olivenöl nativ extra-10,48€/29.6.22', 'Griechisches natives Olivenöl e', 'Olivenöl', 'Natives Olivenöl Extra', 'Olivenöl fruchtig', 'Olivenöl nativ extra mild', 'Ölivenöl Finca la Torre', 'Olivenöl', 'Öl - Olivenöl Extra G.G.A. Chania Kritis', 'Olivenöl nativ extra', 'Rapunzel Olivenöl Fruchtig, Nativ Extra, 0,5 LTR Flasche', 'Natives Olivenöl Originale', 'Natives Olivenöl Extra', 'EDEKA Bio Natives Olivenöl extra 750ml 6.65€ 1l 9.27€', 'Olivenöl', 'Olivenöl Extra Natives', 'Italienisches natives Olivenöl extra', 'Olivenöl Natives Extra Gentile SANFT', 'Natives Bio-Olivenöl Extra', 'Natives Olivenöl extra', 'Olivenöl ideal für warme Speisen', 'Natives Olivenöl Extra', 'Natives Ölivenöl extra', 'Spanisches Natives Olivenöl extra', 'Natives Olivenöl Extra', 'Bio natives Olivenöl', 'Bio natives Olivenöl extra', 'Natives Olivenöl extra', 'Natives Olivenöl Extra', 'Natives Olivenöl Extra Lesvos g.g.A.', 'Griechisches Natives Olivenöl Extra');

--- a/db/pipelines/oils-vinegars-de/PIPELINE__oils-vinegars-de__03_add_nutrition.sql
+++ b/db/pipelines/oils-vinegars-de/PIPELINE__oils-vinegars-de__03_add_nutrition.sql
@@ -1,0 +1,87 @@
+-- PIPELINE (Oils & Vinegars): add nutrition facts
+-- Source: Open Food Facts verified per-100g data
+
+-- 1) Remove existing
+delete from nutrition_facts
+where product_id in (
+  select p.product_id
+  from products p
+  where p.country = 'DE' and p.category = 'Oils & Vinegars'
+    and p.is_deprecated is not true
+);
+
+-- 2) Insert
+insert into nutrition_facts
+  (product_id, calories, total_fat_g, saturated_fat_g, trans_fat_g,
+   carbs_g, sugars_g, fibre_g, protein_g, salt_g)
+select
+  p.product_id,
+  d.calories, d.total_fat_g, d.saturated_fat_g, d.trans_fat_g,
+  d.carbs_g, d.sugars_g, d.fibre_g, d.protein_g, d.salt_g
+from (
+  values
+    ('Bellasan', 'Natives Olivenöl Extra', 824.0, 91.6, 13.5, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Primadonna', 'Natives Olivenöl Extra', 824.0, 91.6, 14.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('DmBio', 'Natives Olivenöl extra', 824.0, 92.0, 16.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Lyttos', 'Olivenöl', 828.0, 92.0, 14.0, 0, 0.5, 0.5, 0, 0.5, 0.0),
+    ('DmBio', 'Bratolivenöl', 824.0, 92.0, 15.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Camaletti', 'Camaletti Olivenöl', 822.0, 91.3, 13.4, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Gut Bio', 'Natives Olivenöl Extra', 824.0, 92.0, 14.0, 0, 0.5, 0.5, 0, 0.5, 0.0),
+    ('Lyttos', 'Griechisches natives Olivenöl extra', 824.0, 91.6, 77.4, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Primadonna', 'Brat Olivenöl', 824.0, 91.6, 14.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Primadonna', 'Olivenöl (nativ, extra)', 824.0, 91.6, 14.2, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Aldi', 'Griechisches natives Olivenöl Extra', 822.0, 91.0, 12.0, 0, 0.5, 0.5, 0, 0.5, 0),
+    ('Bellasan', 'Oliven Öl', 822.0, 91.0, 14.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('K-Classic', 'Natives Olivenöl extra', 807.4, 91.0, 14.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Lidl', 'Natives Olivenöl extra aus Griechenland', 824.0, 91.6, 14.2, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('DmBio', 'Natives Olivenöl extra naturtrüb', 824.0, 92.0, 14.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Cucina Nobile', 'Natives Olivenöl', 824.0, 91.0, 12.0, 0, 0.5, 0.5, 0, 0.5, 0.0),
+    ('Aldi Bellasan', 'ALDI BELLASAN Natives Olivenöl extra für kalte Zubereitungen wie Salate und Vinaigretten geeignet, in PET-Flasche 1l 8.99€', 822.0, 91.0, 14.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Bellasan', 'Olivenöl', 824.0, 92.0, 13.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Aldi', 'Natives Olivenöl Extra', 824.0, 92.0, 13.0, 0, 0.5, 0.5, 0, 0.5, 0),
+    ('Primadonna', 'Olivenöl', 824.0, 91.6, 14.3, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Rapunzel', 'Ö-Kreta Olivenöl nativ extra-10,48€/29.6.22', 819.0, 91.0, 14.7, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Ener Bio', 'Griechisches natives Olivenöl e', 824.0, 92.0, 16.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Deluxe', 'Olivenöl', 824.0, 91.6, 14.2, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('K Favorites', 'Natives Olivenöl Extra', 824.0, 92.0, 13.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Rapunzel', 'Olivenöl fruchtig', 900.0, 100.0, 15.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Rapunzel', 'Olivenöl nativ extra mild', 900.0, 100.0, 21.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Rapunzel', 'Ölivenöl Finca la Torre', 900.0, 100.0, 14.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Biozentrsle', 'Olivenöl', 828.0, 92.0, 13.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Deluxe', 'Öl - Olivenöl Extra G.G.A. Chania Kritis', 824.0, 91.6, 14.2, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Dennree', 'Olivenöl nativ extra', 824.0, 92.0, 14.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Rapunzel', 'Rapunzel Olivenöl Fruchtig, Nativ Extra, 0,5 LTR Flasche', 900.0, 100.0, 14.1, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Bertolli', 'Natives Olivenöl Originale', 821.0, 91.0, 15.0, 0, 0.0, 0, 0, 0.0, 0.0),
+    ('Rewe', 'Natives Olivenöl Extra', 824.0, 91.6, 13.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Edeka Bio', 'EDEKA Bio Natives Olivenöl extra 750ml 6.65€ 1l 9.27€', 824.0, 91.6, 14.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Alnatura', 'Olivenöl', 828.0, 92.0, 14.0, 0, 0.5, 0.5, 0.5, 0.5, 0.0),
+    ('Gut & Günstig', 'Olivenöl Extra Natives', 822.0, 91.3, 13.3, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('D.O.P. Terra Di Bari Castel Del Monte', 'Italienisches natives Olivenöl extra', 822.0, 91.0, 13.0, 0, 0.0, 0, 0, 0.0, 0),
+    ('Bertolli', 'Olivenöl Natives Extra Gentile SANFT', 821.0, 91.0, 15.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('BioBio', 'Natives Bio-Olivenöl Extra', 822.0, 91.3, 13.4, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('EDEKA Bio', 'Natives Olivenöl extra', 824.0, 91.6, 14.2, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Rewe beste Wahl', 'Olivenöl ideal für warme Speisen', 822.0, 91.3, 14.1, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Ja!', 'Natives Olivenöl Extra', 824.0, 92.0, 15.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('La Espaniola', 'Natives Ölivenöl extra', 822.0, 92.0, 12.8, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Las Cuarenta', 'Spanisches Natives Olivenöl extra', 823.0, 91.4, 12.8, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Natur Gut', 'Natives Olivenöl Extra', 824.0, 91.6, 13.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Bio', 'Bio natives Olivenöl', 824.0, 92.0, 16.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Primadonna', 'Bio natives Olivenöl extra', 824.0, 91.6, 13.2, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Vegola', 'Natives Olivenöl extra', 822.0, 91.3, 13.0, 0, 0.0, 0.0, 0, 0.0, 0.0),
+    ('Fiore', 'Natives Olivenöl Extra', 822.0, 91.3, 13.7, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('REWE Feine Welt', 'Natives Olivenöl Extra Lesvos g.g.A.', 824.0, 92.0, 13.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0),
+    ('Edeka', 'Griechisches Natives Olivenöl Extra', 824.0, 91.6, 14.2, 0, 0.0, 0.0, 0.0, 0.0, 0.0)
+) as d(brand, product_name, calories, total_fat_g, saturated_fat_g, trans_fat_g,
+       carbs_g, sugars_g, fibre_g, protein_g, salt_g)
+join products p on p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name
+  and p.category = 'Oils & Vinegars' and p.is_deprecated is not true
+on conflict (product_id) do update set
+  calories = excluded.calories,
+  total_fat_g = excluded.total_fat_g,
+  saturated_fat_g = excluded.saturated_fat_g,
+  trans_fat_g = excluded.trans_fat_g,
+  carbs_g = excluded.carbs_g,
+  sugars_g = excluded.sugars_g,
+  fibre_g = excluded.fibre_g,
+  protein_g = excluded.protein_g,
+  salt_g = excluded.salt_g;

--- a/db/pipelines/oils-vinegars-de/PIPELINE__oils-vinegars-de__04_scoring.sql
+++ b/db/pipelines/oils-vinegars-de/PIPELINE__oils-vinegars-de__04_scoring.sql
@@ -1,0 +1,123 @@
+-- PIPELINE (Oils & Vinegars): scoring
+-- Generated: 2026-03-08
+
+-- 2. Nutri-Score
+update products p set
+  nutri_score_label = d.ns
+from (
+  values
+    ('Bellasan', 'Natives Olivenöl Extra', 'B'),
+    ('Primadonna', 'Natives Olivenöl Extra', 'B'),
+    ('DmBio', 'Natives Olivenöl extra', 'B'),
+    ('Lyttos', 'Olivenöl', 'B'),
+    ('DmBio', 'Bratolivenöl', 'B'),
+    ('Camaletti', 'Camaletti Olivenöl', 'B'),
+    ('Gut Bio', 'Natives Olivenöl Extra', 'B'),
+    ('Lyttos', 'Griechisches natives Olivenöl extra', 'D'),
+    ('Primadonna', 'Brat Olivenöl', 'B'),
+    ('Primadonna', 'Olivenöl (nativ, extra)', 'B'),
+    ('Aldi', 'Griechisches natives Olivenöl Extra', 'UNKNOWN'),
+    ('Bellasan', 'Oliven Öl', 'B'),
+    ('K-Classic', 'Natives Olivenöl extra', 'B'),
+    ('Lidl', 'Natives Olivenöl extra aus Griechenland', 'B'),
+    ('DmBio', 'Natives Olivenöl extra naturtrüb', 'B'),
+    ('Cucina Nobile', 'Natives Olivenöl', 'B'),
+    ('Aldi Bellasan', 'ALDI BELLASAN Natives Olivenöl extra für kalte Zubereitungen wie Salate und Vinaigretten geeignet, in PET-Flasche 1l 8.99€', 'B'),
+    ('Bellasan', 'Olivenöl', 'B'),
+    ('Aldi', 'Natives Olivenöl Extra', 'UNKNOWN'),
+    ('Primadonna', 'Olivenöl', 'B'),
+    ('Rapunzel', 'Ö-Kreta Olivenöl nativ extra-10,48€/29.6.22', 'B'),
+    ('Ener Bio', 'Griechisches natives Olivenöl e', 'B'),
+    ('Deluxe', 'Olivenöl', 'B'),
+    ('K Favorites', 'Natives Olivenöl Extra', 'B'),
+    ('Rapunzel', 'Olivenöl fruchtig', 'B'),
+    ('Rapunzel', 'Olivenöl nativ extra mild', 'C'),
+    ('Rapunzel', 'Ölivenöl Finca la Torre', 'B'),
+    ('Biozentrsle', 'Olivenöl', 'B'),
+    ('Deluxe', 'Öl - Olivenöl Extra G.G.A. Chania Kritis', 'B'),
+    ('Dennree', 'Olivenöl nativ extra', 'B'),
+    ('Rapunzel', 'Rapunzel Olivenöl Fruchtig, Nativ Extra, 0,5 LTR Flasche', 'B'),
+    ('Bertolli', 'Natives Olivenöl Originale', 'B'),
+    ('Rewe', 'Natives Olivenöl Extra', 'B'),
+    ('Edeka Bio', 'EDEKA Bio Natives Olivenöl extra 750ml 6.65€ 1l 9.27€', 'B'),
+    ('Alnatura', 'Olivenöl', 'B'),
+    ('Gut & Günstig', 'Olivenöl Extra Natives', 'B'),
+    ('D.O.P. Terra Di Bari Castel Del Monte', 'Italienisches natives Olivenöl extra', 'UNKNOWN'),
+    ('Bertolli', 'Olivenöl Natives Extra Gentile SANFT', 'B'),
+    ('BioBio', 'Natives Bio-Olivenöl Extra', 'B'),
+    ('EDEKA Bio', 'Natives Olivenöl extra', 'B'),
+    ('Rewe beste Wahl', 'Olivenöl ideal für warme Speisen', 'B'),
+    ('Ja!', 'Natives Olivenöl Extra', 'B'),
+    ('La Espaniola', 'Natives Ölivenöl extra', 'B'),
+    ('Las Cuarenta', 'Spanisches Natives Olivenöl extra', 'B'),
+    ('Natur Gut', 'Natives Olivenöl Extra', 'B'),
+    ('Bio', 'Bio natives Olivenöl', 'B'),
+    ('Primadonna', 'Bio natives Olivenöl extra', 'B'),
+    ('Vegola', 'Natives Olivenöl extra', 'B'),
+    ('Fiore', 'Natives Olivenöl Extra', 'B'),
+    ('REWE Feine Welt', 'Natives Olivenöl Extra Lesvos g.g.A.', 'B'),
+    ('Edeka', 'Griechisches Natives Olivenöl Extra', 'B')
+) as d(brand, product_name, ns)
+where p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name;
+
+-- 3. NOVA classification
+update products p set
+  nova_classification = d.nova
+from (
+  values
+    ('Bellasan', 'Natives Olivenöl Extra', '2'),
+    ('Primadonna', 'Natives Olivenöl Extra', '2'),
+    ('DmBio', 'Natives Olivenöl extra', '2'),
+    ('Lyttos', 'Olivenöl', '2'),
+    ('DmBio', 'Bratolivenöl', '2'),
+    ('Camaletti', 'Camaletti Olivenöl', '2'),
+    ('Gut Bio', 'Natives Olivenöl Extra', '2'),
+    ('Lyttos', 'Griechisches natives Olivenöl extra', '2'),
+    ('Primadonna', 'Brat Olivenöl', '2'),
+    ('Primadonna', 'Olivenöl (nativ, extra)', '2'),
+    ('Aldi', 'Griechisches natives Olivenöl Extra', '2'),
+    ('Bellasan', 'Oliven Öl', '2'),
+    ('K-Classic', 'Natives Olivenöl extra', '2'),
+    ('Lidl', 'Natives Olivenöl extra aus Griechenland', '2'),
+    ('DmBio', 'Natives Olivenöl extra naturtrüb', '2'),
+    ('Cucina Nobile', 'Natives Olivenöl', '2'),
+    ('Aldi Bellasan', 'ALDI BELLASAN Natives Olivenöl extra für kalte Zubereitungen wie Salate und Vinaigretten geeignet, in PET-Flasche 1l 8.99€', '2'),
+    ('Bellasan', 'Olivenöl', '2'),
+    ('Aldi', 'Natives Olivenöl Extra', '2'),
+    ('Primadonna', 'Olivenöl', '2'),
+    ('Rapunzel', 'Ö-Kreta Olivenöl nativ extra-10,48€/29.6.22', '2'),
+    ('Ener Bio', 'Griechisches natives Olivenöl e', '2'),
+    ('Deluxe', 'Olivenöl', '2'),
+    ('K Favorites', 'Natives Olivenöl Extra', '4'),
+    ('Rapunzel', 'Olivenöl fruchtig', '2'),
+    ('Rapunzel', 'Olivenöl nativ extra mild', '2'),
+    ('Rapunzel', 'Ölivenöl Finca la Torre', '2'),
+    ('Biozentrsle', 'Olivenöl', '2'),
+    ('Deluxe', 'Öl - Olivenöl Extra G.G.A. Chania Kritis', '2'),
+    ('Dennree', 'Olivenöl nativ extra', '2'),
+    ('Rapunzel', 'Rapunzel Olivenöl Fruchtig, Nativ Extra, 0,5 LTR Flasche', '2'),
+    ('Bertolli', 'Natives Olivenöl Originale', '4'),
+    ('Rewe', 'Natives Olivenöl Extra', '2'),
+    ('Edeka Bio', 'EDEKA Bio Natives Olivenöl extra 750ml 6.65€ 1l 9.27€', '2'),
+    ('Alnatura', 'Olivenöl', '2'),
+    ('Gut & Günstig', 'Olivenöl Extra Natives', '4'),
+    ('D.O.P. Terra Di Bari Castel Del Monte', 'Italienisches natives Olivenöl extra', '2'),
+    ('Bertolli', 'Olivenöl Natives Extra Gentile SANFT', '4'),
+    ('BioBio', 'Natives Bio-Olivenöl Extra', '2'),
+    ('EDEKA Bio', 'Natives Olivenöl extra', '2'),
+    ('Rewe beste Wahl', 'Olivenöl ideal für warme Speisen', '2'),
+    ('Ja!', 'Natives Olivenöl Extra', '2'),
+    ('La Espaniola', 'Natives Ölivenöl extra', '2'),
+    ('Las Cuarenta', 'Spanisches Natives Olivenöl extra', '4'),
+    ('Natur Gut', 'Natives Olivenöl Extra', '2'),
+    ('Bio', 'Bio natives Olivenöl', '2'),
+    ('Primadonna', 'Bio natives Olivenöl extra', '2'),
+    ('Vegola', 'Natives Olivenöl extra', '2'),
+    ('Fiore', 'Natives Olivenöl Extra', '2'),
+    ('REWE Feine Welt', 'Natives Olivenöl Extra Lesvos g.g.A.', '2'),
+    ('Edeka', 'Griechisches Natives Olivenöl Extra', '2')
+) as d(brand, product_name, nova)
+where p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name;
+
+-- 0/1/4/5. Score category (concern defaults, unhealthiness, flags, confidence)
+CALL score_category('Oils & Vinegars', 100, 'DE');

--- a/db/pipelines/oils-vinegars-de/PIPELINE__oils-vinegars-de__05_source_provenance.sql
+++ b/db/pipelines/oils-vinegars-de/PIPELINE__oils-vinegars-de__05_source_provenance.sql
@@ -1,0 +1,65 @@
+-- PIPELINE (Oils & Vinegars): source provenance
+-- Generated: 2026-03-08
+
+-- 1. Update source info on products
+UPDATE products p SET
+  source_type = 'off_api',
+  source_url = d.source_url,
+  source_ean = d.source_ean
+FROM (
+  VALUES
+    ('Bellasan', 'Natives Olivenöl Extra', 'https://world.openfoodfacts.org/product/4061462150685', '4061462150685'),
+    ('Primadonna', 'Natives Olivenöl Extra', 'https://world.openfoodfacts.org/product/4056489017479', '4056489017479'),
+    ('DmBio', 'Natives Olivenöl extra', 'https://world.openfoodfacts.org/product/4067796070255', '4067796070255'),
+    ('Lyttos', 'Olivenöl', 'https://world.openfoodfacts.org/product/4061462626883', '4061462626883'),
+    ('DmBio', 'Bratolivenöl', 'https://world.openfoodfacts.org/product/4066447258936', '4066447258936'),
+    ('Camaletti', 'Camaletti Olivenöl', 'https://world.openfoodfacts.org/product/4028856014978', '4028856014978'),
+    ('Gut Bio', 'Natives Olivenöl Extra', 'https://world.openfoodfacts.org/product/4061458029650', '4061458029650'),
+    ('Lyttos', 'Griechisches natives Olivenöl extra', 'https://world.openfoodfacts.org/product/4069365106273', '4069365106273'),
+    ('Primadonna', 'Brat Olivenöl', 'https://world.openfoodfacts.org/product/4056489017493', '4056489017493'),
+    ('Primadonna', 'Olivenöl (nativ, extra)', 'https://world.openfoodfacts.org/product/4056489957652', '4056489957652'),
+    ('Aldi', 'Griechisches natives Olivenöl Extra', 'https://world.openfoodfacts.org/product/4061458063074', '4061458063074'),
+    ('Bellasan', 'Oliven Öl', 'https://world.openfoodfacts.org/product/4047247949293', '4047247949293'),
+    ('K-Classic', 'Natives Olivenöl extra', 'https://world.openfoodfacts.org/product/4028856015272', '4028856015272'),
+    ('Lidl', 'Natives Olivenöl extra aus Griechenland', 'https://world.openfoodfacts.org/product/4056489412472', '4056489412472'),
+    ('DmBio', 'Natives Olivenöl extra naturtrüb', 'https://world.openfoodfacts.org/product/4058172777400', '4058172777400'),
+    ('Cucina Nobile', 'Natives Olivenöl', 'https://world.openfoodfacts.org/product/4061458063470', '4061458063470'),
+    ('Aldi Bellasan', 'ALDI BELLASAN Natives Olivenöl extra für kalte Zubereitungen wie Salate und Vinaigretten geeignet, in PET-Flasche 1l 8.99€', 'https://world.openfoodfacts.org/product/4047247949286', '4047247949286'),
+    ('Bellasan', 'Olivenöl', 'https://world.openfoodfacts.org/product/4099200023526', '4099200023526'),
+    ('Aldi', 'Natives Olivenöl Extra', 'https://world.openfoodfacts.org/product/4061459138856', '4061459138856'),
+    ('Primadonna', 'Olivenöl', 'https://world.openfoodfacts.org/product/4056489166856', '4056489166856'),
+    ('Rapunzel', 'Ö-Kreta Olivenöl nativ extra-10,48€/29.6.22', 'https://world.openfoodfacts.org/product/4006040002062', '4006040002062'),
+    ('Ener Bio', 'Griechisches natives Olivenöl e', 'https://world.openfoodfacts.org/product/4068134060273', '4068134060273'),
+    ('Deluxe', 'Olivenöl', 'https://world.openfoodfacts.org/product/4056489798552', '4056489798552'),
+    ('K Favorites', 'Natives Olivenöl Extra', 'https://world.openfoodfacts.org/product/4063367000614', '4063367000614'),
+    ('Rapunzel', 'Olivenöl fruchtig', 'https://world.openfoodfacts.org/product/4006040196518', '4006040196518'),
+    ('Rapunzel', 'Olivenöl nativ extra mild', 'https://world.openfoodfacts.org/product/4006040205548', '4006040205548'),
+    ('Rapunzel', 'Ölivenöl Finca la Torre', 'https://world.openfoodfacts.org/product/4006040112327', '4006040112327'),
+    ('Biozentrsle', 'Olivenöl', 'https://world.openfoodfacts.org/product/4005009103048', '4005009103048'),
+    ('Deluxe', 'Öl - Olivenöl Extra G.G.A. Chania Kritis', 'https://world.openfoodfacts.org/product/4056489639817', '4056489639817'),
+    ('Dennree', 'Olivenöl nativ extra', 'https://world.openfoodfacts.org/product/4021851585139', '4021851585139'),
+    ('Rapunzel', 'Rapunzel Olivenöl Fruchtig, Nativ Extra, 0,5 LTR Flasche', 'https://world.openfoodfacts.org/product/4006040205111', '4006040205111'),
+    ('Bertolli', 'Natives Olivenöl Originale', 'https://world.openfoodfacts.org/product/8002470031944', '8002470031944'),
+    ('Rewe', 'Natives Olivenöl Extra', 'https://world.openfoodfacts.org/product/4337256414371', '4337256414371'),
+    ('Edeka Bio', 'EDEKA Bio Natives Olivenöl extra 750ml 6.65€ 1l 9.27€', 'https://world.openfoodfacts.org/product/4311501635773', '4311501635773'),
+    ('Alnatura', 'Olivenöl', 'https://world.openfoodfacts.org/product/4104420248823', '4104420248823'),
+    ('Gut & Günstig', 'Olivenöl Extra Natives', 'https://world.openfoodfacts.org/product/4311596421626', '4311596421626'),
+    ('D.O.P. Terra Di Bari Castel Del Monte', 'Italienisches natives Olivenöl extra', 'https://world.openfoodfacts.org/product/4337256021654', '4337256021654'),
+    ('Bertolli', 'Olivenöl Natives Extra Gentile SANFT', 'https://world.openfoodfacts.org/product/8002470031937', '8002470031937'),
+    ('BioBio', 'Natives Bio-Olivenöl Extra', 'https://world.openfoodfacts.org/product/4316268576161', '4316268576161'),
+    ('EDEKA Bio', 'Natives Olivenöl extra', 'https://world.openfoodfacts.org/product/4311501311943', '4311501311943'),
+    ('Rewe beste Wahl', 'Olivenöl ideal für warme Speisen', 'https://world.openfoodfacts.org/product/4337256079792', '4337256079792'),
+    ('Ja!', 'Natives Olivenöl Extra', 'https://world.openfoodfacts.org/product/4337256625784', '4337256625784'),
+    ('La Espaniola', 'Natives Ölivenöl extra', 'https://world.openfoodfacts.org/product/8410660101153', '8410660101153'),
+    ('Las Cuarenta', 'Spanisches Natives Olivenöl extra', 'https://world.openfoodfacts.org/product/4316268510738', '4316268510738'),
+    ('Natur Gut', 'Natives Olivenöl Extra', 'https://world.openfoodfacts.org/product/21596278', '21596278'),
+    ('Bio', 'Bio natives Olivenöl', 'https://world.openfoodfacts.org/product/8002802103288', '8002802103288'),
+    ('Primadonna', 'Bio natives Olivenöl extra', 'https://world.openfoodfacts.org/product/4335619110694', '4335619110694'),
+    ('Vegola', 'Natives Olivenöl extra', 'https://world.openfoodfacts.org/product/4316268393478', '4316268393478'),
+    ('Fiore', 'Natives Olivenöl Extra', 'https://world.openfoodfacts.org/product/8008460004332', '8008460004332'),
+    ('REWE Feine Welt', 'Natives Olivenöl Extra Lesvos g.g.A.', 'https://world.openfoodfacts.org/product/4337256876872', '4337256876872'),
+    ('Edeka', 'Griechisches Natives Olivenöl Extra', 'https://world.openfoodfacts.org/product/4311501490884', '4311501490884')
+) AS d(brand, product_name, source_url, source_ean)
+WHERE p.country = 'DE' AND p.brand = d.brand
+  AND p.product_name = d.product_name
+  AND p.category = 'Oils & Vinegars' AND p.is_deprecated IS NOT TRUE;

--- a/db/pipelines/oils-vinegars-de/PIPELINE__oils-vinegars-de__06_add_images.sql
+++ b/db/pipelines/oils-vinegars-de/PIPELINE__oils-vinegars-de__06_add_images.sql
@@ -1,0 +1,79 @@
+-- PIPELINE (Oils & Vinegars): add product images
+-- Source: Open Food Facts API image URLs
+-- Generated: 2026-03-08
+
+-- 1. Remove existing OFF images for this category
+DELETE FROM product_images
+WHERE source = 'off_api'
+  AND product_id IN (
+    SELECT p.product_id FROM products p
+    WHERE p.country = 'DE' AND p.category = 'Oils & Vinegars'
+      AND p.is_deprecated IS NOT TRUE
+  );
+
+-- 2. Insert images
+INSERT INTO product_images
+  (product_id, url, source, image_type, is_primary, alt_text, off_image_id)
+SELECT
+  p.product_id, d.url, d.source, d.image_type, d.is_primary, d.alt_text, d.off_image_id
+FROM (
+  VALUES
+    ('Bellasan', 'Natives Olivenöl Extra', 'https://images.openfoodfacts.org/images/products/406/146/215/0685/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061462150685', 'front_4061462150685'),
+    ('Primadonna', 'Natives Olivenöl Extra', 'https://images.openfoodfacts.org/images/products/405/648/901/7479/front_en.64.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489017479', 'front_4056489017479'),
+    ('DmBio', 'Natives Olivenöl extra', 'https://images.openfoodfacts.org/images/products/406/779/607/0255/front_en.5.400.jpg', 'off_api', 'front', true, 'Front — EAN 4067796070255', 'front_4067796070255'),
+    ('Lyttos', 'Olivenöl', 'https://images.openfoodfacts.org/images/products/406/146/262/6883/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061462626883', 'front_4061462626883'),
+    ('DmBio', 'Bratolivenöl', 'https://images.openfoodfacts.org/images/products/406/644/725/8936/front_de.26.400.jpg', 'off_api', 'front', true, 'Front — EAN 4066447258936', 'front_4066447258936'),
+    ('Camaletti', 'Camaletti Olivenöl', 'https://images.openfoodfacts.org/images/products/402/885/601/4978/front_de.5.400.jpg', 'off_api', 'front', true, 'Front — EAN 4028856014978', 'front_4028856014978'),
+    ('Gut Bio', 'Natives Olivenöl Extra', 'https://images.openfoodfacts.org/images/products/406/145/802/9650/front_en.77.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458029650', 'front_4061458029650'),
+    ('Lyttos', 'Griechisches natives Olivenöl extra', 'https://images.openfoodfacts.org/images/products/406/936/510/6273/front_de.18.400.jpg', 'off_api', 'front', true, 'Front — EAN 4069365106273', 'front_4069365106273'),
+    ('Primadonna', 'Brat Olivenöl', 'https://images.openfoodfacts.org/images/products/405/648/901/7493/front_en.29.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489017493', 'front_4056489017493'),
+    ('Primadonna', 'Olivenöl (nativ, extra)', 'https://images.openfoodfacts.org/images/products/405/648/995/7652/front_de.4.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489957652', 'front_4056489957652'),
+    ('Aldi', 'Griechisches natives Olivenöl Extra', 'https://images.openfoodfacts.org/images/products/406/145/806/3074/front_de.21.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458063074', 'front_4061458063074'),
+    ('Bellasan', 'Oliven Öl', 'https://images.openfoodfacts.org/images/products/404/724/794/9293/front_de.27.400.jpg', 'off_api', 'front', true, 'Front — EAN 4047247949293', 'front_4047247949293'),
+    ('K-Classic', 'Natives Olivenöl extra', 'https://images.openfoodfacts.org/images/products/402/885/601/5272/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4028856015272', 'front_4028856015272'),
+    ('Lidl', 'Natives Olivenöl extra aus Griechenland', 'https://images.openfoodfacts.org/images/products/405/648/941/2472/front_de.31.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489412472', 'front_4056489412472'),
+    ('DmBio', 'Natives Olivenöl extra naturtrüb', 'https://images.openfoodfacts.org/images/products/405/817/277/7400/front_de.22.400.jpg', 'off_api', 'front', true, 'Front — EAN 4058172777400', 'front_4058172777400'),
+    ('Cucina Nobile', 'Natives Olivenöl', 'https://images.openfoodfacts.org/images/products/406/145/806/3470/front_de.19.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458063470', 'front_4061458063470'),
+    ('Aldi Bellasan', 'ALDI BELLASAN Natives Olivenöl extra für kalte Zubereitungen wie Salate und Vinaigretten geeignet, in PET-Flasche 1l 8.99€', 'https://images.openfoodfacts.org/images/products/404/724/794/9286/front_de.23.400.jpg', 'off_api', 'front', true, 'Front — EAN 4047247949286', 'front_4047247949286'),
+    ('Bellasan', 'Olivenöl', 'https://images.openfoodfacts.org/images/products/409/920/002/3526/front_de.14.400.jpg', 'off_api', 'front', true, 'Front — EAN 4099200023526', 'front_4099200023526'),
+    ('Aldi', 'Natives Olivenöl Extra', 'https://images.openfoodfacts.org/images/products/406/145/913/8856/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061459138856', 'front_4061459138856'),
+    ('Primadonna', 'Olivenöl', 'https://images.openfoodfacts.org/images/products/405/648/916/6856/front_en.31.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489166856', 'front_4056489166856'),
+    ('Rapunzel', 'Ö-Kreta Olivenöl nativ extra-10,48€/29.6.22', 'https://images.openfoodfacts.org/images/products/400/604/000/2062/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4006040002062', 'front_4006040002062'),
+    ('Ener Bio', 'Griechisches natives Olivenöl e', 'https://images.openfoodfacts.org/images/products/406/813/406/0273/front_de.5.400.jpg', 'off_api', 'front', true, 'Front — EAN 4068134060273', 'front_4068134060273'),
+    ('Deluxe', 'Olivenöl', 'https://images.openfoodfacts.org/images/products/405/648/979/8552/front_en.6.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489798552', 'front_4056489798552'),
+    ('K Favorites', 'Natives Olivenöl Extra', 'https://images.openfoodfacts.org/images/products/406/336/700/0614/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4063367000614', 'front_4063367000614'),
+    ('Rapunzel', 'Olivenöl fruchtig', 'https://images.openfoodfacts.org/images/products/400/604/019/6518/front_en.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4006040196518', 'front_4006040196518'),
+    ('Rapunzel', 'Olivenöl nativ extra mild', 'https://images.openfoodfacts.org/images/products/400/604/020/5548/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4006040205548', 'front_4006040205548'),
+    ('Rapunzel', 'Ölivenöl Finca la Torre', 'https://images.openfoodfacts.org/images/products/400/604/011/2327/front_de.10.400.jpg', 'off_api', 'front', true, 'Front — EAN 4006040112327', 'front_4006040112327'),
+    ('Biozentrsle', 'Olivenöl', 'https://images.openfoodfacts.org/images/products/400/500/910/3048/front_de.5.400.jpg', 'off_api', 'front', true, 'Front — EAN 4005009103048', 'front_4005009103048'),
+    ('Deluxe', 'Öl - Olivenöl Extra G.G.A. Chania Kritis', 'https://images.openfoodfacts.org/images/products/405/648/963/9817/front_en.7.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489639817', 'front_4056489639817'),
+    ('Dennree', 'Olivenöl nativ extra', 'https://images.openfoodfacts.org/images/products/402/185/158/5139/front_de.17.400.jpg', 'off_api', 'front', true, 'Front — EAN 4021851585139', 'front_4021851585139'),
+    ('Rapunzel', 'Rapunzel Olivenöl Fruchtig, Nativ Extra, 0,5 LTR Flasche', 'https://images.openfoodfacts.org/images/products/400/604/020/5111/front_de.4.400.jpg', 'off_api', 'front', true, 'Front — EAN 4006040205111', 'front_4006040205111'),
+    ('Bertolli', 'Natives Olivenöl Originale', 'https://images.openfoodfacts.org/images/products/800/247/003/1944/front_de.25.400.jpg', 'off_api', 'front', true, 'Front — EAN 8002470031944', 'front_8002470031944'),
+    ('Rewe', 'Natives Olivenöl Extra', 'https://images.openfoodfacts.org/images/products/433/725/641/4371/front_de.18.400.jpg', 'off_api', 'front', true, 'Front — EAN 4337256414371', 'front_4337256414371'),
+    ('Edeka Bio', 'EDEKA Bio Natives Olivenöl extra 750ml 6.65€ 1l 9.27€', 'https://images.openfoodfacts.org/images/products/431/150/163/5773/front_en.5.400.jpg', 'off_api', 'front', true, 'Front — EAN 4311501635773', 'front_4311501635773'),
+    ('Alnatura', 'Olivenöl', 'https://images.openfoodfacts.org/images/products/410/442/024/8823/front_en.21.400.jpg', 'off_api', 'front', true, 'Front — EAN 4104420248823', 'front_4104420248823'),
+    ('Gut & Günstig', 'Olivenöl Extra Natives', 'https://images.openfoodfacts.org/images/products/431/159/642/1626/front_de.87.400.jpg', 'off_api', 'front', true, 'Front — EAN 4311596421626', 'front_4311596421626'),
+    ('D.O.P. Terra Di Bari Castel Del Monte', 'Italienisches natives Olivenöl extra', 'https://images.openfoodfacts.org/images/products/433/725/602/1654/front_hr.4.400.jpg', 'off_api', 'front', true, 'Front — EAN 4337256021654', 'front_4337256021654'),
+    ('Bertolli', 'Olivenöl Natives Extra Gentile SANFT', 'https://images.openfoodfacts.org/images/products/800/247/003/1937/front_de.27.400.jpg', 'off_api', 'front', true, 'Front — EAN 8002470031937', 'front_8002470031937'),
+    ('BioBio', 'Natives Bio-Olivenöl Extra', 'https://images.openfoodfacts.org/images/products/431/626/857/6161/front_de.48.400.jpg', 'off_api', 'front', true, 'Front — EAN 4316268576161', 'front_4316268576161'),
+    ('EDEKA Bio', 'Natives Olivenöl extra', 'https://images.openfoodfacts.org/images/products/431/150/131/1943/front_de.15.400.jpg', 'off_api', 'front', true, 'Front — EAN 4311501311943', 'front_4311501311943'),
+    ('Rewe beste Wahl', 'Olivenöl ideal für warme Speisen', 'https://images.openfoodfacts.org/images/products/433/725/607/9792/front_de.4.400.jpg', 'off_api', 'front', true, 'Front — EAN 4337256079792', 'front_4337256079792'),
+    ('Ja!', 'Natives Olivenöl Extra', 'https://images.openfoodfacts.org/images/products/433/725/662/5784/front_de.23.400.jpg', 'off_api', 'front', true, 'Front — EAN 4337256625784', 'front_4337256625784'),
+    ('La Espaniola', 'Natives Ölivenöl extra', 'https://images.openfoodfacts.org/images/products/841/066/010/1153/front_de.41.400.jpg', 'off_api', 'front', true, 'Front — EAN 8410660101153', 'front_8410660101153'),
+    ('Las Cuarenta', 'Spanisches Natives Olivenöl extra', 'https://images.openfoodfacts.org/images/products/431/626/851/0738/front_de.20.400.jpg', 'off_api', 'front', true, 'Front — EAN 4316268510738', 'front_4316268510738'),
+    ('Natur Gut', 'Natives Olivenöl Extra', 'https://images.openfoodfacts.org/images/products/000/002/159/6278/front_de.4.400.jpg', 'off_api', 'front', true, 'Front — EAN 21596278', 'front_21596278'),
+    ('Bio', 'Bio natives Olivenöl', 'https://images.openfoodfacts.org/images/products/800/280/210/3288/front_de.29.400.jpg', 'off_api', 'front', true, 'Front — EAN 8002802103288', 'front_8002802103288'),
+    ('Primadonna', 'Bio natives Olivenöl extra', 'https://images.openfoodfacts.org/images/products/433/561/911/0694/front_de.5.400.jpg', 'off_api', 'front', true, 'Front — EAN 4335619110694', 'front_4335619110694'),
+    ('Vegola', 'Natives Olivenöl extra', 'https://images.openfoodfacts.org/images/products/431/626/839/3478/front_de.21.400.jpg', 'off_api', 'front', true, 'Front — EAN 4316268393478', 'front_4316268393478'),
+    ('Fiore', 'Natives Olivenöl Extra', 'https://images.openfoodfacts.org/images/products/800/846/000/4332/front_en.41.400.jpg', 'off_api', 'front', true, 'Front — EAN 8008460004332', 'front_8008460004332'),
+    ('REWE Feine Welt', 'Natives Olivenöl Extra Lesvos g.g.A.', 'https://images.openfoodfacts.org/images/products/433/725/687/6872/front_en.9.400.jpg', 'off_api', 'front', true, 'Front — EAN 4337256876872', 'front_4337256876872'),
+    ('Edeka', 'Griechisches Natives Olivenöl Extra', 'https://images.openfoodfacts.org/images/products/431/150/149/0884/front_de.40.400.jpg', 'off_api', 'front', true, 'Front — EAN 4311501490884', 'front_4311501490884')
+) AS d(brand, product_name, url, source, image_type, is_primary, alt_text, off_image_id)
+JOIN products p ON p.country = 'DE' AND p.brand = d.brand AND p.product_name = d.product_name
+  AND p.category = 'Oils & Vinegars' AND p.is_deprecated IS NOT TRUE
+ON CONFLICT (off_image_id) WHERE off_image_id IS NOT NULL DO UPDATE SET
+  url = EXCLUDED.url,
+  image_type = EXCLUDED.image_type,
+  is_primary = EXCLUDED.is_primary,
+  alt_text = EXCLUDED.alt_text;

--- a/db/pipelines/oils-vinegars-de/PIPELINE__oils-vinegars-de__07_store_availability.sql
+++ b/db/pipelines/oils-vinegars-de/PIPELINE__oils-vinegars-de__07_store_availability.sql
@@ -1,0 +1,56 @@
+-- PIPELINE (Oils & Vinegars): store availability
+-- Source: Open Food Facts API store field
+-- Generated: 2026-03-08
+
+INSERT INTO product_store_availability (product_id, store_id, verified_at, source)
+SELECT
+  p.product_id,
+  sr.store_id,
+  NOW(),
+  'pipeline'
+FROM (
+  VALUES
+    ('Bellasan', 'Natives Olivenöl Extra', 'Aldi'),
+    ('Primadonna', 'Natives Olivenöl Extra', 'Lidl'),
+    ('DmBio', 'Natives Olivenöl extra', 'dm'),
+    ('Lyttos', 'Olivenöl', 'Aldi'),
+    ('DmBio', 'Bratolivenöl', 'dm'),
+    ('Camaletti', 'Camaletti Olivenöl', 'Penny'),
+    ('Gut Bio', 'Natives Olivenöl Extra', 'Aldi'),
+    ('Lyttos', 'Griechisches natives Olivenöl extra', 'Aldi'),
+    ('Primadonna', 'Brat Olivenöl', 'Lidl'),
+    ('Primadonna', 'Olivenöl (nativ, extra)', 'Lidl'),
+    ('Aldi', 'Griechisches natives Olivenöl Extra', 'Aldi'),
+    ('Bellasan', 'Oliven Öl', 'Aldi'),
+    ('K-Classic', 'Natives Olivenöl extra', 'Kaufland'),
+    ('Lidl', 'Natives Olivenöl extra aus Griechenland', 'Lidl'),
+    ('DmBio', 'Natives Olivenöl extra naturtrüb', 'dm'),
+    ('Cucina Nobile', 'Natives Olivenöl', 'Aldi'),
+    ('Aldi Bellasan', 'ALDI BELLASAN Natives Olivenöl extra für kalte Zubereitungen wie Salate und Vinaigretten geeignet, in PET-Flasche 1l 8.99€', 'Aldi'),
+    ('Bellasan', 'Olivenöl', 'Aldi'),
+    ('Aldi', 'Natives Olivenöl Extra', 'Aldi'),
+    ('Bertolli', 'Natives Olivenöl Originale', 'Edeka'),
+    ('Bertolli', 'Natives Olivenöl Originale', 'REWE'),
+    ('Rewe', 'Natives Olivenöl Extra', 'REWE'),
+    ('Edeka Bio', 'EDEKA Bio Natives Olivenöl extra 750ml 6.65€ 1l 9.27€', 'Edeka'),
+    ('Alnatura', 'Olivenöl', 'Edeka'),
+    ('Gut & Günstig', 'Olivenöl Extra Natives', 'Edeka'),
+    ('D.O.P. Terra Di Bari Castel Del Monte', 'Italienisches natives Olivenöl extra', 'REWE'),
+    ('Bertolli', 'Olivenöl Natives Extra Gentile SANFT', 'Edeka'),
+    ('BioBio', 'Natives Bio-Olivenöl Extra', 'Netto'),
+    ('Rewe beste Wahl', 'Olivenöl ideal für warme Speisen', 'REWE'),
+    ('Ja!', 'Natives Olivenöl Extra', 'REWE'),
+    ('La Espaniola', 'Natives Ölivenöl extra', 'Kaufland'),
+    ('Las Cuarenta', 'Spanisches Natives Olivenöl extra', 'Netto'),
+    ('Natur Gut', 'Natives Olivenöl Extra', 'Penny'),
+    ('Bio', 'Bio natives Olivenöl', 'Kaufland'),
+    ('Primadonna', 'Bio natives Olivenöl extra', 'Lidl'),
+    ('Vegola', 'Natives Olivenöl extra', 'Netto'),
+    ('Fiore', 'Natives Olivenöl Extra', 'REWE'),
+    ('REWE Feine Welt', 'Natives Olivenöl Extra Lesvos g.g.A.', 'REWE'),
+    ('Edeka', 'Griechisches Natives Olivenöl Extra', 'Edeka')
+) AS d(brand, product_name, store_name)
+JOIN products p ON p.country = 'DE' AND p.brand = d.brand AND p.product_name = d.product_name
+  AND p.category = 'Oils & Vinegars' AND p.is_deprecated IS NOT TRUE
+JOIN store_ref sr ON sr.country = 'DE' AND sr.store_name = d.store_name AND sr.is_active = true
+ON CONFLICT (product_id, store_id) DO NOTHING;

--- a/db/pipelines/spreads-dips-de/PIPELINE__spreads-dips-de__01_insert_products.sql
+++ b/db/pipelines/spreads-dips-de/PIPELINE__spreads-dips-de__01_insert_products.sql
@@ -1,0 +1,95 @@
+-- PIPELINE (Spreads & Dips): insert products
+-- Source: Open Food Facts API (automated pipeline)
+-- Generated: 2026-03-08
+
+-- 0a. DEPRECATE old products in this category & release their EANs
+update products
+set is_deprecated = true, deprecated_reason = 'Replaced by pipeline refresh', ean = null
+where country = 'DE'
+  and category = 'Spreads & Dips'
+  and is_deprecated is not true;
+
+-- 0b. Release EANs across ALL categories to prevent unique constraint conflicts
+update products set ean = null
+where ean in ('4061461937348', '4058094300021', '4061459397161', '4061459397048', '4061459673012', '4061459397116', '4061458024082', '40466156', '4061462591938', '4061463929853', '4051009041989', '4061462642463', '4061458024068', '4058094300014', '4061458024037', '4063367405440', '4058094300083', '4061461937430', '4067796010831', '4056489550600', '4063367170713', '4056489459545', '4058094310105', '4061461937362', '4056489550617', '4045800719635', '4056489665588', '4061461825140', '4061461937409', '4056489963004', '4061461559175', '4061461568948', '4013182024098', '4056489242079', '4061458023238', '4061461825225', '4045800505269', '4063367146978', '4056489456544', '4051009026733', '4061461825263', '4056489459514', '4061461825249', '4006495162700', '4051009035636', '4047247622004', '4061459397062', '4056489008170', '4058094300113', '4001242108239', '4001242108222')
+  and ean is not null;
+
+-- 0c. Deprecate cross-category products whose identity_key collides with this batch
+update products
+set is_deprecated = true,
+    deprecated_reason = 'Reassigned to Spreads & Dips by pipeline',
+    ean = null
+where country = 'DE'
+  and category != 'Spreads & Dips'
+  and identity_key in ('01251f0671e0c48071fba2456559ec2b', '043bf60fbbc572b5edb4caca2ccf9fcb', '05996c149496e85c3f07a321abf02857', '062db50fdc1242c5909b0f834b99ebb7', '0a36aaecfcade06d1695adaeb4f65aa6', '0d646c9e182e7db04b9145b0a339026b', '154a9a7d93f251843eda1d311d71658e', '15ed4ddf7928224eb7f4569f1c5dc32f', '18657ec7223331382f054557ccc61244', '1969f38f91e6b5526735a5680dc7f56d', '228bb86461b16f44614be173b7b57945', '25ff210993ccbd9433328f1967a7e66f', '2987224f0671ba26dc191b296a110f98', '3185f027246e56e5555f8b941c6ca956', '408b4aad43a395cc2d0b4c1f33629085', '4b079e9adc55872d70e54c99001d9d5a', '5629d15fe758091a6be9ad58262d176c', '5af091d27f1ae17d2d90fd53bf683bf3', '5f002af01052925d9b43ac3fcd815bf3', '5f97d67d86e7a105e6d11b5821650cf4', '62788ba6f45ff562f1bd29c01e280955', '6510f491bdc592ce0118b93dfc5f7d95', '70fe1e7d6251fe21d812f7f9d0429ab7', '72e0f55edf28fdca602ee5894178fd6c', '74d0eb77fba242c3bc40767f3ae4d189', '7586c845aaadcd9da2aa14fba32e581e', '75b1d769fe5c703e64541e5620b5a9c8', '7af35fb71df22defc710427d98fd20f8', '7dba3ef0cb957b888c937b3c67c256f7', '98137e09656b3373c2a7cdd13945888f', 'ab85f582926cb062f5b018bd7cf52d22', 'ac4a17fe5c0ad618d2963a4652854b5b', 'b082e21285cf6dbac2eb3441b227debd', 'b2eaf9a19ce449edcde5808e06740b76', 'be1f6faaf58173e22c844ba2e618223f', 'bebcfad118a83cd4419fc642be98e6c7', 'bf2954620252e349fbf217b5eddfca49', 'c45df460b8425fee3d6110e0a54b74cc', 'c88efa44d437cf548153b97a123b0345', 'c9dc3dc92536e9e263f5a3aa3d2ec852', 'd0caf278b8bb1f1db807383e88872f88', 'd4ed5ce14b671ed06e984dc15a05e40a', 'd8d855bfd73a68c14f676205870da392', 'da9f64b28635fc7b43c1c56edfe3908a', 'f329823434ba86db7fa990ea18108dce', 'f4e2aa775a125fdc670c7f1f54368c13', 'f6086773fc2e80734876e2e5120a947d', 'fbb84fe79190e6a5027fd6ef6f22070e', 'fcd52273f44439b8b27d6ebeaaff95fb', 'fe065bc2fef0bd6e51638bd37d6b8c4c', 'fed8125ba1a734177461e15d97671a55')
+  and is_deprecated is not true;
+
+-- 1. INSERT products
+insert into products (country, brand, product_type, category, product_name, prep_method, store_availability, controversies, ean)
+values
+  ('DE', 'Aldi', 'Grocery', 'Spreads & Dips', 'Vegane Bio-Streichcreme - Kräuter-Tomate', 'not-applicable', 'Aldi', 'none', '4061461937348'),
+  ('DE', 'Noa', 'Grocery', 'Spreads & Dips', 'Noa Brotaufstrich Hummus Kräuter', 'not-applicable', null, 'none', '4058094300021'),
+  ('DE', 'Lyttos', 'Grocery', 'Spreads & Dips', 'Griechischer Pitabrot-Dip - Grüne Oliven, Aprikosen & Mandeln', 'not-applicable', 'Aldi', 'none', '4061459397161'),
+  ('DE', 'Lyttos', 'Grocery', 'Spreads & Dips', 'Griechischer Pitabrot-Dip - Tomaten, Walnüsse & Basilikum', 'not-applicable', 'Aldi', 'none', '4061459397048'),
+  ('DE', 'Unknown', 'Grocery', 'Spreads & Dips', 'Hummus Kürbis Kürbis Kichererbsenpüree mit Kürbis und Sesam', 'not-applicable', 'Aldi', 'none', '4061459673012'),
+  ('DE', 'Lyttos', 'Grocery', 'Spreads & Dips', 'Griechischer Pitabrot-Dip - Rote Linsen, Tomaten & Kürbis', 'not-applicable', 'Aldi', 'none', '4061459397116'),
+  ('DE', 'Menken Salades & Sauzen', 'Grocery', 'Spreads & Dips', 'Hummus - Kürbis', 'not-applicable', 'Aldi', 'none', '4061458024082'),
+  ('DE', 'Milram', 'Grocery', 'Spreads & Dips', 'Fein-würzige Sour Cream', 'not-applicable', null, 'none', '40466156'),
+  ('DE', 'BLM', 'Grocery', 'Spreads & Dips', 'Bruschetta-Creme mit Paprika und Ricottakäse', 'not-applicable', null, 'none', '4061462591938'),
+  ('DE', 'Sun Snacks', 'Grocery', 'Spreads & Dips', 'Salsa Dip Käse', 'not-applicable', null, 'none', '4061463929853'),
+  ('DE', 'Kühlmann', 'Grocery', 'Spreads & Dips', 'Kichererbsenpüree', 'not-applicable', null, 'none', '4051009041989'),
+  ('DE', 'W', 'Grocery', 'Spreads & Dips', 'Bio Hummus - Kichererbsenpüree mit Sesam und rotem Pesto', 'not-applicable', null, 'none', '4061462642463'),
+  ('DE', 'Schätze des Orients', 'Grocery', 'Spreads & Dips', 'Hummus Natur', 'not-applicable', 'Aldi', 'none', '4061458024068'),
+  ('DE', 'NOA', 'Grocery', 'Spreads & Dips', 'Hummus , Natur', 'not-applicable', 'Kaufland', 'none', '4058094300014'),
+  ('DE', 'Heinrich Kuhmann GmbH', 'Grocery', 'Spreads & Dips', 'Hummus - Pikant', 'not-applicable', 'Aldi', 'none', '4061458024037'),
+  ('DE', 'K Bio (Kaufland)', 'Grocery', 'Spreads & Dips', 'Bio Hummus Classic', 'not-applicable', 'Kaufland', 'none', '4063367405440'),
+  ('DE', 'Noa', 'Grocery', 'Spreads & Dips', 'Hummus Paprika-Chili', 'not-applicable', 'Lidl', 'none', '4058094300083'),
+  ('DE', 'My Vay', 'Grocery', 'Spreads & Dips', 'Bio Streichcreme', 'not-applicable', 'Aldi', 'none', '4061461937430'),
+  ('DE', 'DmBio', 'Grocery', 'Spreads & Dips', 'Hummus Natur', 'not-applicable', null, 'none', '4067796010831'),
+  ('DE', 'Chef Select', 'Grocery', 'Spreads & Dips', 'Bio Hummus Natur', 'not-applicable', 'Lidl', 'none', '4056489550600'),
+  ('DE', 'Kaufland', 'Grocery', 'Spreads & Dips', 'Veganer Hummus Classic', 'not-applicable', 'Kaufland', 'none', '4063367170713'),
+  ('DE', 'Deluxe', 'Grocery', 'Spreads & Dips', 'Hummus und Guacamole', 'not-applicable', 'Lidl', 'none', '4056489459545'),
+  ('DE', 'Noa', 'Grocery', 'Spreads & Dips', 'Brotaufstrich Kichererbse Tomate-Basilikum', 'not-applicable', null, 'none', '4058094310105'),
+  ('DE', 'Aldi', 'Grocery', 'Spreads & Dips', 'Vegane Bio-Streichcreme - Aubergine', 'not-applicable', 'Aldi', 'none', '4061461937362'),
+  ('DE', 'Chef select', 'Grocery', 'Spreads & Dips', 'Bio organic humus', 'not-applicable', 'Lidl', 'none', '4056489550617'),
+  ('DE', 'Feinkost Popp', 'Grocery', 'Spreads & Dips', 'Hummus Klassisch', 'not-applicable', null, 'none', '4045800719635'),
+  ('DE', 'Milbona', 'Grocery', 'Spreads & Dips', 'Zaziki', 'fermented', 'Lidl', 'none', '4056489665588'),
+  ('DE', 'Aldi', 'Grocery', 'Spreads & Dips', 'Bio-Hummus - Natur', 'not-applicable', 'Aldi', 'none', '4061461825140'),
+  ('DE', 'Aldi', 'Grocery', 'Spreads & Dips', 'Vegane Bio-Streichcreme - Rote Bete-Meerrettich', 'not-applicable', 'Aldi', 'none', '4061461937409'),
+  ('DE', 'Chef Select', 'Grocery', 'Spreads & Dips', 'Guacamole scharf', 'not-applicable', 'Lidl', 'none', '4056489963004'),
+  ('DE', 'Nur Nur Natur', 'Grocery', 'Spreads & Dips', 'Bio Humus Paprika Kurkuma Chili', 'not-applicable', 'Aldi', 'none', '4061461559175'),
+  ('DE', 'Nur Nur Natur', 'Grocery', 'Spreads & Dips', 'Bio-Hummus - Rote Bete, Meerrettich, Hibiskus', 'not-applicable', 'Aldi', 'none', '4061461568948'),
+  ('DE', 'Nabio', 'Grocery', 'Spreads & Dips', 'Gegrillte Paprika Cashew', 'not-applicable', null, 'none', '4013182024098'),
+  ('DE', 'Chef Select', 'Grocery', 'Spreads & Dips', 'Guacamole Avocado-Dip mild', 'not-applicable', 'Lidl', 'none', '4056489242079'),
+  ('DE', 'Wonnemeyer', 'Grocery', 'Spreads & Dips', 'Antipasticreme - Feta', 'not-applicable', 'Aldi', 'none', '4061458023238'),
+  ('DE', 'Nur Nur Natur', 'Grocery', 'Spreads & Dips', 'Bio-Hummus - Tomate', 'not-applicable', 'Aldi', 'none', '4061461825225'),
+  ('DE', 'Popp', 'Grocery', 'Spreads & Dips', 'Brotaufstrich Bruschetta', 'not-applicable', null, 'none', '4045800505269'),
+  ('DE', 'Kaufland', 'Grocery', 'Spreads & Dips', 'Guacamole', 'not-applicable', 'Kaufland', 'none', '4063367146978'),
+  ('DE', 'Chef select', 'Grocery', 'Spreads & Dips', 'Hummus Nature', 'not-applicable', 'Lidl', 'none', '4056489456544'),
+  ('DE', 'Kühlmann', 'Grocery', 'Spreads & Dips', 'Hummus Trio', 'not-applicable', null, 'none', '4051009026733'),
+  ('DE', 'Aldi', 'Grocery', 'Spreads & Dips', 'Bio-Hummus - Rote Beete', 'not-applicable', 'Aldi', 'none', '4061461825263'),
+  ('DE', 'Chef Select', 'Grocery', 'Spreads & Dips', 'Hummus bruschetta', 'not-applicable', 'Lidl', 'none', '4056489459514'),
+  ('DE', 'Aldi', 'Grocery', 'Spreads & Dips', 'Bio-Hummus - Paprika', 'not-applicable', 'Aldi', 'none', '4061461825249'),
+  ('DE', 'Grossmann', 'Grocery', 'Spreads & Dips', 'Knoblauch-Dip', 'not-applicable', null, 'none', '4006495162700'),
+  ('DE', 'Kaufland', 'Grocery', 'Spreads & Dips', 'Hummus mit Topping Grünes Pesto', 'not-applicable', null, 'none', '4051009035636'),
+  ('DE', 'Wonnemeyer', 'Grocery', 'Spreads & Dips', 'Antipasticreme - Dattel-Curry', 'not-applicable', 'Aldi', 'none', '4047247622004'),
+  ('DE', 'Lyttos', 'Grocery', 'Spreads & Dips', 'Griechischer Pitabrot-Dip - Paprika, Feta & Tomaten', 'not-applicable', 'Aldi', 'none', '4061459397062'),
+  ('DE', 'Chef Select', 'Grocery', 'Spreads & Dips', 'Kirschpaprika Antipasti-Creme', 'not-applicable', 'Lidl', 'none', '4056489008170'),
+  ('DE', 'Noa', 'Grocery', 'Spreads & Dips', 'Hummus Dattel Curry', 'not-applicable', null, 'none', '4058094300113'),
+  ('DE', 'Chio', 'Grocery', 'Spreads & Dips', 'Hot Cheese Dip!', 'not-applicable', null, 'none', '4001242108239'),
+  ('DE', 'Chio', 'Grocery', 'Spreads & Dips', 'Chip dip', 'not-applicable', null, 'none', '4001242108222')
+on conflict (country, brand, product_name) do update set
+  category = excluded.category,
+  ean = excluded.ean,
+  product_type = excluded.product_type,
+  store_availability = excluded.store_availability,
+  controversies = excluded.controversies,
+  prep_method = excluded.prep_method,
+  is_deprecated = false;
+
+-- 2. DEPRECATE removed products
+update products
+set is_deprecated = true, deprecated_reason = 'Removed from pipeline batch'
+where country = 'DE' and category = 'Spreads & Dips'
+  and is_deprecated is not true
+  and product_name not in ('Vegane Bio-Streichcreme - Kräuter-Tomate', 'Noa Brotaufstrich Hummus Kräuter', 'Griechischer Pitabrot-Dip - Grüne Oliven, Aprikosen & Mandeln', 'Griechischer Pitabrot-Dip - Tomaten, Walnüsse & Basilikum', 'Hummus Kürbis Kürbis Kichererbsenpüree mit Kürbis und Sesam', 'Griechischer Pitabrot-Dip - Rote Linsen, Tomaten & Kürbis', 'Hummus - Kürbis', 'Fein-würzige Sour Cream', 'Bruschetta-Creme mit Paprika und Ricottakäse', 'Salsa Dip Käse', 'Kichererbsenpüree', 'Bio Hummus - Kichererbsenpüree mit Sesam und rotem Pesto', 'Hummus Natur', 'Hummus , Natur', 'Hummus - Pikant', 'Bio Hummus Classic', 'Hummus Paprika-Chili', 'Bio Streichcreme', 'Hummus Natur', 'Bio Hummus Natur', 'Veganer Hummus Classic', 'Hummus und Guacamole', 'Brotaufstrich Kichererbse Tomate-Basilikum', 'Vegane Bio-Streichcreme - Aubergine', 'Bio organic humus', 'Hummus Klassisch', 'Zaziki', 'Bio-Hummus - Natur', 'Vegane Bio-Streichcreme - Rote Bete-Meerrettich', 'Guacamole scharf', 'Bio Humus Paprika Kurkuma Chili', 'Bio-Hummus - Rote Bete, Meerrettich, Hibiskus', 'Gegrillte Paprika Cashew', 'Guacamole Avocado-Dip mild', 'Antipasticreme - Feta', 'Bio-Hummus - Tomate', 'Brotaufstrich Bruschetta', 'Guacamole', 'Hummus Nature', 'Hummus Trio', 'Bio-Hummus - Rote Beete', 'Hummus bruschetta', 'Bio-Hummus - Paprika', 'Knoblauch-Dip', 'Hummus mit Topping Grünes Pesto', 'Antipasticreme - Dattel-Curry', 'Griechischer Pitabrot-Dip - Paprika, Feta & Tomaten', 'Kirschpaprika Antipasti-Creme', 'Hummus Dattel Curry', 'Hot Cheese Dip!', 'Chip dip');

--- a/db/pipelines/spreads-dips-de/PIPELINE__spreads-dips-de__03_add_nutrition.sql
+++ b/db/pipelines/spreads-dips-de/PIPELINE__spreads-dips-de__03_add_nutrition.sql
@@ -1,0 +1,87 @@
+-- PIPELINE (Spreads & Dips): add nutrition facts
+-- Source: Open Food Facts verified per-100g data
+
+-- 1) Remove existing
+delete from nutrition_facts
+where product_id in (
+  select p.product_id
+  from products p
+  where p.country = 'DE' and p.category = 'Spreads & Dips'
+    and p.is_deprecated is not true
+);
+
+-- 2) Insert
+insert into nutrition_facts
+  (product_id, calories, total_fat_g, saturated_fat_g, trans_fat_g,
+   carbs_g, sugars_g, fibre_g, protein_g, salt_g)
+select
+  p.product_id,
+  d.calories, d.total_fat_g, d.saturated_fat_g, d.trans_fat_g,
+  d.carbs_g, d.sugars_g, d.fibre_g, d.protein_g, d.salt_g
+from (
+  values
+    ('Aldi', 'Vegane Bio-Streichcreme - Kräuter-Tomate', 323.0, 30.0, 3.2, 0, 6.6, 5.4, 4.0, 4.7, 0.6),
+    ('Noa', 'Noa Brotaufstrich Hummus Kräuter', 230.0, 16.3, 2.4, 0, 11.2, 0.9, 0, 6.8, 1.7),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Grüne Oliven, Aprikosen & Mandeln', 214.0, 17.6, 3.0, 0, 9.0, 8.4, 4.2, 2.8, 1.2),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Tomaten, Walnüsse & Basilikum', 164.0, 11.9, 1.5, 0, 9.0, 8.4, 5.7, 2.3, 2.8),
+    ('Unknown', 'Hummus Kürbis Kürbis Kichererbsenpüree mit Kürbis und Sesam', 167.0, 9.3, 0.9, 0, 14.0, 6.3, 0, 5.0, 1.0),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Rote Linsen, Tomaten & Kürbis', 118.0, 7.2, 0.8, 0, 8.5, 4.7, 3.6, 3.1, 1.5),
+    ('Menken Salades & Sauzen', 'Hummus - Kürbis', 149.0, 9.1, 1.1, 0, 10.0, 5.4, 0, 4.0, 1.0),
+    ('Milram', 'Fein-würzige Sour Cream', 144.0, 10.3, 6.1, 0, 3.7, 3.7, 0, 8.7, 1.1),
+    ('BLM', 'Bruschetta-Creme mit Paprika und Ricottakäse', 240.0, 20.0, 5.5, 0, 8.6, 5.5, 0, 6.3, 3.5),
+    ('Sun Snacks', 'Salsa Dip Käse', 237.0, 20.0, 2.6, 0, 12.0, 1.5, 0, 2.1, 2.0),
+    ('Kühlmann', 'Kichererbsenpüree', 253.0, 15.0, 1.7, 0, 13.0, 2.7, 0, 14.0, 1.2),
+    ('W', 'Bio Hummus - Kichererbsenpüree mit Sesam und rotem Pesto', 280.0, 20.0, 2.4, 0, 15.0, 4.6, 0, 6.6, 1.1),
+    ('Schätze des Orients', 'Hummus Natur', 307.0, 22.7, 2.1, 0, 15.1, 3.4, 4.9, 8.0, 1.0),
+    ('NOA', 'Hummus , Natur', 332.0, 29.0, 2.5, 0, 9.0, 1.0, 0, 6.4, 1.5),
+    ('Heinrich Kuhmann GmbH', 'Hummus - Pikant', 159.0, 24.6, 2.3, 0, 14.8, 4.6, 4.3, 7.3, 1.4),
+    ('K Bio (Kaufland)', 'Bio Hummus Classic', 281.0, 22.0, 2.2, 0, 9.2, 1.4, 7.5, 7.7, 1.0),
+    ('Noa', 'Hummus Paprika-Chili', 279.0, 22.0, 2.1, 0, 11.5, 3.0, 0, 6.0, 1.3),
+    ('My Vay', 'Bio Streichcreme', 241.0, 20.0, 2.1, 0, 9.4, 4.5, 2.3, 4.6, 1.0),
+    ('DmBio', 'Hummus Natur', 251.0, 22.0, 2.7, 0, 7.2, 0.6, 3.8, 3.8, 1.1),
+    ('Chef Select', 'Bio Hummus Natur', 257.0, 18.5, 1.9, 0, 11.2, 2.2, 6.6, 8.2, 1.0),
+    ('Kaufland', 'Veganer Hummus Classic', 256.0, 20.0, 2.0, 0, 7.5, 0.7, 8.2, 7.5, 1.2),
+    ('Deluxe', 'Hummus und Guacamole', 247.0, 19.5, 2.6, 0, 7.0, 0.7, 8.9, 6.5, 0.9),
+    ('Noa', 'Brotaufstrich Kichererbse Tomate-Basilikum', 174.0, 11.8, 1.1, 0, 10.3, 2.8, 0, 4.5, 1.5),
+    ('Aldi', 'Vegane Bio-Streichcreme - Aubergine', 352.0, 34.0, 3.8, 0, 6.0, 3.4, 2.7, 4.1, 1.1),
+    ('Chef select', 'Bio organic humus', 253.0, 18.9, 2.0, 0, 9.4, 2.4, 7.2, 7.8, 1.1),
+    ('Feinkost Popp', 'Hummus Klassisch', 367.0, 29.6, 2.9, 0, 12.2, 0.9, 0, 9.2, 0.8),
+    ('Milbona', 'Zaziki', 115.0, 7.6, 1.4, 0, 8.3, 5.5, 0.1, 3.2, 0.9),
+    ('Aldi', 'Bio-Hummus - Natur', 223.0, 19.0, 2.8, 0, 6.5, 0.6, 0, 3.7, 1.1),
+    ('Aldi', 'Vegane Bio-Streichcreme - Rote Bete-Meerrettich', 338.0, 32.0, 3.4, 0, 7.4, 5.5, 3.4, 3.5, 1.4),
+    ('Chef Select', 'Guacamole scharf', 174.0, 14.7, 2.4, 0, 6.3, 0.8, 4.8, 1.7, 1.0),
+    ('Nur Nur Natur', 'Bio Humus Paprika Kurkuma Chili', 181.0, 11.3, 1.7, 0, 10.4, 3.1, 8.6, 5.0, 0.7),
+    ('Nur Nur Natur', 'Bio-Hummus - Rote Bete, Meerrettich, Hibiskus', 198.0, 13.5, 2.0, 0, 9.4, 2.2, 9.0, 5.1, 0.8),
+    ('Nabio', 'Gegrillte Paprika Cashew', 219.0, 18.0, 2.3, 0, 7.7, 5.0, 3.1, 4.7, 1.3),
+    ('Chef Select', 'Guacamole Avocado-Dip mild', 147.0, 12.7, 2.9, 0, 4.6, 3.0, 0, 1.8, 0),
+    ('Wonnemeyer', 'Antipasticreme - Feta', 272.0, 23.0, 12.0, 0, 6.5, 4.2, 0, 11.0, 2.3),
+    ('Nur Nur Natur', 'Bio-Hummus - Tomate', 175.0, 13.0, 1.8, 0, 9.3, 3.9, 0, 3.7, 1.4),
+    ('Popp', 'Brotaufstrich Bruschetta', 89.0, 7.3, 0.5, 0, 3.7, 3.0, 0, 1.1, 1.4),
+    ('Kaufland', 'Guacamole', 146.0, 13.0, 3.1, 0, 2.1, 1.2, 5.7, 1.5, 0.8),
+    ('Chef select', 'Hummus Nature', 255.0, 19.8, 2.0, 0, 7.5, 0.7, 8.5, 7.4, 1.2),
+    ('Kühlmann', 'Hummus Trio', 289.0, 21.0, 2.1, 0, 14.0, 3.9, 0, 7.3, 1.9),
+    ('Aldi', 'Bio-Hummus - Rote Beete', 190.0, 15.0, 2.2, 0, 7.8, 3.0, 0, 3.4, 1.3),
+    ('Chef Select', 'Hummus bruschetta', 245.0, 19.8, 1.9, 0, 6.9, 1.6, 7.0, 6.3, 0.0),
+    ('Aldi', 'Bio-Hummus - Paprika', 182.0, 13.0, 1.8, 0, 10.0, 4.8, 0, 3.7, 1.3),
+    ('Grossmann', 'Knoblauch-Dip', 468.0, 46.5, 4.0, 0, 10.4, 5.3, 0, 1.5, 1.4),
+    ('Kaufland', 'Hummus mit Topping Grünes Pesto', 321.0, 25.0, 24.0, 0, 14.0, 3.2, 4.6, 7.8, 1.3),
+    ('Wonnemeyer', 'Antipasticreme - Dattel-Curry', 274.0, 23.0, 13.0, 0, 13.0, 11.0, 1.3, 3.5, 3.2),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Paprika, Feta & Tomaten', 154.0, 10.7, 2.1, 0, 10.0, 9.5, 3.1, 2.8, 2.2),
+    ('Chef Select', 'Kirschpaprika Antipasti-Creme', 269.0, 21.9, 13.8, 0, 12.4, 9.4, 0.3, 5.3, 1.5),
+    ('Noa', 'Hummus Dattel Curry', 304.0, 23.6, 2.2, 0, 15.0, 8.5, 0, 5.5, 1.4),
+    ('Chio', 'Hot Cheese Dip!', 150.0, 8.8, 2.4, 0, 15.0, 0.4, 0, 2.7, 1.7),
+    ('Chio', 'Chip dip', 106.0, 1.2, 0.3, 0, 22.0, 15.0, 0, 1.1, 2.6)
+) as d(brand, product_name, calories, total_fat_g, saturated_fat_g, trans_fat_g,
+       carbs_g, sugars_g, fibre_g, protein_g, salt_g)
+join products p on p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name
+  and p.category = 'Spreads & Dips' and p.is_deprecated is not true
+on conflict (product_id) do update set
+  calories = excluded.calories,
+  total_fat_g = excluded.total_fat_g,
+  saturated_fat_g = excluded.saturated_fat_g,
+  trans_fat_g = excluded.trans_fat_g,
+  carbs_g = excluded.carbs_g,
+  sugars_g = excluded.sugars_g,
+  fibre_g = excluded.fibre_g,
+  protein_g = excluded.protein_g,
+  salt_g = excluded.salt_g;

--- a/db/pipelines/spreads-dips-de/PIPELINE__spreads-dips-de__04_scoring.sql
+++ b/db/pipelines/spreads-dips-de/PIPELINE__spreads-dips-de__04_scoring.sql
@@ -1,0 +1,123 @@
+-- PIPELINE (Spreads & Dips): scoring
+-- Generated: 2026-03-08
+
+-- 2. Nutri-Score
+update products p set
+  nutri_score_label = d.ns
+from (
+  values
+    ('Aldi', 'Vegane Bio-Streichcreme - Kräuter-Tomate', 'C'),
+    ('Noa', 'Noa Brotaufstrich Hummus Kräuter', 'C'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Grüne Oliven, Aprikosen & Mandeln', 'C'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Tomaten, Walnüsse & Basilikum', 'D'),
+    ('Unknown', 'Hummus Kürbis Kürbis Kichererbsenpüree mit Kürbis und Sesam', 'C'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Rote Linsen, Tomaten & Kürbis', 'B'),
+    ('Menken Salades & Sauzen', 'Hummus - Kürbis', 'C'),
+    ('Milram', 'Fein-würzige Sour Cream', 'D'),
+    ('BLM', 'Bruschetta-Creme mit Paprika und Ricottakäse', 'E'),
+    ('Sun Snacks', 'Salsa Dip Käse', 'D'),
+    ('Kühlmann', 'Kichererbsenpüree', 'C'),
+    ('W', 'Bio Hummus - Kichererbsenpüree mit Sesam und rotem Pesto', 'C'),
+    ('Schätze des Orients', 'Hummus Natur', 'C'),
+    ('NOA', 'Hummus , Natur', 'D'),
+    ('Heinrich Kuhmann GmbH', 'Hummus - Pikant', 'C'),
+    ('K Bio (Kaufland)', 'Bio Hummus Classic', 'A'),
+    ('Noa', 'Hummus Paprika-Chili', 'C'),
+    ('My Vay', 'Bio Streichcreme', 'C'),
+    ('DmBio', 'Hummus Natur', 'C'),
+    ('Chef Select', 'Bio Hummus Natur', 'A'),
+    ('Kaufland', 'Veganer Hummus Classic', 'A'),
+    ('Deluxe', 'Hummus und Guacamole', 'A'),
+    ('Noa', 'Brotaufstrich Kichererbse Tomate-Basilikum', 'C'),
+    ('Aldi', 'Vegane Bio-Streichcreme - Aubergine', 'D'),
+    ('Chef select', 'Bio organic humus', 'B'),
+    ('Feinkost Popp', 'Hummus Klassisch', 'C'),
+    ('Milbona', 'Zaziki', 'C'),
+    ('Aldi', 'Bio-Hummus - Natur', 'C'),
+    ('Aldi', 'Vegane Bio-Streichcreme - Rote Bete-Meerrettich', 'D'),
+    ('Chef Select', 'Guacamole scharf', 'B'),
+    ('Nur Nur Natur', 'Bio Humus Paprika Kurkuma Chili', 'A'),
+    ('Nur Nur Natur', 'Bio-Hummus - Rote Bete, Meerrettich, Hibiskus', 'A'),
+    ('Nabio', 'Gegrillte Paprika Cashew', 'C'),
+    ('Chef Select', 'Guacamole Avocado-Dip mild', 'UNKNOWN'),
+    ('Wonnemeyer', 'Antipasticreme - Feta', 'E'),
+    ('Nur Nur Natur', 'Bio-Hummus - Tomate', 'C'),
+    ('Popp', 'Brotaufstrich Bruschetta', 'C'),
+    ('Kaufland', 'Guacamole', 'A'),
+    ('Chef select', 'Hummus Nature', 'A'),
+    ('Kühlmann', 'Hummus Trio', 'D'),
+    ('Aldi', 'Bio-Hummus - Rote Beete', 'C'),
+    ('Chef Select', 'Hummus bruschetta', 'A'),
+    ('Aldi', 'Bio-Hummus - Paprika', 'C'),
+    ('Grossmann', 'Knoblauch-Dip', 'D'),
+    ('Kaufland', 'Hummus mit Topping Grünes Pesto', 'D'),
+    ('Wonnemeyer', 'Antipasticreme - Dattel-Curry', 'E'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Paprika, Feta & Tomaten', 'D'),
+    ('Chef Select', 'Kirschpaprika Antipasti-Creme', 'E'),
+    ('Noa', 'Hummus Dattel Curry', 'D'),
+    ('Chio', 'Hot Cheese Dip!', 'D'),
+    ('Chio', 'Chip dip', 'D')
+) as d(brand, product_name, ns)
+where p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name;
+
+-- 3. NOVA classification
+update products p set
+  nova_classification = d.nova
+from (
+  values
+    ('Aldi', 'Vegane Bio-Streichcreme - Kräuter-Tomate', '3'),
+    ('Noa', 'Noa Brotaufstrich Hummus Kräuter', '3'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Grüne Oliven, Aprikosen & Mandeln', '3'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Tomaten, Walnüsse & Basilikum', '3'),
+    ('Unknown', 'Hummus Kürbis Kürbis Kichererbsenpüree mit Kürbis und Sesam', '3'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Rote Linsen, Tomaten & Kürbis', '4'),
+    ('Menken Salades & Sauzen', 'Hummus - Kürbis', '4'),
+    ('Milram', 'Fein-würzige Sour Cream', '3'),
+    ('BLM', 'Bruschetta-Creme mit Paprika und Ricottakäse', '4'),
+    ('Sun Snacks', 'Salsa Dip Käse', '4'),
+    ('Kühlmann', 'Kichererbsenpüree', '4'),
+    ('W', 'Bio Hummus - Kichererbsenpüree mit Sesam und rotem Pesto', '4'),
+    ('Schätze des Orients', 'Hummus Natur', '3'),
+    ('NOA', 'Hummus , Natur', '3'),
+    ('Heinrich Kuhmann GmbH', 'Hummus - Pikant', '3'),
+    ('K Bio (Kaufland)', 'Bio Hummus Classic', '3'),
+    ('Noa', 'Hummus Paprika-Chili', '3'),
+    ('My Vay', 'Bio Streichcreme', '3'),
+    ('DmBio', 'Hummus Natur', '4'),
+    ('Chef Select', 'Bio Hummus Natur', '3'),
+    ('Kaufland', 'Veganer Hummus Classic', '3'),
+    ('Deluxe', 'Hummus und Guacamole', '4'),
+    ('Noa', 'Brotaufstrich Kichererbse Tomate-Basilikum', '3'),
+    ('Aldi', 'Vegane Bio-Streichcreme - Aubergine', '3'),
+    ('Chef select', 'Bio organic humus', '4'),
+    ('Feinkost Popp', 'Hummus Klassisch', '3'),
+    ('Milbona', 'Zaziki', '4'),
+    ('Aldi', 'Bio-Hummus - Natur', '3'),
+    ('Aldi', 'Vegane Bio-Streichcreme - Rote Bete-Meerrettich', '3'),
+    ('Chef Select', 'Guacamole scharf', '3'),
+    ('Nur Nur Natur', 'Bio Humus Paprika Kurkuma Chili', '3'),
+    ('Nur Nur Natur', 'Bio-Hummus - Rote Bete, Meerrettich, Hibiskus', '3'),
+    ('Nabio', 'Gegrillte Paprika Cashew', '4'),
+    ('Chef Select', 'Guacamole Avocado-Dip mild', '4'),
+    ('Wonnemeyer', 'Antipasticreme - Feta', '3'),
+    ('Nur Nur Natur', 'Bio-Hummus - Tomate', '3'),
+    ('Popp', 'Brotaufstrich Bruschetta', '4'),
+    ('Kaufland', 'Guacamole', '3'),
+    ('Chef select', 'Hummus Nature', '3'),
+    ('Kühlmann', 'Hummus Trio', '4'),
+    ('Aldi', 'Bio-Hummus - Rote Beete', '3'),
+    ('Chef Select', 'Hummus bruschetta', '3'),
+    ('Aldi', 'Bio-Hummus - Paprika', '3'),
+    ('Grossmann', 'Knoblauch-Dip', '4'),
+    ('Kaufland', 'Hummus mit Topping Grünes Pesto', '4'),
+    ('Wonnemeyer', 'Antipasticreme - Dattel-Curry', '4'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Paprika, Feta & Tomaten', '4'),
+    ('Chef Select', 'Kirschpaprika Antipasti-Creme', '4'),
+    ('Noa', 'Hummus Dattel Curry', '3'),
+    ('Chio', 'Hot Cheese Dip!', '4'),
+    ('Chio', 'Chip dip', '4')
+) as d(brand, product_name, nova)
+where p.country = 'DE' and p.brand = d.brand and p.product_name = d.product_name;
+
+-- 0/1/4/5. Score category (concern defaults, unhealthiness, flags, confidence)
+CALL score_category('Spreads & Dips', 100, 'DE');

--- a/db/pipelines/spreads-dips-de/PIPELINE__spreads-dips-de__05_source_provenance.sql
+++ b/db/pipelines/spreads-dips-de/PIPELINE__spreads-dips-de__05_source_provenance.sql
@@ -1,0 +1,65 @@
+-- PIPELINE (Spreads & Dips): source provenance
+-- Generated: 2026-03-08
+
+-- 1. Update source info on products
+UPDATE products p SET
+  source_type = 'off_api',
+  source_url = d.source_url,
+  source_ean = d.source_ean
+FROM (
+  VALUES
+    ('Aldi', 'Vegane Bio-Streichcreme - Kräuter-Tomate', 'https://world.openfoodfacts.org/product/4061461937348', '4061461937348'),
+    ('Noa', 'Noa Brotaufstrich Hummus Kräuter', 'https://world.openfoodfacts.org/product/4058094300021', '4058094300021'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Grüne Oliven, Aprikosen & Mandeln', 'https://world.openfoodfacts.org/product/4061459397161', '4061459397161'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Tomaten, Walnüsse & Basilikum', 'https://world.openfoodfacts.org/product/4061459397048', '4061459397048'),
+    ('Unknown', 'Hummus Kürbis Kürbis Kichererbsenpüree mit Kürbis und Sesam', 'https://world.openfoodfacts.org/product/4061459673012', '4061459673012'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Rote Linsen, Tomaten & Kürbis', 'https://world.openfoodfacts.org/product/4061459397116', '4061459397116'),
+    ('Menken Salades & Sauzen', 'Hummus - Kürbis', 'https://world.openfoodfacts.org/product/4061458024082', '4061458024082'),
+    ('Milram', 'Fein-würzige Sour Cream', 'https://world.openfoodfacts.org/product/40466156', '40466156'),
+    ('BLM', 'Bruschetta-Creme mit Paprika und Ricottakäse', 'https://world.openfoodfacts.org/product/4061462591938', '4061462591938'),
+    ('Sun Snacks', 'Salsa Dip Käse', 'https://world.openfoodfacts.org/product/4061463929853', '4061463929853'),
+    ('Kühlmann', 'Kichererbsenpüree', 'https://world.openfoodfacts.org/product/4051009041989', '4051009041989'),
+    ('W', 'Bio Hummus - Kichererbsenpüree mit Sesam und rotem Pesto', 'https://world.openfoodfacts.org/product/4061462642463', '4061462642463'),
+    ('Schätze des Orients', 'Hummus Natur', 'https://world.openfoodfacts.org/product/4061458024068', '4061458024068'),
+    ('NOA', 'Hummus , Natur', 'https://world.openfoodfacts.org/product/4058094300014', '4058094300014'),
+    ('Heinrich Kuhmann GmbH', 'Hummus - Pikant', 'https://world.openfoodfacts.org/product/4061458024037', '4061458024037'),
+    ('K Bio (Kaufland)', 'Bio Hummus Classic', 'https://world.openfoodfacts.org/product/4063367405440', '4063367405440'),
+    ('Noa', 'Hummus Paprika-Chili', 'https://world.openfoodfacts.org/product/4058094300083', '4058094300083'),
+    ('My Vay', 'Bio Streichcreme', 'https://world.openfoodfacts.org/product/4061461937430', '4061461937430'),
+    ('DmBio', 'Hummus Natur', 'https://world.openfoodfacts.org/product/4067796010831', '4067796010831'),
+    ('Chef Select', 'Bio Hummus Natur', 'https://world.openfoodfacts.org/product/4056489550600', '4056489550600'),
+    ('Kaufland', 'Veganer Hummus Classic', 'https://world.openfoodfacts.org/product/4063367170713', '4063367170713'),
+    ('Deluxe', 'Hummus und Guacamole', 'https://world.openfoodfacts.org/product/4056489459545', '4056489459545'),
+    ('Noa', 'Brotaufstrich Kichererbse Tomate-Basilikum', 'https://world.openfoodfacts.org/product/4058094310105', '4058094310105'),
+    ('Aldi', 'Vegane Bio-Streichcreme - Aubergine', 'https://world.openfoodfacts.org/product/4061461937362', '4061461937362'),
+    ('Chef select', 'Bio organic humus', 'https://world.openfoodfacts.org/product/4056489550617', '4056489550617'),
+    ('Feinkost Popp', 'Hummus Klassisch', 'https://world.openfoodfacts.org/product/4045800719635', '4045800719635'),
+    ('Milbona', 'Zaziki', 'https://world.openfoodfacts.org/product/4056489665588', '4056489665588'),
+    ('Aldi', 'Bio-Hummus - Natur', 'https://world.openfoodfacts.org/product/4061461825140', '4061461825140'),
+    ('Aldi', 'Vegane Bio-Streichcreme - Rote Bete-Meerrettich', 'https://world.openfoodfacts.org/product/4061461937409', '4061461937409'),
+    ('Chef Select', 'Guacamole scharf', 'https://world.openfoodfacts.org/product/4056489963004', '4056489963004'),
+    ('Nur Nur Natur', 'Bio Humus Paprika Kurkuma Chili', 'https://world.openfoodfacts.org/product/4061461559175', '4061461559175'),
+    ('Nur Nur Natur', 'Bio-Hummus - Rote Bete, Meerrettich, Hibiskus', 'https://world.openfoodfacts.org/product/4061461568948', '4061461568948'),
+    ('Nabio', 'Gegrillte Paprika Cashew', 'https://world.openfoodfacts.org/product/4013182024098', '4013182024098'),
+    ('Chef Select', 'Guacamole Avocado-Dip mild', 'https://world.openfoodfacts.org/product/4056489242079', '4056489242079'),
+    ('Wonnemeyer', 'Antipasticreme - Feta', 'https://world.openfoodfacts.org/product/4061458023238', '4061458023238'),
+    ('Nur Nur Natur', 'Bio-Hummus - Tomate', 'https://world.openfoodfacts.org/product/4061461825225', '4061461825225'),
+    ('Popp', 'Brotaufstrich Bruschetta', 'https://world.openfoodfacts.org/product/4045800505269', '4045800505269'),
+    ('Kaufland', 'Guacamole', 'https://world.openfoodfacts.org/product/4063367146978', '4063367146978'),
+    ('Chef select', 'Hummus Nature', 'https://world.openfoodfacts.org/product/4056489456544', '4056489456544'),
+    ('Kühlmann', 'Hummus Trio', 'https://world.openfoodfacts.org/product/4051009026733', '4051009026733'),
+    ('Aldi', 'Bio-Hummus - Rote Beete', 'https://world.openfoodfacts.org/product/4061461825263', '4061461825263'),
+    ('Chef Select', 'Hummus bruschetta', 'https://world.openfoodfacts.org/product/4056489459514', '4056489459514'),
+    ('Aldi', 'Bio-Hummus - Paprika', 'https://world.openfoodfacts.org/product/4061461825249', '4061461825249'),
+    ('Grossmann', 'Knoblauch-Dip', 'https://world.openfoodfacts.org/product/4006495162700', '4006495162700'),
+    ('Kaufland', 'Hummus mit Topping Grünes Pesto', 'https://world.openfoodfacts.org/product/4051009035636', '4051009035636'),
+    ('Wonnemeyer', 'Antipasticreme - Dattel-Curry', 'https://world.openfoodfacts.org/product/4047247622004', '4047247622004'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Paprika, Feta & Tomaten', 'https://world.openfoodfacts.org/product/4061459397062', '4061459397062'),
+    ('Chef Select', 'Kirschpaprika Antipasti-Creme', 'https://world.openfoodfacts.org/product/4056489008170', '4056489008170'),
+    ('Noa', 'Hummus Dattel Curry', 'https://world.openfoodfacts.org/product/4058094300113', '4058094300113'),
+    ('Chio', 'Hot Cheese Dip!', 'https://world.openfoodfacts.org/product/4001242108239', '4001242108239'),
+    ('Chio', 'Chip dip', 'https://world.openfoodfacts.org/product/4001242108222', '4001242108222')
+) AS d(brand, product_name, source_url, source_ean)
+WHERE p.country = 'DE' AND p.brand = d.brand
+  AND p.product_name = d.product_name
+  AND p.category = 'Spreads & Dips' AND p.is_deprecated IS NOT TRUE;

--- a/db/pipelines/spreads-dips-de/PIPELINE__spreads-dips-de__06_add_images.sql
+++ b/db/pipelines/spreads-dips-de/PIPELINE__spreads-dips-de__06_add_images.sql
@@ -1,0 +1,79 @@
+-- PIPELINE (Spreads & Dips): add product images
+-- Source: Open Food Facts API image URLs
+-- Generated: 2026-03-08
+
+-- 1. Remove existing OFF images for this category
+DELETE FROM product_images
+WHERE source = 'off_api'
+  AND product_id IN (
+    SELECT p.product_id FROM products p
+    WHERE p.country = 'DE' AND p.category = 'Spreads & Dips'
+      AND p.is_deprecated IS NOT TRUE
+  );
+
+-- 2. Insert images
+INSERT INTO product_images
+  (product_id, url, source, image_type, is_primary, alt_text, off_image_id)
+SELECT
+  p.product_id, d.url, d.source, d.image_type, d.is_primary, d.alt_text, d.off_image_id
+FROM (
+  VALUES
+    ('Aldi', 'Vegane Bio-Streichcreme - Kräuter-Tomate', 'https://images.openfoodfacts.org/images/products/406/146/193/7348/front_de.44.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061461937348', 'front_4061461937348'),
+    ('Noa', 'Noa Brotaufstrich Hummus Kräuter', 'https://images.openfoodfacts.org/images/products/405/809/430/0021/front_de.38.400.jpg', 'off_api', 'front', true, 'Front — EAN 4058094300021', 'front_4058094300021'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Grüne Oliven, Aprikosen & Mandeln', 'https://images.openfoodfacts.org/images/products/406/145/939/7161/front_de.7.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061459397161', 'front_4061459397161'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Tomaten, Walnüsse & Basilikum', 'https://images.openfoodfacts.org/images/products/406/145/939/7048/front_de.19.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061459397048', 'front_4061459397048'),
+    ('Unknown', 'Hummus Kürbis Kürbis Kichererbsenpüree mit Kürbis und Sesam', 'https://images.openfoodfacts.org/images/products/406/145/967/3012/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061459673012', 'front_4061459673012'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Rote Linsen, Tomaten & Kürbis', 'https://images.openfoodfacts.org/images/products/406/145/939/7116/front_de.12.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061459397116', 'front_4061459397116'),
+    ('Menken Salades & Sauzen', 'Hummus - Kürbis', 'https://images.openfoodfacts.org/images/products/406/145/802/4082/front_de.62.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458024082', 'front_4061458024082'),
+    ('Milram', 'Fein-würzige Sour Cream', 'https://images.openfoodfacts.org/images/products/000/004/046/6156/front_de.20.400.jpg', 'off_api', 'front', true, 'Front — EAN 40466156', 'front_40466156'),
+    ('BLM', 'Bruschetta-Creme mit Paprika und Ricottakäse', 'https://images.openfoodfacts.org/images/products/406/146/259/1938/front_de.11.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061462591938', 'front_4061462591938'),
+    ('Sun Snacks', 'Salsa Dip Käse', 'https://images.openfoodfacts.org/images/products/406/146/392/9853/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061463929853', 'front_4061463929853'),
+    ('Kühlmann', 'Kichererbsenpüree', 'https://images.openfoodfacts.org/images/products/405/100/904/1989/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4051009041989', 'front_4051009041989'),
+    ('W', 'Bio Hummus - Kichererbsenpüree mit Sesam und rotem Pesto', 'https://images.openfoodfacts.org/images/products/406/146/264/2463/front_en.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061462642463', 'front_4061462642463'),
+    ('Schätze des Orients', 'Hummus Natur', 'https://images.openfoodfacts.org/images/products/406/145/802/4068/front_de.101.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458024068', 'front_4061458024068'),
+    ('NOA', 'Hummus , Natur', 'https://images.openfoodfacts.org/images/products/405/809/430/0014/front_en.38.400.jpg', 'off_api', 'front', true, 'Front — EAN 4058094300014', 'front_4058094300014'),
+    ('Heinrich Kuhmann GmbH', 'Hummus - Pikant', 'https://images.openfoodfacts.org/images/products/406/145/802/4037/front_de.116.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458024037', 'front_4061458024037'),
+    ('K Bio (Kaufland)', 'Bio Hummus Classic', 'https://images.openfoodfacts.org/images/products/406/336/740/5440/front_de.9.400.jpg', 'off_api', 'front', true, 'Front — EAN 4063367405440', 'front_4063367405440'),
+    ('Noa', 'Hummus Paprika-Chili', 'https://images.openfoodfacts.org/images/products/405/809/430/0083/front_de.48.400.jpg', 'off_api', 'front', true, 'Front — EAN 4058094300083', 'front_4058094300083'),
+    ('My Vay', 'Bio Streichcreme', 'https://images.openfoodfacts.org/images/products/406/146/193/7430/front_de.27.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061461937430', 'front_4061461937430'),
+    ('DmBio', 'Hummus Natur', 'https://images.openfoodfacts.org/images/products/406/779/601/0831/front_de.19.400.jpg', 'off_api', 'front', true, 'Front — EAN 4067796010831', 'front_4067796010831'),
+    ('Chef Select', 'Bio Hummus Natur', 'https://images.openfoodfacts.org/images/products/405/648/955/0600/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489550600', 'front_4056489550600'),
+    ('Kaufland', 'Veganer Hummus Classic', 'https://images.openfoodfacts.org/images/products/406/336/717/0713/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4063367170713', 'front_4063367170713'),
+    ('Deluxe', 'Hummus und Guacamole', 'https://images.openfoodfacts.org/images/products/405/648/945/9545/front_de.41.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489459545', 'front_4056489459545'),
+    ('Noa', 'Brotaufstrich Kichererbse Tomate-Basilikum', 'https://images.openfoodfacts.org/images/products/405/809/431/0105/front_de.25.400.jpg', 'off_api', 'front', true, 'Front — EAN 4058094310105', 'front_4058094310105'),
+    ('Aldi', 'Vegane Bio-Streichcreme - Aubergine', 'https://images.openfoodfacts.org/images/products/406/146/193/7362/front_de.22.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061461937362', 'front_4061461937362'),
+    ('Chef select', 'Bio organic humus', 'https://images.openfoodfacts.org/images/products/405/648/955/0617/front_en.12.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489550617', 'front_4056489550617'),
+    ('Feinkost Popp', 'Hummus Klassisch', 'https://images.openfoodfacts.org/images/products/404/580/071/9635/front_de.34.400.jpg', 'off_api', 'front', true, 'Front — EAN 4045800719635', 'front_4045800719635'),
+    ('Milbona', 'Zaziki', 'https://images.openfoodfacts.org/images/products/405/648/966/5588/front_en.5.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489665588', 'front_4056489665588'),
+    ('Aldi', 'Bio-Hummus - Natur', 'https://images.openfoodfacts.org/images/products/406/146/182/5140/front_de.21.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061461825140', 'front_4061461825140'),
+    ('Aldi', 'Vegane Bio-Streichcreme - Rote Bete-Meerrettich', 'https://images.openfoodfacts.org/images/products/406/146/193/7409/front_de.16.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061461937409', 'front_4061461937409'),
+    ('Chef Select', 'Guacamole scharf', 'https://images.openfoodfacts.org/images/products/405/648/996/3004/front_de.51.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489963004', 'front_4056489963004'),
+    ('Nur Nur Natur', 'Bio Humus Paprika Kurkuma Chili', 'https://images.openfoodfacts.org/images/products/406/146/155/9175/front_de.5.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061461559175', 'front_4061461559175'),
+    ('Nur Nur Natur', 'Bio-Hummus - Rote Bete, Meerrettich, Hibiskus', 'https://images.openfoodfacts.org/images/products/406/146/156/8948/front_de.13.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061461568948', 'front_4061461568948'),
+    ('Nabio', 'Gegrillte Paprika Cashew', 'https://images.openfoodfacts.org/images/products/401/318/202/4098/front_en.32.400.jpg', 'off_api', 'front', true, 'Front — EAN 4013182024098', 'front_4013182024098'),
+    ('Chef Select', 'Guacamole Avocado-Dip mild', 'https://images.openfoodfacts.org/images/products/405/648/924/2079/front_de.21.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489242079', 'front_4056489242079'),
+    ('Wonnemeyer', 'Antipasticreme - Feta', 'https://images.openfoodfacts.org/images/products/406/145/802/3238/front_de.47.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061458023238', 'front_4061458023238'),
+    ('Nur Nur Natur', 'Bio-Hummus - Tomate', 'https://images.openfoodfacts.org/images/products/406/146/182/5225/front_de.16.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061461825225', 'front_4061461825225'),
+    ('Popp', 'Brotaufstrich Bruschetta', 'https://images.openfoodfacts.org/images/products/404/580/050/5269/front_de.27.400.jpg', 'off_api', 'front', true, 'Front — EAN 4045800505269', 'front_4045800505269'),
+    ('Kaufland', 'Guacamole', 'https://images.openfoodfacts.org/images/products/406/336/714/6978/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4063367146978', 'front_4063367146978'),
+    ('Chef select', 'Hummus Nature', 'https://images.openfoodfacts.org/images/products/405/648/945/6544/front_en.59.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489456544', 'front_4056489456544'),
+    ('Kühlmann', 'Hummus Trio', 'https://images.openfoodfacts.org/images/products/405/100/902/6733/front_de.21.400.jpg', 'off_api', 'front', true, 'Front — EAN 4051009026733', 'front_4051009026733'),
+    ('Aldi', 'Bio-Hummus - Rote Beete', 'https://images.openfoodfacts.org/images/products/406/146/182/5263/front_de.5.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061461825263', 'front_4061461825263'),
+    ('Chef Select', 'Hummus bruschetta', 'https://images.openfoodfacts.org/images/products/405/648/945/9514/front_cs.38.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489459514', 'front_4056489459514'),
+    ('Aldi', 'Bio-Hummus - Paprika', 'https://images.openfoodfacts.org/images/products/406/146/182/5249/front_de.18.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061461825249', 'front_4061461825249'),
+    ('Grossmann', 'Knoblauch-Dip', 'https://images.openfoodfacts.org/images/products/400/649/516/2700/front_de.18.400.jpg', 'off_api', 'front', true, 'Front — EAN 4006495162700', 'front_4006495162700'),
+    ('Kaufland', 'Hummus mit Topping Grünes Pesto', 'https://images.openfoodfacts.org/images/products/405/100/903/5636/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4051009035636', 'front_4051009035636'),
+    ('Wonnemeyer', 'Antipasticreme - Dattel-Curry', 'https://images.openfoodfacts.org/images/products/404/724/762/2004/front_en.27.400.jpg', 'off_api', 'front', true, 'Front — EAN 4047247622004', 'front_4047247622004'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Paprika, Feta & Tomaten', 'https://images.openfoodfacts.org/images/products/406/145/939/7062/front_de.5.400.jpg', 'off_api', 'front', true, 'Front — EAN 4061459397062', 'front_4061459397062'),
+    ('Chef Select', 'Kirschpaprika Antipasti-Creme', 'https://images.openfoodfacts.org/images/products/405/648/900/8170/front_de.18.400.jpg', 'off_api', 'front', true, 'Front — EAN 4056489008170', 'front_4056489008170'),
+    ('Noa', 'Hummus Dattel Curry', 'https://images.openfoodfacts.org/images/products/405/809/430/0113/front_de.3.400.jpg', 'off_api', 'front', true, 'Front — EAN 4058094300113', 'front_4058094300113'),
+    ('Chio', 'Hot Cheese Dip!', 'https://images.openfoodfacts.org/images/products/400/124/210/8239/front_de.40.400.jpg', 'off_api', 'front', true, 'Front — EAN 4001242108239', 'front_4001242108239'),
+    ('Chio', 'Chip dip', 'https://images.openfoodfacts.org/images/products/400/124/210/8222/front_en.24.400.jpg', 'off_api', 'front', true, 'Front — EAN 4001242108222', 'front_4001242108222')
+) AS d(brand, product_name, url, source, image_type, is_primary, alt_text, off_image_id)
+JOIN products p ON p.country = 'DE' AND p.brand = d.brand AND p.product_name = d.product_name
+  AND p.category = 'Spreads & Dips' AND p.is_deprecated IS NOT TRUE
+ON CONFLICT (off_image_id) WHERE off_image_id IS NOT NULL DO UPDATE SET
+  url = EXCLUDED.url,
+  image_type = EXCLUDED.image_type,
+  is_primary = EXCLUDED.is_primary,
+  alt_text = EXCLUDED.alt_text;

--- a/db/pipelines/spreads-dips-de/PIPELINE__spreads-dips-de__07_store_availability.sql
+++ b/db/pipelines/spreads-dips-de/PIPELINE__spreads-dips-de__07_store_availability.sql
@@ -1,0 +1,63 @@
+-- PIPELINE (Spreads & Dips): store availability
+-- Source: Open Food Facts API store field
+-- Generated: 2026-03-08
+
+INSERT INTO product_store_availability (product_id, store_id, verified_at, source)
+SELECT
+  p.product_id,
+  sr.store_id,
+  NOW(),
+  'pipeline'
+FROM (
+  VALUES
+    ('Aldi', 'Vegane Bio-Streichcreme - Kräuter-Tomate', 'Aldi'),
+    ('Noa', 'Noa Brotaufstrich Hummus Kräuter', 'REWE'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Grüne Oliven, Aprikosen & Mandeln', 'Aldi'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Tomaten, Walnüsse & Basilikum', 'Aldi'),
+    ('Unknown', 'Hummus Kürbis Kürbis Kichererbsenpüree mit Kürbis und Sesam', 'Aldi'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Rote Linsen, Tomaten & Kürbis', 'Aldi'),
+    ('Menken Salades & Sauzen', 'Hummus - Kürbis', 'Aldi'),
+    ('Schätze des Orients', 'Hummus Natur', 'Aldi'),
+    ('NOA', 'Hummus , Natur', 'Kaufland'),
+    ('NOA', 'Hummus , Natur', 'Real'),
+    ('Heinrich Kuhmann GmbH', 'Hummus - Pikant', 'Aldi'),
+    ('K Bio (Kaufland)', 'Bio Hummus Classic', 'Kaufland'),
+    ('Noa', 'Hummus Paprika-Chili', 'Lidl'),
+    ('Noa', 'Hummus Paprika-Chili', 'Edeka'),
+    ('Noa', 'Hummus Paprika-Chili', 'REWE'),
+    ('Noa', 'Hummus Paprika-Chili', 'Netto'),
+    ('Noa', 'Hummus Paprika-Chili', 'Kaufland'),
+    ('My Vay', 'Bio Streichcreme', 'Aldi'),
+    ('DmBio', 'Hummus Natur', 'dm'),
+    ('Chef Select', 'Bio Hummus Natur', 'Lidl'),
+    ('Kaufland', 'Veganer Hummus Classic', 'Kaufland'),
+    ('Deluxe', 'Hummus und Guacamole', 'Lidl'),
+    ('Noa', 'Brotaufstrich Kichererbse Tomate-Basilikum', 'REWE'),
+    ('Aldi', 'Vegane Bio-Streichcreme - Aubergine', 'Aldi'),
+    ('Chef select', 'Bio organic humus', 'Lidl'),
+    ('Milbona', 'Zaziki', 'Lidl'),
+    ('Aldi', 'Bio-Hummus - Natur', 'Aldi'),
+    ('Aldi', 'Vegane Bio-Streichcreme - Rote Bete-Meerrettich', 'Aldi'),
+    ('Chef Select', 'Guacamole scharf', 'Lidl'),
+    ('Nur Nur Natur', 'Bio Humus Paprika Kurkuma Chili', 'Aldi'),
+    ('Nur Nur Natur', 'Bio-Hummus - Rote Bete, Meerrettich, Hibiskus', 'Aldi'),
+    ('Nabio', 'Gegrillte Paprika Cashew', 'REWE'),
+    ('Chef Select', 'Guacamole Avocado-Dip mild', 'Lidl'),
+    ('Wonnemeyer', 'Antipasticreme - Feta', 'Aldi'),
+    ('Nur Nur Natur', 'Bio-Hummus - Tomate', 'Aldi'),
+    ('Popp', 'Brotaufstrich Bruschetta', 'REWE'),
+    ('Kaufland', 'Guacamole', 'Kaufland'),
+    ('Chef select', 'Hummus Nature', 'Lidl'),
+    ('Kühlmann', 'Hummus Trio', 'Edeka'),
+    ('Aldi', 'Bio-Hummus - Rote Beete', 'Aldi'),
+    ('Chef Select', 'Hummus bruschetta', 'Lidl'),
+    ('Aldi', 'Bio-Hummus - Paprika', 'Aldi'),
+    ('Grossmann', 'Knoblauch-Dip', 'REWE'),
+    ('Wonnemeyer', 'Antipasticreme - Dattel-Curry', 'Aldi'),
+    ('Lyttos', 'Griechischer Pitabrot-Dip - Paprika, Feta & Tomaten', 'Aldi'),
+    ('Chef Select', 'Kirschpaprika Antipasti-Creme', 'Lidl')
+) AS d(brand, product_name, store_name)
+JOIN products p ON p.country = 'DE' AND p.brand = d.brand AND p.product_name = d.product_name
+  AND p.category = 'Spreads & Dips' AND p.is_deprecated IS NOT TRUE
+JOIN store_ref sr ON sr.country = 'DE' AND sr.store_name = d.store_name AND sr.is_active = true
+ON CONFLICT (product_id, store_id) DO NOTHING;


### PR DESCRIPTION
## Summary

Closes #713

Generate pipeline SQL files for the final 2 DE categories, achieving **full 21/21 DE parity** with PL (minus Żabka which is PL-only).

### Changes

- **DE Oils & Vinegars** (`oils-vinegars-de/`): 51 products from OFF API (153 raw → 138 validated → 128 deduped → 51 selected)
- **DE Spreads & Dips** (`spreads-dips-de/`): 51 products from OFF API
- 12 new SQL files (6 per category: insert, nutrition, scoring, provenance, images, store availability)
- Updated `copilot-instructions.md` category counts: 20→22 PL, 19→21 DE, 39→43 pipeline folders
- Updated `CURRENT_STATE.md` category counts

### Pipeline structure

\\\
Pipeline structure check PASSED — 43 categories verified.
\\\

### Verification

- [x] `python check_pipeline_structure.py` — 43 categories verified ✅
- [x] 51 products each in both category SQL files ✅
- [x] Both folders contain all 6 required SQL files ✅
- [ ] DB execution deferred — Docker/Supabase unavailable (port 54322 in Hyper-V excluded range)
- [ ] Ingredient enrichment deferred — requires DB access
- [ ] QA suite validation deferred — requires DB access

### Note on DB-dependent steps

Docker Desktop is returning 500 errors due to Windows Hyper-V port reservation conflict on port 54322. The SQL files are correctly generated and structurally validated. DB execution, ingredient enrichment, scoring, and QA validation will be performed when Docker is restored (requires system reboot or admin `net stop winnat`).

### File Impact

**14 files changed, +1,032 / -11 lines**
- 12 new pipeline SQL files (2 categories × 6 files)
- 2 doc updates (copilot-instructions.md, CURRENT_STATE.md)