### PR TITLE
docs: refresh stale documentation numbers and cut v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+---
+
+## [0.2.0] — 2026-03-09
+
 ### Fixed
 
 - Fix enrichment SQL generator portability: replace hardcoded `ingredient_id`
@@ -740,5 +746,6 @@ Changes that **MUST** be flagged as breaking in commits and changelog:
 
 ---
 
-[Unreleased]: https://github.com/ericsocrat/tryvit/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/ericsocrat/tryvit/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/ericsocrat/tryvit/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ericsocrat/tryvit/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
 
 <p align="center">
   <a href="https://github.com/ericsocrat/tryvit/actions/workflows/pr-gate.yml"><img src="https://img.shields.io/github/actions/workflow/status/ericsocrat/tryvit/pr-gate.yml?style=flat-square&label=build" alt="Build Status" /></a>
-  <img src="https://img.shields.io/badge/QA%20checks-733%20passing-brightgreen?style=flat-square" alt="QA Checks" />
+  <img src="https://img.shields.io/badge/QA%20checks-747%20passing-brightgreen?style=flat-square" alt="QA Checks" />
   <img src="https://img.shields.io/badge/coverage-%E2%89%A588%25-brightgreen?style=flat-square" alt="Coverage" />
-  <img src="https://img.shields.io/badge/products-1%2C281-1DB954?style=flat-square" alt="Products" />
-  <img src="https://img.shields.io/badge/market-Poland-1DB954?style=flat-square" alt="Market" />
-  <img src="https://img.shields.io/badge/scoring-v3.2-7c3aed?style=flat-square" alt="Scoring Version" />
+  <img src="https://img.shields.io/badge/products-2%2C438-1DB954?style=flat-square" alt="Products" />
+  <img src="https://img.shields.io/badge/market-PL%20%2B%20DE-1DB954?style=flat-square" alt="Market" />
+  <img src="https://img.shields.io/badge/scoring-v3.3-7c3aed?style=flat-square" alt="Scoring Version" />
   <a href="LICENSE"><img src="https://img.shields.io/github/license/ericsocrat/tryvit?style=flat-square" alt="License" /></a>
   <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" />
   <img src="https://img.shields.io/badge/PostgreSQL-16-336791?style=flat-square&logo=postgresql&logoColor=white" alt="PostgreSQL" />
@@ -137,7 +137,7 @@ supabase db reset                        # Full rebuild (migrations + seed)
 .\RUN_SEED.ps1                           # Seed reference data only
 
 # ── Testing ──
-.\RUN_QA.ps1                             # 733 QA checks across 48 suites
+.\RUN_QA.ps1                             # 747 QA checks across 48 suites
 .\RUN_NEGATIVE_TESTS.ps1                 # 23 constraint violation tests
 .\RUN_SANITY.ps1 -Env local              # Row-count + schema assertions
 python validate_eans.py                  # EAN checksum validation
@@ -168,15 +168,15 @@ echo "SELECT * FROM v_master LIMIT 5;" | docker exec -i supabase_db_tryvit psql 
 ```
 ┌─────────────────┐     ┌──────────────────┐     ┌─────────────────────────┐
 │  Open Food Facts │────▶│  Python Pipeline │────▶│  PostgreSQL (Supabase)  │
-│  API v2          │     │  sql_generator   │     │  185 migrations         │
-│  (category tags, │     │  validator       │     │  25 pipeline folders    │
-│   countries=PL)  │     │  off_client      │     │  products + nutrition   │
+│  API v2          │     │  sql_generator   │     │  199 migrations         │
+│  (category tags, │     │  validator       │     │  43 pipeline folders    │
+│   countries=PL,DE│     │  off_client      │     │  products + nutrition   │
 └─────────────────┘     └──────────────────┘     │  + ingredients + scores │
                                                   └───────────┬─────────────┘
                                                               │
                                                   ┌───────────▼─────────────┐
                                                   │  API Layer              │
-                                                  │  30+ RPC functions      │
+                                                  │  190+ RPC functions     │
                                                   │  RLS + SECURITY DEFINER │
                                                   │  pg_trgm search         │
                                                   └───────────┬─────────────┘
@@ -189,19 +189,22 @@ echo "SELECT * FROM v_master LIMIT 5;" | docker exec -i supabase_db_tryvit psql 
                                                   └─────────────────────────┘
 ```
 
-**Data flow:** OFF API → Python pipeline generates idempotent SQL → PostgreSQL stores products, nutrition, ingredients, allergens → Scoring function `compute_unhealthiness_v32()` computes scores → API functions expose structured JSONB → Next.js frontend renders.
+**Data flow:** OFF API → Python pipeline generates idempotent SQL → PostgreSQL stores products, nutrition, ingredients, allergens → Scoring function `compute_unhealthiness_v33()` computes scores (9 penalty factors − nutrient density bonus) → API functions expose structured JSONB → Next.js frontend renders.
 
 ---
 
 <!-- ═══════════════════════════ 8. SCORING SUMMARY ═══════════════════════ -->
 
