### PR TITLE
test(coverage): boost line coverage to 92.22% & fix lint warnings

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -71,10 +71,11 @@
       }
     },
     {
-      // Logger utility — intentional console usage
+      // Logger & metrics utilities — intentional console usage
       "files": [
         "**/logger.ts",
-        "**/monitoring/**"
+        "**/monitoring/**",
+        "**/web-vitals.ts"
       ],
       "rules": {
         "no-console": "off"

--- a/frontend/src/app/LandingSections.test.tsx
+++ b/frontend/src/app/LandingSections.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LandingSections } from "./LandingSections";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("@/components/common/Button", () => ({
+  ButtonLink: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/components/common/Logo", () => ({
+  Logo: () => <div data-testid="logo" />,
+}));
+
+vi.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("lucide-react", () => ({
+  BarChart3: () => <span data-testid="icon-barchart" />,
+  Camera: () => <span data-testid="icon-camera" />,
+  ChevronRight: () => <span data-testid="icon-chevron" />,
+  Database: () => <span data-testid="icon-database" />,
+  Layers: () => <span data-testid="icon-layers" />,
+  Search: () => <span data-testid="icon-search" />,
+  Shield: () => <span data-testid="icon-shield" />,
+  ShoppingBasket: () => <span data-testid="icon-basket" />,
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("LandingSections", () => {
+  it("renders the hero tagline", () => {
+    render(<LandingSections />);
+    expect(screen.getByText("landing.tagline")).toBeInTheDocument();
+  });
+
+  it("renders the hero description", () => {
+    render(<LandingSections />);
+    expect(screen.getByText("landing.description")).toBeInTheDocument();
+  });
+
+  it("renders sign-up and sign-in links", () => {
+    render(<LandingSections />);
+    const signupLinks = screen.getAllByText("landing.getStarted");
+    expect(signupLinks.length).toBeGreaterThanOrEqual(1);
+    expect(signupLinks[0].closest("a")).toHaveAttribute(
+      "href",
+      "/auth/signup",
+    );
+
+    const signInLink = screen.getByText("landing.signIn");
+    expect(signInLink.closest("a")).toHaveAttribute("href", "/auth/login");
+  });
+
+  it("renders features heading and 3 feature cards", () => {
+    render(<LandingSections />);
+    expect(
+      screen.getByText("landing.featuresHeading"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("landing.featureSearch")).toBeInTheDocument();
+    expect(screen.getByText("landing.featureScan")).toBeInTheDocument();
+    expect(screen.getByText("landing.featureCompare")).toBeInTheDocument();
+  });
+
+  it("renders how-it-works heading and 3 steps", () => {
+    render(<LandingSections />);
+    expect(
+      screen.getByText("landing.howItWorksHeading"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("landing.step1Title")).toBeInTheDocument();
+    expect(screen.getByText("landing.step2Title")).toBeInTheDocument();
+    expect(screen.getByText("landing.step3Title")).toBeInTheDocument();
+  });
+
+  it("renders stats heading and 4 stat values", () => {
+    render(<LandingSections />);
+    expect(screen.getByText("landing.statsHeading")).toBeInTheDocument();
+    expect(screen.getByText("2,400+")).toBeInTheDocument();
+    // "25", "9", "2" may conflict with step numbers — use getAllByText and verify at least one
+    expect(screen.getAllByText("25").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("9").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("2").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders CTA repeat section", () => {
+    render(<LandingSections />);
+    expect(screen.getByText("landing.ctaHeading")).toBeInTheDocument();
+    expect(
+      screen.getByText("landing.ctaDescription"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the logo in hero section", () => {
+    render(<LandingSections />);
+    expect(screen.getByTestId("logo")).toBeInTheDocument();
+  });
+
+  it("renders all heading elements", () => {
+    render(<LandingSections />);
+    const headings = screen.getAllByRole("heading");
+    // h1 (tagline) + h2 (features, howItWorks, stats, cta) + h3 (3 features + 3 steps) = 11
+    expect(headings.length).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/frontend/src/app/app/scan/page.tsx
+++ b/frontend/src/app/app/scan/page.tsx
@@ -227,7 +227,7 @@ export default function ScanPage() {
         setCameraError("generic");
       }
     }
-  }, [stopScanner, t]);
+  }, [stopScanner]);
 
   async function toggleTorch() {
     if (!streamRef.current) return;

--- a/frontend/src/app/auth/forgot-password/page.test.tsx
+++ b/frontend/src/app/auth/forgot-password/page.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ForgotPasswordPage from "./page";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("@/components/common/LoadingSpinner", () => ({
+  LoadingSpinner: ({ className }: { className?: string }) => (
+    <div data-testid="loading-spinner" className={className} />
+  ),
+}));
+
+vi.mock("./ForgotPasswordForm", () => ({
+  ForgotPasswordForm: () => (
+    <div data-testid="forgot-password-form" />
+  ),
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("ForgotPasswordPage", () => {
+  it("renders the forgot-password form", () => {
+    render(<ForgotPasswordPage />);
+    expect(screen.getByTestId("forgot-password-form")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/auth/layout.tsx
+++ b/frontend/src/app/auth/layout.tsx
@@ -1,4 +1,5 @@
 import { Logo } from "@/components/common/Logo";
+import Image from "next/image";
 
 export default function AuthLayout({
   children,
@@ -10,13 +11,14 @@ export default function AuthLayout({
       {/* ── Illustration panel (desktop only) ─────────────────────── */}
       <div className="auth-illustration hidden lg:flex lg:w-1/2 flex-col items-center justify-center gap-8 p-12">
         <Logo variant="lockup" size={40} />
-        <img
+        <Image
           src="/illustrations/onboarding/step-1-welcome.svg"
           alt=""
           aria-hidden="true"
           width={280}
           height={280}
           className="w-full max-w-xs"
+          priority
         />
         <p className="max-w-xs text-center text-sm font-medium text-foreground-secondary">
           Search, scan, and compare food products. Get instant health scores and

--- a/frontend/src/app/learn/additives/page.test.tsx
+++ b/frontend/src/app/learn/additives/page.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import AdditivesPage from "./page";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/components/layout/Header", () => ({
+  Header: () => <header data-testid="header" />,
+}));
+
+vi.mock("@/components/layout/Footer", () => ({
+  Footer: () => <footer data-testid="footer" />,
+}));
+
+vi.mock("@/components/common/SkipLink", () => ({
+  SkipLink: () => <div data-testid="skip-link" />,
+}));
+
+vi.mock("@/components/learn/LearnSidebar", () => ({
+  LearnSidebar: () => <nav data-testid="learn-sidebar" />,
+}));
+
+vi.mock("@/components/learn/Disclaimer", () => ({
+  Disclaimer: () => <div data-testid="disclaimer" />,
+}));
+
+vi.mock("@/components/learn/SourceCitation", () => ({
+  SourceCitation: ({ title }: { title: string }) => (
+    <div data-testid="source-citation">{title}</div>
+  ),
+}));
+
+vi.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("AdditivesPage", () => {
+  it("renders the page title", () => {
+    render(<AdditivesPage />);
+    expect(screen.getByText("learn.additives.title")).toBeInTheDocument();
+  });
+
+  it("renders the summary block", () => {
+    render(<AdditivesPage />);
+    expect(screen.getByText("learn.additives.summary")).toBeInTheDocument();
+  });
+
+  it("renders whatAre section", () => {
+    render(<AdditivesPage />);
+    expect(
+      screen.getByText("learn.additives.whatAreTitle"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("learn.additives.whatAreText"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders notDangerous section", () => {
+    render(<AdditivesPage />);
+    expect(
+      screen.getByText("learn.additives.notDangerousTitle"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all 4 concern tier cards", () => {
+    render(<AdditivesPage />);
+    for (let i = 0; i <= 3; i++) {
+      expect(
+        screen.getByText(`learn.additives.concernTier${i}`),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("applies correct color styling to tier cards", () => {
+    render(<AdditivesPage />);
+    const tier0 = screen
+      .getByText("learn.additives.concernTier0")
+      .closest("div.rounded-lg");
+    expect(tier0?.className).toContain("bg-success-bg");
+
+    const tier3 = screen
+      .getByText("learn.additives.concernTier3")
+      .closest("div.rounded-lg");
+    expect(tier3?.className).toContain("bg-error-bg");
+  });
+
+  it("renders howWeUse section", () => {
+    render(<AdditivesPage />);
+    expect(
+      screen.getByText("learn.additives.howWeUseTitle"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders polishContext section", () => {
+    render(<AdditivesPage />);
+    expect(
+      screen.getByText("learn.additives.polishContextTitle"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders layout components", () => {
+    render(<AdditivesPage />);
+    expect(screen.getByTestId("header")).toBeInTheDocument();
+    expect(screen.getByTestId("footer")).toBeInTheDocument();
+    expect(screen.getByTestId("learn-sidebar")).toBeInTheDocument();
+    expect(screen.getByTestId("disclaimer")).toBeInTheDocument();
+  });
+
+  it("renders source citations", () => {
+    render(<AdditivesPage />);
+    const citations = screen.getAllByTestId("source-citation");
+    expect(citations).toHaveLength(2);
+  });
+
+  it("renders back-to-hub link", () => {
+    render(<AdditivesPage />);
+    const backLink = screen.getByText("learn.backToHub");
+    expect(backLink.closest("a")).toHaveAttribute("href", "/learn");
+  });
+});

--- a/frontend/src/app/learn/allergens/page.test.tsx
+++ b/frontend/src/app/learn/allergens/page.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import AllergensPage from "./page";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/components/layout/Header", () => ({
+  Header: () => <header data-testid="header" />,
+}));
+
+vi.mock("@/components/layout/Footer", () => ({
+  Footer: () => <footer data-testid="footer" />,
+}));
+
+vi.mock("@/components/common/SkipLink", () => ({
+  SkipLink: () => <div data-testid="skip-link" />,
+}));
+
+vi.mock("@/components/learn/LearnSidebar", () => ({
+  LearnSidebar: () => <nav data-testid="learn-sidebar" />,
+}));
+
+vi.mock("@/components/learn/Disclaimer", () => ({
+  Disclaimer: () => <div data-testid="disclaimer" />,
+}));
+
+vi.mock("@/components/learn/SourceCitation", () => ({
+  SourceCitation: ({ title }: { title: string }) => (
+    <div data-testid="source-citation">{title}</div>
+  ),
+}));
+
+vi.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("AllergensPage", () => {
+  it("renders the page title", () => {
+    render(<AllergensPage />);
+    expect(screen.getByText("learn.allergens.title")).toBeInTheDocument();
+  });
+
+  it("renders the summary block", () => {
+    render(<AllergensPage />);
+    expect(screen.getByText("learn.allergens.summary")).toBeInTheDocument();
+  });
+
+  it("renders EU 14 allergens heading", () => {
+    render(<AllergensPage />);
+    expect(
+      screen.getByText("learn.allergens.eu14Title"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("learn.allergens.eu14Text"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all 14 allergen items", () => {
+    render(<AllergensPage />);
+    const listItems = screen.getAllByRole("listitem");
+    // Filter to only allergen items (page may have other list items)
+    const allergenItems = listItems.filter((li) =>
+      li.textContent?.startsWith("learn.allergens.allergen"),
+    );
+    expect(allergenItems).toHaveLength(14);
+  });
+
+  it("renders containsVsTraces section", () => {
+    render(<AllergensPage />);
+    expect(
+      screen.getByText("learn.allergens.containsVsTracesTitle"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders polishLabels section", () => {
+    render(<AllergensPage />);
+    expect(
+      screen.getByText("learn.allergens.polishLabelsTitle"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders inTryVit section", () => {
+    render(<AllergensPage />);
+    expect(
+      screen.getByText("learn.allergens.inTryVitTitle"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders layout components", () => {
+    render(<AllergensPage />);
+    expect(screen.getByTestId("header")).toBeInTheDocument();
+    expect(screen.getByTestId("footer")).toBeInTheDocument();
+    expect(screen.getByTestId("learn-sidebar")).toBeInTheDocument();
+    expect(screen.getByTestId("disclaimer")).toBeInTheDocument();
+  });
+
+  it("renders source citation", () => {
+    render(<AllergensPage />);
+    const citations = screen.getAllByTestId("source-citation");
+    expect(citations).toHaveLength(1);
+  });
+
+  it("renders back-to-hub link", () => {
+    render(<AllergensPage />);
+    const backLink = screen.getByText("learn.backToHub");
+    expect(backLink.closest("a")).toHaveAttribute("href", "/learn");
+  });
+});

--- a/frontend/src/app/learn/confidence/page.test.tsx
+++ b/frontend/src/app/learn/confidence/page.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ConfidencePage from "./page";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/components/layout/Header", () => ({
+  Header: () => <header data-testid="header" />,
+}));
+
+vi.mock("@/components/layout/Footer", () => ({
+  Footer: () => <footer data-testid="footer" />,
+}));
+
+vi.mock("@/components/common/SkipLink", () => ({
+  SkipLink: () => <div data-testid="skip-link" />,
+}));
+
+vi.mock("@/components/learn/LearnSidebar", () => ({
+  LearnSidebar: () => <nav data-testid="learn-sidebar" />,
+}));
+
+vi.mock("@/components/learn/Disclaimer", () => ({
+  Disclaimer: () => <div data-testid="disclaimer" />,
+}));
+
+vi.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("ConfidencePage", () => {
+  it("renders the page title", () => {
+    render(<ConfidencePage />);
+    expect(screen.getByText("learn.confidence.title")).toBeInTheDocument();
+  });
+
+  it("renders the summary block", () => {
+    render(<ConfidencePage />);
+    expect(screen.getByText("learn.confidence.summary")).toBeInTheDocument();
+  });
+
+  it("renders why section", () => {
+    render(<ConfidencePage />);
+    expect(
+      screen.getByText("learn.confidence.whyTitle"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("learn.confidence.whyText"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all 3 confidence level cards", () => {
+    render(<ConfidencePage />);
+    expect(
+      screen.getByText("learn.confidence.levelVerified"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("learn.confidence.levelEstimated"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("learn.confidence.levelLow"),
+    ).toBeInTheDocument();
+  });
+
+  it("applies correct color styling to level cards", () => {
+    render(<ConfidencePage />);
+    const verified = screen
+      .getByText("learn.confidence.levelVerified")
+      .closest("div.rounded-lg");
+    expect(verified?.className).toContain("bg-success-bg");
+
+    const low = screen
+      .getByText("learn.confidence.levelLow")
+      .closest("div.rounded-lg");
+    expect(low?.className).toContain("bg-error-bg");
+  });
+
+  it("renders completeness section", () => {
+    render(<ConfidencePage />);
+    expect(
+      screen.getByText("learn.confidence.completenessTitle"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders howWeImprove section", () => {
+    render(<ConfidencePage />);
+    expect(
+      screen.getByText("learn.confidence.howWeImproveTitle"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders whatYouCanDo section", () => {
+    render(<ConfidencePage />);
+    expect(
+      screen.getByText("learn.confidence.whatYouCanDoTitle"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders layout components", () => {
+    render(<ConfidencePage />);
+    expect(screen.getByTestId("header")).toBeInTheDocument();
+    expect(screen.getByTestId("footer")).toBeInTheDocument();
+    expect(screen.getByTestId("learn-sidebar")).toBeInTheDocument();
+    expect(screen.getByTestId("disclaimer")).toBeInTheDocument();
+  });
+
+  it("renders back-to-hub link", () => {
+    render(<ConfidencePage />);
+    const backLink = screen.getByText("learn.backToHub");
+    expect(backLink.closest("a")).toHaveAttribute("href", "/learn");
+  });
+});

--- a/frontend/src/app/learn/nova-groups/page.test.tsx
+++ b/frontend/src/app/learn/nova-groups/page.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import NovaGroupsPage from "./page";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/components/layout/Header", () => ({
+  Header: () => <header data-testid="header" />,
+}));
+
+vi.mock("@/components/layout/Footer", () => ({
+  Footer: () => <footer data-testid="footer" />,
+}));
+
+vi.mock("@/components/common/SkipLink", () => ({
+  SkipLink: () => <div data-testid="skip-link" />,
+}));
+
+vi.mock("@/components/learn/LearnSidebar", () => ({
+  LearnSidebar: () => <nav data-testid="learn-sidebar" />,
+}));
+
+vi.mock("@/components/learn/Disclaimer", () => ({
+  Disclaimer: () => <div data-testid="disclaimer" />,
+}));
+
+vi.mock("@/components/learn/SourceCitation", () => ({
+  SourceCitation: ({ title }: { title: string }) => (
+    <div data-testid="source-citation">{title}</div>
+  ),
+}));
+
+vi.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("NovaGroupsPage", () => {
+  it("renders the page title", () => {
+    render(<NovaGroupsPage />);
+    expect(screen.getByText("learn.novaGroups.title")).toBeInTheDocument();
+  });
+
+  it("renders the summary block", () => {
+    render(<NovaGroupsPage />);
+    expect(screen.getByText("learn.novaGroups.summary")).toBeInTheDocument();
+  });
+
+  it("renders whatIs section", () => {
+    render(<NovaGroupsPage />);
+    expect(
+      screen.getByText("learn.novaGroups.whatIsTitle"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("learn.novaGroups.whatIsText"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all 4 NOVA group cards", () => {
+    render(<NovaGroupsPage />);
+    for (const n of ["1", "2", "3", "4"]) {
+      expect(
+        screen.getByText(`learn.novaGroups.group${n}Title`),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(`learn.novaGroups.group${n}Text`),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("applies correct color styling to group cards", () => {
+    render(<NovaGroupsPage />);
+    const group1 = screen.getByText("learn.novaGroups.group1Title").closest("div.rounded-lg");
+    expect(group1?.className).toContain("bg-success-bg");
+
+    const group4 = screen.getByText("learn.novaGroups.group4Title").closest("div.rounded-lg");
+    expect(group4?.className).toContain("bg-error-bg");
+  });
+
+  it("renders whyItMatters section", () => {
+    render(<NovaGroupsPage />);
+    expect(
+      screen.getByText("learn.novaGroups.whyItMattersTitle"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders polishContext section", () => {
+    render(<NovaGroupsPage />);
+    expect(
+      screen.getByText("learn.novaGroups.polishContextTitle"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders processingRisk section", () => {
+    render(<NovaGroupsPage />);
+    expect(
+      screen.getByText("learn.novaGroups.processingRiskTitle"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders layout components", () => {
+    render(<NovaGroupsPage />);
+    expect(screen.getByTestId("header")).toBeInTheDocument();
+    expect(screen.getByTestId("footer")).toBeInTheDocument();
+    expect(screen.getByTestId("learn-sidebar")).toBeInTheDocument();
+    expect(screen.getByTestId("disclaimer")).toBeInTheDocument();
+  });
+
+  it("renders source citations", () => {
+    render(<NovaGroupsPage />);
+    const citations = screen.getAllByTestId("source-citation");
+    expect(citations).toHaveLength(3);
+  });
+
+  it("renders back-to-hub link", () => {
+    render(<NovaGroupsPage />);
+    const backLink = screen.getByText("learn.backToHub");
+    expect(backLink.closest("a")).toHaveAttribute("href", "/learn");
+  });
+});

--- a/frontend/src/app/learn/nutri-score/page.test.tsx
+++ b/frontend/src/app/learn/nutri-score/page.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import NutriScorePage from "./page";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/components/layout/Header", () => ({
+  Header: () => <header data-testid="header" />,
+}));
+
+vi.mock("@/components/layout/Footer", () => ({
+  Footer: () => <footer data-testid="footer" />,
+}));
+
+vi.mock("@/components/common/SkipLink", () => ({
+  SkipLink: () => <div data-testid="skip-link" />,
+}));
+
+vi.mock("@/components/learn/LearnSidebar", () => ({
+  LearnSidebar: () => <nav data-testid="learn-sidebar" />,
+}));
+
+vi.mock("@/components/learn/Disclaimer", () => ({
+  Disclaimer: () => <div data-testid="disclaimer" />,
+}));
+
+vi.mock("@/components/learn/SourceCitation", () => ({
+  SourceCitation: ({ title }: { title: string }) => (
+    <div data-testid="source-citation">{title}</div>
+  ),
+}));
+
+vi.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("NutriScorePage", () => {
+  it("renders the page title", () => {
+    render(<NutriScorePage />);
+    expect(screen.getByText("learn.nutriScore.title")).toBeInTheDocument();
+  });
+
+  it("renders the summary block", () => {
+    render(<NutriScorePage />);
+    expect(screen.getByText("learn.nutriScore.summary")).toBeInTheDocument();
+  });
+
+  it("renders whatIs section", () => {
+    render(<NutriScorePage />);
+    expect(
+      screen.getByText("learn.nutriScore.whatIsTitle"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("learn.nutriScore.whatIsText"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders howItWorks section", () => {
+    render(<NutriScorePage />);
+    expect(
+      screen.getByText("learn.nutriScore.howItWorksTitle"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("learn.nutriScore.howItWorksText"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders negative and positive factor cards", () => {
+    render(<NutriScorePage />);
+    expect(
+      screen.getByText("learn.nutriScore.negativeLabel"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("learn.nutriScore.positiveLabel"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all 5 grade items (A–E)", () => {
+    render(<NutriScorePage />);
+    for (const grade of ["A", "B", "C", "D", "E"]) {
+      expect(
+        screen.getByText(`learn.nutriScore.grade${grade}`),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("renders limitations section", () => {
+    render(<NutriScorePage />);
+    expect(
+      screen.getByText("learn.nutriScore.limitationsTitle"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("learn.nutriScore.limitationsText"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders unknown score section", () => {
+    render(<NutriScorePage />);
+    expect(
+      screen.getByText("learn.nutriScore.unknownTitle"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders our approach section", () => {
+    render(<NutriScorePage />);
+    expect(
+      screen.getByText("learn.nutriScore.ourApproachTitle"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders layout components", () => {
+    render(<NutriScorePage />);
+    expect(screen.getByTestId("header")).toBeInTheDocument();
+    expect(screen.getByTestId("footer")).toBeInTheDocument();
+    expect(screen.getByTestId("learn-sidebar")).toBeInTheDocument();
+    expect(screen.getByTestId("disclaimer")).toBeInTheDocument();
+  });
+
+  it("renders source citations", () => {
+    render(<NutriScorePage />);
+    const citations = screen.getAllByTestId("source-citation");
+    expect(citations).toHaveLength(2);
+  });
+
+  it("renders back-to-hub link", () => {
+    render(<NutriScorePage />);
+    const backLink = screen.getByText("learn.backToHub");
+    expect(backLink.closest("a")).toHaveAttribute("href", "/learn");
+  });
+});


### PR DESCRIPTION
## Summary

Boosts line coverage from **91.9% → 92.22%** (crossing the 92% threshold) and fixes all 3 ESLint warnings.

## Changes

### Test Coverage (7 new files, 64 new tests)

| File | Tests | Coverage Target |
|------|-------|-----------------|
| `learn/nutri-score/page.test.tsx` | 12 | Nutri-Score educational page |
| `learn/nova-groups/page.test.tsx` | 11 | NOVA groups educational page |
| `learn/confidence/page.test.tsx` | 10 | Confidence scoring page |
| `learn/additives/page.test.tsx` | 11 | Additives & concern tiers page |
| `learn/allergens/page.test.tsx` | 10 | Allergens educational page |
| `LandingSections.test.tsx` | 9 | Hero, Features, HowItWorks, Stats, CTA |
| `forgot-password/page.test.tsx` | 1 | Suspense wrapper rendering |

### Lint Fixes (3 warnings → 0)

- **`scan/page.tsx`**: Removed unused `t` from `useCallback` dependency array
- **`auth/layout.tsx`**: Replaced `<img>` with Next.js `<Image>` component (`@next/next/no-img-element`)
- **`.eslintrc.json`**: Added `web-vitals.ts` to `no-console: "off"` override (intentional dev-only `console.debug`)

## Verification

```
npx tsc --noEmit                → 0 errors
npx vitest run                  → 5,430/5,430 tests pass (326 files, 2 skipped)
npx vitest run --coverage       → Lines: 92.22% (was 91.9%, threshold: 92%)
                                  Stmts: 90.88%, Branch: 85.84%, Funcs: 89%
```

## Coverage Thresholds

| Metric | Before | After | Threshold | Status |
|--------|--------|-------|-----------|--------|
| Lines | 91.9% | **92.22%** | 92% | ✅ |
| Statements | 90.58% | 90.88% | 90% | ✅ |
| Branches | 85.84% | 85.84% | 85% | ✅ |
| Functions | 88.52% | 89% | 88% | ✅ |
