### PR TITLE
fix(scoring): invert filter slider & category stats to TryVit Score

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -281,7 +281,7 @@
     "nova2": "2 — Verarbeitete Zutaten",
     "nova3": "3 — Verarbeitet",
     "nova4": "4 — Hochverarbeitet",
-    "maxHealthScore": "Max. TryVit Score",
+    "minHealthScore": "Min. TryVit Score",
     "any": "Beliebig",
     "clearAll": "Alle zurücksetzen",
     "closeFilters": "Filter schließen",
@@ -582,8 +582,8 @@
     "toggleViewMode": "Ansichtsmodus umschalten",
     "compactView": "Kompakt",
     "detailedView": "Detailliert",
-    "statAvgScore": "Durchschn. Bewertung",
-    "scoreRange": "Bewertungsbereich",
+    "statAvgScore": "Durchschn. TryVit Score",
+    "scoreRange": "TryVit Score Bereich",
     "nutriAB": "Nutri-Score A–B",
     "nova4Pct": "NOVA 4",
     "bestInCategory": "★ Bester in der Kategorie"
@@ -1089,7 +1089,7 @@
     "nutri": "Nutri {value}",
     "nova_group": "NOVA {value}",
     "allergenFree": "{label}-frei",
-    "scoreMax": "Bewertung ≤ {value}",
+    "scoreMin": "TryVit Score ≥ {value}",
     "sortLabel": "Sortierung: {label}",
     "removeFilter": "Filter {label} entfernen"
   },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -281,7 +281,7 @@
     "nova2": "2 — Processed ingredients",
     "nova3": "3 — Processed",
     "nova4": "4 — Ultra-processed",
-    "maxHealthScore": "Max TryVit Score",
+    "minHealthScore": "Min TryVit Score",
     "any": "Any",
     "clearAll": "Clear all",
     "closeFilters": "Close filters",
@@ -582,8 +582,8 @@
     "toggleViewMode": "Toggle view mode",
     "compactView": "Compact",
     "detailedView": "Detailed",
-    "statAvgScore": "Avg. Score",
-    "scoreRange": "Score Range",
+    "statAvgScore": "Avg. TryVit Score",
+    "scoreRange": "TryVit Score Range",
     "nutriAB": "Nutri-Score A–B",
     "nova4Pct": "NOVA 4",
     "bestInCategory": "★ Best in category"
@@ -1089,7 +1089,7 @@
     "nutri": "Nutri {value}",
     "nova_group": "NOVA {value}",
     "allergenFree": "{label}-free",
-    "scoreMax": "Score ≤ {value}",
+    "scoreMin": "TryVit Score ≥ {value}",
     "sortLabel": "Sort: {label}",
     "removeFilter": "Remove {label} filter"
   },

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -281,7 +281,7 @@
     "nova2": "2 — Przetworzone składniki",
     "nova3": "3 — Przetworzone",
     "nova4": "4 — Ultraprzetworzone",
-    "maxHealthScore": "Maks. wynik TryVit",
+    "minHealthScore": "Min. wynik TryVit",
     "any": "Dowolny",
     "clearAll": "Wyczyść wszystko",
     "closeFilters": "Zamknij filtry",
@@ -582,8 +582,8 @@
     "toggleViewMode": "Przełącz widok",
     "compactView": "Kompaktowy",
     "detailedView": "Szczegółowy",
-    "statAvgScore": "Śr. wynik",
-    "scoreRange": "Zakres wyników",
+    "statAvgScore": "Śr. wynik TryVit",
+    "scoreRange": "Zakres wyników TryVit",
     "nutriAB": "Nutri-Score A–B",
     "nova4Pct": "NOVA 4",
     "bestInCategory": "★ Najlepszy w kategorii"
@@ -1089,7 +1089,7 @@
     "nutri": "Nutri {value}",
     "nova_group": "NOVA {value}",
     "allergenFree": "Bez {label}",
-    "scoreMax": "Wynik ≤ {value}",
+    "scoreMin": "Wynik TryVit ≥ {value}",
     "sortLabel": "Sortuj: {label}",
     "removeFilter": "Usuń filtr {label}"
   },

--- a/frontend/src/app/app/categories/[slug]/page.tsx
+++ b/frontend/src/app/app/categories/[slug]/page.tsx
@@ -2,6 +2,7 @@
 
 // ─── Category listing — paginated product list for a single category ────────
 