-## 📈 Scoring Engine (v3.2)
+## 📈 Scoring Engine (v3.3)
 
 ```
-unhealthiness_score (1–100) =
+penalty_sum (9 factors, weights sum to 1.00) =
   sat_fat(0.17) + sugars(0.17) + salt(0.17) + calories(0.10) +
   trans_fat(0.11) + additives(0.07) + prep_method(0.08) +
   controversies(0.08) + ingredient_concern(0.05)
+
+nutrient_density_bonus = protein_bonus + fibre_bonus  (0–100, tiered)
+unhealthiness_score (1–100) = penalty_sum − nutrient_density_bonus × 0.08
 ```
 
 <table>
@@ -216,7 +219,7 @@ unhealthiness_score (1–100) =
 
 **Ceilings** (per 100 g): sat fat 10 g · sugars 27 g · salt 3 g · trans fat 2 g · calories 600 kcal · additives 10
 
-Every score is fully explainable via `api_score_explanation()` — returns the 9 factors with raw values, weights, and category context (rank, average, percentile).
+Every score is fully explainable via `api_score_explanation()` — returns the 9 penalty factors plus the nutrient density bonus with raw values, weights, and category context (rank, average, percentile).
 
 📄 [Full methodology →](docs/SCORING_METHODOLOGY.md)
 
@@ -228,23 +231,23 @@ Every score is fully explainable via `api_score_explanation()` — returns the 9
 
 <table>
   <tr>
-    <td align="center" width="16%"><strong>1,281</strong><br />Active Products</td>
-    <td align="center" width="16%"><strong>25</strong><br />Categories</td>
-    <td align="center" width="16%"><strong>PL</strong><br />Primary Market</td>
+    <td align="center" width="16%"><strong>2,438</strong><br />Active Products</td>
+    <td align="center" width="16%"><strong>43</strong><br />Categories</td>
+    <td align="center" width="16%"><strong>PL + DE</strong><br />Markets</td>
     <td align="center" width="16%"><strong>2,995</strong><br />Ingredients</td>
-    <td align="center" width="16%"><strong>99.8%</strong><br />EAN Coverage</td>
-    <td align="center" width="16%"><strong>182</strong><br />Migrations</td>
+    <td align="center" width="16%"><strong>99.9%</strong><br />EAN Coverage</td>
+    <td align="center" width="16%"><strong>199</strong><br />Migrations</td>
   </tr>
 </table>
 
 <table>
   <tr>
-    <td align="center" width="16%"><strong>733</strong><br />QA Checks</td>
+    <td align="center" width="16%"><strong>747</strong><br />QA Checks</td>
     <td align="center" width="16%"><strong>48</strong><br />Test Suites</td>
     <td align="center" width="16%"><strong>23</strong><br />Negative Tests</td>
     <td align="center" width="16%"><strong>≥88%</strong><br />Line Coverage</td>
-    <td align="center" width="16%"><strong>30+</strong><br />API Functions</td>
-    <td align="center" width="16%"><strong>v3.2</strong><br />Scoring Engine</td>
+    <td align="center" width="16%"><strong>190+</strong><br />API Functions</td>
+    <td align="center" width="16%"><strong>v3.3</strong><br />Scoring Engine</td>
   </tr>
 </table>
 
@@ -285,26 +288,22 @@ tryvit/
 │   ├── off_client.py                # OFF API v2 client with retry logic
 │   ├── sql_generator.py             # Generates 4–5 SQL files per category
 │   ├── validator.py                 # Data validation before SQL generation
-│   ├── categories.py                # 25 category definitions + OFF tag mappings
+│   ├── categories.py                # 43 category definitions + OFF tag mappings
 │   └── image_importer.py            # Product image import utility
 │
 ├── db/
-│   ├── pipelines/                   # 25 category folders (20 PL + 5 DE)
+│   ├── pipelines/                   # 43 category folders (22 PL + 21 DE)
 │   │   ├── chips-pl/                # Reference PL implementation
-│   │   ├── chips-de/                # Germany micro-pilot (51 products)
-│   │   ├── bread-de/                # DE Bread
-│   │   ├── dairy-de/                # DE Dairy
-│   │   ├── drinks-de/               # DE Drinks
-│   │   ├── sweets-de/               # DE Sweets
-│   │   └── ... (19 more PL)         # Variable product counts per category
-│   ├── qa/                          # 48 test suites (733 checks)
+│   │   ├── chips-de/                # DE Chips (51 products)
+│   │   └── ... (21 more PL + 20 DE) # Variable product counts per category
+│   ├── qa/                          # 48 test suites (747 checks)
 │   └── views/                       # Reference view definitions
 │
 ├── supabase/
