### PR TITLE
fix(frontend): SonarCloud reliability + maintainability fixes, auth-aware Header

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -748,6 +748,7 @@
     "sessionExpired": "Sitzung abgelaufen. Bitte melden Sie sich erneut an.",
     "preferencesFailed": "Einstellungen konnten nicht geladen werden.",
     "signIn": "Anmelden",
+    "dashboard": "Dashboard",
     "welcomeBack": "Willkommen zurück",
     "signInSubtitle": "Melden Sie sich bei Ihrem TryVit-Konto an.",
     "sessionExpiredBanner": "Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an.",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -748,6 +748,7 @@
     "sessionExpired": "Session expired. Please log in again.",
     "preferencesFailed": "Failed to load preferences.",
     "signIn": "Sign In",
+    "dashboard": "Dashboard",
     "welcomeBack": "Welcome back",
     "signInSubtitle": "Sign in to your TryVit account.",
     "sessionExpiredBanner": "Your session has expired. Please sign in again.",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -748,6 +748,7 @@
     "sessionExpired": "Sesja wygasła. Zaloguj się ponownie.",
     "preferencesFailed": "Nie udało się załadować preferencji.",
     "signIn": "Zaloguj się",
+    "dashboard": "Panel",
     "welcomeBack": "Witaj ponownie",
     "signInSubtitle": "Zaloguj się do konta TryVit.",
     "sessionExpiredBanner": "Twoja sesja wygasła. Zaloguj się ponownie.",

