### PR TITLE
fix(ci): add extensions to CI search_path before migrations (#773)

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -104,6 +104,10 @@ jobs:
       - name: Apply schema migrations
         run: |
           set -euo pipefail
+          # Include "extensions" schema in search_path so that functions
+          # installed there (e.g. pgcrypto's digest()) are visible without
+          # schema-qualification — mirrors the Supabase CLI default.
+          psql -c "ALTER DATABASE postgres SET search_path TO public, extensions;"
           for f in $(ls supabase/migrations/*.sql | sort); do
             echo "Applying: $f"
             psql -v ON_ERROR_STOP=1 -f "$f"


### PR DESCRIPTION
## Problem

PR #797 fixed the `extensions.digest()` qualification in the migration SQL, but the **DB Integrity CI check remains broken** because:

1. `qa.yml` applies migrations sequentially via `psql -v ON_ERROR_STOP=1`
2. The *old* migration `20260315001910` fails at line 804 (`function digest(text, unknown) does not exist`) **before** the fix migration `20260316000500` is ever reached
3. The bare `postgres:17` CI container doesn't include `extensions` in `search_path`

## Fix

Add `ALTER DATABASE postgres SET search_path TO public, extensions;` before the migration loop in `qa.yml`. This mirrors what Supabase CLI does locally — the `extensions` schema (where `pgcrypto` lives) becomes visible to all subsequent `psql` connections.

### Why this works

- `ALTER DATABASE` sets the default `search_path` for new connections
- Each `psql -f` call in the migration loop is a new connection → picks up the default
- PostgreSQL silently ignores non-existent schemas in `search_path`, so the ALTER runs safely before `extensions` schema is created by the first migration
- After migration `20260207000100` creates the `extensions` schema + `pgcrypto`, all subsequent migrations can find `digest()` without schema-qualification

## Verification

- `qa.yml` change is purely additive (4 lines)
- The fix migration `20260316000500` (from PR #797) remains valid and idempotent
- DB Integrity CI will re-run and should now pass

Closes #773
