### PR TITLE
fix(e2e): use exact match for Password label to prevent strict mode violation

### DIFF
--- a/frontend/e2e/auth.setup.ts
+++ b/frontend/e2e/auth.setup.ts
@@ -20,7 +20,7 @@ setup("create user and authenticate via UI", async ({ page }) => {
   // ── 2. Login via the UI ───────────────────────────────────────────────────
   await page.goto("/auth/login");
   await page.getByLabel("Email").fill(TEST_EMAIL);
-  await page.getByLabel("Password").fill(TEST_PASSWORD);
+  await page.getByLabel("Password", { exact: true }).fill(TEST_PASSWORD);
   await page.getByRole("button", { name: "Sign In" }).click();
 
   // After login the user is already onboarded (ensureTestUser pre-creates

--- a/frontend/e2e/authenticated.spec.ts
+++ b/frontend/e2e/authenticated.spec.ts
@@ -52,7 +52,7 @@ test.describe("Signup form", () => {
       page.getByRole("heading", { name: /create your account/i }),
     ).toBeVisible();
     await expect(page.getByLabel("Email")).toBeVisible();
-    await expect(page.getByLabel("Password")).toBeVisible();
+    await expect(page.getByLabel("Password", { exact: true })).toBeVisible();
     await expect(
       page.getByRole("button", { name: /sign up/i }),
     ).toBeVisible();
@@ -61,7 +61,7 @@ test.describe("Signup form", () => {
   test("shows validation for short password", async ({ page }) => {
     await page.goto("/auth/signup");
     await page.getByLabel("Email").fill("test-short-pw@example.com");
-    await page.getByLabel("Password").fill("ab"); // too short (min 6)
+    await page.getByLabel("Password", { exact: true }).fill("ab"); // too short (min 6)
     await page.getByRole("button", { name: /sign up/i }).click();
 
     // HTML5 minLength prevents submission — button still visible, no redirect
@@ -85,7 +85,7 @@ test.describe("Signup form", () => {
 
     await page.goto("/auth/signup");
     await page.getByLabel("Email").fill("signup-test@example.com");
-    await page.getByLabel("Password").fill("StrongPassword123!");
+    await page.getByLabel("Password", { exact: true }).fill("StrongPassword123!");
     await page.getByRole("button", { name: /sign up/i }).click();
 
     // App redirects to login with msg=check-email after successful signup,

--- a/frontend/e2e/functional-onboarding.spec.ts
+++ b/frontend/e2e/functional-onboarding.spec.ts
@@ -116,7 +116,7 @@ test.describe("Onboarding: wizard flow", () => {
     // Log in as the onboarding user
     await page.goto("/auth/login");
     await page.getByLabel("Email").fill(ONBOARDING_EMAIL);
-    await page.getByLabel("Password").fill(ONBOARDING_PASSWORD);
+    await page.getByLabel("Password", { exact: true }).fill(ONBOARDING_PASSWORD);
     await page.getByRole("button", { name: "Sign In" }).click();
 
     // Should land on onboarding (no preferences set)
@@ -136,7 +136,7 @@ test.describe("Onboarding: wizard flow", () => {
   test("Skip All from welcome goes to /app/search", async ({ page }) => {
     await page.goto("/auth/login");
     await page.getByLabel("Email").fill(ONBOARDING_EMAIL);
-    await page.getByLabel("Password").fill(ONBOARDING_PASSWORD);
+    await page.getByLabel("Password", { exact: true }).fill(ONBOARDING_PASSWORD);
     await page.getByRole("button", { name: "Sign In" }).click();
 
     await page.waitForURL(/\/(onboarding|app)/, { timeout: 15_000 });
@@ -154,7 +154,7 @@ test.describe("Onboarding: wizard flow", () => {
 
     await page.goto("/auth/login");
     await page.getByLabel("Email").fill(ONBOARDING_EMAIL);
-    await page.getByLabel("Password").fill(ONBOARDING_PASSWORD);
+    await page.getByLabel("Password", { exact: true }).fill(ONBOARDING_PASSWORD);
     await page.getByRole("button", { name: "Sign In" }).click();
 
     await page.waitForURL(/\/(onboarding|app)/, { timeout: 15_000 });
@@ -178,7 +178,7 @@ test.describe("Onboarding: wizard flow", () => {
 
     await page.goto("/auth/login");
     await page.getByLabel("Email").fill(ONBOARDING_EMAIL);
-    await page.getByLabel("Password").fill(ONBOARDING_PASSWORD);
+    await page.getByLabel("Password", { exact: true }).fill(ONBOARDING_PASSWORD);
     await page.getByRole("button", { name: "Sign In" }).click();
 
     await page.waitForURL(/\/(onboarding|app)/, { timeout: 15_000 });
@@ -210,7 +210,7 @@ test.describe("Onboarding: wizard flow", () => {
 
     await page.goto("/auth/login");
     await page.getByLabel("Email").fill(ONBOARDING_EMAIL);
-    await page.getByLabel("Password").fill(ONBOARDING_PASSWORD);
+    await page.getByLabel("Password", { exact: true }).fill(ONBOARDING_PASSWORD);
     await page.getByRole("button", { name: "Sign In" }).click();
 
     await page.waitForURL(/\/(onboarding|app)/, { timeout: 15_000 });

--- a/frontend/e2e/screenshot-capture.spec.ts
+++ b/frontend/e2e/screenshot-capture.spec.ts
@@ -199,7 +199,7 @@ async function signInViaUI(page: Page) {
   await page.goto("/auth/login");
   await page.waitForLoadState("networkidle");
   await page.getByLabel("Email").fill(TEST_EMAIL);
-  await page.getByLabel("Password").fill(TEST_PASSWORD);
+  await page.getByLabel("Password", { exact: true }).fill(TEST_PASSWORD);
   await page.getByRole("button", { name: "Sign In" }).click();
 
   // Wait for navigation to authenticated area (longer timeout for SSR warmup)

--- a/frontend/e2e/smoke-extended.spec.ts
+++ b/frontend/e2e/smoke-extended.spec.ts
@@ -185,7 +185,7 @@ test.describe("Login page details", () => {
 test.describe("Signup page details", () => {
   test("password field has correct placeholder", async ({ page }) => {
     await page.goto("/auth/signup");
-    const passwordInput = page.getByLabel("Password");
+    const passwordInput = page.getByLabel("Password", { exact: true });
     await expect(passwordInput).toHaveAttribute(
       "placeholder",
       "At least 6 characters",

--- a/frontend/e2e/visual-audit.spec.ts
+++ b/frontend/e2e/visual-audit.spec.ts
@@ -146,7 +146,7 @@ async function signInViaUI(page: Page) {
   await page.goto("/auth/login");
   await page.waitForLoadState("networkidle").catch(() => {});
   await page.getByLabel("Email").fill(TEST_EMAIL);
-  await page.getByLabel("Password").fill(TEST_PASSWORD);
+  await page.getByLabel("Password", { exact: true }).fill(TEST_PASSWORD);
   await page.getByRole("button", { name: "Sign In" }).click();
   await page.waitForURL(/\/(app|onboarding)/, { timeout: 30_000 });
 


### PR DESCRIPTION
## Problem

\getByLabel('Password')\ in Playwright E2E tests matched **two elements** — the password input (via \<label for>\) and the 'Show password' toggle button (via substring match on \ria-label='Show password'\). This caused a Playwright strict mode violation that failed the Quality Gate CI check.

Introduced by PR #727 (password toggle feature).

## Fix

Added \{ exact: true }\ to all 12 \getByLabel('Password')\ calls across 6 E2E test files. This ensures only the exact label text 'Password' is matched, excluding 'Show password'.

## Files Changed

| File | Occurrences Fixed |
|------|-------------------|
| \2e/auth.setup.ts\ | 1 |
| \2e/authenticated.spec.ts\ | 3 |
| \2e/visual-audit.spec.ts\ | 1 |
| \2e/screenshot-capture.spec.ts\ | 1 |
| \2e/smoke-extended.spec.ts\ | 1 |
| \2e/functional-onboarding.spec.ts\ | 5 |

## Verification

- \
px tsc --noEmit\ — 0 errors
- No functional test changes — only locator precision improvement