-│   ├── migrations/                  # 185 append-only schema migrations
+│   ├── migrations/                  # 199 append-only schema migrations
 │   ├── seed/                        # Reference data seeds
 │   ├── tests/                       # pgTAP integration tests
-│   └── functions/                   # Edge Functions (API gateway, push notifications)
+│   └── functions/                   # Edge Functions (API gateway, push notifications, CAPTCHA)
 │
 ├── frontend/                        # Next.js 15 App Router
 │   ├── src/
@@ -314,21 +313,21 @@ tryvit/
 │   │   ├── stores/                  # Zustand stores
 │   │   └── lib/                     # API clients, types, utilities
 │   ├── e2e/                         # Playwright E2E tests
-│   └── messages/                    # i18n dictionaries (en, pl)
+│   └── messages/                    # i18n dictionaries (en, pl, de)
 │
-├── docs/                            # 45+ project documents
-│   ├── SCORING_METHODOLOGY.md       # v3.2 algorithm specification
+├── docs/                            # 51 project documents
+│   ├── SCORING_METHODOLOGY.md       # v3.3 algorithm specification
 │   ├── API_CONTRACTS.md             # API surface contracts
 │   ├── ARCHITECTURE.md              # System architecture overview
 │   ├── decisions/                   # Architecture Decision Records (MADR 3.0)
 │   └── assets/                      # Brand assets (logo, banners)
 │
-├── .github/workflows/               # 18 CI/CD workflows
+├── .github/workflows/               # 20 CI/CD workflows
 ├── scripts/                         # Utility & governance scripts
 ├── monitoring/                      # Alert definitions
 │
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
-├── RUN_QA.ps1                       # QA test runner (733 checks)
+├── RUN_QA.ps1                       # QA test runner (747 checks)
 ├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (23 tests)
 ├── RUN_SANITY.ps1                   # Sanity checks
 ├── CHANGELOG.md                     # Structured changelog
@@ -344,7 +343,7 @@ tryvit/
 
 ## 🧪 Testing
 
-Every change is validated against **733 automated checks** across 48 QA suites plus 20 negative validation tests. No data enters the database without verification.
+Every change is validated against **747 automated checks** across 48 QA suites plus 23 negative validation tests. No data enters the database without verification.
 
 <table>
   <tr>
@@ -356,7 +355,7 @@ Every change is validated against **733 automated checks** across 48 QA suites p
   <tr>
     <td>Database QA</td>
     <td>Raw SQL (zero rows = pass)</td>
-    <td>733</td>
+    <td>747</td>
     <td><code>db/qa/QA__*.sql</code></td>
   </tr>
   <tr>
@@ -401,7 +400,7 @@ Every change is validated against **733 automated checks** across 48 QA suites p
 
 1. **PR Gate** — Typecheck → Lint → Build → Unit tests → Playwright smoke E2E
 2. **Main Gate** — Above + Coverage → SonarCloud Quality Gate
-3. **QA Gate** — Schema → Pipelines → 733 QA checks → Sanity → Confidence threshold
+3. **QA Gate** — Schema → Pipelines → 747 QA checks → Sanity → Confidence threshold
 4. **Nightly** — Full Playwright (all projects) + Data Integrity Audit
 
 ---
@@ -416,7 +415,7 @@ Contributions are welcome! Please follow the project conventions:
 2. **Commit messages:** [Conventional Commits](https://www.conventionalcommits.org/) — enforced on PR titles
 3. **Testing:** Every change must include tests. See [copilot-instructions.md](copilot-instructions.md) §8
 4. **Migrations:** Append-only. Never modify existing `supabase/migrations/` files
-5. **QA:** `.\RUN_QA.ps1` must pass (733/733) before merging
+5. **QA:** `.\RUN_QA.ps1` must pass (747/747) before merging
 
 ---
 
@@ -427,7 +426,7 @@ Contributions are welcome! Please follow the project conventions:
 <details>
 <summary><strong>Core</strong></summary>
 
-- [SCORING_METHODOLOGY.md](docs/SCORING_METHODOLOGY.md) — v3.2 algorithm (9 factors, ceilings, bands)
+- [SCORING_METHODOLOGY.md](docs/SCORING_METHODOLOGY.md) — v3.3 algorithm (9 penalty factors + nutrient density bonus)
 - [API_CONTRACTS.md](docs/API_CONTRACTS.md) — API surface contracts and response shapes
 - [API_CONVENTIONS.md](docs/API_CONVENTIONS.md) — RPC naming, breaking changes, security standards
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md) — System architecture overview

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -8,7 +8,7 @@
 > **Servings:** removed as separate table — all nutrition data is per-100g on nutrition_facts
 > **Ingredient analytics:** 5,340 unique ingredients (all clean ASCII English), 2,691 allergen declarations, 2,702 trace declarations
 > **Ingredient concerns:** EFSA-based 4-tier additive classification (0=none, 1=low, 2=moderate, 3=high)
