### PR TITLE
fix(frontend): mobile typography audit — standardize headings, spacing, touch targets (#793)

### DIFF
--- a/frontend/docs/DESIGN_SYSTEM.md
+++ b/frontend/docs/DESIGN_SYSTEM.md
@@ -208,6 +208,45 @@ This document defines the design token vocabulary for the tryvit frontend. All v
 | `--transition-normal` | `200ms ease` |
 | `--transition-slow`   | `300ms ease` |
 
+### Mobile Typography Standards
+
+Standardized text sizing and spacing rules for visual consistency across all pages.
+
+#### Page Headings (h1)
+
+All top-level page headings follow this pattern:
+
+```
+className="text-xl font-bold text-foreground lg:text-2xl"
+```
+
+- **Mobile (< lg):** `text-xl` (20px)
+- **Desktop (≥ lg):** `text-2xl` (24px)
+- **Icon size:** 22px (`size={22}`) when inline with heading text
+- **Icon gap:** `gap-2` (8px) between icon and text
+
+#### Page Spacing
+
+All top-level page containers use consistent vertical rhythm:
+
+| Pattern                     | Usage                                          |
+| --------------------------- | ---------------------------------------------- |
+| `space-y-6`                 | Standard page section spacing (most pages)     |
+| `space-y-6 lg:space-y-8`   | Dashboard and content-heavy pages              |
+| `space-y-3`                 | Compact card/form internals                    |
+
+#### Touch Targets (WCAG 2.5.5)
+
+All interactive elements must meet 44×44px minimum:
+
+| Button Size | Min Height | Enforced Via            |
+| ----------- | ---------- | ----------------------- |
+| `sm`        | Auto       | Inline actions only     |
+| `md`        | 44px       | `min-h-[44px]` in class |
+| `lg`        | 44px       | `min-h-[44px]` in class |
+
+Use `.touch-target` or `.touch-target-expanded` utilities from `globals.css` for non-button interactive elements.
+
 ---
 
 ## Component Classes

--- a/frontend/src/app/app/achievements/page.tsx
+++ b/frontend/src/app/app/achievements/page.tsx
@@ -49,7 +49,7 @@ export default function AchievementsPage() {
 
   return (
     <PullToRefresh onRefresh={handleRefresh}>
-      <div>
+      <div className="space-y-6">
         <Breadcrumbs
         items={[
           { labelKey: "nav.home", href: "/app" },
@@ -58,10 +58,10 @@ export default function AchievementsPage() {
       />
 
       {/* Header */}
-      <div className="mb-6 flex items-center gap-3">
+      <div className="flex items-center gap-3">
         <Icon icon={Trophy} size="lg" className="text-brand" />
         <div>
-          <h1 className="text-xl font-bold text-foreground">
+          <h1 className="text-xl font-bold text-foreground lg:text-2xl">
             {t("achievements.title")}
           </h1>
           <p className="text-sm text-foreground-secondary">

--- a/frontend/src/app/app/categories/[slug]/page.tsx
+++ b/frontend/src/app/app/categories/[slug]/page.tsx
@@ -137,7 +137,7 @@ export default function CategoryListingPage() {
 
   return (
     <PullToRefresh onRefresh={handleRefresh}>
-    <div className="space-y-4">
+    <div className="space-y-6">
       {/* Breadcrumbs */}
       <Breadcrumbs
         items={[
@@ -149,7 +149,7 @@ export default function CategoryListingPage() {
 
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-bold capitalize text-foreground">
+        <h1 className="text-xl font-bold capitalize text-foreground lg:text-2xl">
           {formatSlug(slug)}
         </h1>
         {data && (

--- a/frontend/src/app/app/categories/page.tsx
+++ b/frontend/src/app/app/categories/page.tsx
@@ -53,14 +53,14 @@ export default function CategoriesPage() {
   }
 
   return (
-    <div>
+    <div className="space-y-6">
       <Breadcrumbs
         items={[
           { labelKey: "nav.home", href: "/app" },
           { labelKey: "nav.categories" },
         ]}
       />
-      <h1 className="mb-4 text-xl font-bold text-foreground lg:text-2xl">
+      <h1 className="text-xl font-bold text-foreground lg:text-2xl">
         {t("categories.title")}
       </h1>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 lg:gap-4">

--- a/frontend/src/app/app/compare/page.tsx
+++ b/frontend/src/app/app/compare/page.tsx
@@ -84,8 +84,8 @@ export default function ComparePage() {
   // Empty state — no IDs provided
   if (productIds.length < 2) {
     return (
-      <div className="space-y-4">
-        <h1 className="flex items-center gap-2 text-xl font-bold text-foreground">
+      <div className="space-y-6">
+        <h1 className="flex items-center gap-2 text-xl font-bold text-foreground lg:text-2xl">
           <Scale size={22} aria-hidden="true" /> {t("compare.title")}
         </h1>
         <EmptyStateIllustration
@@ -103,7 +103,7 @@ export default function ComparePage() {
   }
 
   return (
-    <div className="compare-print-container space-y-4">
+    <div className="compare-print-container space-y-6">
       <Breadcrumbs
         items={[
           { labelKey: "nav.home", href: "/app" },
@@ -112,7 +112,7 @@ export default function ComparePage() {
       />
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="flex items-center gap-2 text-xl font-bold text-foreground">
+        <h1 className="flex items-center gap-2 text-xl font-bold text-foreground lg:text-2xl">
           <Scale size={22} aria-hidden="true" /> {t("compare.title")}
         </h1>
         <div className="no-print flex items-center gap-2">

--- a/frontend/src/app/app/lists/page.tsx
+++ b/frontend/src/app/app/lists/page.tsx
@@ -87,8 +87,8 @@ export default function ListsPage() {
       />
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-bold text-foreground flex items-center gap-1.5 lg:text-2xl">
-          <ClipboardList size={20} aria-hidden="true" /> {t("lists.title")}
+        <h1 className="text-xl font-bold text-foreground flex items-center gap-2 lg:text-2xl">
+          <ClipboardList size={22} aria-hidden="true" /> {t("lists.title")}
         </h1>
         <Button
           size="sm"

--- a/frontend/src/app/app/scan/page.tsx
+++ b/frontend/src/app/app/scan/page.tsx
@@ -399,7 +399,7 @@ export default function ScanPage() {
 
   return (
     <PullToRefresh onRefresh={handleRefresh}>
-    <div className="space-y-4">
+    <div className="space-y-6">
       <Breadcrumbs
         items={[
           { labelKey: "nav.home", href: "/app" },
@@ -408,7 +408,7 @@ export default function ScanPage() {
       />
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="flex items-center gap-2 text-xl font-bold text-foreground">
+        <h1 className="flex items-center gap-2 text-xl font-bold text-foreground lg:text-2xl">
           <Camera size={22} aria-hidden="true" /> {t("scan.title")}
         </h1>
         <div className="flex gap-2">

--- a/frontend/src/app/app/watchlist/page.tsx
+++ b/frontend/src/app/app/watchlist/page.tsx
@@ -102,7 +102,7 @@ export default function WatchlistPage() {
   const totalPages = data?.total_pages ?? 1;
 
   return (
-    <div>
+    <div className="space-y-6">
       <Breadcrumbs
         items={[
           { labelKey: "nav.home", href: "/app" },
@@ -110,10 +110,10 @@ export default function WatchlistPage() {
         ]}
       />
 
-      <div className="mb-6 flex items-center gap-3">
+      <div className="flex items-center gap-3">
         <Icon icon={Eye} size="lg" className="text-brand" />
         <div>
-          <h1 className="text-xl font-bold text-foreground">
+          <h1 className="text-xl font-bold text-foreground lg:text-2xl">
             {t("watchlist.title")}
           </h1>
           <p className="text-sm text-foreground-secondary">

--- a/frontend/src/components/common/Button.test.tsx
+++ b/frontend/src/components/common/Button.test.tsx
@@ -41,6 +41,15 @@ describe("Button", () => {
     expect(screen.getByRole("button").className).toContain("text-base");
   });
 
+  it("enforces 44px min-height on md and lg sizes", () => {
+    const { rerender } = render(<Button size="md">M</Button>);
+    expect(screen.getByRole("button").className).toContain("min-h-[44px]");
+    rerender(<Button size="lg">L</Button>);
+    expect(screen.getByRole("button").className).toContain("min-h-[44px]");
+    rerender(<Button size="sm">S</Button>);
+    expect(screen.getByRole("button").className).not.toContain("min-h-[44px]");
+  });
+
   it("shows loading spinner and disables button", () => {
     const onClick = vi.fn();
     render(

--- a/frontend/src/components/common/Button.tsx
+++ b/frontend/src/components/common/Button.tsx
@@ -53,8 +53,8 @@ const VARIANT_CLASSES: Record<ButtonVariant, string> = {
 
 const SIZE_CLASSES: Record<ButtonSize, string> = {
   sm: "px-3 py-1.5 text-xs gap-1.5 rounded-md",
-  md: "px-4 py-2.5 text-sm gap-2 rounded-lg",
-  lg: "px-6 py-3 text-base gap-2.5 rounded-lg",
+  md: "px-4 py-2.5 text-sm gap-2 rounded-lg min-h-[44px]",
+  lg: "px-6 py-3 text-base gap-2.5 rounded-lg min-h-[44px]",
 };
 
 const SPINNER_SIZES: Record<ButtonSize, string> = {


### PR DESCRIPTION
## Summary
Fixes #793 — Mobile typography, spacing, and visual consistency audit.

### Changes
- **Button touch targets:** Added min-h-[44px] to md and lg button sizes for WCAG 2.5.5 compliance
- **Page headings:** Standardized all h1 elements to text-xl lg:text-2xl across compare, scan, categories/[slug], watchlist, achievements pages
- **Icon consistency:** Normalized lists page icon to size={22} with gap-2 (matching other pages)
- **Page spacing:** Upgraded all pages to space-y-6 outer spacing (matching Dashboard reference pattern); removed redundant mb-4/mb-6 margins
- **DESIGN_SYSTEM.md:** Added Mobile Typography Standards section documenting heading, spacing, and touch target conventions

### Files Changed (10)
- Button.tsx — min-h-[44px] on md/lg sizes
- Button.test.tsx — touch target compliance test (3 assertions)
- 7 page files — heading + spacing standardization
- DESIGN_SYSTEM.md — new section

### Verification
- tsc --noEmit: 0 errors
- vitest: 125/125 tests pass (including new touch target test)
