### PR TITLE
fix(ci): add --include-all to supabase db push for out-of-order migrations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -207,7 +207,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "Pushing pending migrations to ${{ github.event.inputs.environment }}..."
-          supabase db push --linked
+          supabase db push --linked --include-all
           echo "✅ Migrations applied successfully" >> "$GITHUB_STEP_SUMMARY"
 
       # ── Post-deploy sanity checks ──────────────────────────────────────

--- a/.github/workflows/sync-cloud-db.yml
+++ b/.github/workflows/sync-cloud-db.yml
@@ -96,7 +96,7 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
           echo "Pushing migrations to staging..."
-          supabase db push --linked
+          supabase db push --linked --include-all
           echo "## Staging Sync" >> "$GITHUB_STEP_SUMMARY"
           echo "Migrations applied to **staging** at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_STEP_SUMMARY"
           echo "Commit: \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
@@ -180,7 +180,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "Pushing migrations to PRODUCTION..."
-          supabase db push --linked
+          supabase db push --linked --include-all
           echo "## Production Sync" >> "$GITHUB_STEP_SUMMARY"
           echo "Migrations applied to **production** at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_STEP_SUMMARY"
           echo "Commit: \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

Production deploy (run 22969505695) failed at the 'Push migrations' step:

\\\
Found local migration files to be inserted before the last migration on remote database.
\\\

Two enrichment migrations have non-standard timestamps that fall before already-applied remote migrations:
- \20260309120331_populate_ingredients_allergens.sql\
- \20260309132842_populate_ingredients_allergens.sql\

## Fix

Add \--include-all\ flag to all \supabase db push --linked\ commands:
- **deploy.yml** - Push migrations step
- **sync-cloud-db.yml** - Staging sync + Production sync steps

This flag tells Supabase CLI to apply out-of-order migrations safely.

## Verification

No code or schema changes — workflow-only fix. The \--include-all\ flag is the Supabase-recommended solution for this scenario.