### PR TITLE
fix(migration): guard orphan ingredient_ref cleanup against all FK references

### DIFF
--- a/supabase/migrations/20260316000700_cleanup_orphan_ingredient_refs.sql
+++ b/supabase/migrations/20260316000700_cleanup_orphan_ingredient_refs.sql
@@ -10,6 +10,18 @@ DELETE FROM ingredient_ref ir
 WHERE NOT EXISTS (
     SELECT 1 FROM product_ingredient pi
     WHERE pi.ingredient_id = ir.ingredient_id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM product_ingredient pi
+    WHERE pi.parent_ingredient_id = ir.ingredient_id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM recipe_ingredient ri
+    WHERE ri.ingredient_ref_id = ir.ingredient_id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM ingredient_translations it
+    WHERE it.ingredient_id = ir.ingredient_id
 );
 
 -- Deduplicate product_ingredient rows sharing the same (product_id, position)
@@ -32,6 +44,18 @@ DELETE FROM ingredient_ref ir
 WHERE NOT EXISTS (
     SELECT 1 FROM product_ingredient pi
     WHERE pi.ingredient_id = ir.ingredient_id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM product_ingredient pi
+    WHERE pi.parent_ingredient_id = ir.ingredient_id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM recipe_ingredient ri
+    WHERE ri.ingredient_ref_id = ir.ingredient_id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM ingredient_translations it
+    WHERE it.ingredient_id = ir.ingredient_id
 );
 
 -- Re-score affected categories after ingredient count changes


### PR DESCRIPTION
## Problem

Production deploy failed at migration `20260316000700_cleanup_orphan_ingredient_refs.sql`:

```
ERROR: update or delete on table "ingredient_ref" violates foreign key constraint
"product_ingredient_parent_ingredient_id_fkey" on table "product_ingredient"
Key (ingredient_id)=(15894) is still referenced from table "product_ingredient".
```

The DELETE only checked `product_ingredient.ingredient_id` but ingredient 15894 is referenced via `parent_ingredient_id`.

## Fix

Guard both DELETE statements against all four FK references:
- `product_ingredient.ingredient_id`
- `product_ingredient.parent_ingredient_id`
- `recipe_ingredient.ingredient_ref_id`
- `ingredient_translations.ingredient_id`

## Safety

This migration was **never applied** to production (it failed mid-execution). No hash mismatch risk. The 6 migrations before it (20260309120331 through 20260316000600) were applied successfully.
