### PR TITLE
fix(frontend): remove /80 opacity modifiers failing WCAG AA contrast

### DIFF
--- a/frontend/src/app/learn/nutri-score/page.tsx
+++ b/frontend/src/app/learn/nutri-score/page.tsx
@@ -60,7 +60,7 @@ export default function NutriScorePage() {
                 <p className="text-sm font-medium text-error-text">
                   {t("learn.nutriScore.negativeLabel")}
                 </p>
-                <p className="mt-1 text-sm text-error-text/80">
+                <p className="mt-1 text-sm text-error-text">
                   {t("learn.nutriScore.negativeItems")}
                 </p>
               </div>
@@ -68,7 +68,7 @@ export default function NutriScorePage() {
                 <p className="text-sm font-medium text-success-text">
                   {t("learn.nutriScore.positiveLabel")}
                 </p>
-                <p className="mt-1 text-sm text-success-text/80">
+                <p className="mt-1 text-sm text-success-text">
                   {t("learn.nutriScore.positiveItems")}
                 </p>
               </div>

--- a/frontend/src/components/compare/ComparisonGrid.tsx
+++ b/frontend/src/components/compare/ComparisonGrid.tsx
@@ -485,7 +485,7 @@ function MobileSwipeView({
         <p className="mt-1 text-sm font-bold text-success-text">
           {products[winnerIdx].product_name}
         </p>
-        <p className="text-xs text-success-text/80">
+        <p className="text-xs text-success-text">
           {t("compare.winnerVerdict", { points: scoreDelta })}
         </p>
       </div>

--- a/frontend/src/components/product/HealthWarningsCard.tsx
+++ b/frontend/src/components/product/HealthWarningsCard.tsx
@@ -154,7 +154,7 @@ export function HealthWarningsCard({
             <p className="text-sm font-medium text-success-text">
               {t("healthWarnings.withinLimits")}
             </p>
-            <p className="text-xs text-success-text/80">
+            <p className="text-xs text-success-text">
               {t("healthWarnings.noWarningsFor", {
                 name: profileData.profile?.profile_name ?? "",
               })}

--- a/frontend/src/components/product/ScoreBreakdownPanel.tsx
+++ b/frontend/src/components/product/ScoreBreakdownPanel.tsx
@@ -183,7 +183,7 @@ function BreakdownContent({
             </span>
           </div>
           {bonus.components && (
-            <div className="mt-1 flex gap-3 text-xs text-success-text/80">
+            <div className="mt-1 flex gap-3 text-xs text-success-text">
               {bonus.components.protein_bonus > 0 && (
                 <span>
                   {t("tooltip.scoreBreakdown.proteinBonus", {


### PR DESCRIPTION
Removes Tailwind /80 opacity modifiers from 	ext-error-text and 	ext-success-text classes across 4 files. The 80% opacity reduced contrast below the WCAG 2.1 AA 4.5:1 threshold for normal-weight 14px text.

**Files changed:** nutri-score learn page, ScoreBreakdownPanel, HealthWarningsCard, ComparisonGrid

**Verification:** Playwright smoke 119/119 pass, tsc --noEmit clean