### PR TITLE
fix(qa): use UNKNOWN instead of null for QA fixture nutri_score_label

### DIFF
--- a/frontend/tests/quality/fixtures.ts
+++ b/frontend/tests/quality/fixtures.ts
@@ -66,7 +66,7 @@ export type FixtureKey = keyof FixtureValues;
  * | productWithAlternatives  | At least one alternative product                  |
  * | productNoAlternatives    | Zero alternatives                                 |
  * | productWithAllergens     | Allergen warnings present                         |
- * | productMissingNutriscore | Nutri-Score is null                               |
+ * | productMissingNutriscore | Nutri-Score is UNKNOWN                            |
  * | categorySlug             | Category with ≥ 3 products                        |
  * | ingredientId             | Ingredient with linked products                   |
  */

--- a/frontend/tests/quality/seed-fixtures.mjs
+++ b/frontend/tests/quality/seed-fixtures.mjs
@@ -277,7 +277,7 @@ const NUTRITION_ALLERGENS = {
 };
 
 /**
- * Product 4: Missing Nutri-Score — null label.
+ * Product 4: Unknown Nutri-Score — label set to UNKNOWN.
  * Used for: QA_PRODUCT_MISSING_NS.
  */
 const PRODUCT_NO_NS = {
@@ -289,8 +289,8 @@ const PRODUCT_NO_NS = {
   prep_method: "not-applicable",
   controversies: "none",
   unhealthiness_score: 12,
-  nutri_score_label: null,
-  nutri_score_source: null,
+  nutri_score_label: "UNKNOWN",
+  nutri_score_source: "unknown",
   nova_classification: "1",
   confidence: "low",
   data_completeness_pct: 55,


### PR DESCRIPTION
## Problem

The QA Kefir Tradycyjny test fixture (product_id 1234) had \
utri_score_label\ set to \
ull\, which caused sanity check 11 (Nutri-Score coverage) to fail on production after the deploy (run 22972567069).

## Fix

Changed \
utri_score_label: null\ → \'UNKNOWN'\ and \
utri_score_source: null\ → \'unknown'\ in the seed fixture. \UNKNOWN\ is a valid value in \
utri_score_ref\ and still represents missing Nutri-Score data.

Production data was already fixed via direct UPDATE.

## Files Changed

- \rontend/tests/quality/seed-fixtures.mjs\ — fixture value change
- \rontend/tests/quality/fixtures.ts\ — doc comment update

## Verification

- All 16 sanity checks pass on production (confirmed via psql)
- No spec files reference \productMissingNutriscore\ — no test breakage