-> **QA:** 736 checks across 48 suites + 23 negative validation tests — all passing
+> **QA:** 747 checks across 48 suites + 23 negative validation tests — all passing
 
 ---
 
@@ -118,7 +118,7 @@ tryvit/
 │   │   ├── QA__event_intelligence.sql    # 18 event intelligence checks
 │   │   ├── QA__source_coverage.sql  # 8 informational reports (non-blocking)
 │   │   ├── QA__recipe_integrity.sql      # 6 recipe data integrity checks
-│   │   └── TEST__negative_checks.sql     # 20 negative validation tests
+│   │   └── TEST__negative_checks.sql     # 23 negative validation tests
 │   └── views/
 │       └── VIEW__master_product_view.sql  # v_master definition (reference copy)
 ├── supabase/
@@ -147,7 +147,7 @@ tryvit/
 │   │   ├── api-gateway/             # Write-path gateway (rate limiting, validation) (#478)
 │   │   └── send-push-notification/  # Push notification handler
 │   ├── dr-drill/                    # Disaster recovery drill artifacts
-│   └── migrations/                  # 185 append-only schema migrations
+│   └── migrations/                  # 199 append-only schema migrations
 │       ├── 20260207000100_create_schema.sql
 │       ├── 20260207000200_baseline.sql
 │       ├── 20260207000300_add_chip_metadata.sql
@@ -175,7 +175,7 @@ tryvit/
 │       ├── 20260210001600_clean_ingredient_names.sql      # Translate 375 foreign ingredient names to English
 │       ├── 20260210001700_add_real_servings.sql            # 317 real per-serving rows + nutrition
 │       ├── 20260210001800_fix_vmaster_serving_fanout.sql   # Filter v_master to per-100g + add per-serving columns
-│       └── 20260210001900_ingredient_concern_scoring.sql   # EFSA concern tiers + v3.2 scoring function
+│       └── 20260210001900_ingredient_concern_scoring.sql   # EFSA concern tiers + v3.2 scoring function (superseded by v3.3)
 │       └── ...                                              # (migrations 2000–2700: see file listing)
 │       ├── 20260210002800_api_surfaces.sql                  # API views + RPC functions + pg_trgm search indexes
 │       ├── 20260210002900_confidence_scoring.sql            # Composite confidence score (0-100) + MV
@@ -260,7 +260,7 @@ tryvit/
 │       ├── 006-append-only-migrations.md
 │       └── 007-english-canonical-ingredients.md
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
-├── RUN_QA.ps1                       # QA test runner (736 checks across 48 suites)
+├── RUN_QA.ps1                       # QA test runner (747 checks across 48 suites)
 ├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (23 injection tests)
 ├── RUN_SANITY.ps1                   # Sanity checks (16) — row counts, schema assertions
 ├── RUN_REMOTE.ps1                   # Remote deployment (requires confirmation)
@@ -631,7 +631,7 @@ a mix of `'baked'`, `'fried'`, and `'none'`.
 
 ## 7. Migrations
 
-**Location:** `supabase/migrations/` — managed by Supabase CLI. Currently **195 migrations**.
+**Location:** `supabase/migrations/` — managed by Supabase CLI. Currently **199 migrations**.
 
 **Rules:**
 
@@ -703,7 +703,7 @@ A change is **not done** unless relevant tests were added/updated, every suite i
 | Component tests     | **Testing Library React** + Vitest                | `frontend/src/components/**/*.test.tsx`      | same as above                        |
 | E2E smoke           | **Playwright 1.58** (Chromium)                    | `frontend/e2e/smoke.spec.ts`                 | `cd frontend && npx playwright test` |
 | E2E auth            | Playwright (requires `SUPABASE_SERVICE_ROLE_KEY`) | `frontend/e2e/authenticated.spec.ts`         | same (CI auto-detects key)           |
-| DB QA (736 checks)  | Raw SQL (zero rows = pass)                        | `db/qa/QA__*.sql` (48 suites)                | `.\RUN_QA.ps1`                       |
+| DB QA (747 checks)  | Raw SQL (zero rows = pass)                        | `db/qa/QA__*.sql` (48 suites)                | `.\RUN_QA.ps1`                       |
 | Negative validation | SQL injection/constraint tests                    | `db/qa/TEST__negative_checks.sql`            | `.\RUN_NEGATIVE_TESTS.ps1`           |
 | DB sanity           | Row-count + schema assertions                     | via `RUN_SANITY.ps1`                         | `.\RUN_SANITY.ps1 -Env local`        |
 | Pipeline structure  | Python validator                                  | `check_pipeline_structure.py`                | `python check_pipeline_structure.py` |
