### PR TITLE
feat(compare): mobile-optimized comparison with winner verdict and key differences

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -604,7 +604,10 @@
     "compareProducts": "{count} {count|Produkt|Produkte} vergleichen",
     "deleteComparison": "Vergleich löschen",
     "productsNotFound": "{count} {count|Produkt|Produkte} nicht gefunden.",
-    "onlyShowingAvailable": "Es werden nur verfügbare Produkte angezeigt."
+    "onlyShowingAvailable": "Es werden nur verfügbare Produkte angezeigt.",
+    "winnerVerdict": "{points} Punkte gesünder",
+    "keyDifferences": "Wichtigste Unterschiede",
+    "fullNutrition": "Vollständige Nährwerte"
   },
   "settings": {
     "title": "Einstellungen",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -604,7 +604,10 @@
     "compareProducts": "Compare {count} {count|product|products}",
     "deleteComparison": "Delete comparison",
     "productsNotFound": "{count} {count|product|products} not found.",
-    "onlyShowingAvailable": "Only showing available products."
+    "onlyShowingAvailable": "Only showing available products.",
+    "winnerVerdict": "{points} points healthier",
+    "keyDifferences": "Key Differences",
+    "fullNutrition": "Full Nutrition"
   },
   "settings": {
     "title": "Settings",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -604,7 +604,10 @@
     "compareProducts": "Porównaj {count} {count|produkt|produkty|produktów}",
     "deleteComparison": "Usuń porównanie",
     "productsNotFound": "{count} {count|produkt nie znaleziony|produkty nie znalezione|produktów nie znalezionych}.",
-    "onlyShowingAvailable": "Pokazano tylko dostępne produkty."
+    "onlyShowingAvailable": "Pokazano tylko dostępne produkty.",
+    "winnerVerdict": "O {points} pkt zdrowszy",
+    "keyDifferences": "Kluczowe różnice",
+    "fullNutrition": "Pełne wartości odżywcze"
   },
   "settings": {
     "title": "Ustawienia",

--- a/frontend/src/components/compare/ComparisonGrid.test.tsx
+++ b/frontend/src/components/compare/ComparisonGrid.test.tsx
@@ -245,4 +245,57 @@ describe("ComparisonGrid", () => {
     const badges = screen.getAllByText(/Healthiest/);
     expect(badges.length).toBeGreaterThanOrEqual(1);
   });
+
+  // ─── Mobile-specific: winner announcement ───────────────────────────────
+
+  it("renders winner announcement on mobile", () => {
+    render(<ComparisonGrid products={products} />);
+    const announcement = screen.getByTestId("winner-announcement");
+    expect(announcement).toBeInTheDocument();
+    // Product A (score 35) is healthier → winner
+    expect(announcement).toHaveTextContent("Product A");
+  });
+
+  it("shows score delta in winner announcement", () => {
+    render(<ComparisonGrid products={products} />);
+    const announcement = screen.getByTestId("winner-announcement");
+    // TryVit scores: A=65, B=40 → delta=25
+    expect(announcement).toHaveTextContent("25");
+  });
+
+  // ─── Mobile-specific: key differences ───────────────────────────────────
+
+  it("renders key differences section on mobile", () => {
+    render(<ComparisonGrid products={products} />);
+    const section = screen.getByTestId("key-differences");
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveTextContent("Key Differences");
+  });
+
+  it("shows nutrient values in key differences", () => {
+    render(<ComparisonGrid products={products} />);
+    const section = screen.getByTestId("key-differences");
+    // Products differ in sugars (5 vs 20), saturated fat (10 vs 15), etc.
+    // At least one row should be visible
+    expect(section.querySelectorAll(".flex.items-center.justify-between").length).toBeGreaterThan(0);
+  });
+
+  // ─── Mobile-specific: collapsible sections ──────────────────────────────
+
+  it("renders collapsible nutrition section", () => {
+    render(<ComparisonGrid products={products} />);
+    expect(screen.getAllByText("Full Nutrition").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders collapsible allergens section", () => {
+    render(<ComparisonGrid products={products} />);
+    const allergenSections = screen.getAllByText("Allergens");
+    expect(allergenSections.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders collapsible warnings section", () => {
+    render(<ComparisonGrid products={products} />);
+    const warnSections = screen.getAllByText("Warnings");
+    expect(warnSections.length).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/frontend/src/components/compare/ComparisonGrid.tsx
+++ b/frontend/src/components/compare/ComparisonGrid.tsx
@@ -11,13 +11,14 @@ import { useTranslation } from "@/lib/i18n";
 import { nutriScoreLabel } from "@/lib/nutri-label";
 import { toTryVitScore } from "@/lib/score-utils";
 import type { CellValue, CompareProduct } from "@/lib/types";
-import { Check, Scale, Trophy, X as XIcon } from "lucide-react";
+import { Check, ChevronDown, Scale, Trophy, X as XIcon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
     fmtStr,
     fmtUnit,
     getBestWorst,
     getCellHighlightClass,
+    getKeyDifferences,
     getWinnerIndex,
 } from "./comparison-helpers";
 
@@ -356,7 +357,39 @@ function DesktopGrid({
   );
 }
 
-// ─── Mobile Swipe View ──────────────────────────────────────────────────────
+// ─── Mobile Comparison View ─────────────────────────────────────────────────
+
+/** Collapsible section with chevron toggle */
+function CollapsibleSection({
+  title,
+  defaultOpen = false,
+  children,
+}: Readonly<{
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}>) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div className="border-t border">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center justify-between px-4 py-3 touch-target"
+        aria-expanded={open}
+      >
+        <span className="text-sm font-semibold text-foreground">{title}</span>
+        <ChevronDown
+          size={16}
+          aria-hidden="true"
+          className={`text-foreground-muted transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+      {open && <div className="px-4 pb-4">{children}</div>}
+    </div>
+  );
+}
 
 function MobileSwipeView({
   products,
@@ -367,6 +400,13 @@ function MobileSwipeView({
   const containerRef = useRef<HTMLDivElement>(null);
   const touchStartX = useRef(0);
   const winnerIdx = getWinnerIndex(products);
+  const keyDiffs = getKeyDifferences(products);
+  const scoreDelta = Math.abs(
+    toTryVitScore(products[winnerIdx].unhealthiness_score) -
+      toTryVitScore(
+        products[winnerIdx === 0 ? 1 : 0].unhealthiness_score,
+      ),
+  );
 
   const swipeTo = useCallback(
     (idx: number) => {
@@ -400,14 +440,89 @@ function MobileSwipeView({
   }, [activeIdx, swipeTo]);
 
   const product = products[activeIdx];
-  const band = SCORE_BANDS[scoreBandFromScore(product.unhealthiness_score)];
   const nutriClass = product.nutri_score
     ? NUTRI_COLORS[product.nutri_score]
     : "bg-surface-muted text-foreground-secondary";
 
   return (
     <div className="md:hidden">
-      {/* Sticky header with product names */}
+      {/* ── Score header — all products side by side ── */}
+      <div className="px-4 pt-4 pb-2">
+        <div className="flex items-stretch justify-center gap-3">
+          {products.map((p, i) => {
+            const band = SCORE_BANDS[scoreBandFromScore(p.unhealthiness_score)];
+            return (
+              <div
+                key={p.product_id}
+                className={`flex-1 text-center rounded-xl p-3 ${i === winnerIdx ? "ring-2 ring-success-text bg-success-bg/30" : "bg-surface-alt"}`}
+              >
+                <div
+                  className={`mx-auto flex h-12 w-12 items-center justify-center rounded-lg text-lg font-bold ${band.bg} ${band.color}`}
+                >
+                  {toTryVitScore(p.unhealthiness_score)}
+                  <span className="sr-only">{band.label}</span>
+                </div>
+                <p className="mt-1 text-xs font-semibold text-foreground line-clamp-2">
+                  {p.product_name}
+                </p>
+                <p className="text-xs text-foreground-secondary line-clamp-1">
+                  {p.brand}
+                </p>
+                {showAvoidBadge && (
+                  <div className="mt-1">
+                    <AvoidBadge productId={p.product_id} />
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ── Winner announcement ── */}
+      <div className="mx-4 mb-3 rounded-xl bg-success-bg p-3 text-center" data-testid="winner-announcement">
+        <Trophy size={20} aria-hidden="true" className="inline text-success-text" />
+        <p className="mt-1 text-sm font-bold text-success-text">
+          {products[winnerIdx].product_name}
+        </p>
+        <p className="text-xs text-success-text/80">
+          {t("compare.winnerVerdict", { points: scoreDelta })}
+        </p>
+      </div>
+
+      {/* ── Key differences ── */}
+      {keyDiffs.length > 0 && (
+        <div className="mx-4 mb-3 card" data-testid="key-differences">
+          <p className="text-sm font-semibold text-foreground mb-2">
+            {t("compare.keyDifferences")}
+          </p>
+          <div className="space-y-2">
+            {keyDiffs.map((diff) => (
+              <div key={diff.labelKey} className="flex items-center justify-between text-sm">
+                <span className="text-foreground-secondary">
+                  {t(diff.labelKey) ?? diff.label}
+                </span>
+                <div className="flex items-center gap-2">
+                  {products.map((_, i) => (
+                    <span
+                      key={products[i].product_id}
+                      className={`text-xs font-medium ${i === diff.betterIdx ? "text-success-text" : "text-foreground-secondary"}`}
+                    >
+                      {diff.values[i]}
+                      {diff.unit ? ` ${diff.unit}` : ""}
+                      {i === diff.betterIdx && (
+                        <Check size={12} className="inline ml-0.5 text-success-text" aria-hidden="true" />
+                      )}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Swipeable detail tabs ── */}
       <div className="sticky top-12 md:top-14 z-30 bg-surface border-b border-border px-4 py-2">
         <div className="flex items-center justify-center gap-2" role="tablist">
           {products.map((p, i) => (
@@ -450,22 +565,16 @@ function MobileSwipeView({
         </div>
       </div>
 
-      {/* Swipeable card */}
+      {/* Swipeable card with collapsible sections */}
       <div
         ref={containerRef}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
-        className="mt-4 px-4"
+        className="mt-2 px-4"
       >
-        <div className="card space-y-4">
+        <div className="card overflow-hidden p-0">
           {/* Product header */}
-          <div className="flex items-start gap-3">
-            <div
-              className={`flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-xl text-xl font-bold ${band.bg} ${band.color}`}
-            >
-              {toTryVitScore(product.unhealthiness_score)}
-              <span className="sr-only">{band.label}</span>
-            </div>
+          <div className="flex items-start gap-3 p-4">
             <div className="min-w-0 flex-1">
               <p className="font-bold text-foreground">
                 {product.product_name}
@@ -488,74 +597,68 @@ function MobileSwipeView({
                     {t("compare.best")}
                   </span>
                 )}
-                {showAvoidBadge && (
-                  <AvoidBadge productId={product.product_id} />
-                )}
               </div>
             </div>
           </div>
 
-          {/* Nutrition data */}
-          <div className="divide-y divide-gray-100">
-            {COMPARE_ROWS.filter(
-              (r) => r.key !== "nutri_score" && r.key !== "nova_group",
-            ).map((row) => {
-              const rawValue = row.getValue(product);
-              const formatted = row.format
-                ? row.format(rawValue)
-                : fmtStr(rawValue);
+          {/* Nutrition data — collapsible */}
+          <CollapsibleSection title={t("compare.fullNutrition")} defaultOpen>
+            <div className="divide-y divide-gray-100">
+              {COMPARE_ROWS.filter(
+                (r) => r.key !== "nutri_score" && r.key !== "nova_group",
+              ).map((row) => {
+                const rawValue = row.getValue(product);
+                const formatted = row.format
+                  ? row.format(rawValue)
+                  : fmtStr(rawValue);
 
-              // Compare with other products
-              const allValues = products.map((p) => {
-                const v = row.getValue(p);
-                return typeof v === "number" ? v : null;
-              });
-              const ranking = getBestWorst(allValues, row.betterDirection);
-              let indicator = "";
-              if (ranking) {
-                if (activeIdx === ranking.bestIdx)
-                  indicator = "text-success-text font-semibold";
-                else if (activeIdx === ranking.worstIdx)
-                  indicator = "text-error-text";
-              }
+                const allValues = products.map((p) => {
+                  const v = row.getValue(p);
+                  return typeof v === "number" ? v : null;
+                });
+                const ranking = getBestWorst(allValues, row.betterDirection);
+                let indicator = "";
+                if (ranking) {
+                  if (activeIdx === ranking.bestIdx)
+                    indicator = "text-success-text font-semibold";
+                  else if (activeIdx === ranking.worstIdx)
+                    indicator = "text-error-text";
+                }
 
-              return (
-                <div
-                  key={row.key}
-                  className="flex items-center justify-between py-2"
-                >
-                  <span className="text-sm text-foreground-secondary">
-                    {t(ROW_LABEL_KEYS[row.key]) ?? row.label}
-                  </span>
-                  <span className={`text-sm ${indicator || "text-foreground"}`}>
-                    {formatted}
-                    {ranking?.bestIdx === activeIdx && (
-                      <Check
-                        size={14}
-                        className="inline ml-1 text-success-text"
-                        aria-hidden="true"
-                      />
-                    )}
-                    {ranking?.worstIdx === activeIdx && (
-                      <XIcon
-                        size={14}
-                        className="inline ml-1 text-error-text"
-                        aria-hidden="true"
-                      />
-                    )}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
+                return (
+                  <div
+                    key={row.key}
+                    className="flex items-center justify-between py-2"
+                  >
+                    <span className="text-sm text-foreground-secondary">
+                      {t(ROW_LABEL_KEYS[row.key]) ?? row.label}
+                    </span>
+                    <span className={`text-sm ${indicator || "text-foreground"}`}>
+                      {formatted}
+                      {ranking?.bestIdx === activeIdx && (
+                        <Check
+                          size={14}
+                          className="inline ml-1 text-success-text"
+                          aria-hidden="true"
+                        />
+                      )}
+                      {ranking?.worstIdx === activeIdx && (
+                        <XIcon
+                          size={14}
+                          className="inline ml-1 text-error-text"
+                          aria-hidden="true"
+                        />
+                      )}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </CollapsibleSection>
 
-          {/* Allergens */}
-          <div className="pt-2 border-t border">
-            <p className="text-xs font-medium text-foreground-muted uppercase mb-1">
-              {t("product.allergens")}
-            </p>
+          {/* Allergens — collapsible */}
+          <CollapsibleSection title={t("product.allergens")}>
             <p className="text-sm text-foreground-secondary">
-              {/* Tags are bare canonical IDs; strip legacy en: prefix as fallback */}
               {product.allergen_tags
                 ? product.allergen_tags
                     .split(", ")
@@ -563,13 +666,10 @@ function MobileSwipeView({
                     .join(", ")
                 : t("compare.noneDeclared")}
             </p>
-          </div>
+          </CollapsibleSection>
 
-          {/* Flags */}
-          <div>
-            <p className="text-xs font-medium text-foreground-muted uppercase mb-1">
-              {t("product.warnings")}
-            </p>
+          {/* Flags — collapsible */}
+          <CollapsibleSection title={t("product.warnings")}>
             <div className="flex flex-wrap gap-1">
               {product.high_salt && (
                 <span className="rounded bg-warning-bg px-2 py-0.5 text-xs text-warning-text">
@@ -600,7 +700,7 @@ function MobileSwipeView({
                   </span>
                 )}
             </div>
-          </div>
+          </CollapsibleSection>
         </div>
 
         {/* Swipe hint */}

--- a/frontend/src/components/compare/comparison-helpers.test.ts
+++ b/frontend/src/components/compare/comparison-helpers.test.ts
@@ -7,6 +7,7 @@ import {
     fmtUnit,
     getBestWorst,
     getCellHighlightClass,
+    getKeyDifferences,
     getProductWarnings,
     getWinnerIndex,
 } from "./comparison-helpers";
@@ -329,5 +330,81 @@ describe("getCellHighlightClass", () => {
     expect(getCellHighlightClass(1, ranking, 1)).toBe(
       "bg-success-bg text-success-text font-semibold",
     );
+  });
+});
+
+// ─── getKeyDifferences ──────────────────────────────────────────────────────
+
+describe("getKeyDifferences", () => {
+  it("returns differences sorted by significance", () => {
+    const a = makeProduct({ calories: 100, sugars_g: 5, salt_g: 0.2 });
+    const b = makeProduct({ calories: 500, sugars_g: 6, salt_g: 0.3 });
+    const diffs = getKeyDifferences([a, b]);
+
+    // Calories diff = 400/600 = 0.667, sugars diff = 1/50 = 0.02, salt diff = 0.1/5 = 0.02
+    expect(diffs[0].label).toBe("Calories");
+    expect(diffs[0].betterIdx).toBe(0); // lower is better for calories
+  });
+
+  it("respects maxResults limit", () => {
+    const a = makeProduct({
+      calories: 100,
+      sugars_g: 30,
+      salt_g: 4,
+      total_fat_g: 40,
+      saturated_fat_g: 20,
+      protein_g: 5,
+      fibre_g: 1,
+      additives_count: 8,
+    });
+    const b = makeProduct({
+      calories: 500,
+      sugars_g: 5,
+      salt_g: 0.5,
+      total_fat_g: 5,
+      saturated_fat_g: 2,
+      protein_g: 30,
+      fibre_g: 10,
+      additives_count: 1,
+    });
+    const diffs = getKeyDifferences([a, b], 3);
+    expect(diffs).toHaveLength(3);
+  });
+
+  it("returns empty array when products have identical values", () => {
+    const a = makeProduct();
+    const b = makeProduct();
+    const diffs = getKeyDifferences([a, b]);
+    expect(diffs).toHaveLength(0);
+  });
+
+  it("identifies correct better index for higher-is-better nutrients", () => {
+    const a = makeProduct({ protein_g: 5 });
+    const b = makeProduct({ protein_g: 30 });
+    const diffs = getKeyDifferences([a, b]);
+    const proteinDiff = diffs.find((d) => d.label === "Protein");
+    expect(proteinDiff).toBeDefined();
+    expect(proteinDiff!.betterIdx).toBe(1); // higher protein is better
+  });
+
+  it("handles null values gracefully", () => {
+    const a = makeProduct({ fibre_g: null as unknown as number });
+    const b = makeProduct({ fibre_g: 5 });
+    const diffs = getKeyDifferences([a, b]);
+    // fibre should be skipped since one value is null/undefined
+    const fibreDiff = diffs.find((d) => d.label === "Fibre");
+    expect(fibreDiff).toBeUndefined();
+  });
+
+  it("works with 3+ products", () => {
+    const a = makeProduct({ calories: 100 });
+    const b = makeProduct({ calories: 300 });
+    const c = makeProduct({ calories: 500 });
+    const diffs = getKeyDifferences([a, b, c]);
+    const calDiff = diffs.find((d) => d.label === "Calories");
+    expect(calDiff).toBeDefined();
+    // Max diff is 500-100=400, best is lowest
+    expect(calDiff!.betterIdx).toBe(0);
+    expect(calDiff!.values).toEqual([100, 300, 500]);
   });
 });

--- a/frontend/src/components/compare/comparison-helpers.ts
+++ b/frontend/src/components/compare/comparison-helpers.ts
@@ -104,3 +104,88 @@ export function getCellHighlightClass(
   if (idx === winnerIdx) return "bg-success-bg/30";
   return "";
 }
+
+// ─── Key differences ────────────────────────────────────────────────────────
+
+export interface KeyDifference {
+  /** Row label (display name) */
+  label: string;
+  /** i18n key for the row label */
+  labelKey: string;
+  /** Raw values per product */
+  values: number[];
+  /** Unit suffix (e.g. "g", "kcal") */
+  unit?: string;
+  /** Index of the product with the better value */
+  betterIdx: number;
+  /** Absolute difference between best and worst */
+  absoluteDiff: number;
+  /** 'lower' or 'higher' — which direction is better */
+  betterDirection: "lower" | "higher";
+}
+
+/** Nutrient row definition for key-differences extraction. */
+interface NutrientRow {
+  label: string;
+  labelKey: string;
+  key: keyof CompareProduct;
+  betterDirection: "lower" | "higher";
+  unit?: string;
+  /** Maximum realistic value for normalization (per 100g) */
+  ceiling: number;
+}
+
+const NUTRIENT_ROWS: NutrientRow[] = [
+  { label: "Calories", labelKey: "product.caloriesLabel", key: "calories", betterDirection: "lower", unit: "kcal", ceiling: 600 },
+  { label: "Total Fat", labelKey: "product.totalFat", key: "total_fat_g", betterDirection: "lower", unit: "g", ceiling: 50 },
+  { label: "Saturated Fat", labelKey: "product.saturatedFat", key: "saturated_fat_g", betterDirection: "lower", unit: "g", ceiling: 25 },
+  { label: "Sugars", labelKey: "product.sugars", key: "sugars_g", betterDirection: "lower", unit: "g", ceiling: 50 },
+  { label: "Salt", labelKey: "product.salt", key: "salt_g", betterDirection: "lower", unit: "g", ceiling: 5 },
+  { label: "Fibre", labelKey: "product.fibre", key: "fibre_g", betterDirection: "higher", unit: "g", ceiling: 15 },
+  { label: "Protein", labelKey: "product.protein", key: "protein_g", betterDirection: "higher", unit: "g", ceiling: 40 },
+  { label: "Additives", labelKey: "product.additives", key: "additives_count", betterDirection: "lower", ceiling: 10 },
+];
+
+/**
+ * Identify the top-N most different nutrients between products.
+ * Uses ceiling-normalized absolute difference to rank significance.
+ * Only works with 2+ products; returns empty array otherwise.
+ */
+export function getKeyDifferences(
+  products: CompareProduct[],
+  maxResults = 5,
+): KeyDifference[] {
+  if (products.length < 2) return [];
+
+  const diffs: (KeyDifference & { normalizedDiff: number })[] = [];
+
+  for (const row of NUTRIENT_ROWS) {
+    const values = products.map((p) => {
+      const v = p[row.key];
+      return typeof v === "number" ? v : null;
+    });
+
+    const valid = filterNumericEntries(values as (number | null)[]);
+    if (valid.length < 2) continue;
+
+    const best = findExtreme(valid, row.betterDirection === "lower" ? "min" : "max");
+    const worst = findExtreme(valid, row.betterDirection === "lower" ? "max" : "min");
+
+    const absDiff = Math.abs(best.val - worst.val);
+    if (absDiff === 0) continue;
+
+    diffs.push({
+      label: row.label,
+      labelKey: row.labelKey,
+      values: values.map((v) => v ?? 0),
+      unit: row.unit,
+      betterIdx: best.idx,
+      absoluteDiff: absDiff,
+      betterDirection: row.betterDirection,
+      normalizedDiff: absDiff / row.ceiling,
+    });
+  }
+
+  diffs.sort((a, b) => b.normalizedDiff - a.normalizedDiff);
+  return diffs.slice(0, maxResults).map(({ normalizedDiff: _, ...rest }) => rest);
+}


### PR DESCRIPTION
Closes #783

## Changes

- **Winner announcement**: Shows healthiest product with trophy icon and point delta (`data-testid=winner-announcement`)
- **Key differences**: Top 5 ceiling-normalized nutrient differences with check marks on better product (`data-testid=key-differences`)
- **Progressive disclosure**: Collapsible sections for Full Nutrition, Allergens, and Warnings via new `CollapsibleSection` component
- **Score header**: All products visible side-by-side with ring highlight on winner
- **i18n**: Added `winnerVerdict`, `keyDifferences`, `fullNutrition` keys to en/pl/de

## Files Changed (7)

- `comparison-helpers.ts` - Added `getKeyDifferences()` with ceiling-normalized sorting
- `ComparisonGrid.tsx` - Rewrote `MobileSwipeView` + added `CollapsibleSection`
- `messages/{en,pl,de}.json` - 3 new compare keys each
- `comparison-helpers.test.ts` - 6 new `getKeyDifferences` tests
- `ComparisonGrid.test.tsx` - 8 new mobile-specific tests (winner, key diff, collapsible)

## Verification

- `npx tsc --noEmit` - 0 errors
- 75/75 compare tests passing (0 failures)