### PR TITLE
fix(frontend): dark mode polish, design system alignment, ARIA improvements

### DIFF
--- a/frontend/src/app/app/settings/notifications/page.tsx
+++ b/frontend/src/app/app/settings/notifications/page.tsx
@@ -2,6 +2,7 @@
 
 // ─── Settings — Notifications (Push Toggle, Score Alerts, Frequency) ────────
 
+import { Button } from "@/components/common/Button";
 import { SettingsSkeleton } from "@/components/common/skeletons";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
 import { useAnalytics } from "@/hooks/use-analytics";
@@ -259,7 +260,7 @@ export default function NotificationSettingsPage() {
               className="peer sr-only"
               data-testid="score-changes-toggle"
             />
-            <div className="peer h-6 w-11 rounded-full bg-surface-muted after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-strong after:bg-white after:transition-all after:content-[''] peer-checked:bg-brand peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-brand/40" />
+            <div className="peer h-6 w-11 rounded-full bg-surface-muted after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-strong after:bg-surface after:transition-all after:content-[''] peer-checked:bg-brand peer-checked:after:translate-x-full peer-checked:after:border-surface peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-brand/40" />
           </label>
         </div>
       </section>
@@ -309,7 +310,7 @@ export default function NotificationSettingsPage() {
                 }`}
               >
                 {frequency === option.value && (
-                  <div className="m-0.5 h-2 w-2 rounded-full bg-white" />
+                  <div className="m-0.5 h-2 w-2 rounded-full bg-surface" />
                 )}
               </div>
               <div>
@@ -328,15 +329,15 @@ export default function NotificationSettingsPage() {
       {/* ─── Save button — sticky bar at bottom when dirty ─────────────── */}
       {dirty && (
         <div className="sticky bottom-0 z-30 -mx-4 flex animate-slide-in-up justify-end border-t border-border bg-surface/95 px-4 py-3 backdrop-blur sm:-mx-6 sm:px-6">
-          <button
-            type="button"
+          <Button
+            variant="primary"
             onClick={handleSavePreferences}
             disabled={savingPrefs}
-            className="rounded-lg bg-brand px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed"
+            loading={savingPrefs}
             data-testid="save-notification-prefs"
           >
             {savingPrefs ? t("common.loading") : t("common.save")}
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -18,7 +18,8 @@
 import React, { Component, type ErrorInfo, type ReactNode } from "react";
 import { reportBoundaryError, type ErrorContext } from "@/lib/error-reporter";
 import { translate } from "@/lib/i18n";
-import { AlertTriangle } from "lucide-react";
+import { buttonClasses } from "@/components/common/Button";
+import { ErrorIllustration } from "@/components/common/ErrorIllustration";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -56,44 +57,30 @@ function PageFallback({
       role="alert"
       data-testid="error-boundary-page"
     >
-      <div className="mb-3" aria-hidden="true">
-        <AlertTriangle size={40} style={{ color: "var(--color-warning)" }} />
+      <div className="mb-4" aria-hidden="true">
+        <ErrorIllustration type="server-error" width={160} height={133} />
       </div>
-      <h2
-        className="mb-2 text-xl font-bold"
-        style={{ color: "var(--color-text-primary)" }}
-      >
+      <h2 className="mb-2 text-xl font-bold text-foreground">
         {translate("en", "errorBoundary.pageTitle")}
       </h2>
-      <p
-        className="mb-6 max-w-md text-sm"
-        style={{ color: "var(--color-text-secondary)" }}
-      >
+      <p className="mb-6 max-w-md text-sm text-foreground-secondary">
         {translate("en", "errorBoundary.pageDescription")}
       </p>
       {digest && (
-        <p
-          className="mb-4 font-mono text-xs"
-          style={{ color: "var(--color-text-muted)" }}
-        >
+        <p className="mb-4 font-mono text-xs text-foreground-muted">
           {translate("en", "errorBoundary.errorId")}: {digest}
         </p>
       )}
       <div className="flex gap-3">
         <button
           onClick={onReset}
-          className="rounded-lg px-5 py-2.5 text-sm font-medium text-white"
-          style={{ backgroundColor: "var(--color-brand)" }}
+          className={buttonClasses("primary", "md")}
         >
           {translate("en", "common.tryAgain")}
         </button>
         <a
           href="/app"
-          className="rounded-lg border px-5 py-2.5 text-sm font-medium"
-          style={{
-            borderColor: "var(--color-border)",
-            color: "var(--color-text-primary)",
-          }}
+          className={buttonClasses("secondary", "md")}
         >
           {translate("en", "errorBoundary.goHome")}
         </a>
@@ -105,24 +92,19 @@ function PageFallback({
 function SectionFallback({ onReset }: Readonly<{ onReset: () => void }>) {
   return (
     <div
-      className="my-4 flex flex-col items-center justify-center rounded-lg border border-dashed p-6 text-center"
+      className="my-4 flex flex-col items-center justify-center rounded-lg border border-dashed border-strong p-6 text-center"
       role="alert"
       data-testid="error-boundary-section"
-      style={{ borderColor: "var(--color-border-strong)" }}
     >
       <div className="mb-2" aria-hidden="true">
-        <AlertTriangle size={28} style={{ color: "var(--color-warning)" }} />
+        <ErrorIllustration type="server-error" width={80} height={67} />
       </div>
-      <p
-        className="mb-3 text-sm font-medium"
-        style={{ color: "var(--color-text-primary)" }}
-      >
+      <p className="mb-3 text-sm font-medium text-foreground">
         {translate("en", "errorBoundary.sectionTitle")}
       </p>
       <button
         onClick={onReset}
-        className="rounded-md px-4 py-1.5 text-sm font-medium text-white"
-        style={{ backgroundColor: "var(--color-brand)" }}
+        className={buttonClasses("primary", "sm")}
       >
         {translate("en", "common.tryAgain")}
       </button>
@@ -133,13 +115,9 @@ function SectionFallback({ onReset }: Readonly<{ onReset: () => void }>) {
 function ComponentFallback() {
   return (
     <span
-      className="inline-flex items-center justify-center rounded border border-dashed px-2 py-0.5 text-xs"
+      className="inline-flex items-center justify-center rounded border border-dashed border-border px-2 py-0.5 text-xs text-foreground-muted"
       role="alert"
       data-testid="error-boundary-component"
-      style={{
-        borderColor: "var(--color-border)",
-        color: "var(--color-text-muted)",
-      }}
       title={translate("en", "errorBoundary.componentTooltip")}
     >
       —

--- a/frontend/src/components/common/Toggle.tsx
+++ b/frontend/src/components/common/Toggle.tsx
@@ -78,7 +78,7 @@ export function Toggle({
         <span
           aria-hidden="true"
           className={[
-            "pointer-events-none inline-block transform rounded-full bg-white shadow-sm ring-0 transition-transform",
+            "pointer-events-none inline-block transform rounded-full bg-surface shadow-sm ring-0 transition-transform",
             THUMB_SIZES[size].size,
             checked ? THUMB_SIZES[size].translate : "translate-x-0",
           ].join(" ")}

--- a/frontend/src/components/compare/ComparisonGrid.tsx
+++ b/frontend/src/components/compare/ComparisonGrid.tsx
@@ -409,11 +409,13 @@ function MobileSwipeView({
     <div className="md:hidden">
       {/* Sticky header with product names */}
       <div className="sticky top-12 md:top-14 z-30 bg-surface border-b border-border px-4 py-2">
-        <div className="flex items-center justify-center gap-2">
+        <div className="flex items-center justify-center gap-2" role="tablist">
           {products.map((p, i) => (
             <button
               key={p.product_id}
               onClick={() => setActiveIdx(i)}
+              role="tab"
+              aria-selected={i === activeIdx}
               className={`touch-target rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
                 i === activeIdx
                   ? "bg-brand text-white"


### PR DESCRIPTION
## Summary

Elite dark mode, design system alignment, and accessibility polish across 4 files.

### Changes

**Dark mode fixes:**
- `Toggle.tsx`: `bg-white` → `bg-surface` on toggle knob — eliminates stark white dot in dark mode
- `notifications/page.tsx`: `bg-white` → `bg-surface` on score-changes toggle knob and radio button inner dot

**Design system alignment:**
- `ErrorBoundary.tsx`: Replace `AlertTriangle` icon with `ErrorIllustration` component (consistent with error pages)
- `ErrorBoundary.tsx`: Replace 3 raw `<button>`/`<a>` elements with `buttonClasses()` from design system
- `ErrorBoundary.tsx`: Replace all inline `style={{}}` with Tailwind semantic tokens (`text-foreground`, `border-strong`, etc.)
- `notifications/page.tsx`: Replace raw save `<button>` with `<Button variant="primary">` component

**Accessibility:**
- `ComparisonGrid.tsx`: Add `role="tablist"` on mobile product switcher wrapper, `role="tab"` + `aria-selected` on individual buttons

### Verification

```
npx tsc --noEmit          → 0 errors
npx vitest run            → 319 passed | 2 skipped (5355 tests, 29 skipped)
```

4 files changed, +25 / -44 lines (net reduction from removing inline styles)

Closes #712 (partial — dark mode visual audit)
