### PR TITLE
feat(frontend): PWA manifest completeness + branded error illustrations (#710)

### DIFF
--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,8 +1,10 @@
 {
   "id": "/app",
-  "name": "TryVit",
+  "name": "TryVit — Know What You Eat",
   "short_name": "TryVit",
   "description": "Scan food barcodes and see a health score from 1–100. Find healthier alternatives instantly.",
+  "lang": "en",
+  "dir": "ltr",
   "start_url": "/app",
   "scope": "/",
   "display": "standalone",

--- a/frontend/src/app/app/error.test.tsx
+++ b/frontend/src/app/app/error.test.tsx
@@ -4,10 +4,26 @@ import AppError from "./error";
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
-const mockPush = vi.fn();
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: mockPush }),
+vi.mock("next/image", () => ({
+  default: ({ priority, ...props }: Record<string, unknown>) => (
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    <img {...props} data-priority={priority ? "true" : "false"} />
+  ),
 }));
 
 vi.mock("@/lib/i18n", () => ({
@@ -53,11 +69,10 @@ describe("AppError (app-level error boundary)", () => {
     expect(reset).toHaveBeenCalledOnce();
   });
 
-  it("renders Go Home button that navigates to /app", () => {
+  it("renders Go Home link that points to /app", () => {
     render(<AppError error={baseError} reset={vi.fn()} />);
-    const btn = screen.getByRole("button", { name: "Go Home" });
-    fireEvent.click(btn);
-    expect(mockPush).toHaveBeenCalledWith("/app");
+    const link = screen.getByRole("link", { name: "Go Home" });
+    expect(link).toHaveAttribute("href", "/app");
   });
 
   it("shows error digest when present", () => {
@@ -82,10 +97,13 @@ describe("AppError (app-level error boundary)", () => {
     spy.mockRestore();
   });
 
-  it("renders warning icon as decorative", () => {
-    render(<AppError error={baseError} reset={vi.fn()} />);
-    const alert = screen.getByRole("alert");
-    const svg = alert.querySelector("svg");
-    expect(svg).toHaveAttribute("aria-hidden", "true");
+  it("renders error illustration", () => {
+    const { container } = render(
+      <AppError error={baseError} reset={vi.fn()} />,
+    );
+    const img = container.querySelector(
+      "img[data-illustration='server-error']",
+    );
+    expect(img).toBeTruthy();
   });
 });

--- a/frontend/src/app/app/error.tsx
+++ b/frontend/src/app/app/error.tsx
@@ -5,9 +5,9 @@
 "use client";
 
 import { useEffect } from "react";
-import { AlertTriangle } from "lucide-react";
 import { useTranslation } from "@/lib/i18n";
-import { useRouter } from "next/navigation";
+import { Button, ButtonLink } from "@/components/common/Button";
+import { ErrorIllustration } from "@/components/common/ErrorIllustration";
 
 export default function AppError({
   error,
@@ -17,7 +17,6 @@ export default function AppError({
   reset: () => void;
 }>) {
   const { t } = useTranslation();
-  const router = useRouter();
 
   useEffect(() => {
     if (process.env.NODE_ENV === "development") {
@@ -31,49 +30,25 @@ export default function AppError({
       role="alert"
       data-testid="error-boundary-page"
     >
-      <AlertTriangle
-        size={40}
-        aria-hidden="true"
-        className="mb-3 text-warning"
-      />
-      <h2
-        className="mb-2 text-xl font-bold"
-        style={{ color: "var(--color-text-primary)" }}
-      >
+      <ErrorIllustration type="server-error" className="mb-4" />
+      <h2 className="mb-2 text-xl font-bold text-foreground">
         {t("errorBoundary.pageTitle")}
       </h2>
-      <p
-        className="mb-6 max-w-md text-sm"
-        style={{ color: "var(--color-text-secondary)" }}
-      >
+      <p className="mb-6 max-w-md text-sm text-foreground-secondary">
         {t("errorBoundary.pageDescription")}
       </p>
       {error.digest && (
-        <p
-          className="mb-4 font-mono text-xs"
-          style={{ color: "var(--color-text-muted)" }}
-        >
+        <p className="mb-4 font-mono text-xs text-foreground-muted">
           {t("errorBoundary.errorId")}: {error.digest}
         </p>
       )}
       <div className="flex gap-3">
-        <button
-          onClick={reset}
-          className="rounded-lg px-5 py-2.5 text-sm font-medium text-white"
-          style={{ backgroundColor: "var(--color-brand)" }}
-        >
+        <Button onClick={reset}>
           {t("common.tryAgain")}
-        </button>
-        <button
-          onClick={() => router.push("/app")}
-          className="rounded-lg border px-5 py-2.5 text-sm font-medium"
-          style={{
-            borderColor: "var(--color-border)",
-            color: "var(--color-text-primary)",
-          }}
-        >
+        </Button>
+        <ButtonLink href="/app" variant="secondary">
           {t("errorBoundary.goHome")}
-        </button>
+        </ButtonLink>
       </div>
     </div>
   );

--- a/frontend/src/app/app/recipes/page.tsx
+++ b/frontend/src/app/app/recipes/page.tsx
@@ -3,6 +3,7 @@
 // ─── Recipes browse — grid of curated recipe cards with filters ─────────────
 // Issue #53 — Recipes v0
 
+import { Button } from "@/components/common/Button";
 import { EmptyState } from "@/components/common/EmptyState";
 import { PullToRefresh } from "@/components/common/PullToRefresh";
 import { RecipeGridSkeleton } from "@/components/common/skeletons";
@@ -65,14 +66,10 @@ export default function RecipesBrowsePage() {
   if (error) {
     return (
       <div className="py-12 text-center">
-        <p className="mb-3 text-sm text-red-500">{t("recipes.loadFailed")}</p>
-        <button
-          type="button"
-          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-          onClick={handleRetry}
-        >
+        <p className="mb-3 text-sm text-error">{t("recipes.loadFailed")}</p>
+        <Button onClick={handleRetry} size="sm">
           {t("common.retry")}
-        </button>
+        </Button>
       </div>
     );
   }

--- a/frontend/src/app/error.test.tsx
+++ b/frontend/src/app/error.test.tsx
@@ -2,6 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import ErrorPage from "./error";
 
+vi.mock("next/image", () => ({
+  default: ({ priority, ...props }: Record<string, unknown>) => (
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    <img {...props} data-priority={priority ? "true" : "false"} />
+  ),
+}));
+
 describe("ErrorPage", () => {
   it("renders heading", () => {
     render(<ErrorPage error={new Error("test")} reset={vi.fn()} />);
@@ -30,12 +37,13 @@ describe("ErrorPage", () => {
     spy.mockRestore();
   });
 
-  it("renders AlertTriangle icon", () => {
+  it("renders error illustration", () => {
     const { container } = render(
       <ErrorPage error={new Error("test")} reset={vi.fn()} />,
     );
-    const svg = container.querySelector("svg");
-    expect(svg).toBeTruthy();
-    expect(svg?.getAttribute("aria-hidden")).toBe("true");
+    const img = container.querySelector(
+      "img[data-illustration='server-error']",
+    );
+    expect(img).toBeTruthy();
   });
 });

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -5,9 +5,9 @@
 "use client";
 
 import { Button } from "@/components/common/Button";
+import { ErrorIllustration } from "@/components/common/ErrorIllustration";
 import { useTranslation } from "@/lib/i18n";
 import * as Sentry from "@sentry/nextjs";
-import { AlertTriangle } from "lucide-react";
 import { useEffect } from "react";
 
 export default function ErrorPage({
@@ -31,7 +31,7 @@ export default function ErrorPage({
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center px-4">
-      <AlertTriangle size={48} className="mb-4 text-error" aria-hidden="true" />
+      <ErrorIllustration type="server-error" className="mb-6" />
       <h1 className="mb-2 text-2xl font-bold text-foreground">
         {t("error.somethingWrong")}
       </h1>

--- a/frontend/src/app/not-found.test.tsx
+++ b/frontend/src/app/not-found.test.tsx
@@ -17,6 +17,13 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+vi.mock("next/image", () => ({
+  default: ({ priority, ...props }: Record<string, unknown>) => (
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    <img {...props} data-priority={priority ? "true" : "false"} />
+  ),
+}));
+
 describe("NotFound (404)", () => {
   it("renders 404 heading", () => {
     render(<NotFound />);
@@ -34,10 +41,11 @@ describe("NotFound (404)", () => {
     expect(link.closest("a")).toHaveAttribute("href", "/");
   });
 
-  it("renders FileQuestion icon", () => {
+  it("renders error illustration", () => {
     const { container } = render(<NotFound />);
-    const svg = container.querySelector("svg");
-    expect(svg).toBeTruthy();
-    expect(svg?.getAttribute("aria-hidden")).toBe("true");
+    const img = container.querySelector(
+      "img[data-illustration='not-found']",
+    );
+    expect(img).toBeTruthy();
   });
 });

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -3,14 +3,14 @@
 "use client";
 
 import { ButtonLink } from "@/components/common/Button";
+import { ErrorIllustration } from "@/components/common/ErrorIllustration";
 import { useTranslation } from "@/lib/i18n";
-import { FileQuestion } from "lucide-react";
 
 export default function NotFound() {
   const { t } = useTranslation();
   return (
     <div className="flex min-h-screen flex-col items-center justify-center px-4">
-      <FileQuestion size={48} className="mb-4 text-foreground-muted" aria-hidden="true" />
+      <ErrorIllustration type="not-found" priority className="mb-6" />
       <h1 className="mb-2 text-6xl font-bold text-foreground">
         {t("error.notFoundCode")}
       </h1>

--- a/frontend/src/app/offline/page.test.tsx
+++ b/frontend/src/app/offline/page.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import OfflinePage from "./page";
+
+vi.mock("next/image", () => ({
+  default: ({ priority, ...props }: Record<string, unknown>) => (
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    <img {...props} data-priority={priority ? "true" : "false"} />
+  ),
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("OfflinePage", () => {
+  it("renders offline title", () => {
+    render(<OfflinePage />);
+    expect(screen.getByText("You're Offline")).toBeInTheDocument();
+  });
+
+  it("renders offline description", () => {
+    render(<OfflinePage />);
+    expect(
+      screen.getByText(/lost your internet connection/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders error illustration", () => {
+    const { container } = render(<OfflinePage />);
+    const img = container.querySelector("img[data-illustration='offline']");
+    expect(img).toBeTruthy();
+  });
+
+  it("renders try again button", () => {
+    render(<OfflinePage />);
+    expect(
+      screen.getByRole("button", { name: "Try Again" }),
+    ).toBeInTheDocument();
+  });
+
+  it("reloads page on try again click", () => {
+    const reloadMock = vi.fn();
+    Object.defineProperty(globalThis, "location", {
+      value: { reload: reloadMock },
+      writable: true,
+    });
+    render(<OfflinePage />);
+    fireEvent.click(screen.getByRole("button", { name: "Try Again" }));
+    expect(reloadMock).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/app/offline/page.tsx
+++ b/frontend/src/app/offline/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { Button } from "@/components/common/Button";
+import { ErrorIllustration } from "@/components/common/ErrorIllustration";
 import { useTranslation } from "@/lib/i18n";
-import { WifiOff } from "lucide-react";
 
 export default function OfflinePage() {
   const { t } = useTranslation();
   return (
     <div className="flex min-h-[60vh] flex-col items-center justify-center px-4 text-center">
-      <WifiOff size={48} aria-hidden="true" className="text-foreground-muted" />
+      <ErrorIllustration type="offline" className="mb-2" />
       <h1 className="mt-4 text-xl font-bold text-foreground">
         {t("offline.title")}
       </h1>

--- a/frontend/src/lib/pwa-metadata.test.ts
+++ b/frontend/src/lib/pwa-metadata.test.ts
@@ -15,12 +15,17 @@ describe("PWA Manifest", () => {
   const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
 
   it("has required PWA fields", () => {
-    expect(manifest.name).toBe("TryVit");
+    expect(manifest.name).toBe("TryVit \u2014 Know What You Eat");
     expect(manifest.short_name).toBe("TryVit");
     expect(manifest.start_url).toBe("/app");
     expect(manifest.display).toBe("standalone");
     expect(manifest.theme_color).toBeTruthy();
     expect(manifest.background_color).toBeTruthy();
+  });
+
+  it("has language and direction", () => {
+    expect(manifest.lang).toBe("en");
+    expect(manifest.dir).toBe("ltr");
   });
 
   it("has app identity id field", () => {


### PR DESCRIPTION
## Summary

Completes issue #710 (PWA manifest completeness) and adds elite enhancements: branded error illustrations across all error pages plus component standardization.

### Changes

**PWA Manifest** (`manifest.webmanifest`)
- Added `lang: "en"` and `dir: "ltr"` — required W3C fields for accessibility
- Expanded `name` to `"TryVit — Know What You Eat"` (full app identity; `short_name` stays `"TryVit"`)

**Error Page Illustrations** (elite enhancement)
- Wired pre-existing `ErrorIllustration` component into all 4 error-related pages:
  - `app/not-found.tsx` — replaced `FileQuestion` Lucide icon
  - `app/error.tsx` — replaced `AlertTriangle` Lucide icon
  - `app/offline/page.tsx` — replaced `WifiOff` Lucide icon
  - `app/app/error.tsx` — replaced `AlertTriangle` Lucide icon

**Component Standardization** (elite enhancement)
- `app/app/error.tsx`: replaced 2 raw `<button>` elements with `<Button>` and `<ButtonLink variant="secondary">` components; removed `useRouter` import
- `app/app/recipes/page.tsx`: replaced raw `<button>` with `<Button>` component; changed `text-red-500` to `text-error` and removed hardcoded `bg-blue-600`

### Tests

- **New:** `offline/page.test.tsx` — 5 tests (title, description, illustration, button, reload behavior)
- **Updated:** `not-found.test.tsx`, `error.test.tsx`, `app/error.test.tsx` — SVG icon assertions to ErrorIllustration img assertions
- **Updated:** `pwa-metadata.test.ts` — expanded name assertion + new lang/dir test

### Verification

```
npx tsc --noEmit           → 0 errors
npx vitest run             → 5355 passed, 0 failed (319 files)
```

**11 files changed, +133 / -70 lines**

Closes #710
