### PR TITLE
feat(frontend): standardize skeleton loading screens (#789)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Standardize skeleton loading screens — rewrite `ProductProfileSkeleton` to
+  match current 2-column grid layout with progressive disclosure, replace all
+  `animate-pulse` Tailwind classes with unified `.skeleton` CSS shimmer in
+  `ProductHeroImage` and `HealthWarningsCard`, add grid layout test (#789)
+
 ### Fixed
 
 - Fix QA CI broken on main — qualify `digest()` as `extensions.digest()` in

--- a/frontend/src/components/common/skeletons/ProductProfileSkeleton.tsx
+++ b/frontend/src/components/common/skeletons/ProductProfileSkeleton.tsx
@@ -1,92 +1,137 @@
 /**
  * ProductProfileSkeleton — shimmer placeholder for /app/product/[id].
- * Mirrors: back button, hero area, product name, tabs, content blocks.
+ * Mirrors the 2-column grid layout with progressive disclosure.
+ * Left: hero image, score gauge, name, badges, flags.
+ * Right: quick summary cards (score interpretation, traffic lights, alternatives).
  */
 
 import { Skeleton, SkeletonContainer } from "@/components/common/Skeleton";
 
 export function ProductProfileSkeleton() {
   return (
-    <SkeletonContainer label="Loading product" className="space-y-4">
-      {/* Back link */}
-      <Skeleton variant="text" width="4rem" height={16} />
+    <SkeletonContainer label="Loading product" className="space-y-4 lg:space-y-6">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2">
+        <Skeleton variant="text" width="3rem" height={14} />
+        <Skeleton variant="text" width="1rem" height={14} />
+        <Skeleton variant="text" width="4rem" height={14} />
+        <Skeleton variant="text" width="1rem" height={14} />
+        <Skeleton variant="text" width="8rem" height={14} />
+      </div>
 
-      {/* Hero / image area */}
-      <div className="card space-y-4">
-        {/* Product header */}
-        <div className="flex items-start gap-4">
-          {/* Hero image placeholder */}
-          <Skeleton
-            variant="rect"
-            width={96}
-            height={96}
-            className="flex-shrink-0 !rounded-lg"
-          />
-
-          <div className="flex-1 space-y-2">
-            {/* Product name */}
-            <Skeleton variant="text" width="80%" height={20} />
-            {/* Brand / category */}
-            <Skeleton variant="text" width="50%" height={14} />
-            {/* Score pill row */}
-            <div className="flex items-center gap-2">
+      {/* Desktop: 2-column grid; Mobile: single column */}
+      <div className="lg:grid lg:grid-cols-12 lg:gap-6">
+        {/* Left column */}
+        <div className="space-y-4 lg:col-span-5 lg:space-y-6">
+          <div className="card">
+            {/* Hero image placeholder */}
+            <div className="mb-4">
               <Skeleton
                 variant="rect"
-                width={48}
-                height={24}
-                className="!rounded-full"
+                width="100%"
+                height={200}
+                className="!rounded-xl"
               />
-              <Skeleton variant="circle" width={24} height={24} />
             </div>
+
+            {/* Score gauge + product info */}
+            <div className="flex items-start gap-4">
+              <Skeleton
+                variant="circle"
+                width={64}
+                height={64}
+                className="flex-shrink-0"
+              />
+              <div className="min-w-0 flex-1 space-y-2">
+                {/* Product name */}
+                <Skeleton variant="text" width="85%" height={22} />
+                {/* Brand */}
+                <Skeleton variant="text" width="50%" height={16} />
+                {/* Action buttons */}
+                <div className="flex flex-wrap gap-2">
+                  {Array.from({ length: 4 }, (_, i) => (
+                    <Skeleton
+                      key={i}
+                      variant="rect"
+                      width={36}
+                      height={36}
+                      className="!rounded-lg"
+                    />
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* Badge row: Nutri-Score, NOVA, score band */}
+            <div className="mt-2 flex items-center gap-2">
+              <Skeleton variant="rect" width={56} height={22} className="!rounded-full" />
+              <Skeleton variant="rect" width={64} height={22} className="!rounded-full" />
+              <Skeleton variant="rect" width={60} height={22} className="!rounded-full" />
+            </div>
+
+            {/* Metadata row */}
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Skeleton variant="text" width="5rem" height={12} />
+              <Skeleton variant="text" width="7rem" height={12} />
+            </div>
+          </div>
+
+          {/* Score interpretation card */}
+          <div className="card">
+            <Skeleton variant="text" width="70%" height={16} />
           </div>
         </div>
 
-        {/* Action buttons row */}
-        <div className="flex items-center gap-2">
+        {/* Right column — quick summary (default collapsed state) */}
+        <div className="mt-4 space-y-4 lg:col-span-7 lg:mt-0 lg:space-y-6">
+          {/* Score summary card */}
+          <div className="card space-y-3">
+            <Skeleton variant="text" width="60%" height={18} />
+            <Skeleton variant="text" lines={2} />
+          </div>
+
+          {/* Traffic light strip card */}
+          <div className="card">
+            <div className="flex items-center justify-between gap-2">
+              {Array.from({ length: 4 }, (_, i) => (
+                <Skeleton
+                  key={i}
+                  variant="rect"
+                  width="24%"
+                  height={48}
+                  className="!rounded-lg"
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Alternatives preview card */}
+          <div className="card space-y-3">
+            <Skeleton variant="text" width="50%" height={16} />
+            {Array.from({ length: 2 }, (_, i) => (
+              <div key={i} className="flex items-center gap-3">
+                <Skeleton
+                  variant="rect"
+                  width={48}
+                  height={48}
+                  className="flex-shrink-0 !rounded-lg"
+                />
+                <div className="flex-1 space-y-1">
+                  <Skeleton variant="text" width="70%" height={14} />
+                  <Skeleton variant="text" width="40%" height={12} />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Expand button */}
           <Skeleton
             variant="rect"
-            width={80}
-            height={32}
-            className="!rounded-lg"
-          />
-          <Skeleton
-            variant="rect"
-            width={80}
-            height={32}
-            className="!rounded-lg"
-          />
-          <Skeleton
-            variant="rect"
-            width={80}
-            height={32}
+            width="100%"
+            height={40}
             className="!rounded-lg"
           />
         </div>
-      </div>
-
-      {/* Tabs */}
-      <div className="flex gap-1 border-b border">
-        {Array.from({ length: 4 }, (_, i) => (
-          <Skeleton
-            key={i}
-            variant="rect"
-            width={80}
-            height={36}
-            className="!rounded-t-lg !rounded-b-none"
-          />
-        ))}
-      </div>
-
-      {/* Tab content — nutrition-like blocks */}
-      <div className="card space-y-3">
-        <Skeleton variant="text" width="40%" height={18} />
-        <Skeleton variant="text" lines={3} />
-        <Skeleton
-          variant="rect"
-          width="100%"
-          height={120}
-          className="!rounded-lg"
-        />
       </div>
     </SkeletonContainer>
   );

--- a/frontend/src/components/common/skeletons/skeletons.test.tsx
+++ b/frontend/src/components/common/skeletons/skeletons.test.tsx
@@ -76,7 +76,17 @@ describe("ProductProfileSkeleton", () => {
   it("renders shimmer blocks for content areas", () => {
     const { container } = render(<ProductProfileSkeleton />);
     const blocks = container.querySelectorAll(".skeleton");
-    expect(blocks.length).toBeGreaterThan(5);
+    expect(blocks.length).toBeGreaterThan(10);
+  });
+
+  it("renders 2-column grid layout", () => {
+    const { container } = render(<ProductProfileSkeleton />);
+    const grid = container.querySelector(".lg\\:grid-cols-12");
+    expect(grid).toBeTruthy();
+    const leftCol = grid?.querySelector(".lg\\:col-span-5");
+    const rightCol = grid?.querySelector(".lg\\:col-span-7");
+    expect(leftCol).toBeTruthy();
+    expect(rightCol).toBeTruthy();
   });
 });
 

--- a/frontend/src/components/product/HealthWarningsCard.tsx
+++ b/frontend/src/components/product/HealthWarningsCard.tsx
@@ -81,10 +81,10 @@ export function HealthWarningsCard({
   // Loading profile — show skeleton to avoid layout jump
   if (profileLoading) {
     return (
-      <div className="card animate-pulse" data-testid="health-warnings-card">
+      <div className="card" data-testid="health-warnings-card">
         <div className="flex items-center gap-2">
-          <div className="h-5 w-5 rounded-full bg-surface-muted" />
-          <div className="h-4 w-48 rounded bg-surface-muted" />
+          <div className="skeleton h-5 w-5 rounded-full" />
+          <div className="skeleton h-4 w-48 rounded" />
         </div>
       </div>
     );
@@ -130,9 +130,9 @@ export function HealthWarningsCard({
   // Loading warnings
   if (warningsLoading) {
     return (
-      <div className="card animate-pulse" data-testid="health-warnings-card">
-        <div className="h-4 w-40 rounded bg-surface-muted" />
-        <div className="mt-2 h-3 w-64 rounded bg-surface-muted" />
+      <div className="card" data-testid="health-warnings-card">
+        <div className="skeleton h-4 w-40 rounded" />
+        <div className="skeleton mt-2 h-3 w-64 rounded" />
       </div>
     );
   }

--- a/frontend/src/components/product/ProductHeroImage.tsx
+++ b/frontend/src/components/product/ProductHeroImage.tsx
@@ -78,8 +78,7 @@ export function ProductHeroImage({
       return (
         <div className="flex h-32 w-full items-center justify-center overflow-hidden rounded-xl bg-surface-muted">
           <div
-            className="absolute inset-0 animate-pulse bg-gradient-to-br from-gray-200 via-gray-100 to-gray-200"
-            style={{ filter: "blur(8px)" }}
+            className="skeleton absolute inset-0"
             aria-hidden="true"
           />
           <span className="relative text-sm text-foreground-muted">
@@ -103,8 +102,7 @@ export function ProductHeroImage({
         {/* Blur placeholder shown until image fully loads */}
         {!imageLoaded && (
           <div
-            className="absolute inset-0 animate-pulse bg-gradient-to-br from-gray-200 via-gray-100 to-gray-200"
-            style={{ filter: "blur(8px)" }}
+            className="skeleton absolute inset-0"
             aria-hidden="true"
             data-testid="image-blur-placeholder"
           />


### PR DESCRIPTION
## Summary

Standardize skeleton loading screens by eliminating all non-standard `animate-pulse` Tailwind shimmer patterns and aligning `ProductProfileSkeleton` with the current page layout.

Closes #789

## Changes

### ProductProfileSkeleton — Full Rewrite
The old skeleton rendered a single card with image/name/score pills/tabs — completely mismatched with the actual 2-column grid layout. Rewritten to mirror:
- **Breadcrumb** strip (5 text skeletons with separators)
- **Left column** (`lg:col-span-5`): hero image rect (200px), score gauge circle (64px), product name/brand text, 4 action button rects, 3 badge pills, metadata rows, score interpretation card
- **Right column** (`lg:col-span-7`): score summary card, traffic light strip (4 rects), alternatives preview (2 items), expand button

### Shimmer Standardization
Replaced all `animate-pulse bg-gradient-to-br from-gray-200 via-gray-100 to-gray-200` patterns with the unified `.skeleton` CSS class (shimmer animation via `@keyframes shimmer` in globals.css):
- **ProductHeroImage.tsx** — 2 occurrences (OFF loading state + image placeholder)
- **HealthWarningsCard.tsx** — 2 occurrences (profile loading + warnings loading)

After this PR, zero `animate-pulse` usage remains in component code (only a comment in WatchlistSkeleton).

### Tests
- Updated skeleton block count assertion from `> 5` to `> 10`
- Added "renders 2-column grid layout" test verifying `lg:grid-cols-12`, `lg:col-span-5`, `lg:col-span-7`

## Verification

```
npx tsc --noEmit                → 0 errors
npx vitest run (targeted)       → 52/52 pass (3 files)
npx vitest run (full suite)     → 5,431 passed, 0 failures
grep animate-pulse **/*.tsx     → 1 match (comment only in WatchlistSkeleton)
```

## Files Changed (5)

| File | Change |
|------|--------|
| `frontend/src/components/common/skeletons/ProductProfileSkeleton.tsx` | Rewritten for 2-column grid layout |
| `frontend/src/components/common/skeletons/skeletons.test.tsx` | Updated assertions + new grid layout test |
| `frontend/src/components/product/ProductHeroImage.tsx` | `animate-pulse` → `.skeleton` (2×) |
| `frontend/src/components/product/HealthWarningsCard.tsx` | `animate-pulse` → `.skeleton` (2×) |
| `CHANGELOG.md` | Added entry under [Unreleased] |
