### PR TITLE
feat(search): instant as-you-type search with 300ms debounce (#786)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Search results now appear instantly as-you-type with 300ms debounce (≥ 2
+  chars) — no longer requires pressing Enter or clicking the Search button.
+  Explicit submit still works for immediate results (#786)
+
 - Standardize skeleton loading screens — rewrite `ProductProfileSkeleton` to
   match current 2-column grid layout with progressive disclosure, replace all
   `animate-pulse` Tailwind classes with unified `.skeleton` CSS shimmer in

--- a/frontend/src/app/app/search/page.test.tsx
+++ b/frontend/src/app/app/search/page.test.tsx
@@ -998,4 +998,35 @@ describe("SearchPage", () => {
       });
     }
   });
+
+  // ── Instant as-you-type search (issue #786) ─────────────────────────────
+
+  it("shows results as-you-type without clicking Search button", async () => {
+    mockSearchProducts.mockResolvedValue(makeSearchResponse());
+    const user = userEvent.setup();
+
+    render(<SearchPage />, { wrapper: createWrapper() });
+
+    // Type a query (≥ 2 chars triggers instant search after 300ms debounce)
+    await user.type(screen.getByPlaceholderText("Search products…"), "chips");
+
+    // Results should appear without clicking search button
+    await waitFor(() => {
+      expect(screen.getByText("Test Chips")).toBeInTheDocument();
+    });
+    expect(mockSearchProducts).toHaveBeenCalled();
+  });
+
+  it("does not trigger instant search for single character", async () => {
+    const user = userEvent.setup();
+
+    render(<SearchPage />, { wrapper: createWrapper() });
+
+    await user.type(screen.getByPlaceholderText("Search products…"), "c");
+
+    // Wait a tick to ensure debounce would have fired
+    await new Promise((r) => setTimeout(r, 400));
+
+    expect(mockSearchProducts).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/app/app/search/page.tsx
+++ b/frontend/src/app/app/search/page.tsx
@@ -47,6 +47,17 @@ import {
 import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+/* ── Debounce hook for instant search ─────────────────────────────────────── */
+
+function useDebounce(value: string, delay: number): string {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+  return debounced;
+}
+
 const AVOID_TOGGLE_KEY = "tryvit:show-avoided";
 const VIEW_MODE_KEY = "tryvit:search-view";
 const PAGE_SIZE = 20;
@@ -103,7 +114,10 @@ export default function SearchPage() {
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
 
-  // The active search query (submitted)
+  // Debounced query for instant as-you-type search (300ms delay)
+  const debouncedQuery = useDebounce(query, 300);
+
+  // The active search query (submitted or debounced)
   const activeQuery = submittedQuery || undefined;
 
   // Load localStorage prefs on mount
@@ -112,6 +126,16 @@ export default function SearchPage() {
     setShowAvoided(getShowAvoided());
     setViewMode(getViewMode());
   }, []);
+
+  // Auto-trigger search as the user types (instant search)
+  useEffect(() => {
+    const trimmed = debouncedQuery.trim();
+    if (trimmed.length >= 2) {
+      setSubmittedQuery(trimmed);
+    } else if (trimmed.length === 0 && !hasActiveFilters(filters)) {
+      setSubmittedQuery("");
+    }
+  }, [debouncedQuery, filters]);
 
   // Reset page when filters or query change
   useEffect(() => {


### PR DESCRIPTION
Implements instant as-you-type search for issue #786. Adds useDebounce hook (300ms), auto-trigger via useEffect (>=2 chars), 2 new tests. Full suite: 326 files, 5438 tests pass. Closes #786