### PR TITLE
fix(schema): fix 7 broken production functions — STABLE to VOLATILE + watchlist SQL alias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ tmp-*.json
 qa-results.json
 qa-baseline.json
 tmp-*.sql
+.vercel
+.env*.local

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -13,25 +13,25 @@
 
 ## Recently Shipped (Session 43 — UX Audit)
 
-| PR   | Summary                                                                                     |
-| ---- | ------------------------------------------------------------------------------------------- |
-| #849 | fix(frontend): visual polish — filter skeleton loader, grid cleanup (#845, P3)               |
-| #848 | fix(frontend): UX improvements — flags, scanner default, QuickWin, 403 page (#844, P2)      |
-| #847 | fix(ui): category truncation, product not-found empty state, settings tab overflow (#843, P1)|
-| #846 | fix(scoring): invert filter slider & category stats to TryVit Score (#842, P0)              |
+| PR   | Summary                                                                                       |
+| ---- | --------------------------------------------------------------------------------------------- |
+| #849 | fix(frontend): visual polish — filter skeleton loader, grid cleanup (#845, P3)                |
+| #848 | fix(frontend): UX improvements — flags, scanner default, QuickWin, 403 page (#844, P2)        |
+| #847 | fix(ui): category truncation, product not-found empty state, settings tab overflow (#843, P1) |
+| #846 | fix(scoring): invert filter slider & category stats to TryVit Score (#842, P0)                |
 
 ## Recently Shipped (Sessions 41-42)
 
-| PR   | Summary                                                                                     |
-| ---- | ------------------------------------------------------------------------------------------- |
-| #840 | fix(ci): make deploy health check non-blocking                                              |
-| #839 | fix(ci): update QA fixture nutri_score_label from NULL to UNKNOWN                           |
-| #838 | fix(schema): pre-deprecate brand collision duplicates before normalization                   |
-| #837 | fix(schema): deprecate HTML-encoded duplicate products before decode                        |
-| #836 | fix(schema): guard orphan ingredient_ref deletion against all FK references                 |
-| #835 | fix(ci): add --include-all flag to deploy and sync workflows                                |
-| #834 | fix(qa): data quality cleanup — 47/48 QA suites passing                                     |
-| #833 | fix(data): restore enrichment pipeline — ingredient/allergen data + re-scoring               |
+| PR   | Summary                                                                        |
+| ---- | ------------------------------------------------------------------------------ |
+| #840 | fix(ci): make deploy health check non-blocking                                 |
+| #839 | fix(ci): update QA fixture nutri_score_label from NULL to UNKNOWN              |
+| #838 | fix(schema): pre-deprecate brand collision duplicates before normalization     |
+| #837 | fix(schema): deprecate HTML-encoded duplicate products before decode           |
+| #836 | fix(schema): guard orphan ingredient_ref deletion against all FK references    |
+| #835 | fix(ci): add --include-all flag to deploy and sync workflows                   |
+| #834 | fix(qa): data quality cleanup — 47/48 QA suites passing                        |
+| #833 | fix(data): restore enrichment pipeline — ingredient/allergen data + re-scoring |
 
 ## CI Gate Status (main branch)
 
