### PR TITLE
feat(frontend): integrate EmptyStateIllustration into all pages (#790)

### DIFF
--- a/frontend/src/app/app/admin/submissions/page.tsx
+++ b/frontend/src/app/app/admin/submissions/page.tsx
@@ -5,6 +5,7 @@
 // that bypass RLS. In production, restrict route via middleware or auth check.
 
 import { Button } from "@/components/common/Button";
+import { EmptyStateIllustration } from "@/components/common/EmptyStateIllustration";
 import { SubmissionsSkeleton } from "@/components/common/skeletons";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
 import { useTranslation } from "@/lib/i18n";
@@ -278,11 +279,11 @@ export default function AdminSubmissionsPage() {
 
       {/* Empty */}
       {data?.submissions.length === 0 && (
-        <div className="py-12 text-center">
-          <p className="text-sm text-foreground-secondary">
-            {t("admin.noSubmissions", { status: statusFilter })}
-          </p>
-        </div>
+        <EmptyStateIllustration
+          type="no-submissions"
+          titleKey="admin.noSubmissions"
+          titleParams={{ status: statusFilter }}
+        />
       )}
 
       {/* Submission cards */}

--- a/frontend/src/app/app/compare/page.tsx
+++ b/frontend/src/app/app/compare/page.tsx
@@ -6,6 +6,7 @@
 // Authenticated users can save comparisons and see avoid badges.
 
 import { EmptyState } from "@/components/common/EmptyState";
+import { EmptyStateIllustration } from "@/components/common/EmptyStateIllustration";
 import { ErrorBoundary } from "@/components/common/ErrorBoundary";
 import { PrintButton } from "@/components/common/PrintButton";
 import { ComparisonGridSkeleton } from "@/components/common/skeletons";
@@ -87,9 +88,8 @@ export default function ComparePage() {
         <h1 className="flex items-center gap-2 text-xl font-bold text-foreground">
           <Scale size={22} aria-hidden="true" /> {t("compare.title")}
         </h1>
-        <EmptyState
-          variant="no-data"
-          icon={<Scale size={48} className="text-foreground-muted" />}
+        <EmptyStateIllustration
+          type="no-comparisons"
           titleKey="compare.selectPrompt"
           descriptionKey="compare.useCheckbox"
           action={{ labelKey: "compare.searchProducts", href: "/app/search" }}

--- a/frontend/src/app/app/compare/saved/page.tsx
+++ b/frontend/src/app/app/compare/saved/page.tsx
@@ -4,6 +4,7 @@
 // URL: /app/compare/saved
 
 import { EmptyState } from "@/components/common/EmptyState";
+import { EmptyStateIllustration } from "@/components/common/EmptyStateIllustration";
 import { SavedItemsSkeleton } from "@/components/common/skeletons";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
 import { useDeleteComparison, useSavedComparisons } from "@/hooks/use-compare";
@@ -43,9 +44,8 @@ export default function SavedComparisonsPage() {
 
       {/* Empty state */}
       {data?.comparisons.length === 0 && (
-        <EmptyState
-          variant="no-data"
-          icon={<FolderOpen size={40} />}
+        <EmptyStateIllustration
+          type="no-comparisons"
           titleKey="compare.noSaved"
           descriptionKey="compare.noSavedDescription"
           action={{ labelKey: "compare.findProducts", href: "/app/search" }}

--- a/frontend/src/app/app/lists/[id]/page.tsx
+++ b/frontend/src/app/app/lists/[id]/page.tsx
@@ -7,6 +7,7 @@
 import { Button } from "@/components/common/Button";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { EmptyState } from "@/components/common/EmptyState";
+import { EmptyStateIllustration } from "@/components/common/EmptyStateIllustration";
 import { ListDetailSkeleton } from "@/components/common/skeletons";
 import { ExportButton } from "@/components/export/ExportButton";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
@@ -286,9 +287,8 @@ export default function ListDetailPage() {
 
       {/* Empty state */}
       {items.length === 0 && (
-        <EmptyState
-          variant="no-data"
-          icon={<span>📭</span>}
+        <EmptyStateIllustration
+          type="no-lists"
           titleKey="lists.emptyList"
           action={{ labelKey: "lists.searchProducts", href: "/app/search" }}
         />

--- a/frontend/src/app/app/lists/page.tsx
+++ b/frontend/src/app/app/lists/page.tsx
@@ -7,6 +7,7 @@
 import { Button } from "@/components/common/Button";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { EmptyState } from "@/components/common/EmptyState";
+import { EmptyStateIllustration } from "@/components/common/EmptyStateIllustration";
 import { PullToRefresh } from "@/components/common/PullToRefresh";
 import { ListViewSkeleton } from "@/components/common/skeletons";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
@@ -144,7 +145,7 @@ export default function ListsPage() {
 
       {/* Empty state */}
       {lists.length === 0 && (
-        <EmptyState variant="no-data" titleKey="lists.emptyState" />
+        <EmptyStateIllustration type="no-lists" titleKey="lists.emptyState" />
       )}
 
       {/* List grid */}

--- a/frontend/src/app/app/recipes/page.tsx
+++ b/frontend/src/app/app/recipes/page.tsx
@@ -6,7 +6,7 @@
 
 import { Button } from "@/components/common/Button";
 import { Chip } from "@/components/common/Chip";
-import { EmptyState } from "@/components/common/EmptyState";
+import { EmptyStateIllustration } from "@/components/common/EmptyStateIllustration";
 import { PullToRefresh } from "@/components/common/PullToRefresh";
 import { RecipeGridSkeleton } from "@/components/common/skeletons";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
@@ -204,8 +204,8 @@ export default function RecipesBrowsePage() {
           ))}
         </div>
       ) : (
-        <EmptyState
-          variant="no-results"
+        <EmptyStateIllustration
+          type="no-results"
           titleKey="recipes.emptyTitle"
           descriptionKey="recipes.emptyDescription"
         />

--- a/frontend/src/app/app/scan/history/page.tsx
+++ b/frontend/src/app/app/scan/history/page.tsx
@@ -4,6 +4,7 @@
 
 import { Button } from "@/components/common/Button";
 import { EmptyState } from "@/components/common/EmptyState";
+import { EmptyStateIllustration } from "@/components/common/EmptyStateIllustration";
 import { ScanHistorySkeleton } from "@/components/common/skeletons";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
 import { getScanHistory } from "@/lib/api";
@@ -13,7 +14,7 @@ import { queryKeys, staleTimes } from "@/lib/query-keys";
 import { createClient } from "@/lib/supabase/client";
 import type { ScanHistoryItem } from "@/lib/types";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Camera, ClipboardList } from "lucide-react";
+import { ClipboardList } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
@@ -110,9 +111,8 @@ export default function ScanHistoryPage() {
 
       {/* Empty */}
       {data?.scans.length === 0 && (
-        <EmptyState
-          variant="no-data"
-          icon={<Camera size={48} className="text-foreground-muted" />}
+        <EmptyStateIllustration
+          type="no-scan-history"
           titleKey="scanHistory.emptyTitle"
           descriptionKey="scanHistory.emptyMessage"
           action={{ labelKey: "scanHistory.startScanning", href: "/app/scan" }}

--- a/frontend/src/app/app/search/page.tsx
+++ b/frontend/src/app/app/search/page.tsx
@@ -5,6 +5,7 @@
 import { AllergenChips } from "@/components/common/AllergenChips";
 import { Button } from "@/components/common/Button";
 import { EmptyState } from "@/components/common/EmptyState";
+import { EmptyStateIllustration } from "@/components/common/EmptyStateIllustration";
 import { LiveRegion } from "@/components/common/LiveRegion";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { NovaBadge } from "@/components/common/NovaBadge";
@@ -41,7 +42,6 @@ import {
     LayoutGrid,
     LayoutList,
     Save,
-    Search,
     SlidersHorizontal,
 } from "lucide-react";
 import Link from "next/link";
@@ -468,9 +468,8 @@ export default function SearchPage() {
 
           {/* Empty state — no search or filters active */}
           {!isSearchActive && recentSearches.length === 0 && (
-            <EmptyState
-              variant="no-data"
-              icon={<Search size={40} />}
+            <EmptyStateIllustration
+              type="no-results"
               titleKey="search.emptyState"
             />
           )}
@@ -525,8 +524,8 @@ export default function SearchPage() {
 
               {data.results.length === 0 ? (
                 <div className="space-y-4" data-testid="zero-results">
-                  <EmptyState
-                    variant="no-results"
+                  <EmptyStateIllustration
+                    type="no-results"
                     titleKey={
                       data.query
                         ? "search.noMatchSearch"

--- a/frontend/src/app/app/search/saved/page.tsx
+++ b/frontend/src/app/app/search/saved/page.tsx
@@ -4,6 +4,7 @@
 
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { EmptyState } from "@/components/common/EmptyState";
+import { EmptyStateIllustration } from "@/components/common/EmptyStateIllustration";
 import { SavedItemsSkeleton } from "@/components/common/skeletons";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
 import { deleteSavedSearch, getSavedSearches } from "@/lib/api";
@@ -13,7 +14,7 @@ import { queryKeys, staleTimes } from "@/lib/query-keys";
 import { createClient } from "@/lib/supabase/client";
 import type { SavedSearch, SearchFilters } from "@/lib/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ClipboardList, Save, Trash2 } from "lucide-react";
+import { ClipboardList, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
 
@@ -96,9 +97,8 @@ export default function SavedSearchesPage() {
 
       {/* Empty state */}
       {data?.searches.length === 0 && (
-        <EmptyState
-          variant="no-data"
-          icon={<Save size={40} />}
+        <EmptyStateIllustration
+          type="no-saved-searches"
           titleKey="savedSearches.emptyTitle"
           descriptionKey="savedSearches.emptyMessage"
           action={{ labelKey: "savedSearches.goToSearch", href: "/app/search" }}

--- a/frontend/src/app/app/watchlist/page.tsx
+++ b/frontend/src/app/app/watchlist/page.tsx
@@ -6,7 +6,7 @@
  * score deltas, and reformulation badges.
  */
 
-import { ButtonLink } from "@/components/common/Button";
+import { EmptyStateIllustration } from "@/components/common/EmptyStateIllustration";
 import { Icon } from "@/components/common/Icon";
 import { WatchlistSkeleton } from "@/components/common/skeletons";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
@@ -138,21 +138,12 @@ export default function WatchlistPage() {
       )}
 
       {!isLoading && !error && items.length === 0 && (
-        <div
-          className="flex flex-col items-center gap-3 rounded-xl border border-border bg-surface p-8 text-center"
-          data-testid="watchlist-empty"
-        >
-          <Icon icon={Eye} size="xl" className="text-foreground-muted" />
-          <h2 className="text-lg font-semibold text-foreground">
-            {t("watchlist.emptyTitle")}
-          </h2>
-          <p className="max-w-md text-sm text-foreground-secondary">
-            {t("watchlist.emptyDescription")}
-          </p>
-          <ButtonLink href="/app/search" className="mt-2" size="sm">
-            {t("watchlist.browseProducts")}
-          </ButtonLink>
-        </div>
+        <EmptyStateIllustration
+          type="no-favorites"
+          titleKey="watchlist.emptyTitle"
+          descriptionKey="watchlist.emptyDescription"
+          action={{ labelKey: "watchlist.browseProducts", href: "/app/search" }}
+        />
       )}
 
       {items.length > 0 && (

--- a/frontend/src/components/product/score-history-watchlist.test.tsx
+++ b/frontend/src/components/product/score-history-watchlist.test.tsx
@@ -622,7 +622,7 @@ describe("WatchlistPage", () => {
     render(<WatchlistPage />, { wrapper: createWrapper() });
 
     await waitFor(() => {
-      expect(screen.getByTestId("watchlist-empty")).toBeInTheDocument();
+      expect(screen.getByTestId("empty-state")).toBeInTheDocument();
       expect(screen.getByText("watchlist.emptyTitle")).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary

Integrates the existing `EmptyStateIllustration` component — 8 branded SVG illustrations that were built but **never used** — into all 10 pages that previously showed generic empty states.

Closes #790

## Changes

### Pages updated (10 pages, 11 files)

| Page | Illustration Type | Notes |
|------|------------------|-------|
| Watchlist | `no-favorites` | Replaced hand-coded div with EmptyStateIllustration |
| Admin Submissions | `no-submissions` | Replaced minimal status-filtered div |
| Scan History | `no-scan-history` | Replaced generic EmptyState; removed unused `Camera` icon import |
| Compare | `no-comparisons` | Replaced no-data EmptyState; kept `secondaryAction` for browse link |
| Saved Comparisons | `no-comparisons` | Replaced no-data EmptyState |
| Search (initial + zero results) | `no-results` | Replaced both initial and zero-results EmptyState; removed unused `Search` icon import |
| Saved Searches | `no-saved-searches` | Replaced no-data EmptyState; removed unused `Save` icon import |
| Lists | `no-lists` | Replaced no-data EmptyState |
| List Detail | `no-lists` | Replaced emoji-based (📭) EmptyState |
| Recipes | `no-results` | Replaced EmptyState import entirely (no error variant on this page) |

### What was preserved
- All `error` variant EmptyState usages remain unchanged (7 pages)
- All action buttons and secondary actions carried over to new component
- All i18n keys preserved

### Test updates
- Updated `score-history-watchlist.test.tsx`: changed `data-testid` assertion from `"watchlist-empty"` → `"empty-state"` (new component's standard testid)

### Unused imports cleaned
- `ButtonLink` from watchlist (was only used in old hand-coded empty state)
- `Camera` from scan/history
- `Save` from search/saved
- `Search` from search (no longer needed after EmptyState replacement)

## Verification

```
npx tsc --noEmit              → 0 errors
npx vitest run                → 326 passed, 0 failed, 2 skipped (5430 tests)
```