@@ -844,7 +844,7 @@ E2E tests are the **only** exception — they run against a live dev server but 
   - **`pr-title-lint.yml`**: PR title conventional-commit validation (all PRs)
   - **`main-gate.yml`**: Typecheck → Lint → Build → Unit tests with coverage → Playwright smoke E2E → SonarCloud scan + BLOCKING Quality Gate → Sentry sourcemap upload
   - **`nightly.yml`**: Full Playwright (all projects incl. visual regression) + Data Integrity Audit (parallel)
-  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (736 checks) → Sanity (17 checks) → Confidence threshold
+  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (747 checks) → Sanity (17 checks) → Confidence threshold
   - **`deploy.yml`**: Manual trigger → Schema diff → Approval gate (production) → Pre-deploy backup → `supabase db push` → Post-deploy sanity
   - **`sync-cloud-db.yml`**: Auto-sync migrations to production on merge to `main`
 - **Required (merge-blocking) checks:** `Unit Tests`, `Playwright Smoke`, `Typecheck & Lint`, `Build`. These four must pass before a PR can merge.
@@ -881,7 +881,7 @@ If adding/changing DB schema or SQL functions:
 - For rollback procedures, see `DEPLOYMENT.md` → **Rollback Procedures** (5 scenarios + emergency checklist).
 - Add a QA check that verifies the migration outcome (row counts, constraint behavior).
 - Ensure idempotency (`IF NOT EXISTS`, `ON CONFLICT`, `DO UPDATE SET`).
-- Run `.\RUN_QA.ps1` to verify all 736 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 23 injection tests.
+- Run `.\RUN_QA.ps1` to verify all 747 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 23 injection tests.
 
 ### 8.14 Snapshots Are Not Enough
 
@@ -975,7 +975,7 @@ At the end of every PR-like change, include a **Verification** section:
 | Recipe Integrity          | `QA__recipe_integrity.sql`          |      6 | Yes       |
 | **Negative Validation**   | `TEST__negative_checks.sql`         |     23 | Yes       |
 
-**Run:** `.\RUN_QA.ps1` — expects **736/736 checks passing** (+ EAN validation).
+**Run:** `.\RUN_QA.ps1` — expects **747/747 checks passing** (+ EAN validation).
 **Run:** `.\RUN_NEGATIVE_TESTS.ps1` — expects **23/23 caught**.
 
 ### 8.19 Key Regression Tests (Scoring Suite)
@@ -1118,7 +1118,7 @@ security(rls): lock down product_submissions to authenticated users
 
 **Pre-commit checklist:**
 
-1. `.\RUN_QA.ps1` — 460/460 pass
+1. `.\RUN_QA.ps1` — 747/747 pass
 2. No credentials in committed files
 3. No modifications to existing `supabase/migrations/`
 4. Docs updated if schema or methodology changed
@@ -1492,8 +1492,8 @@ Before a feature is considered complete, verify against all CI gates:
 | Gate                | Command                               | Expected                        |
 | ------------------- | ------------------------------------- | ------------------------------- |
 | Pipeline structure  | `python check_pipeline_structure.py`  | 0 errors                        |
-| DB QA               | `.\RUN_QA.ps1`                        | All checks pass (currently 699) |
-| Negative tests      | `.\RUN_NEGATIVE_TESTS.ps1`            | All caught (currently 29)       |
+| DB QA               | `.\RUN_QA.ps1`                        | All checks pass (currently 747) |
+| Negative tests      | `.\RUN_NEGATIVE_TESTS.ps1`            | All caught (currently 23)       |
 | pgTAP tests         | `supabase test db`                    | All pass                        |
 | TypeScript          | `cd frontend && npx tsc --noEmit`     | 0 errors                        |
 | Unit tests          | `cd frontend && npx vitest run`       | All pass                        |
@@ -1637,10 +1637,10 @@ Produce **exactly this structure** — fill every section with real data:
 
 | Metric                    | Current Value   | Target / Baseline       | Status   |
 | ------------------------- | --------------- | ----------------------- | -------- |
-| Active products (PL+DE)   | ~X,XXX          | ≥1,281                  | ✅/⚠️/❌ |
-| QA checks passing         | XXX/736         | 736/736                 | ✅/⚠️/❌ |
+| Active products (PL+DE)   | ~X,XXX          | ≥2,366                  | ✅/⚠️/❌ |
+| QA checks passing         | XXX/747         | 747/747                 | ✅/⚠️/❌ |
 | Negative tests passing    | 23/23           | 23/23                   | ✅/⚠️/❌ |