--- a/frontend/src/app/app/admin/metrics/page.tsx
+++ b/frontend/src/app/app/admin/metrics/page.tsx
@@ -185,7 +185,7 @@ function FeatureUsageChart({
       {data.slice(0, 12).map((item) => (
         <BarRow
           key={item.feature}
-          label={item.feature.replace(/_/g, " ")}
+          label={item.feature.replaceAll("_", " ")}
           value={item.usage_count}
           maxValue={maxVal}
           color="bg-chart-blue"
@@ -218,7 +218,7 @@ function ScanSearchRatio({
             style={{ flex: pct }}
           >
             <span className="text-xs font-medium opacity-80">
-              {item.method.replace(/_/g, " ")}
+              {item.method.replaceAll("_", " ")}
             </span>
             <span className="text-lg font-bold">{pct}%</span>
             <span className="text-xs opacity-80">
@@ -484,7 +484,7 @@ export default function AdminMetricsPage() {
                     <BarRow
                       key={item.allergen}
                       // Tags are bare canonical IDs; strip legacy en: prefix as fallback
-                      label={item.allergen.replace("en:", "")}
+                      label={item.allergen.replace(/^en:/, "")}
                       value={item.user_count}
                       maxValue={data.allergen_distribution[0].user_count}
                       color="bg-chart-amber"

--- a/frontend/src/app/app/search/saved/page.tsx
+++ b/frontend/src/app/app/search/saved/page.tsx
@@ -195,7 +195,7 @@ function FilterSummaryChips({ filters }: Readonly<{ filters: SearchFilters }>) {
     const labels = filters.allergen_free.map((tag) => {
       const info = ALLERGEN_TAGS.find((a) => a.tag === tag);
       // Tags are bare canonical IDs; strip legacy en: prefix as fallback
-      return info?.label ?? tag.replace("en:", "");
+      return info?.label ?? tag.replace(/^en:/, "");
     });
     chips.push(
       t("savedSearches.allergenFreeFilter", { values: labels.join(", ") }),

--- a/frontend/src/app/app/settings/notifications/page.tsx
+++ b/frontend/src/app/app/settings/notifications/page.tsx
@@ -259,6 +259,7 @@ export default function NotificationSettingsPage() {
               }}
               className="peer sr-only"
               data-testid="score-changes-toggle"
+              aria-label={t("notifications.scoreChangesTitle")}
             />
             <div className="peer h-6 w-11 rounded-full bg-surface-muted after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-strong after:bg-surface after:transition-all after:content-[''] peer-checked:bg-brand peer-checked:after:translate-x-full peer-checked:after:border-surface peer-focus-visible:outline-hidden peer-focus-visible:ring-2 peer-focus-visible:ring-brand/40" />
           </label>

--- a/frontend/src/components/compare/ComparisonGrid.tsx
+++ b/frontend/src/components/compare/ComparisonGrid.tsx
@@ -292,7 +292,7 @@ function DesktopGrid({
                 {p.allergen_tags
                   ? p.allergen_tags
                       .split(", ")
-                      .map((tag) => tag.replace("en:", ""))
+                      .map((tag) => tag.replace(/^en:/, ""))
                       .join(", ")
                   : t("compare.none")}
               </td>
@@ -662,7 +662,7 @@ function MobileSwipeView({
               {product.allergen_tags
                 ? product.allergen_tags
                     .split(", ")
-                    .map((tag) => tag.replace("en:", ""))
+                    .map((tag) => tag.replace(/^en:/, ""))
                     .join(", ")
                 : t("compare.noneDeclared")}
             </p>

--- a/frontend/src/components/dashboard/AllergenAlert.tsx
+++ b/frontend/src/components/dashboard/AllergenAlert.tsx
@@ -21,7 +21,8 @@ export function AllergenAlert({ alerts }: Readonly<AllergenAlertProps>) {
   // Deduplicate allergen tags for the summary
   // Tags are bare canonical IDs; strip legacy en: prefix as fallback
   const uniqueAllergens = [
-    ...new Set(alerts.products.map((p) => p.allergen.replace("en:", ""))),
+    ...new Set(alerts.products.map((p) => p.allergen.replace(/^en:/, ""))),
+
   ];
 
   return (

--- a/frontend/src/components/dashboard/HealthInsightsSummary.tsx
+++ b/frontend/src/components/dashboard/HealthInsightsSummary.tsx
@@ -54,7 +54,8 @@ export function HealthInsightsSummary({
         <div
           className={`flex h-14 w-14 items-center justify-center rounded-full border-4 ${bandCfg.bg}`}
           style={{
-            borderColor: `var(--color-${bandCfg.color.replace("text-", "")})`,
+            borderColor: `var(--color-${bandCfg.color.replace(/^text-/, "")})`,
+
           }}
           data-testid="avg-score-circle"
         >

--- a/frontend/src/components/layout/Header.test.tsx
+++ b/frontend/src/components/layout/Header.test.tsx
@@ -1,6 +1,16 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Header } from "./Header";
+
+const mockGetUser = vi.fn();
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      getUser: () => mockGetUser(),
+    },
+  }),
+}));
 
 vi.mock("next/link", () => ({
   default: ({
@@ -18,18 +28,30 @@ vi.mock("next/link", () => ({
 }));
 
 describe("Header", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+  });
+
   it("renders logo linking to home", () => {
     render(<Header />);
     const logo = screen.getByAltText("TryVit");
     expect(logo.closest("a")).toHaveAttribute("href", "/");
   });
 
-  it("renders Sign In link", () => {
+  it("renders Sign In link when not authenticated", () => {
     render(<Header />);
     expect(screen.getByText("Sign In").closest("a")).toHaveAttribute(
       "href",
       "/auth/login",
     );
+  });
+
+  it("renders Dashboard link when authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    render(<Header />);
+    const link = await screen.findByText("Dashboard");
+    expect(link.closest("a")).toHaveAttribute("href", "/app");
   });
 
   it("renders Contact link", () => {

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -4,12 +4,26 @@ import { ButtonLink } from "@/components/common/Button";
 import { Logo } from "@/components/common/Logo";
 import { useTheme } from "@/hooks/use-theme";
 import { useTranslation } from "@/lib/i18n";
+import { createClient } from "@/lib/supabase/client";
 import { Moon, Sun } from "lucide-react";
 import Link from "next/link";
+import { useEffect, useState } from "react";
 
 export function Header() {
   const { t } = useTranslation();
   const { resolved, setMode } = useTheme();
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    try {
+      const supabase = createClient();
+      supabase.auth.getUser().then(({ data }) => {
+        setIsAuthenticated(!!data.user);
+      });
+    } catch {
+      // Supabase client unavailable (SSR / test env) — stay unauthenticated
+    }
+  }, []);
 
   function toggleTheme() {
     setMode(resolved === "dark" ? "light" : "dark");
@@ -42,8 +56,8 @@ export function Header() {
               <Moon size={20} aria-hidden="true" />
             )}
           </button>
-          <ButtonLink href="/auth/login">
-            {t("auth.signIn")}
+          <ButtonLink href={isAuthenticated ? "/app" : "/auth/login"}>
+            {isAuthenticated ? t("auth.dashboard") : t("auth.signIn")}
           </ButtonLink>
         </nav>
       </div>

--- a/frontend/src/components/search/ActiveFilterChips.tsx
+++ b/frontend/src/components/search/ActiveFilterChips.tsx
@@ -73,7 +73,7 @@ export function ActiveFilterChips({
     // Tags are bare canonical IDs; strip legacy en: prefix as fallback
     const label = info
       ? t("chips.allergenFree", { label: info.label })
-      : t("chips.allergenFree", { label: tag.replace("en:", "") });
+      : t("chips.allergenFree", { label: tag.replace(/^en:/, "") });
     chips.push({
       key: `al-${tag}`,
       label,

--- a/frontend/src/components/search/FilterPanel.tsx
+++ b/frontend/src/components/search/FilterPanel.tsx
@@ -297,7 +297,7 @@ export function FilterPanel({
                 {data.allergens.map((al) => {
                   const labelInfo = ALLERGEN_TAGS.find((a) => a.tag === al.tag);
                   // Tags are bare canonical IDs; strip legacy en: prefix as fallback
-                  const label = labelInfo?.label ?? al.tag.replace("en:", "");
+                  const label = labelInfo?.label ?? al.tag.replace(/^en:/, "");
                   const selected = (filters.allergen_free ?? []).includes(
                     al.tag,
                   );

--- a/frontend/src/lib/flags/evaluator.ts
+++ b/frontend/src/lib/flags/evaluator.ts
@@ -14,7 +14,8 @@ export function deterministicHash(flagKey: string, identifier: string): number {
   let hash = 2166136261;
   const input = `${flagKey}:${identifier}`;
   for (let i = 0; i < input.length; i++) {
-    hash ^= input.charCodeAt(i);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- index always valid within loop bounds
+    hash ^= input.codePointAt(i)!;
     hash = Math.imul(hash, 16777619);
   }
   return Math.abs(hash) % 100;

--- a/frontend/src/lib/turnstile.ts
+++ b/frontend/src/lib/turnstile.ts
@@ -108,11 +108,11 @@ export async function verifyTurnstileToken(
 export function isTurnstileSuccess(
   result: TurnstileVerifyResult,
 ): result is TurnstileVerifySuccess {
-  return result.valid === true;
+  return result.valid;
 }
 
 export function isTurnstileFailure(
   result: TurnstileVerifyResult,
 ): result is TurnstileVerifyFailure {
-  return result.valid === false;
+  return !result.valid;
 }


### PR DESCRIPTION
## Summary

Fixes 4 SonarCloud reliability issues + 9 maintainability issues + adds auth-aware Header behavior.

**15 files changed, +60 / -17 lines**

---

## SonarCloud Reliability Fixes (4 issues)

| File | Issue | Fix |
|------|-------|-----|
| `admin/metrics/page.tsx` L188 | `.replace(/_/g, " ")` not matching `/g` semantics | → `.replaceAll("_", " ")` |
| `admin/metrics/page.tsx` L221 | Same pattern | → `.replaceAll("_", " ")` |
| `admin/metrics/page.tsx` L487 | `.replace("en:","")` replaces first occurrence only | → `.replace(/^en:/,"")` anchored regex |
| `notifications/page.tsx` | Toggle input missing accessible label | Added `aria-label` |
| `evaluator.ts` L19 | `.charCodeAt()` doesn't handle Unicode surrogate pairs | → `.codePointAt()` |

## SonarCloud Maintainability Fixes (9 issues)

| Category | Files | Fix |
|----------|-------|-----|
| `.replace("en:", "")` → anchored regex | FilterPanel, ActiveFilterChips, AllergenAlert, ComparisonGrid (×2), saved/page | `.replace(/^en:/, "")` |
| `.replace("text-", "")` → anchored regex | HealthInsightsSummary | `.replace(/^text-/, "")` |
| Redundant boolean comparison | turnstile.ts (×2) | `=== true` → direct, `=== false` → negation |

## Header Auth-Aware Sign In

- **Problem:** Header showed "Sign In" button even when user is authenticated (visible on `/learn/*` pages)
- **Fix:** Added `useEffect` that checks `supabase.auth.getUser()` — shows "Dashboard" link when authenticated, "Sign In" when not
- **Safety:** Wrapped in try-catch for graceful degradation in test/SSR environments
- **i18n:** Added `auth.dashboard` key to en.json ("Dashboard"), pl.json ("Panel"), de.json ("Dashboard")
- **Tests:** Updated Header.test.tsx with Supabase mock and new authenticated state test

## Verification

```
npx tsc --noEmit              → 0 errors
npm run lint                  → 0 warnings, 0 errors
npx vitest run                → 5,617/5,617 passed (341 files, 29 skipped)
```

## Remaining SonarCloud Items (not in this PR)

- ~45 empty catch blocks — mostly intentional (localStorage, clipboard, notifications). Would need `// intentionally empty` comments or routing to logger.
- ~22 console.* statements — legitimate error/warn in RPC layer and push-manager
- 7 `return await` instances — cosmetic, no functional impact
- 6 `dangerouslySetInnerHTML` — all standard Next.js patterns (JSON-LD, GTM)
