### PR TITLE
fix(ci): increase Playwright step timeout and fix dark mode a11y flakiness

### DIFF
--- a/.github/workflows/main-gate.yml
+++ b/.github/workflows/main-gate.yml
@@ -284,7 +284,7 @@ jobs:
 
       - name: Playwright smoke E2E
         run: npx playwright test --project=smoke 2>&1 | tee ../playwright-stdout.log
-        timeout-minutes: 5
+        timeout-minutes: 8
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL_STAGING || secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY_STAGING || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}

--- a/frontend/e2e/smoke-a11y.spec.ts
+++ b/frontend/e2e/smoke-a11y.spec.ts
@@ -47,6 +47,7 @@ test.describe("A11y audit — dark mode", () => {
     await page.emulateMedia({ colorScheme: "dark" });
     await page.goto("/");
     await page.waitForLoadState("networkidle");
+    await page.waitForSelector("html[data-theme='dark']");
     await assertNoA11yViolations(page);
   });
 
@@ -54,6 +55,7 @@ test.describe("A11y audit — dark mode", () => {
     await page.emulateMedia({ colorScheme: "dark" });
     await page.goto("/auth/login");
     await page.waitForLoadState("networkidle");
+    await page.waitForSelector("html[data-theme='dark']");
     await assertNoA11yViolations(page);
   });
 });


### PR DESCRIPTION
## Problem

Main Gate CI fails because the Playwright smoke E2E step times out at 5 minutes. Tests actually pass (118 passed, 1 flaky) but the step is killed before it can report success.

The flaky test (smoke-a11y.spec.ts:46 - landing page passes a11y in dark mode) causes retries, pushing total runtime to ~5 minutes. The flakiness is caused by axe-core running before data-theme=dark CSS variables fully resolve.

## Changes

1. Step timeout: 5 to 8 minutes (main-gate.yml)
2. Dark mode a11y stabilization (smoke-a11y.spec.ts) - wait for html[data-theme=dark] before running axe-core
3. Sentry auth token updated in GitHub Actions secrets

## Verification

No functional code changed - only CI workflow timeout and E2E test synchronization.
