### PR TITLE
feat(frontend): recipe page UX improvements (#788)

### DIFF
--- a/frontend/src/app/app/recipes/page.test.tsx
+++ b/frontend/src/app/app/recipes/page.test.tsx
@@ -204,13 +204,27 @@ describe("RecipesBrowsePage", () => {
     });
   });
 
-  it("renders category filter dropdown", async () => {
+  it("renders category tabs", async () => {
     render(<RecipesBrowsePage />, { wrapper: createWrapper() });
 
     await waitFor(() => {
       expect(
-        screen.getByRole("combobox", { name: /Filter by category/i }),
+        screen.getByTestId("recipe-category-tabs"),
       ).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("tab", { name: /All categories/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Breakfast/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Soup/i })).toBeInTheDocument();
+  });
+
+  it("marks 'All categories' tab as selected by default", async () => {
+    render(<RecipesBrowsePage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("tab", { name: /All categories/i }),
+      ).toHaveAttribute("aria-selected", "true");
     });
   });
 
@@ -224,20 +238,17 @@ describe("RecipesBrowsePage", () => {
     });
   });
 
-  it("passes category filter to API when selected", async () => {
+  it("passes category filter to API when tab is clicked", async () => {
     render(<RecipesBrowsePage />, { wrapper: createWrapper() });
     const user = userEvent.setup();
 
     await waitFor(() => {
       expect(
-        screen.getByRole("combobox", { name: /Filter by category/i }),
+        screen.getByRole("tab", { name: /Breakfast/i }),
       ).toBeInTheDocument();
     });
 
-    const categorySelect = screen.getByRole("combobox", {
-      name: /Filter by category/i,
-    });
-    await user.selectOptions(categorySelect, "breakfast");
+    await user.click(screen.getByRole("tab", { name: /Breakfast/i }));
 
     await waitFor(() => {
       const lastCall =
@@ -364,20 +375,17 @@ describe("RecipesBrowsePage", () => {
 
   // ─── Filter chips ──────────────────────────────────────────────────────
 
-  it("shows filter chips when a category is selected", async () => {
+  it("shows filter chips when a category tab is selected", async () => {
     render(<RecipesBrowsePage />, { wrapper: createWrapper() });
     const user = userEvent.setup();
 
     await waitFor(() => {
       expect(
-        screen.getByRole("combobox", { name: /Filter by category/i }),
+        screen.getByRole("tab", { name: /Breakfast/i }),
       ).toBeInTheDocument();
     });
 
-    const categorySelect = screen.getByRole("combobox", {
-      name: /Filter by category/i,
-    });
-    await user.selectOptions(categorySelect, "breakfast");
+    await user.click(screen.getByRole("tab", { name: /Breakfast/i }));
 
     await waitFor(() => {
       expect(screen.getByTestId("active-filter-chips")).toBeInTheDocument();
@@ -392,14 +400,11 @@ describe("RecipesBrowsePage", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("combobox", { name: /Filter by category/i }),
+        screen.getByRole("tab", { name: /Breakfast/i }),
       ).toBeInTheDocument();
     });
 
-    const categorySelect = screen.getByRole("combobox", {
-      name: /Filter by category/i,
-    });
-    await user.selectOptions(categorySelect, "breakfast");
+    await user.click(screen.getByRole("tab", { name: /Breakfast/i }));
 
     await waitFor(() => {
       expect(screen.getByTestId("active-filter-chips")).toBeInTheDocument();
@@ -418,14 +423,11 @@ describe("RecipesBrowsePage", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("combobox", { name: /Filter by category/i }),
+        screen.getByRole("tab", { name: /Breakfast/i }),
       ).toBeInTheDocument();
     });
 
-    const categorySelect = screen.getByRole("combobox", {
-      name: /Filter by category/i,
-    });
-    await user.selectOptions(categorySelect, "breakfast");
+    await user.click(screen.getByRole("tab", { name: /Breakfast/i }));
 
     await waitFor(() => {
       expect(screen.getByText("Clear all")).toBeInTheDocument();

--- a/frontend/src/app/app/recipes/page.tsx
+++ b/frontend/src/app/app/recipes/page.tsx
@@ -112,9 +112,9 @@ export default function RecipesBrowsePage() {
         {t("recipes.title")}
       </h1>
 
-      {/* ── Search + Filters ─────────────────────────────────────── */}
-      <div className="mb-4 flex flex-wrap gap-2" data-testid="recipe-filter">
-        <div className="relative w-full sm:w-auto sm:min-w-[220px]">
+      {/* ── Search bar ────────────────────────────────────────────── */}
+      <div className="mb-3 flex gap-2" data-testid="recipe-filter">
+        <div className="relative flex-1">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-foreground-secondary" aria-hidden="true" />
           <input
             type="search"
@@ -137,23 +137,9 @@ export default function RecipesBrowsePage() {
         </div>
 
         <select
-          value={category}
-          onChange={(e) => setCategory(e.target.value as RecipeCategory | "")}
-          className="input rounded-lg px-3 py-2 text-sm"
-          aria-label={t("recipes.filterCategory")}
-        >
-          <option value="">{t("recipes.allCategories")}</option>
-          {CATEGORY_OPTIONS.map((c) => (
-            <option key={c} value={c}>
-              {t(`recipes.category.${c}`)}
-            </option>
-          ))}
-        </select>
-
-        <select
           value={difficulty}
           onChange={(e) => setDifficulty(e.target.value as RecipeDifficulty | "")}
-          className="input rounded-lg px-3 py-2 text-sm"
+          className="input shrink-0 rounded-lg px-3 py-2 text-sm"
           aria-label={t("recipes.filterDifficulty")}
         >
           <option value="">{t("recipes.allDifficulties")}</option>
@@ -163,6 +149,48 @@ export default function RecipesBrowsePage() {
             </option>
           ))}
         </select>
+      </div>
+
+      {/* ── Category tabs (horizontal scroll) ────────────────────── */}
+      <div
+        className="mb-4 -mx-4 px-4 overflow-x-auto scrollbar-hide"
+        role="tablist"
+        aria-label={t("recipes.filterCategory")}
+        data-testid="recipe-category-tabs"
+      >
+        <div className="flex gap-1.5 whitespace-nowrap pb-1">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={category === ""}
+            onClick={() => setCategory("")}
+            className={[
+              "rounded-full px-3.5 py-1.5 text-sm font-medium transition-colors",
+              category === ""
+                ? "bg-brand-primary text-on-brand"
+                : "bg-surface-muted text-foreground-secondary hover:bg-surface-muted/80",
+            ].join(" ")}
+          >
+            {t("recipes.allCategories")}
+          </button>
+          {CATEGORY_OPTIONS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              role="tab"
+              aria-selected={category === c}
+              onClick={() => setCategory(c)}
+              className={[
+                "rounded-full px-3.5 py-1.5 text-sm font-medium transition-colors",
+                category === c
+                  ? "bg-brand-primary text-on-brand"
+                  : "bg-surface-muted text-foreground-secondary hover:bg-surface-muted/80",
+              ].join(" ")}
+            >
+              {t(`recipes.category.${c}`)}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* ── Active filter chips ──────────────────────────────────── */}
@@ -186,13 +214,15 @@ export default function RecipesBrowsePage() {
               {t(`recipes.difficulty.${difficulty}`)}
             </Chip>
           )}
-          <button
-            type="button"
-            onClick={handleClearAll}
-            className="text-xs font-medium text-brand hover:underline"
-          >
-            {t("recipes.clearFilters")}
-          </button>
+          {(category || difficulty) && (
+            <button
+              type="button"
+              onClick={handleClearAll}
+              className="text-xs font-medium text-brand hover:underline"
+            >
+              {t("recipes.clearFilters")}
+            </button>
+          )}
         </div>
       )}
 

--- a/frontend/src/components/recipes/IngredientProductList.test.tsx
+++ b/frontend/src/components/recipes/IngredientProductList.test.tsx
@@ -38,6 +38,7 @@ const mockProducts: LinkedProduct[] = [
     unhealthiness_score: 12,
     image_url: "https://example.com/oat.jpg",
     is_primary: true,
+    match_confidence: 0.92,
   },
   {
     product_id: 102,
@@ -46,6 +47,7 @@ const mockProducts: LinkedProduct[] = [
     unhealthiness_score: 25,
     image_url: null,
     is_primary: false,
+    match_confidence: 0.65,
   },
   {
     product_id: 103,
@@ -54,6 +56,7 @@ const mockProducts: LinkedProduct[] = [
     unhealthiness_score: null,
     image_url: null,
     is_primary: false,
+    match_confidence: null,
   },
 ];
 
@@ -152,9 +155,12 @@ describe("IngredientProductList", () => {
     const user = userEvent.setup();
     render(<IngredientProductList products={mockProducts} />);
     await user.click(screen.getByRole("button"));
-    // Oat Bran has null brand — should have score-badge span + product name span only (no brand, no primary)
+    // Oat Bran has null brand and null match_confidence — score-badge + product name only
     const items = screen.getByTestId("ingredient-product-list").querySelectorAll("li");
-    expect(items[2].querySelectorAll("span")).toHaveLength(2); // score-badge + product name only
+    const spans = items[2].querySelectorAll("span");
+    const spanTexts = Array.from(spans).map((s) => s.textContent);
+    expect(spanTexts).not.toContain("BioFarm");
+    expect(spanTexts).not.toContain("Morning Best");
   });
 
   it("shows primary badge for primary products", async () => {
@@ -195,5 +201,24 @@ describe("IngredientProductList", () => {
     );
     await user.click(screen.getByRole("button"));
     expect(screen.getByText("Oat Flakes Organic")).toBeInTheDocument();
+  });
+
+  it("shows match confidence percentage when available", async () => {
+    const user = userEvent.setup();
+    render(<IngredientProductList products={mockProducts} />);
+    await user.click(screen.getByRole("button"));
+    // First product: 0.92 → 92%
+    expect(screen.getByText("92%")).toBeInTheDocument();
+    // Second product: 0.65 → 65%
+    expect(screen.getByText("65%")).toBeInTheDocument();
+  });
+
+  it("does not show match confidence when null", async () => {
+    const user = userEvent.setup();
+    render(<IngredientProductList products={mockProducts} />);
+    await user.click(screen.getByRole("button"));
+    const items = screen.getByTestId("ingredient-product-list").querySelectorAll("li");
+    // Third product has null match_confidence — no percentage badge
+    expect(items[2].textContent).not.toMatch(/\d+%/);
   });
 });

--- a/frontend/src/components/recipes/IngredientProductList.tsx
+++ b/frontend/src/components/recipes/IngredientProductList.tsx
@@ -66,6 +66,21 @@ export function IngredientProductList({
                     {product.brand}
                   </span>
                 )}
+                {product.match_confidence != null && (
+                  <span
+                    className={[
+                      "shrink-0 rounded px-1.5 py-0.5 text-xxs font-medium",
+                      product.match_confidence >= 0.8
+                        ? "bg-success/10 text-success-text"
+                        : product.match_confidence >= 0.5
+                          ? "bg-warning/10 text-warning-text"
+                          : "bg-surface-muted text-foreground-muted",
+                    ].join(" ")}
+                    title={`${Math.round(product.match_confidence * 100)}% match`}
+                  >
+                    {Math.round(product.match_confidence * 100)}%
+                  </span>
+                )}
                 {product.is_primary && (
                   <span className="shrink-0 rounded bg-primary/10 px-1.5 py-0.5 text-xxs font-semibold text-primary">
                     {t("recipes.linkedProducts.primary")}

--- a/frontend/src/components/recipes/RecipeScoreBadge.test.tsx
+++ b/frontend/src/components/recipes/RecipeScoreBadge.test.tsx
@@ -144,9 +144,15 @@ describe("RecipeScoreBadge", () => {
     expect(
       screen.getByTestId("recipe-score-nutrition"),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Calories: 150.5 kcal/)).toBeInTheDocument();
-    expect(screen.getByText(/Protein: 5 g/)).toBeInTheDocument();
-    expect(screen.getByText(/Salt: 0.3 g/)).toBeInTheDocument();
+
+    // Nutrient bars rendered with progressbar role
+    const bars = screen.getAllByRole("progressbar");
+    expect(bars.length).toBeGreaterThanOrEqual(3);
+
+    // Verify specific nutrient bars exist
+    expect(screen.getByTestId("nutrient-bar-calories")).toBeInTheDocument();
+    expect(screen.getByTestId("nutrient-bar-protein")).toBeInTheDocument();
+    expect(screen.getByTestId("nutrient-bar-salt")).toBeInTheDocument();
   });
 
   // ─── Accessibility ──────────────────────────────────────────────────────

--- a/frontend/src/components/recipes/RecipeScoreBadge.tsx
+++ b/frontend/src/components/recipes/RecipeScoreBadge.tsx
@@ -33,6 +33,46 @@ const CONFIDENCE_STYLE: Record<string, { label: string; className: string }> = {
   low: { label: "Low confidence", className: "text-error-text" },
 };
 
+// ─── NutrientBar — visual bar for a single nutrient value ───────────────────
+
+interface NutrientBarProps {
+  readonly label: string;
+  readonly value: number | null | undefined;
+  readonly unit: string;
+  /** Daily reference intake ceiling for the bar. */
+  readonly max: number;
+  /** Positive nutrient (protein, fibre) — use brand color instead of warning. */
+  readonly positive?: boolean;
+}
+
+function NutrientBar({ label, value, unit, max, positive }: NutrientBarProps) {
+  if (value == null) return null;
+  const pct = Math.min(Math.round((value / max) * 100), 100);
+  const barColor = positive ? "bg-success" : pct > 75 ? "bg-warning" : "bg-brand-primary";
+
+  return (
+    <div className="text-xs" data-testid={`nutrient-bar-${label.toLowerCase()}`}>
+      <div className="flex items-center justify-between text-foreground-muted mb-0.5">
+        <span>{label}</span>
+        <span>
+          {value} {unit}
+        </span>
+      </div>
+      <div className="h-1.5 w-full rounded-full bg-surface-muted overflow-hidden">
+        <div
+          className={`h-full rounded-full ${barColor} transition-all duration-500`}
+          style={{ width: `${pct}%` }}
+          role="progressbar"
+          aria-valuenow={value}
+          aria-valuemin={0}
+          aria-valuemax={max}
+          aria-label={`${label}: ${value} ${unit}`}
+        />
+      </div>
+    </div>
+  );
+}
+
 // ─── Component ──────────────────────────────────────────────────────────────
 
 export const RecipeScoreBadge = React.memo(function RecipeScoreBadge({
@@ -132,25 +172,13 @@ export const RecipeScoreBadge = React.memo(function RecipeScoreBadge({
 
       {/* Optional nutrition summary */}
       {showNutrition && score.nutrition_summary && (
-        <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-foreground-muted" data-testid="recipe-score-nutrition">
-          {score.nutrition_summary.avg_calories != null && (
-            <span>Calories: {score.nutrition_summary.avg_calories} kcal</span>
-          )}
-          {score.nutrition_summary.avg_protein_g != null && (
-            <span>Protein: {score.nutrition_summary.avg_protein_g} g</span>
-          )}
-          {score.nutrition_summary.avg_total_fat_g != null && (
-            <span>Fat: {score.nutrition_summary.avg_total_fat_g} g</span>
-          )}
-          {score.nutrition_summary.avg_sugars_g != null && (
-            <span>Sugars: {score.nutrition_summary.avg_sugars_g} g</span>
-          )}
-          {score.nutrition_summary.avg_salt_g != null && (
-            <span>Salt: {score.nutrition_summary.avg_salt_g} g</span>
-          )}
-          {score.nutrition_summary.avg_fibre_g != null && (
-            <span>Fibre: {score.nutrition_summary.avg_fibre_g} g</span>
-          )}
+        <div className="mt-3 space-y-2" data-testid="recipe-score-nutrition">
+          <NutrientBar label="Calories" value={score.nutrition_summary.avg_calories} unit="kcal" max={2000} />
+          <NutrientBar label="Protein" value={score.nutrition_summary.avg_protein_g} unit="g" max={50} positive />
+          <NutrientBar label="Fat" value={score.nutrition_summary.avg_total_fat_g} unit="g" max={70} />
+          <NutrientBar label="Sugars" value={score.nutrition_summary.avg_sugars_g} unit="g" max={90} />
+          <NutrientBar label="Salt" value={score.nutrition_summary.avg_salt_g} unit="g" max={6} />
+          <NutrientBar label="Fibre" value={score.nutrition_summary.avg_fibre_g} unit="g" max={30} positive />
         </div>
       )}
     </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1564,6 +1564,7 @@ export interface LinkedProduct {
   unhealthiness_score: number | null;
   image_url: string | null;
   is_primary: boolean;
+  match_confidence: number | null;
 }
 
 export interface RecipeIngredient {


### PR DESCRIPTION
Closes #788

## Changes

1. **Horizontal category tabs** - Replace category dropdown with scrollable pill-button tabs (role=tablist, aria-selected)
2. **Nutrition progress bars** - Replace plain text nutrition with visual NutrientBar components (role=progressbar, daily reference intakes)
3. **Match confidence display** - Show color-coded match percentage badge on linked products (green >=80%, yellow >=50%, muted <50%)

## Files Changed (7)

- recipes/page.tsx - Category select -> tab bar
- recipes/page.test.tsx - 5 tests updated, 1 new test
- RecipeScoreBadge.tsx - NutrientBar progress bars
- RecipeScoreBadge.test.tsx - Progressbar role assertions
- IngredientProductList.tsx - Match confidence badge
- IngredientProductList.test.tsx - Mock data + 2 new tests
- types.ts - match_confidence on LinkedProduct

## Verification

- npx tsc --noEmit: 0 errors
- Vitest: 54/54 pass (0 failures)
- 180 insertions, 73 deletions