-| Migrations committed      | XXX             | ≥182                    | ✅/⚠️/❌ |
+| Migrations committed      | XXX             | ≥199                    | ✅/⚠️/❌ |
 | Vitest coverage (lines)   | XX%             | ≥88%                    | ✅/⚠️/❌ |
 | SonarCloud quality gate   | PASS/FAIL       | PASS                    | ✅/⚠️/❌ |
 | EAN coverage              | XXXX/XXXX (XX%) | ≥99.8%                  | ✅/⚠️/❌ |
@@ -1959,7 +1959,7 @@ Else → fallback Z (always safe, always returns a value)
 ## Verification Checklist (Definition of Done)
 
 - [ ] `python check_pipeline_structure.py` — 0 errors
-- [ ] `.\RUN_QA.ps1` — all XXX checks pass
+- [ ] `.\RUN_QA.ps1` — all 747 checks pass
 - [ ] `.\RUN_NEGATIVE_TESTS.ps1` — 23/23 caught
 - [ ] `supabase test db` — all pgTAP pass
 - [ ] `cd frontend && npx tsc --noEmit` — 0 errors
@@ -2399,8 +2399,8 @@ Execute every command. Record output. Do not skip.
 ```powershell
 # ── Database layer ───────────────────────────────────────────────────
 supabase test db                               # All pgTAP tests pass
-.\RUN_QA.ps1                                   # All 736+ QA checks pass
-.\RUN_NEGATIVE_TESTS.ps1                       # All 20 negative tests caught
+.\RUN_QA.ps1                                   # All 747+ QA checks pass
+.\RUN_NEGATIVE_TESTS.ps1                       # All 23 negative tests caught
 python check_pipeline_structure.py            # 0 errors
 python validate_eans.py                       # 0 EAN failures
 python check_enrichment_identity.py           # 0 violations
@@ -2449,7 +2449,7 @@ After implementation, update ALL of these that apply (per §18.1):
 
 ```powershell
 supabase test db                  → XX/XX pgTAP tests pass