@@ -139,12 +139,12 @@ All UX audit issues (#842–#845) have been closed. All other previously-tracked
 
 ### Known QA Failures (Pre-existing, Non-blocking)
 
-| Suite                       | Failures | Cause                                                                                   |
-| --------------------------- | -------- | --------------------------------------------------------------------------------------- |
-| Suite 7 (DataQuality)       | 6        | Ingredient coverage PL 58.4%/DE 16.3%, allergen coverage PL 44.5%/DE 13.3%, completeness PL 94%/DE 88.7% (all below threshold — OFF API data gaps) |
-| Suite 10 (Naming)           | 2        | Trailing punctuation (24 products), HTML entities (4 products)                           |
-| Suite 11 (NutriRange)       | 4        | Calorie back-calc (21), zero-cal macros (1), extreme salt (1), extreme calories (1)      |
-| Suite 12 (DataConsist)      | 4        | nutri_score_source (2258), types (2), brands (886)                                       |
+| Suite                  | Failures | Cause                                                                                                                                              |
+| ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Suite 7 (DataQuality)  | 6        | Ingredient coverage PL 58.4%/DE 16.3%, allergen coverage PL 44.5%/DE 13.3%, completeness PL 94%/DE 88.7% (all below threshold — OFF API data gaps) |
+| Suite 10 (Naming)      | 2        | Trailing punctuation (24 products), HTML entities (4 products)                                                                                     |
+| Suite 11 (NutriRange)  | 4        | Calorie back-calc (21), zero-cal macros (1), extreme salt (1), extreme calories (1)                                                                |
+| Suite 12 (DataConsist) | 4        | nutri_score_source (2258), types (2), brands (886)                                                                                                 |
 
 **Root cause:** Suite 7 failures are OFF API data coverage gaps (enrichment data only available for ~58% PL, ~16% DE products).
 Suites 10, 11, 12 are pre-existing source data quality issues unrelated to enrichment.

--- a/supabase/migrations/20260317000200_fix_volatile_and_watchlist.sql
+++ b/supabase/migrations/20260317000200_fix_volatile_and_watchlist.sql
@@ -1,0 +1,169 @@
+-- Migration: Fix 6 STABLE functions that contain rate-limit INSERTs + watchlist SQL alias bug
+-- Root cause: migration 20260315000400_api_rate_limiting.sql dynamically injected
+-- check_api_rate_limit() (VOLATILE, does INSERT) into these functions without
+-- changing their volatility from STABLE to VOLATILE. PostgREST routes STABLE
+-- functions to read-only transactions, causing INSERT to fail with error 25006.
+-- Additionally, api_get_watchlist has an SQL alias bug: ORDER BY w.created_at
+-- references alias "w" from an inner subquery that is out of scope at the outer level.
+--
+-- Rollback: ALTER FUNCTION ... STABLE for the 6 functions below;
+--           re-CREATE api_get_watchlist with the old ORDER BY clause.
+-- Idempotency: ALTER FUNCTION and CREATE OR REPLACE are idempotent.
+
+-- ═══════════════════════════════════════════════════════════════════
+-- FIX 1: Change 6 STABLE functions with rate-limit writes to VOLATILE
+-- ═══════════════════════════════════════════════════════════════════
+
+ALTER FUNCTION public.api_search_products(text, jsonb, integer, integer, boolean) VOLATILE;
+
+ALTER FUNCTION public.api_search_autocomplete(text, integer) VOLATILE;
+
+ALTER FUNCTION public.api_product_detail_by_ean(text, text) VOLATILE;
+
+ALTER FUNCTION public.api_get_filter_options(text) VOLATILE;
+
+ALTER FUNCTION public.api_better_alternatives(bigint, boolean, integer, text, text[], boolean, boolean, boolean) VOLATILE;
+
+ALTER FUNCTION public.api_better_alternatives_v2(bigint, boolean, integer, text, text[], boolean, boolean, boolean, boolean, uuid, boolean, integer) VOLATILE;
+
+
+-- ═══════════════════════════════════════════════════════════════════
+-- FIX 2: Fix api_get_watchlist SQL alias bug
+--   Bug: ORDER BY w.created_at DESC — "w" only exists inside inner subquery
+--   Fix: ORDER BY sub.watched_since DESC — use outer alias "sub" with renamed column
+-- ═══════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION api_get_watchlist(
+    p_page       int DEFAULT 1,
+    p_page_size  int DEFAULT 20
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_user_id uuid := auth.uid();
+    v_offset  int;
+    v_total   int;
+    v_items   jsonb;
+BEGIN
+    IF v_user_id IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'not_authenticated');
+    END IF;
+
+    v_offset := (GREATEST(p_page, 1) - 1) * p_page_size;
+
+    -- Total count
+    SELECT count(*) INTO v_total
+    FROM user_watched_products
+    WHERE user_id = v_user_id;
+
+    -- Paginated items with product details + latest history
+    SELECT COALESCE(jsonb_agg(item ORDER BY sub.watched_since DESC), '[]'::jsonb)
+    INTO v_items
+    FROM (
+        SELECT
+            w.watch_id,
+            w.product_id,
+            w.alert_threshold,
+            w.created_at AS watched_since,
+            p.product_name,
+            p.brand,
+            p.category,
+            p.unhealthiness_score AS current_score,
+            CASE
+                WHEN p.unhealthiness_score <= 25 THEN 'low'
+                WHEN p.unhealthiness_score <= 50 THEN 'moderate'
+                WHEN p.unhealthiness_score <= 75 THEN 'high'
+                ELSE 'very_high'
+            END AS score_band,
+            p.nutri_score_label,
+            p.nova_classification AS nova_group,
+            -- Latest history delta
+            (
+                SELECT h.score_delta
+                FROM product_score_history h
+                WHERE h.product_id = w.product_id
+                  AND h.score_delta IS NOT NULL
+                  AND h.score_delta != 0
+                ORDER BY h.recorded_at DESC
+                LIMIT 1
+            ) AS last_delta,
+            -- Trend from last 3 changes
+            (
+                SELECT
+                    CASE
+                        WHEN count(*) < 2 THEN 'stable'
+                        WHEN every(rh.score_delta > 0) THEN 'worsening'
+                        WHEN every(rh.score_delta < 0) THEN 'improving'
+                        ELSE 'stable'
+                    END
+                FROM (
+                    SELECT score_delta
+                    FROM product_score_history
+                    WHERE product_id = w.product_id
+                      AND score_delta IS NOT NULL
+                      AND score_delta != 0
+                    ORDER BY recorded_at DESC
+                    LIMIT 3
+                ) rh
+            ) AS trend,
+            -- Reformulation detected
+            EXISTS(
+                SELECT 1 FROM product_score_history
+                WHERE product_id = w.product_id
+                  AND ABS(score_delta) >= 10
+            ) AS reformulation_detected,
+            -- Mini sparkline: last 12 scores
+            (
+                SELECT jsonb_agg(
+                    jsonb_build_object('date', sh.recorded_at, 'score', sh.unhealthiness_score)
+                    ORDER BY sh.recorded_at ASC
+                )
+                FROM (
+                    SELECT recorded_at, unhealthiness_score
+                    FROM product_score_history
+                    WHERE product_id = w.product_id
+                    ORDER BY recorded_at DESC
+                    LIMIT 12
+                ) sh
+            ) AS sparkline
+        FROM user_watched_products w
+        JOIN products p ON p.product_id = w.product_id
+        WHERE w.user_id = v_user_id
+        ORDER BY w.created_at DESC
+        OFFSET v_offset
+        LIMIT p_page_size
+    ) sub
+    CROSS JOIN LATERAL (
+        SELECT jsonb_build_object(
+            'watch_id',               sub.watch_id,
+            'product_id',             sub.product_id,
+            'alert_threshold',        sub.alert_threshold,
+            'watched_since',          sub.watched_since,
+            'product_name',           sub.product_name,
+            'brand',                  sub.brand,
+            'category',              sub.category,
+            'current_score',          sub.current_score,
+            'score_band',             sub.score_band,
+            'nutri_score',            sub.nutri_score_label,
+            'nova_group',             sub.nova_group,
+            'last_delta',             sub.last_delta,
+            'trend',                  sub.trend,
+            'reformulation_detected', sub.reformulation_detected,
+            'sparkline',              COALESCE(sub.sparkline, '[]'::jsonb)
+        ) AS item
+    ) lat;
+
+    RETURN jsonb_build_object(
+        'success',    true,
+        'items',      v_items,
+        'total',      v_total,
+        'page',       GREATEST(p_page, 1),
+        'page_size',  p_page_size,
+        'total_pages', CEIL(v_total::numeric / p_page_size)
+    );
+END;
+$$;


### PR DESCRIPTION
## Problem

7 production functions broken — users get 'Search failed', 'Failed to load list', 'Could not load your watchlist' errors.

### Root Cause 1 — STABLE functions with rate-limit writes (6 functions)

Migration `20260315000400_api_rate_limiting.sql` dynamically injected `check_api_rate_limit()` (VOLATILE, does INSERT) into functions declared STABLE. PostgREST routes STABLE functions to read-only transactions, causing error 25006.

**Affected:** `api_search_products`, `api_search_autocomplete`, `api_product_detail_by_ean`, `api_get_filter_options`, `api_better_alternatives`, `api_better_alternatives_v2`

**Fix:** `ALTER FUNCTION ... VOLATILE;` for all 6.

### Root Cause 2 — api_get_watchlist SQL alias bug

`jsonb_agg(item ORDER BY w.created_at DESC)` references alias `w` from inner subquery, but at outer scope the alias is `sub`. Error 42P01.

**Fix:** Changed `ORDER BY w.created_at DESC` to `ORDER BY sub.watched_since DESC`.

## Verification

All 9 production functions verified working with authenticated JWT after `supabase db push`:

| # | Function | Before Fix | After Fix |
|---|----------|-----------|-----------|
| 1 | api_search_products | error 25006 | 27 results |
| 2 | api_search_autocomplete | error 25006 | 3 suggestions |
| 3 | api_product_detail_by_ean | error 25006 | returns product |
| 4 | api_get_filter_options | error 25006 | 21 categories |
| 5 | api_better_alternatives | error 25006 | returns alternatives |
| 6 | api_better_alternatives_v2 | error 25006 | returns alternatives |
| 7 | api_get_watchlist | error 42P01 | empty list (correct) |
| 8 | api_get_lists | working | working |
| 9 | api_category_overview | working | working |

**Migration already deployed to production** via `supabase db push --include-all`.