+import { CategoryScoreBar } from "@/components/category/CategoryScoreBar";
 import { AllergenChips } from "@/components/common/AllergenChips";
 import { Button } from "@/components/common/Button";
 import { EmptyState } from "@/components/common/EmptyState";
@@ -9,7 +10,6 @@ import { NutriScoreBadge } from "@/components/common/NutriScoreBadge";
 import { ProductThumbnail } from "@/components/common/ProductThumbnail";
 import { PullToRefresh } from "@/components/common/PullToRefresh";
 import { CategoryListingSkeleton } from "@/components/common/skeletons";
-import { CategoryScoreBar } from "@/components/category/CategoryScoreBar";
 import { CompareCheckbox } from "@/components/compare/CompareCheckbox";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
 import { AddToListMenu } from "@/components/product/AddToListMenu";
@@ -412,7 +412,7 @@ function CategoryStatsCard({
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         <div className="text-center">
           <p className="text-lg font-bold text-foreground">
-            {Math.round(stats.avg_score)}
+            {toTryVitScore(Math.round(stats.avg_score))}
           </p>
           <p className="text-xs text-foreground-secondary">
             {t("categories.statAvgScore")}
@@ -420,7 +420,7 @@ function CategoryStatsCard({
         </div>
         <div className="text-center">
           <p className="text-lg font-bold text-foreground">
-            {stats.min_score}–{stats.max_score}
+            {toTryVitScore(stats.max_score)}–{toTryVitScore(stats.min_score)}
           </p>
           <p className="text-xs text-foreground-secondary">
             {t("categories.scoreRange")}

--- a/frontend/src/components/search/ActiveFilterChips.test.tsx
+++ b/frontend/src/components/search/ActiveFilterChips.test.tsx
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
-import { ActiveFilterChips } from "./ActiveFilterChips";
 import type { SearchFilters } from "@/lib/types";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ActiveFilterChips } from "./ActiveFilterChips";
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
@@ -157,26 +157,26 @@ describe("ActiveFilterChips", () => {
     expect(screen.getByText("mystery-free")).toBeTruthy();
   });
 
-  // ─── Max unhealthiness chip ─────────────────────────────────────────
+  // ─── Min TryVit Score chip ──────────────────────────────────────────
 
-  it("renders max unhealthiness chip", () => {
+  it("renders min TryVit Score chip", () => {
     render(
       <ActiveFilterChips
         filters={{ max_unhealthiness: 50 }}
         onChange={onChange}
       />,
     );
-    expect(screen.getByText("Score ≤ 50")).toBeTruthy();
+    expect(screen.getByText("TryVit Score ≥ 50")).toBeTruthy();
   });
 
-  it("removes max unhealthiness chip on click", () => {
+  it("removes min TryVit Score chip on click", () => {
     render(
       <ActiveFilterChips
         filters={{ max_unhealthiness: 50 }}
         onChange={onChange}
       />,
     );
-    fireEvent.click(screen.getByLabelText("Remove Score ≤ 50 filter"));
+    fireEvent.click(screen.getByLabelText("Remove TryVit Score ≥ 50 filter"));
     expect(onChange).toHaveBeenCalledWith({
       max_unhealthiness: undefined,
     });

--- a/frontend/src/components/search/ActiveFilterChips.tsx
+++ b/frontend/src/components/search/ActiveFilterChips.tsx
@@ -5,6 +5,7 @@
 import { ALLERGEN_TAGS } from "@/lib/constants";
 import { useTranslation } from "@/lib/i18n";
 import { nutriScoreLabel } from "@/lib/nutri-label";
+import { toTryVitScore } from "@/lib/score-utils";
 import type { SearchFilters } from "@/lib/types";
 
 interface ActiveFilterChipsProps {
@@ -90,7 +91,7 @@ export function ActiveFilterChips({
   if (filters.max_unhealthiness !== undefined) {
     chips.push({
       key: "max-score",
-      label: t("chips.scoreMax", { value: filters.max_unhealthiness }),
+      label: t("chips.scoreMin", { value: toTryVitScore(filters.max_unhealthiness ?? 0) }),
       onRemove: () => onChange({ ...filters, max_unhealthiness: undefined }),
     });
   }

--- a/frontend/src/components/search/FilterPanel.test.tsx
+++ b/frontend/src/components/search/FilterPanel.test.tsx
@@ -318,20 +318,20 @@ describe("FilterPanel", () => {
     expect(onChange).toHaveBeenCalledWith({});
   });
 
-  it("renders max health score slider", async () => {
+  it("renders min health score slider", async () => {
     renderPanel();
     await waitFor(() => {
       expect(
-        screen.getAllByText("Max TryVit Score").length,
+        screen.getAllByText("Min TryVit Score").length,
       ).toBeGreaterThanOrEqual(1);
     });
     expect(screen.getAllByText("Any").length).toBeGreaterThanOrEqual(1);
   });
 
-  it("shows current max score value when set", async () => {
+  it("shows current min score value when set", async () => {
     renderPanel({ filters: { max_unhealthiness: 50 } });
     await waitFor(() => {
-      expect(screen.getAllByText("≤ 50").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("≥ 50").length).toBeGreaterThanOrEqual(1);
     });
   });
 

--- a/frontend/src/components/search/FilterPanel.tsx
+++ b/frontend/src/components/search/FilterPanel.tsx
@@ -10,6 +10,7 @@ import { ALLERGEN_TAGS, NUTRI_COLORS } from "@/lib/constants";
 import { useTranslation } from "@/lib/i18n";
 import { nutriScoreLabel } from "@/lib/nutri-label";
 import { queryKeys, staleTimes } from "@/lib/query-keys";
+import { toTryVitScore } from "@/lib/score-utils";
 import { createClient } from "@/lib/supabase/client";
 import type { SearchFilters } from "@/lib/types";
 import { useQuery } from "@tanstack/react-query";
@@ -313,10 +314,10 @@ export function FilterPanel({
             </div>
           )}
 
-          {/* Max Unhealthiness Slider */}
+          {/* Min TryVit Score Slider */}
           <div>
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-foreground-secondary">
-              {t("filters.maxHealthScore")}
+              {t("filters.minHealthScore")}
             </h3>
             <div className="px-1">
               <input
@@ -324,12 +325,16 @@ export function FilterPanel({
                 min={0}
                 max={100}
                 step={5}
-                value={filters.max_unhealthiness ?? 100}
+                value={
+                  filters.max_unhealthiness !== undefined
+                    ? 100 - filters.max_unhealthiness
+                    : 0
+                }
                 onChange={(e) => {
                   const val = Number.parseInt(e.target.value);
-                  setMaxScore(val >= 100 ? undefined : val);
+                  setMaxScore(val <= 0 ? undefined : 100 - val);
                 }}
-                aria-label={t("filters.maxHealthScore")}
+                aria-label={t("filters.minHealthScore")}
                 className="w-full accent-brand"
               />
               <div className="flex justify-between text-xs text-foreground-muted">
@@ -337,7 +342,7 @@ export function FilterPanel({
                 <span className="font-medium text-foreground-secondary">
                   {filters.max_unhealthiness === undefined
                     ? t("filters.any")
-                    : `≤ ${filters.max_unhealthiness}`}
+                    : `≥ ${toTryVitScore(filters.max_unhealthiness)}`}
                 </span>
                 <span>100</span>
               </div>


### PR DESCRIPTION
## Problem

The filter slider displayed **Max TryVit Score** with raw unhealthiness values and `≤ N` direction — semantically backwards. A user setting the slider to 50 was actually filtering by `max_unhealthiness = 50`, showing *less* healthy products than expected.

Similarly, the **CategoryStatsCard** on category detail pages showed raw unhealthiness values labeled as scores (avg, min, max).

## Fix

### Filter slider (FilterPanel + ActiveFilterChips)
- Renamed **Max TryVit Score** → **Min TryVit Score** (since `max_unhealthiness` cap translates to a minimum health threshold)
- Inverted slider direction: right = higher TryVit Score = stricter filter
- Display uses `toTryVitScore()` conversion: `≥ 50` instead of `≤ 50`
- Active filter chip updated to show `TryVit Score ≥ N`

### CategoryStatsCard (category detail page)
- Avg score now uses `toTryVitScore()`
- Score range now inverts via `toTryVitScore()` (with min/max swap)

### i18n
- Updated all 3 locale files (en/pl/de): 4 key changes each
- `maxHealthScore` → `minHealthScore`, `scoreMax` → `scoreMin`, clearer score labels

### Tests
- FilterPanel.test.tsx: 4 assertions updated
- ActiveFilterChips.test.tsx: 4 assertions updated
- All 53 tests pass

## Verification

| Check | Result |
|---|---|
| `npx tsc --noEmit` | 0 errors |
| `npx vitest run` (affected files) | 53/53 pass |

## No backend changes
The internal `max_unhealthiness` filter parameter stays unchanged. This is purely a presentation-layer fix.

Closes #842