-.\RUN_QA.ps1                      → 736/736 checks pass (0 failures)
+.\RUN_QA.ps1                      → 747/747 checks pass (0 failures)
 .\RUN_NEGATIVE_TESTS.ps1          → 23/23 caught
 npx tsc --noEmit                  → 0 errors
 npx vitest run                    → XXX/XXX tests pass

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -62,7 +62,7 @@
 | [erd-core-dark.mmd](diagrams/erd-core-dark.mmd)                               | Mermaid source for core ERD (dark mode)                                | [#428](https://github.com/ericsocrat/tryvit/issues/428) | 2026-03-13   |
 | [pipeline-flow.svg](diagrams/pipeline-flow.svg)                               | Pipeline flow — OFF API to SQL generation to DB execution              | [#429](https://github.com/ericsocrat/tryvit/issues/429) | 2026-03-13   |
 | [ci-cd-pipeline.svg](diagrams/ci-cd-pipeline.svg)                             | CI/CD pipeline — 19 workflows, gates, triggers, artifact flow          | [#429](https://github.com/ericsocrat/tryvit/issues/429) | 2026-03-13   |
-| [qa-overview.svg](diagrams/qa-overview.svg)                                   | QA overview — 47 suites, 733 checks organized by domain                | [#429](https://github.com/ericsocrat/tryvit/issues/429) | 2026-03-13   |
+| [qa-overview.svg](diagrams/qa-overview.svg)                                   | QA overview — 48 suites, 747 checks organized by domain                | [#429](https://github.com/ericsocrat/tryvit/issues/429) | 2026-03-13   |
 | [confidence-model.svg](diagrams/confidence-model.svg)                         | Confidence scoring — 6 components, composite 0-100, band assignment    | [#429](https://github.com/ericsocrat/tryvit/issues/429) | 2026-03-13   |
 | [concern-tiers.svg](diagrams/concern-tiers.svg)                               | EFSA concern tiers — 4-tier additive classification with examples      | [#429](https://github.com/ericsocrat/tryvit/issues/429) | 2026-03-13   |
 | [country-expansion.svg](diagrams/country-expansion.svg)                       | Country expansion — PL primary + DE micro-pilot architecture           | [#429](https://github.com/ericsocrat/tryvit/issues/429) | 2026-03-13   |
@@ -128,13 +128,13 @@
 | [API_VERSIONING.md](API_VERSIONING.md)     | API deprecation & versioning policy — function-name versioning, sunset timelines | [#234](https://github.com/ericsocrat/tryvit/issues/234) | 2026-02-24   |
 | [FRONTEND_API_MAP.md](FRONTEND_API_MAP.md) | Frontend-to-API mapping reference — which pages call which RPCs                  | [#197](https://github.com/ericsocrat/tryvit/issues/197) | 2026-02-13   |
 | [CONTRACT_TESTING.md](CONTRACT_TESTING.md) | API contract testing strategy — pgTAP patterns, response shape validation        | [#197](https://github.com/ericsocrat/tryvit/issues/197) | 2026-02-24   |
-| [api-registry.yaml](api-registry.yaml)     | Structured registry of all 109 API functions (YAML machine-readable)             | [#197](https://github.com/ericsocrat/tryvit/issues/197) | 2026-02-24   |
+| [api-registry.yaml](api-registry.yaml)     | Structured registry of all 191 API functions (YAML machine-readable)             | [#197](https://github.com/ericsocrat/tryvit/issues/197) | 2026-02-24   |
 
 ## Scoring
 
 | Document                                         | Purpose                                                               | Owner Issue                                             | Last Updated |
 | ------------------------------------------------ | --------------------------------------------------------------------- | ------------------------------------------------------- | ------------ |
-| [SCORING_METHODOLOGY.md](SCORING_METHODOLOGY.md) | v3.2 scoring formula — 9 factors, weights, ceilings, bands            | [#189](https://github.com/ericsocrat/tryvit/issues/189) | 2026-02-12   |
+| [SCORING_METHODOLOGY.md](SCORING_METHODOLOGY.md) | v3.3 scoring formula — 9 factors, weights, ceilings, bands, nutrient density bonus | [#189](https://github.com/ericsocrat/tryvit/issues/189) | 2026-02-12   |
 | [SCORING_ENGINE.md](SCORING_ENGINE.md)           | Scoring engine architecture — function versioning, regression testing | [#189](https://github.com/ericsocrat/tryvit/issues/189) | 2026-02-24   |
 
 > **Relationship:** SCORING_METHODOLOGY.md defines the **formula** (what is computed). SCORING_ENGINE.md defines the **architecture** (how it is maintained, versioned, and tested). No redundancy — they serve different audiences.

--- a/supabase/functions/api-gateway/README.md
+++ b/supabase/functions/api-gateway/README.md
@@ -1,0 +1,56 @@
+# Edge Function: api-gateway
+
+> **Issue:** [#478](https://github.com/ericsocrat/tryvit/issues/478)
+> **Runtime:** Deno + TypeScript (Supabase Edge Functions)
+> **Auth:** Requires authenticated user JWT (`Authorization: Bearer <jwt>`)
+
+## Purpose
+
+Centralized write-path gateway for rate limiting, input validation, CAPTCHA verification, trust evaluation, and request forwarding. **Read operations bypass this gateway entirely.**
+
+## Supported Actions
+
+| Action           | Rate Limit       | Description                                          |
+| ---------------- | ---------------- | ---------------------------------------------------- |
+| `record-scan`    | 100 / day / user | Record a barcode scan event                          |
+| `submit-product` | 10 / day / user  | Submit a new product (EAN checksum + sanitization)   |
+| `track-event`    | 10,000 / day     | Track a telemetry event                              |
+| `save-search`    | 50 / day / user  | Save a search query                                  |
+
+## Request Shape
+
+```jsonc
+// POST /functions/v1/api-gateway
+{
+  "action": "record-scan",
+  // ... action-specific fields
+}
+```
+
+## Response Shape
+
+```jsonc
+// Success
+{ "ok": true, "data": { /* action result */ } }
+
+// Error (rate limited, validation failure, auth error)
+{ "ok": false, "error": "RATE_LIMITED", "message": "...", "retry_after": 3600 }
+```
+
+## Internal RPC Calls
+
+- `check_submission_rate_limit()` — submission velocity check
+- `check_scan_rate_limit()` — scan velocity check
+- `score_submission_quality()` — quality scoring for submissions
+- `check_api_rate_limit()` — generic per-endpoint rate limiter
+- `api_admin_batch_reject_user()` — trust enforcement
+
+## Deploy
+
+```bash
+supabase functions deploy api-gateway --no-verify-jwt
+```
+
+## Secrets Required
+
+None beyond the standard Supabase project URL and anon/service-role keys (auto-injected).

--- a/supabase/functions/send-push-notification/README.md
+++ b/supabase/functions/send-push-notification/README.md
@@ -1,0 +1,43 @@
+# Edge Function: send-push-notification
+
+> **Runtime:** Deno + TypeScript (Supabase Edge Functions)
+> **Auth:** Requires `service_role` key (`Authorization: Bearer <service_role_key>`)
+
+## Purpose
+
+Processes the `notification_queue` table and sends Web Push notifications to users with active push subscriptions via the VAPID protocol.
+
+## Trigger
+
+- Cron job (scheduled)
+- Database webhook
+- Manual invocation
+
+## Request Shape
+
+```jsonc
+// POST /functions/v1/send-push-notification
+{
+  "user_id": "uuid",
+  "title": "Notification title",
+  "body": "Notification body text",
+  "url": "/app/product/123"  // optional deep-link
+}
+```
+
+## Deploy
+
+```bash
+supabase functions deploy send-push-notification --no-verify-jwt
+```
+
+## Secrets Required
+
+| Secret              | Description                                       |
+| ------------------- | ------------------------------------------------- |
+| `VAPID_PUBLIC_KEY`  | VAPID public key for Web Push identification      |
+| `VAPID_PRIVATE_KEY` | VAPID private key for JWT signing (P-256 ECDSA)   |
+
+```bash
+supabase secrets set VAPID_PUBLIC_KEY=<key> VAPID_PRIVATE_KEY=<key>
+```

--- a/supabase/functions/verify-turnstile/README.md
+++ b/supabase/functions/verify-turnstile/README.md
@@ -1,0 +1,51 @@
+# Edge Function: verify-turnstile
+
+> **Issue:** [#470](https://github.com/ericsocrat/tryvit/issues/470)
+> **Runtime:** Deno + TypeScript (Supabase Edge Functions)
+> **Auth:** Public (no JWT required)
+
+## Purpose
+
+Server-side Cloudflare Turnstile CAPTCHA token verification. Called by the frontend before auth operations (signup, password reset) and conditionally before product submissions (low trust / high velocity users).
+
+## Request Shape
+
+```jsonc
+// POST /functions/v1/verify-turnstile
+{
+  "token": "<turnstile-challenge-token>"
+}
+```
+
+## Response Shape
+
+```jsonc
+// Success
+{ "valid": true, "challenge_ts": "2026-01-01T00:00:00Z", "hostname": "tryvit.com" }
+
+// Failure
+{ "valid": false, "error": "Token verification failed", "error_codes": ["invalid-input-response"] }
+```
+
+## Test Keys (CI / Development)
+
+| Key          | Value                                          |
+| ------------ | ---------------------------------------------- |
+| Site key     | `1x00000000000000000000AA` (always passes)     |
+| Secret key   | `1x0000000000000000000000000000000AA` (always passes) |
+
+## Deploy
+
+```bash
+supabase functions deploy verify-turnstile --no-verify-jwt
+```
+
+## Secrets Required
+
+| Secret                 | Description                         |
+| ---------------------- | ----------------------------------- |
+| `TURNSTILE_SECRET_KEY` | Cloudflare Turnstile server-side secret key |
+
+```bash
+supabase secrets set TURNSTILE_SECRET_KEY=<key>
+```


### PR DESCRIPTION
## Summary

Refreshes all stale documentation numbers across 4 core docs and cuts the v0.2.0 release in CHANGELOG.md.

Closes #720

## Changes

### README.md (22+ replacements)
- **Badges:** QA 733→747, products 1,281→2,438, market Poland→PL+DE, scoring v3.2→v3.3
- **Architecture diagram:** 185→199 migrations, 25→43 pipelines, PL→PL+DE, 30+→190+ RPC functions
- **Scoring section:** v3.2→v3.3, formula expanded to include nutrient density bonus
- **Stats dashboard:** All 8 metrics corrected (products, categories, markets, EAN, migrations, QA, API, scoring)
- **Project structure:** Pipeline folders 25→43, categories 20 PL + 5 DE → 22 PL + 21 DE, i18n en,pl→en,pl,de, docs 45+→51, CI 18→20
- **Testing/Contributing:** QA counts 733→747, negative tests 20→23

### CHANGELOG.md
- Cut `[0.2.0] — 2026-03-09` release from Unreleased content
- Added fresh empty `[Unreleased]` section
- Updated comparison links at bottom

### copilot-instructions.md (16 replacements)
- QA checks: 736→747 (8 locations), 460→747, 699→747, 29→23
- Migrations: 185→199, 195→199
- Active products baseline: ≥1,281→≥2,366
- Migration count baseline: ≥182→≥199
- Scoring reference: v3.2→v3.3 (superseded note)
- Negative validation: 20→23 (2 locations)

### docs/INDEX.md
- QA overview diagram: 47 suites/733 checks → 48 suites/747 checks
- API registry: 109→191 functions
- Scoring methodology: v3.2→v3.3 with nutrient density bonus

### Edge Function READMEs (3 new)
- `supabase/functions/api-gateway/README.md` — actions, rate limits, RPC calls
- `supabase/functions/send-push-notification/README.md` — VAPID, trigger, secrets
- `supabase/functions/verify-turnstile/README.md` — Cloudflare CAPTCHA verification

## Verification

Docs-only change — no code changes. All modified files are Markdown.
