### PR TITLE
feat(pipeline): deduplication hardening — brand normalization, cross-category EAN dedup, merge framework (#861)

### DIFF
--- a/db/qa/QA__data_quality.sql
+++ b/db/qa/QA__data_quality.sql
@@ -1,5 +1,5 @@
 -- ============================================================
--- QA: Data Quality & Plausibility Checks (29 checks)
+-- QA: Data Quality & Plausibility Checks (39 checks)
 -- Validates data hygiene, plausibility bounds, cross-field
 -- consistency, and coverage regression thresholds.
 -- All checks are BLOCKING unless marked informational.
@@ -351,4 +351,31 @@ FROM (
   GROUP BY p.country
 ) sub
 WHERE avg_completeness < threshold;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 38. Cross-category EAN duplicates
+--     The same EAN must not appear in more than one active product.
+--     (Detects cross-category collisions that the pipeline should prevent.)
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '38. Cross-category EAN duplicate' AS check_name,
+       p.ean || ' appears in ' || string_agg(DISTINCT p.category, ', ' ORDER BY p.category) AS detail
+FROM products p
+WHERE p.ean IS NOT NULL
+  AND p.is_deprecated IS NOT TRUE
+GROUP BY p.ean
+HAVING COUNT(DISTINCT p.category) > 1;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 39. Fuzzy brand variants (normalize_brand collision)
+--     Brands that normalize to the same canonical form but differ in raw
+--     spelling indicate data-entry inconsistencies (e.g. "Dr.Oetker" vs
+--     "Dr. Oetker").  Informational — helps drive brand_alias curation.
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '39. Fuzzy brand variants' AS check_name,
+       normalize_brand(p.brand) || ': ' || string_agg(DISTINCT p.brand, ', ' ORDER BY p.brand) AS detail
+FROM products p
+WHERE p.is_deprecated IS NOT TRUE
+  AND p.brand IS NOT NULL
+GROUP BY normalize_brand(p.brand)
+HAVING COUNT(DISTINCT p.brand) > 1;
 

--- a/pipeline/dedup_manager.py
+++ b/pipeline/dedup_manager.py
@@ -1,0 +1,175 @@
+"""Cross-source deduplication manager for multi-source product ingestion.
+
+Designed for the 10K-scale expansion where products may arrive from
+multiple sources (OFF API, CSV imports, scrapers, user submissions).
+
+Source priority (highest wins):
+    1. off_api  — Open Food Facts API (primary, most structured)
+    2. csv_import — Curated CSV spreadsheets
+    3. scraper   — Automated web scrapers
+    4. user_submission — Community-submitted products
+
+Usage::
+
+    from pipeline.dedup_manager import DedupManager
+
+    mgr = DedupManager()
+    merged = mgr.merge(existing_product, incoming_product)
+    winner = mgr.pick_winner(candidates)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import IntEnum
+
+
+class SourcePriority(IntEnum):
+    """Source priority — lower numeric value = higher trust."""
+
+    OFF_API = 1
+    CSV_IMPORT = 2
+    SCRAPER = 3
+    USER_SUBMISSION = 4
+
+
+# Map DB source_type values to priority enum
+_SOURCE_MAP: dict[str, SourcePriority] = {
+    "off_api": SourcePriority.OFF_API,
+    "csv_import": SourcePriority.CSV_IMPORT,
+    "off_search": SourcePriority.SCRAPER,
+    "scraper": SourcePriority.SCRAPER,
+    "user_submission": SourcePriority.USER_SUBMISSION,
+}
+
+
+@dataclass
+class MergeResult:
+    """Result of merging two product records."""
+
+    product: dict
+    source_used: str
+    fields_from_secondary: list[str] = field(default_factory=list)
+
+
+class DedupManager:
+    """Cross-source deduplication and merge manager.
+
+    Determines which product record wins when the same product arrives
+    from multiple sources, and optionally fills gaps from lower-priority
+    sources.
+    """
+
+    # Nutrition fields that can be back-filled from a secondary source
+    # when the primary source has NULL / 0 values.
+    _BACKFILL_FIELDS: tuple[str, ...] = (
+        "calories",
+        "total_fat",
+        "saturated_fat",
+        "carbs",
+        "sugars",
+        "protein",
+        "fiber",
+        "salt",
+        "trans_fat",
+    )
+
+    # Identity fields — never overwritten by a secondary source.
+    _IDENTITY_FIELDS: tuple[str, ...] = (
+        "product_name",
+        "brand",
+        "ean",
+        "country",
+        "category",
+    )
+
+    @staticmethod
+    def priority(source_type: str) -> SourcePriority:
+        """Return the priority for a given source_type string."""
+        return _SOURCE_MAP.get(source_type, SourcePriority.USER_SUBMISSION)
+
+    def pick_winner(self, candidates: list[dict]) -> dict:
+        """Pick the highest-priority product from a list of candidates.
+
+        When two candidates share the same source priority, the one with
+        more non-NULL nutrition fields wins.
+        """
+        if not candidates:
+            raise ValueError("candidates list must not be empty")
+        if len(candidates) == 1:
+            return candidates[0]
+
+        def _sort_key(p: dict) -> tuple[int, int]:
+            pri = self.priority(p.get("source_type", ""))
+            # Count non-null nutrition fields (more = better, so negate)
+            filled = sum(1 for f in self._BACKFILL_FIELDS if p.get(f) is not None and p.get(f) != 0)
+            return (pri.value, -filled)
+
+        return min(candidates, key=_sort_key)
+
+    def merge(self, primary: dict, secondary: dict) -> MergeResult:
+        """Merge two product records, using *primary* as the base.
+
+        Fields from *secondary* are only used to fill gaps (NULL or 0)
+        in the primary record's nutrition columns.  Identity fields are
+        never overwritten.
+        """
+        merged = dict(primary)
+        backfilled: list[str] = []
+
+        for fld in self._BACKFILL_FIELDS:
+            primary_val = primary.get(fld)
+            secondary_val = secondary.get(fld)
+            if (primary_val is None or primary_val == 0) and secondary_val:
+                merged[fld] = secondary_val
+                backfilled.append(fld)
+
+        return MergeResult(
+            product=merged,
+            source_used=primary.get("source_type", "unknown"),
+            fields_from_secondary=backfilled,
+        )
+
+    def deduplicate(self, products: list[dict], key_fn=None) -> list[dict]:
+        """Deduplicate a list of products, keeping the highest-priority version.
+
+        Parameters
+        ----------
+        products:
+            List of product dicts (must have ``brand``, ``product_name``,
+            and optionally ``source_type``).
+        key_fn:
+            Optional callable to compute the dedup key from a product dict.
+            Defaults to ``(brand.lower().strip(), product_name.lower().strip())``.
+
+        Returns
+        -------
+        list
+            Deduplicated products with secondary-source gap-filling applied.
+        """
+        if key_fn is None:
+
+            def key_fn(p: dict) -> tuple[str, str]:
+                return (
+                    p.get("brand", "").lower().strip(),
+                    p.get("product_name", "").lower().strip(),
+                )
+
+        groups: dict[tuple, list[dict]] = {}
+        for p in products:
+            k = key_fn(p)
+            groups.setdefault(k, []).append(p)
+
+        results: list[dict] = []
+        for group in groups.values():
+            if len(group) == 1:
+                results.append(group[0])
+                continue
+            winner = self.pick_winner(group)
+            for other in group:
+                if other is not winner:
+                    merge_result = self.merge(winner, other)
+                    winner = merge_result.product
+            results.append(winner)
+
+        return results

--- a/pipeline/run.py
+++ b/pipeline/run.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import re
 import sys
 from pathlib import Path
 
@@ -41,6 +42,62 @@ def _dedup(products: list[dict]) -> list[dict]:
             seen.add(key)
             unique.append(p)
     return unique
+
+
+# Pattern to extract EAN literals from pipeline 01_insert SQL files.
+# Matches EAN values in:  ('brand', 'name', 'EAN1234567890', ...)
+_EAN_IN_SQL_RE = re.compile(r"'(\d{8}|\d{13})'")
+
+
+def _collect_existing_eans(pipeline_dir: Path, exclude_slug: str) -> set[str]:
+    """Scan all pipeline 01_insert_products SQL files for EAN values.
+
+    Returns the set of EANs already claimed by *other* categories
+    (i.e. all folders except *exclude_slug*).
+    """
+    eans: set[str] = set()
+    if not pipeline_dir.is_dir():
+        return eans
+    for folder in pipeline_dir.iterdir():
+        if not folder.is_dir() or folder.name == exclude_slug:
+            continue
+        for sql_file in folder.glob("PIPELINE__*__01_insert_products.sql"):
+            try:
+                content = sql_file.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            for match in _EAN_IN_SQL_RE.finditer(content):
+                eans.add(match.group(1))
+    return eans
+
+
+def _cross_category_ean_dedup(
+    products: list[dict],
+    pipeline_dir: Path,
+    current_slug: str,
+) -> tuple[list[dict], list[dict]]:
+    """Remove products whose EANs already exist in other category pipelines.
+
+    First-writer-wins: the category that already has the EAN keeps it.
+
+    Returns
+    -------
+    tuple
+        (kept_products, dropped_products)
+    """
+    existing_eans = _collect_existing_eans(pipeline_dir, current_slug)
+    if not existing_eans:
+        return products, []
+
+    kept: list[dict] = []
+    dropped: list[dict] = []
+    for p in products:
+        ean = p.get("ean") or ""
+        if ean and ean in existing_eans:
+            dropped.append(p)
+        else:
+            kept.append(p)
+    return kept, dropped
 
 
 # ---------------------------------------------------------------------------
@@ -184,11 +241,21 @@ def run_pipeline(
     validated, warn_count, blocked = _validate_products(extracted, category, max_warnings)
     print(f"  After validation: {len(validated)} products")
 
-    # 4. De-duplicate
+    # 4. De-duplicate (within this category run)
     unique = _dedup(validated)
     print(f"  After dedup: {len(unique)} unique products")
     if warn_count:
         print(f"  Warnings: {warn_count} products outside expected ranges")
+
+    # 4b. Cross-category EAN dedup (first-writer-wins)
+    pipeline_base = project_root / "db" / "pipelines"
+    slug_base = _slug(category)
+    dir_slug = f"{slug_base}-{country.lower()}" if country != "PL" else slug_base
+    unique, ean_dropped = _cross_category_ean_dedup(unique, pipeline_base, dir_slug)
+    if ean_dropped:
+        print(f"  Cross-category EAN dedup: {len(ean_dropped)} product(s) removed (EAN already in another category)")
+        for dp in ean_dropped:
+            print(f"    ✗ {dp.get('brand', '?')} / {dp.get('product_name', '?')} (EAN {dp.get('ean', '?')})")
 
     # Anomaly report — blocked products with absolute cap violations
     if blocked:

--- a/supabase/migrations/20260318000400_brand_normalization_and_alias.sql
+++ b/supabase/migrations/20260318000400_brand_normalization_and_alias.sql
@@ -1,0 +1,74 @@
+-- Migration: Brand normalization function + brand_alias table for dedup hardening
+-- Issue: #861 — Deduplication hardening for multi-source 10K scale
+-- Rollback: DROP TABLE IF EXISTS brand_alias; DROP FUNCTION IF EXISTS normalize_brand(text);
+-- Idempotency: all DDL guarded with IF NOT EXISTS / CREATE OR REPLACE
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 1. normalize_brand() — deterministic brand name normalization
+--    Rules: UPPER → collapse whitespace → space after dots → trim
+--    Examples:
+--      'dr. oetker'  → 'DR. OETKER'
+--      'dr.oetker'   → 'DR. OETKER'
+--      '  Piątnica ' → 'PIĄTNICA'
+-- ═══════════════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION public.normalize_brand(p_brand text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+STRICT
+PARALLEL SAFE
+SET search_path = public
+AS $$
+  SELECT TRIM(
+    REGEXP_REPLACE(
+      REGEXP_REPLACE(
+        UPPER(TRIM(p_brand)),
+        '\s+', ' ', 'g'          -- collapse multiple whitespace to single space
+      ),
+      '\.(\S)', '. \1', 'g'     -- ensure space after dots (DR.OETKER → DR. OETKER)
+    )
+  );
+$$;
+
+COMMENT ON FUNCTION public.normalize_brand IS
+  'Deterministic brand name normalization for dedup matching.
+   Rules: UPPER + collapse whitespace + space after dots + trim.
+   IMMUTABLE STRICT — safe for indexes and generated columns.';
+
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 2. brand_alias table — maps variant spellings to canonical brand names
+--    Alias (PK) → canonical brand name (FK to brand_ref)
+--    One-way: alias resolves to a single canonical brand.
+-- ═══════════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS public.brand_alias (
+  alias           text PRIMARY KEY,
+  canonical_brand text NOT NULL REFERENCES public.brand_ref(brand_name),
+  source          text NOT NULL DEFAULT 'manual'
+    CHECK (source IN ('manual', 'pipeline', 'automated')),
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.brand_alias IS
+  'Maps variant brand spellings to canonical brand_ref entries.
+   Example: "Dr Oetker" → "Dr. Oetker", "PIĄTNICA" → "Piątnica".
+   Used by pipeline dedup and QA fuzzy-brand checks.';
+
+-- RLS: readable by all, writable by service_role only
+ALTER TABLE public.brand_alias ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'brand_alias' AND policyname = 'brand_alias_read_all'
+  ) THEN
+    CREATE POLICY brand_alias_read_all ON public.brand_alias
+      FOR SELECT USING (true);
+  END IF;
+END $$;
+
+-- Index for reverse lookups (find all aliases for a canonical brand)
+CREATE INDEX IF NOT EXISTS idx_brand_alias_canonical
+  ON public.brand_alias (canonical_brand);

--- a/supabase/tests/schema_contracts.test.sql
+++ b/supabase/tests/schema_contracts.test.sql
@@ -7,7 +7,7 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 
 BEGIN;
-SELECT plan(283);
+SELECT plan(288);
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 1. Core data tables exist
@@ -352,6 +352,13 @@ SELECT has_column('public', 'brand_ref', 'brand_name',           'brand_ref has 
 SELECT has_column('public', 'brand_ref', 'display_name',         'brand_ref has display_name column');
 SELECT has_column('public', 'brand_ref', 'parent_company',       'brand_ref has parent_company column');
 SELECT has_column('public', 'brand_ref', 'is_store_brand',       'brand_ref has is_store_brand column');
+
+-- ─── Brand Alias & Normalization (#861) ───────────────────────────────────────
+SELECT has_table('public', 'brand_alias',                          'table brand_alias exists');
+SELECT has_column('public', 'brand_alias', 'alias',               'brand_alias has alias column');
+SELECT has_column('public', 'brand_alias', 'canonical_brand',     'brand_alias has canonical_brand column');
+SELECT has_column('public', 'brand_alias', 'source',              'brand_alias has source column');
+SELECT has_function('public', 'normalize_brand',                  'function normalize_brand exists');
 
 -- ─── Ingredient Translations (#355) ─────────────────────────────────────────
 SELECT has_table('public', 'ingredient_translations',                       'table ingredient_translations exists');


### PR DESCRIPTION
## Summary
Implements Issue #861 — deduplication hardening for multi-source 10K scale.

### Changes
- **Migration** `20260318000400`: `normalize_brand()` SQL function + `brand_alias` table with RLS
- **Pipeline** `pipeline/run.py`: Cross-category EAN dedup (first-writer-wins) before SQL generation
- **Framework** `pipeline/dedup_manager.py`: `DedupManager` class with source priority (OFF > CSV > scraper > user), merge with gap-filling
- **QA** `db/qa/QA__data_quality.sql`: 2 new checks (#38 cross-category EAN duplicates, #39 fuzzy brand variants)
- **pgTAP** `schema_contracts.test.sql`: 5 new assertions (brand_alias table + normalize_brand function), plan 283 -> 288

### Verification
- Python compile: OK
- Pipeline structure: 43 categories verified
- Ruff lint: 0 errors
- Data quality QA (checks 38-39): 0 violations

Closes #861