### PR TITLE
feat(pipeline): add CSV bulk import tool for multi-source 10K expansion (#862)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- CSV bulk import tool (`pipeline/csv_importer.py` + `pipeline/csv_import.py`)
+  for multi-source 10K expansion: validates EAN checksums, nutrition caps,
+  cross-field constraints, formula injection defense, deduplication by name and
+  EAN, groups by (category, country), generates standard pipeline SQL via
+  `generate_pipeline()`. Includes CSV template and 25-test pytest suite (#862)
 - Raise scale guardrails for 10K+ products per country: products 15K→25K,
   nutrition_facts 15K→25K, product_ingredient 200K→250K, ingredient_ref
   10K→15K, product_allergen_info 50K→75K, source_nutrition 30K→50K,

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -77,7 +77,12 @@ tryvit/
 │   ├── test_validator.py            # Validator unit tests
 │   ├── utils.py                     # Shared utility helpers
 │   ├── image_importer.py            # Product image import utility
-│   └── categories.py               # 20 category definitions + OFF tag mappings
+│   ├── csv_importer.py              # CSV bulk import → SQL generator (10K expansion)
+│   ├── csv_import.py                # CLI for CSV bulk import
+│   ├── test_csv_importer.py         # CSV importer pytest suite (25 tests)
+│   ├── templates/                   # Import templates
+│   │   └── product_import_template.csv  # CSV template (21 columns)
+│   └── categories.py               # 28 category definitions + OFF tag mappings
 ├── db/
 │   ├── pipelines/                   # 43 category folders (22 PL + 21 DE), 4-5 SQL files each
 │   │   ├── chips-pl/                # Reference PL implementation (copy for new categories)

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -409,7 +409,46 @@ Always verify that the returned product page shows a **Polish label image** befo
 
 ---
 
-## 13. Data Update Policy
+## 13. CSV Bulk Import
+
+For scaling beyond the OFF API pipeline, a CSV bulk import tool ingests products from spreadsheet sources (retailer exports, research datasets, manual curation batches).
+
+### 13.1 Usage
+
+```powershell
+$env:PYTHONIOENCODING="utf-8"
+
+# Validate and generate SQL from a CSV file
+.\.venv\Scripts\python.exe pipeline/csv_import.py --file data/products.csv
+
+# Dry run — validate only, generate no SQL
+.\.venv\Scripts\python.exe pipeline/csv_import.py --file data/products.csv --dry-run
+
+# Custom output directory
+.\.venv\Scripts\python.exe pipeline/csv_import.py --file data/products.csv --output-dir db/pipelines
+```
+
+### 13.2 CSV Format
+
+Use `pipeline/templates/product_import_template.csv` as the starting template. Required columns: `ean`, `brand`, `product_name`, `category`, `country`. All 21 columns are documented in the template header.
+
+### 13.3 Validation Rules
+
+- **EAN:** Must pass GS1 modulo-10 checksum (EAN-8 or EAN-13)
+- **Category:** Must match one of the 28 defined categories in `pipeline/categories.py`
+- **Country:** Must be `PL` or `DE`
+- **Nutrition:** Values capped at `ABSOLUTE_CAPS` from `pipeline/validator.py`; cross-field checks enforce `sugars ≤ carbs` and `sat_fat ≤ total_fat`
+- **Formula injection:** Cells starting with `=`, `+`, `-`, `@`, `\t`, or `\r` are rejected (negative numbers in nutrition columns are allowed)
+- **Duplicates:** Detected by `(country, brand, product_name)` and by EAN; first occurrence wins
+- **Hard cap:** 10,000 rows per file
+
+### 13.4 Output
+
+The tool groups valid rows by `(category, country)` and calls `generate_pipeline()` for each group, producing the standard 4-file pipeline SQL (01_insert_products, 03_add_nutrition, 04_scoring, 05_source_provenance). Files are written to `db/pipelines/<slug>/`. Source type is set to `csv_import`.
+
+---
+
+## 14. Data Update Policy
 
 - **Labels change.** Manufacturers reformulate products (e.g., sugar reduction initiatives). Re-verify data at least annually.
 - **Seasonal products** (e.g., holiday-edition chips) should be flagged and re-checked for availability.

--- a/pipeline/csv_import.py
+++ b/pipeline/csv_import.py
@@ -1,0 +1,83 @@
+"""CLI entry point for the CSV bulk import tool.
+
+Usage::
+
+    python -m pipeline.csv_import --file products.csv
+    python -m pipeline.csv_import --file products.csv --dry-run
+    python -m pipeline.csv_import --file products.csv --output-dir db/pipelines/csv-import
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from pipeline.csv_importer import CSVImporter, CSVImportError
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Import products from a CSV file into pipeline SQL.",
+    )
+    parser.add_argument(
+        "--file",
+        required=True,
+        help="Path to the UTF-8 CSV file to import.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Directory for generated SQL files (default: db/pipelines/csv-import/).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate without writing SQL files.",
+    )
+    args = parser.parse_args()
+
+    try:
+        importer = CSVImporter(
+            csv_path=args.file,
+            output_dir=args.output_dir,
+            dry_run=args.dry_run,
+        )
+        result = importer.run()
+    except CSVImportError as exc:
+        print(f"FATAL: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    # Report
+    print()
+    print("CSV Import Summary")
+    print("=" * 40)
+    print(f"  Total rows:  {result['total_rows']}")
+    print(f"  Valid rows:  {result['valid_rows']}")
+    print(f"  Categories:  {', '.join(result['categories']) or 'none'}")
+
+    if result["warnings"]:
+        print(f"\n  Warnings ({len(result['warnings'])}):")
+        for w in result["warnings"][:20]:
+            print(f"    ⚠ {w}")
+        if len(result["warnings"]) > 20:
+            print(f"    ... and {len(result['warnings']) - 20} more")
+
+    if result["errors"]:
+        print(f"\n  Errors ({len(result['errors'])}):")
+        for e in result["errors"]:
+            print(f"    ✗ {e}")
+        sys.exit(1)
+
+    if result["files_written"]:
+        print(f"\n  Files written ({len(result['files_written'])}):")
+        for f in result["files_written"]:
+            print(f"    → {f}")
+
+    if args.dry_run:
+        print("\n  (dry-run — no files written)")
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/csv_importer.py
+++ b/pipeline/csv_importer.py
@@ -1,0 +1,517 @@
+"""CSV bulk import tool for the tryvit pipeline.
+
+Reads a UTF-8 CSV file, validates each row, deduplicates, and delegates
+SQL generation to :func:`pipeline.sql_generator.generate_pipeline`.
+
+Usage (via CLI wrapper)::
+
+    python -m pipeline.csv_import --file products.csv --output-dir db/pipelines/csv-import
+    python -m pipeline.csv_import --file products.csv --dry-run
+"""
+
+from __future__ import annotations
+
+import csv
+import re
+from pathlib import Path
+
+from pipeline.categories import (
+    CAT_ALCOHOL,
+    CAT_BABY,
+    CAT_BREAD,
+    CAT_BREAKFAST,
+    CAT_CANNED,
+    CAT_CEREALS,
+    CAT_CHIPS,
+    CAT_COFFEE_TEA,
+    CAT_CONDIMENTS,
+    CAT_DAIRY,
+    CAT_DESSERTS,
+    CAT_DRINKS,
+    CAT_FROZEN,
+    CAT_FROZEN_VEG,
+    CAT_INSTANT,
+    CAT_MEAT,
+    CAT_NUTS,
+    CAT_OILS,
+    CAT_PASTA_RICE,
+    CAT_PLANT,
+    CAT_READY_MEALS,
+    CAT_SAUCES,
+    CAT_SEAFOOD,
+    CAT_SNACKS,
+    CAT_SOUPS,
+    CAT_SPICES,
+    CAT_SPREADS,
+    CAT_SWEETS,
+)
+from pipeline.sql_generator import generate_pipeline
+from pipeline.utils import slug as _slug
+from pipeline.validator import ABSOLUTE_CAPS, validate_ean_checksum
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MAX_ROWS = 10_000
+
+VALID_CATEGORIES: frozenset[str] = frozenset(
+    {
+        CAT_CHIPS,
+        CAT_DAIRY,
+        CAT_BREAD,
+        CAT_CEREALS,
+        CAT_DRINKS,
+        CAT_MEAT,
+        CAT_SWEETS,
+        CAT_CANNED,
+        CAT_SAUCES,
+        CAT_CONDIMENTS,
+        CAT_SNACKS,
+        CAT_NUTS,
+        CAT_BABY,
+        CAT_ALCOHOL,
+        CAT_FROZEN,
+        CAT_BREAKFAST,
+        CAT_INSTANT,
+        CAT_PLANT,
+        CAT_SEAFOOD,
+        CAT_OILS,
+        CAT_SPREADS,
+        CAT_PASTA_RICE,
+        CAT_SOUPS,
+        CAT_COFFEE_TEA,
+        CAT_FROZEN_VEG,
+        CAT_READY_MEALS,
+        CAT_DESSERTS,
+        CAT_SPICES,
+    }
+)
+
+VALID_COUNTRIES: frozenset[str] = frozenset({"PL", "DE"})
+
+VALID_PREP_METHODS: frozenset[str] = frozenset(
+    {
+        "air-popped",
+        "baked",
+        "fried",
+        "deep-fried",
+        "grilled",
+        "roasted",
+        "smoked",
+        "steamed",
+        "marinated",
+        "pasteurized",
+        "fermented",
+        "dried",
+        "raw",
+        "none",
+        "not-applicable",
+    }
+)
+
+VALID_NUTRI_SCORES: frozenset[str] = frozenset(
+    {"A", "B", "C", "D", "E", "UNKNOWN", "NOT-APPLICABLE"}
+)
+
+VALID_NOVA: frozenset[str] = frozenset({"1", "2", "3", "4"})
+
+REQUIRED_COLUMNS: frozenset[str] = frozenset(
+    {"ean", "brand", "product_name", "category", "country"}
+)
+
+NUTRITION_COLUMNS: tuple[str, ...] = (
+    "calories_kcal",
+    "total_fat_g",
+    "saturated_fat_g",
+    "carbs_g",
+    "sugars_g",
+    "fibre_g",
+    "protein_g",
+    "salt_g",
+    "trans_fat_g",
+)
+
+# Regex to detect formula injection — values starting with =, +, -, @, \t, \r
+_FORMULA_RE = re.compile(r"^[=+\-@\t\r]")
+
+
+# ---------------------------------------------------------------------------
+# Importer
+# ---------------------------------------------------------------------------
+
+
+class CSVImportError(Exception):
+    """Raised for fatal import errors (file not found, wrong encoding, etc.)."""
+
+
+class CSVImporter:
+    """Validate, deduplicate, and convert a CSV file into pipeline SQL.
+
+    Parameters
+    ----------
+    csv_path:
+        Path to the UTF-8 CSV file.
+    output_dir:
+        Directory for generated SQL files.  When *None*, defaults to
+        ``db/pipelines/csv-import/``.
+    dry_run:
+        If *True*, validate and report without writing SQL files.
+    """
+
+    def __init__(
+        self,
+        csv_path: str | Path,
+        output_dir: str | Path | None = None,
+        dry_run: bool = False,
+    ) -> None:
+        self.csv_path = Path(csv_path)
+        self.dry_run = dry_run
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
+
+        if output_dir is None:
+            project_root = Path(__file__).resolve().parent.parent
+            self.output_dir = project_root / "db" / "pipelines" / "csv-import"
+        else:
+            self.output_dir = Path(output_dir)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(self) -> dict:
+        """Execute the full import pipeline.
+
+        Returns
+        -------
+        dict
+            Summary with keys ``total_rows``, ``valid_rows``, ``errors``,
+            ``warnings``, ``categories``, ``files_written``.
+        """
+        rows = self._read_csv()
+        validated = self._validate_rows(rows)
+        deduped = self._dedup(validated)
+
+        # Abort if >50% rows failed validation
+        total = len(rows)
+        valid = len(deduped)
+        if total > 0 and valid / total < 0.5:
+            self.errors.append(
+                f"Only {valid}/{total} rows passed validation (< 50%) — "
+                f"likely format mismatch. Import aborted."
+            )
+
+        files_written: list[str] = []
+        categories_found: set[str] = set()
+
+        if not self.errors:
+            # Group by (category, country)
+            groups = self._group_by_category_country(deduped)
+            categories_found = {cat for cat, _ in groups}
+
+            if not self.dry_run:
+                for (cat, country), products in groups.items():
+                    written = self._generate_sql(cat, country, products)
+                    files_written.extend(str(f) for f in written)
+
+        return {
+            "total_rows": total,
+            "valid_rows": valid,
+            "errors": list(self.errors),
+            "warnings": list(self.warnings),
+            "categories": sorted(categories_found),
+            "files_written": files_written,
+        }
+
+    # ------------------------------------------------------------------
+    # Internal — reading
+    # ------------------------------------------------------------------
+
+    def _read_csv(self) -> list[dict]:
+        """Read and parse the CSV file with safety checks."""
+        if not self.csv_path.exists():
+            raise CSVImportError(f"File not found: {self.csv_path}")
+
+        try:
+            text = self.csv_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            raise CSVImportError(
+                f"File is not valid UTF-8: {self.csv_path} ({exc})"
+            ) from exc
+
+        reader = csv.DictReader(text.splitlines())
+
+        if reader.fieldnames is None:
+            raise CSVImportError("CSV file is empty or has no header row.")
+
+        # Normalise header names: strip whitespace, lowercase
+        clean_fields = [f.strip().lower() for f in reader.fieldnames]
+        missing = REQUIRED_COLUMNS - set(clean_fields)
+        if missing:
+            raise CSVImportError(
+                f"Missing required columns: {', '.join(sorted(missing))}. "
+                f"Required: {', '.join(sorted(REQUIRED_COLUMNS))}"
+            )
+
+        rows: list[dict] = []
+        for raw_row in reader:
+            if len(rows) >= MAX_ROWS:
+                self.warnings.append(
+                    f"Row limit reached ({MAX_ROWS}). "
+                    f"Remaining rows skipped."
+                )
+                break
+            # Re-key with clean header names (ignore extra columns)
+            row = {}
+            for i, (_, v) in enumerate(raw_row.items()):
+                if i < len(clean_fields):
+                    row[clean_fields[i]] = v.strip() if v else ""
+            rows.append(row)
+
+        return rows
+
+    # ------------------------------------------------------------------
+    # Internal — validation
+    # ------------------------------------------------------------------
+
+    def _validate_rows(self, rows: list[dict]) -> list[dict]:
+        """Validate each row; collect errors and return valid product dicts."""
+        valid: list[dict] = []
+        for line_num, row in enumerate(rows, start=2):  # line 1 = header
+            product, row_errors = self._validate_single_row(row, line_num)
+            if row_errors:
+                for err in row_errors:
+                    self.warnings.append(f"Row {line_num}: {err}")
+            else:
+                valid.append(product)
+        return valid
+
+    def _validate_single_row(
+        self, row: dict, line_num: int
+    ) -> tuple[dict | None, list[str]]:
+        """Validate a single CSV row and return (product_dict, errors)."""
+        errors: list[str] = []
+
+        # Formula injection defence
+        for col, val in row.items():
+            if val and _FORMULA_RE.match(val):
+                # Allow negative numbers in nutrition columns
+                if col in NUTRITION_COLUMNS:
+                    try:
+                        float(val)
+                        continue
+                    except ValueError:
+                        pass
+                errors.append(
+                    f"Potential formula injection in column '{col}': "
+                    f"value starts with '{val[0]}'"
+                )
+
+        if errors:
+            return None, errors
+
+        # Required fields
+        brand = row.get("brand", "").strip()
+        product_name = row.get("product_name", "").strip()
+        category = row.get("category", "").strip()
+        country = row.get("country", "").strip().upper()
+        ean = row.get("ean", "").strip()
+
+        if not brand:
+            errors.append("Missing required field 'brand'")
+        if not product_name:
+            errors.append("Missing required field 'product_name'")
+        if not category:
+            errors.append("Missing required field 'category'")
+        elif category not in VALID_CATEGORIES:
+            errors.append(
+                f"Invalid category '{category}'. "
+                f"Must be one of: {', '.join(sorted(VALID_CATEGORIES))}"
+            )
+        if not country:
+            errors.append("Missing required field 'country'")
+        elif country not in VALID_COUNTRIES:
+            errors.append(f"Invalid country '{country}'. Must be PL or DE.")
+
+        # EAN validation
+        if not ean:
+            errors.append("Missing required field 'ean'")
+        elif not validate_ean_checksum(ean):
+            errors.append(f"Invalid EAN checksum: '{ean}'")
+
+        if errors:
+            return None, errors
+
+        # Optional fields with validation
+        prep_method = row.get("prep_method", "").strip() or "not-applicable"
+        if prep_method not in VALID_PREP_METHODS:
+            errors.append(
+                f"Invalid prep_method '{prep_method}'. "
+                f"Must be one of: {', '.join(sorted(VALID_PREP_METHODS))}"
+            )
+
+        nutri_score = row.get("nutri_score_label", "").strip().upper()
+        if nutri_score and nutri_score not in VALID_NUTRI_SCORES:
+            errors.append(
+                f"Invalid nutri_score_label '{nutri_score}'. "
+                f"Must be one of: {', '.join(sorted(VALID_NUTRI_SCORES))}"
+            )
+
+        nova = row.get("nova_group", "").strip()
+        if nova and nova not in VALID_NOVA:
+            errors.append(f"Invalid nova_group '{nova}'. Must be 1, 2, 3, or 4.")
+
+        # Nutrition parsing
+        nutrition: dict[str, float | None] = {}
+        for col in NUTRITION_COLUMNS:
+            raw = row.get(col, "").strip()
+            if not raw:
+                nutrition[col] = None
+                continue
+            try:
+                val = float(raw)
+                if val < 0:
+                    errors.append(f"Negative value for '{col}': {val}")
+                    continue
+                nutrition[col] = val
+            except ValueError:
+                errors.append(f"Non-numeric value for '{col}': '{raw}'")
+
+        # Cross-field nutrition checks
+        sat_fat = nutrition.get("saturated_fat_g")
+        total_fat = nutrition.get("total_fat_g")
+        if sat_fat is not None and total_fat is not None and sat_fat > total_fat:
+            errors.append(
+                f"saturated_fat_g ({sat_fat}) > total_fat_g ({total_fat})"
+            )
+
+        sugars = nutrition.get("sugars_g")
+        carbs = nutrition.get("carbs_g")
+        if sugars is not None and carbs is not None and sugars > carbs:
+            errors.append(f"sugars_g ({sugars}) > carbs_g ({carbs})")
+
+        # Absolute caps check (reuse validator)
+        cap_map = {
+            "calories_kcal": "calories",
+            "total_fat_g": "total_fat_g",
+            "saturated_fat_g": "saturated_fat_g",
+            "carbs_g": "carbs_g",
+            "sugars_g": "sugars_g",
+            "fibre_g": "fibre_g",
+            "protein_g": "protein_g",
+            "salt_g": "salt_g",
+            "trans_fat_g": "trans_fat_g",
+        }
+        for csv_col, cap_key in cap_map.items():
+            val = nutrition.get(csv_col)
+            if val is not None and cap_key in ABSOLUTE_CAPS and val > ABSOLUTE_CAPS[cap_key]:
+                    errors.append(
+                        f"'{csv_col}' ({val}) exceeds absolute cap "
+                        f"({ABSOLUTE_CAPS[cap_key]})"
+                    )
+
+        if errors:
+            return None, errors
+
+        # Build product dict matching generate_pipeline() expectations
+        product: dict = {
+            "brand": brand,
+            "product_name": product_name,
+            "ean": ean,
+            "category": category,
+            "product_type": row.get("product_type", "").strip() or "Grocery",
+            "prep_method": prep_method,
+            "store_availability": row.get("store_availability", "").strip() or None,
+            "controversies": row.get("controversies", "").strip() or "none",
+            "ingredients_text": row.get("ingredients_text", "").strip() or None,
+            # Nutrition fields (mapped to the key names sql_generator expects)
+            "calories": nutrition.get("calories_kcal"),
+            "total_fat_g": nutrition.get("total_fat_g"),
+            "saturated_fat_g": nutrition.get("saturated_fat_g"),
+            "trans_fat_g": nutrition.get("trans_fat_g"),
+            "carbs_g": nutrition.get("carbs_g"),
+            "sugars_g": nutrition.get("sugars_g"),
+            "fibre_g": nutrition.get("fibre_g"),
+            "protein_g": nutrition.get("protein_g"),
+            "salt_g": nutrition.get("salt_g"),
+            # Scoring fields
+            "nutri_score_label": nutri_score or None,
+            "nova": nova or None,
+            # Source provenance — CSV imports use file path as source
+            "source_url": str(self.csv_path),
+            "source_type": "csv_import",
+            # Country stored on product for grouping
+            "_country": country,
+        }
+
+        return product, []
+
+    # ------------------------------------------------------------------
+    # Internal — deduplication
+    # ------------------------------------------------------------------
+
+    def _dedup(self, products: list[dict]) -> list[dict]:
+        """Deduplicate by (country, brand, product_name), first-seen wins."""
+        seen: set[tuple[str, str, str]] = set()
+        unique: list[dict] = []
+        for p in products:
+            key = (
+                p["_country"],
+                p["brand"].lower().strip(),
+                p["product_name"].lower().strip(),
+            )
+            if key in seen:
+                self.warnings.append(
+                    f"Duplicate skipped: {p['brand']} / {p['product_name']} "
+                    f"({p['_country']})"
+                )
+                continue
+            seen.add(key)
+            unique.append(p)
+
+        # Also dedup EANs — first-seen wins
+        ean_seen: set[str] = set()
+        ean_unique: list[dict] = []
+        for p in unique:
+            ean = p.get("ean", "")
+            if ean and ean in ean_seen:
+                self.warnings.append(
+                    f"Duplicate EAN skipped: {p['brand']} / {p['product_name']} "
+                    f"(EAN {ean})"
+                )
+                continue
+            if ean:
+                ean_seen.add(ean)
+            ean_unique.append(p)
+
+        return ean_unique
+
+    # ------------------------------------------------------------------
+    # Internal — grouping & SQL generation
+    # ------------------------------------------------------------------
+
+    def _group_by_category_country(
+        self, products: list[dict]
+    ) -> dict[tuple[str, str], list[dict]]:
+        """Group products by (category, country)."""
+        groups: dict[tuple[str, str], list[dict]] = {}
+        for p in products:
+            key = (p["category"], p["_country"])
+            groups.setdefault(key, []).append(p)
+        return groups
+
+    def _generate_sql(
+        self, category: str, country: str, products: list[dict]
+    ) -> list[Path]:
+        """Generate pipeline SQL files for one (category, country) group."""
+        slug_base = _slug(category)
+        dir_slug = f"{slug_base}-{country.lower()}" if country != "PL" else slug_base
+        out_dir = self.output_dir / dir_slug
+
+        return generate_pipeline(
+            category=category,
+            products=products,
+            output_dir=str(out_dir),
+            country=country,
+        )

--- a/pipeline/templates/product_import_template.csv
+++ b/pipeline/templates/product_import_template.csv
@@ -1,0 +1,4 @@
+ean,brand,product_name,category,country,product_type,prep_method,store_availability,controversies,calories_kcal,total_fat_g,saturated_fat_g,trans_fat_g,carbs_g,sugars_g,fibre_g,protein_g,salt_g,nutri_score_label,nova_group,ingredients_text
+5901234567893,Example Brand,Example Product Name,Dairy,PL,yogurt,not-applicable,,none,65,3.2,2.1,0,8.5,5.2,0,4.5,0.12,B,1,"milk, sugar, cultures"
+4012345678901,Beispiel Marke,Beispiel Vollkornbrot,Bread,DE,bread,baked,Lidl,none,245,1.2,0.2,0,47,3.5,6.8,8.9,1.1,A,2,"whole wheat flour, water, salt, yeast"
+5901112223330,Marka Testowa,Chipsy Paprykowe,Chips,PL,chips,fried,Biedronka,palm oil,530,32,3.5,0,53,1.2,3.8,6.2,1.45,D,4,"potatoes, sunflower oil, salt, paprika, palm oil"

--- a/pipeline/test_csv_importer.py
+++ b/pipeline/test_csv_importer.py
@@ -1,0 +1,473 @@
+"""Tests for pipeline.csv_importer — CSV bulk import tool.
+
+Covers: valid import, missing columns, bad EAN, formula injection,
+row limit, duplicate detection, empty file, invalid category,
+nutrition cap violations, cross-field checks, dry-run mode.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from pipeline.csv_importer import (
+    MAX_ROWS,
+    VALID_CATEGORIES,
+    VALID_COUNTRIES,
+    VALID_PREP_METHODS,
+    CSVImporter,
+    CSVImportError,
+)
+
+
+def _write_csv(tmp_path: Path, content: str) -> Path:
+    """Write CSV content to a temp file and return its path."""
+    p = tmp_path / "test_import.csv"
+    p.write_text(textwrap.dedent(content).strip(), encoding="utf-8")
+    return p
+
+
+# Valid EAN-13 checksum values for test data
+_VALID_EAN_1 = "5901234567893"
+_VALID_EAN_2 = "4012345678901"
+_VALID_EAN_3 = "5901112223330"
+
+_HEADER = (
+    "ean,brand,product_name,category,country,product_type,prep_method,"
+    "store_availability,controversies,calories_kcal,total_fat_g,"
+    "saturated_fat_g,trans_fat_g,carbs_g,sugars_g,fibre_g,protein_g,"
+    "salt_g,nutri_score_label,nova_group,ingredients_text"
+)
+
+_VALID_ROW_1 = (
+    f"{_VALID_EAN_1},Test Brand,Test Yogurt,Dairy,PL,yogurt,not-applicable,"
+    ",none,65,3.2,2.1,0,8.5,5.2,0,4.5,0.12,B,1,milk"
+)
+
+_VALID_ROW_2 = (
+    f"{_VALID_EAN_2},DE Brand,Test Bread,Bread,DE,bread,baked,"
+    "Lidl,none,245,1.2,0.2,0,47,3.5,6.8,8.9,1.1,A,2,flour"
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Valid import
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestValidImport:
+    """Tests for a well-formed CSV import."""
+
+    def test_valid_import_returns_correct_counts(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            {_VALID_ROW_1}
+            {_VALID_ROW_2}
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        result = importer.run()
+
+        assert result["total_rows"] == 2
+        assert result["valid_rows"] == 2
+        assert result["errors"] == []
+        assert "Dairy" in result["categories"]
+        assert "Bread" in result["categories"]
+        assert len(result["files_written"]) > 0
+
+    def test_valid_import_creates_sql_files(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            {_VALID_ROW_1}
+            """,
+        )
+        out_dir = tmp_path / "out"
+        importer = CSVImporter(csv_path, output_dir=out_dir)
+        result = importer.run()
+
+        for f in result["files_written"]:
+            assert Path(f).exists()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Missing columns
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestMissingColumns:
+    """Tests for missing required CSV columns."""
+
+    def test_missing_required_column_raises(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            """\
+            ean,brand,product_name,country
+            5901234567893,Brand,Name,PL
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        with pytest.raises(CSVImportError, match="Missing required columns"):
+            importer.run()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Bad EAN
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestBadEAN:
+    """Tests for invalid EAN values."""
+
+    def test_invalid_ean_checksum_rejected(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            1234567890123,Brand,Product,Dairy,PL,,,,none,,,,,,,,,,,,milk
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        result = importer.run()
+
+        assert result["valid_rows"] == 0
+        assert any("Invalid EAN" in w for w in result["warnings"])
+
+    def test_missing_ean_rejected(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            ,Brand,Product,Dairy,PL,,,,none,,,,,,,,,,,,"milk"
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        result = importer.run()
+
+        assert result["valid_rows"] == 0
+        assert any("Missing required field 'ean'" in w for w in result["warnings"])
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Formula injection
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestFormulaInjection:
+    """Tests for formula injection defence."""
+
+    def test_equals_sign_rejected(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            {_VALID_EAN_1},=cmd|'/C calc'!A0,Product,Dairy,PL,,,,none,,,,,,,,,,,,"milk"
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        result = importer.run()
+
+        assert result["valid_rows"] == 0
+        assert any("formula injection" in w.lower() for w in result["warnings"])
+
+    def test_at_sign_rejected(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            {_VALID_EAN_1},@SUM(A1),Product,Dairy,PL,,,,none,,,,,,,,,,,,"milk"
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        result = importer.run()
+
+        assert result["valid_rows"] == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Row limit
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestRowLimit:
+    """Tests for MAX_ROWS enforcement."""
+
+    def test_max_rows_constant_is_10000(self) -> None:
+        assert MAX_ROWS == 10_000
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Duplicate detection
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDuplicateDetection:
+    """Tests for deduplication by (country, brand, product_name) and EAN."""
+
+    def test_duplicate_name_deduped(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            {_VALID_EAN_1},Brand,Same Product,Dairy,PL,,,,none,65,3,2,0,8,5,0,4,0.1,B,1,"milk"
+            {_VALID_EAN_2},Brand,Same Product,Dairy,PL,,,,none,70,4,2,0,9,6,0,5,0.2,B,1,"milk"
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        result = importer.run()
+
+        assert result["total_rows"] == 2
+        assert result["valid_rows"] == 1
+        assert any("Duplicate skipped" in w for w in result["warnings"])
+
+    def test_duplicate_ean_deduped(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            {_VALID_EAN_1},Brand A,Product A,Dairy,PL,,,,none,65,3,2,0,8,5,0,4,0.1,B,1,"milk"
+            {_VALID_EAN_1},Brand B,Product B,Dairy,PL,,,,none,70,4,2,0,9,6,0,5,0.2,B,1,"milk"
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        result = importer.run()
+
+        assert result["valid_rows"] == 1
+        assert any("Duplicate EAN" in w for w in result["warnings"])
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Empty file
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestEmptyFile:
+    """Tests for empty or header-only CSV files."""
+
+    def test_no_header_raises(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(tmp_path, "")
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        with pytest.raises(CSVImportError, match="empty"):
+            importer.run()
+
+    def test_header_only_zero_rows(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(tmp_path, _HEADER)
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        result = importer.run()
+
+        assert result["total_rows"] == 0
+        assert result["valid_rows"] == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Invalid category
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestInvalidCategory:
+    """Tests for invalid category values."""
+
+    def test_unknown_category_rejected(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            {_VALID_EAN_1},Brand,Product,Nonexistent Category,PL,,,,none,,,,,,,,,,,,"x"
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        result = importer.run()
+
+        assert result["valid_rows"] == 0
+        assert any("Invalid category" in w for w in result["warnings"])
+
+    def test_valid_categories_set_has_28_entries(self) -> None:
+        assert len(VALID_CATEGORIES) == 28
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Nutrition cap violations
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestNutritionCaps:
+    """Tests for absolute nutrition cap enforcement."""
+
+    def test_calories_over_cap_rejected(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            {_VALID_EAN_1},Brand,Product,Dairy,PL,,,,none,999,3,2,0,8,5,0,4,0.1,B,1,"milk"
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        result = importer.run()
+
+        assert result["valid_rows"] == 0
+        assert any("exceeds absolute cap" in w for w in result["warnings"])
+
+    def test_negative_nutrition_rejected(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            {_VALID_EAN_1},Brand,Product,Dairy,PL,,,,none,-10,3,2,0,8,5,0,4,0.1,B,1,"milk"
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        result = importer.run()
+
+        assert result["valid_rows"] == 0
+        assert any("Negative value" in w for w in result["warnings"])
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Cross-field nutrition checks
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCrossFieldChecks:
+    """Tests for sugars <= carbs and sat_fat <= total_fat constraints."""
+
+    def test_sugars_exceeding_carbs_rejected(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            {_VALID_EAN_1},Brand,Product,Dairy,PL,,,,none,65,3,2,0,8,15,0,4,0.1,B,1,"milk"
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        result = importer.run()
+
+        assert result["valid_rows"] == 0
+        assert any("sugars_g" in w and "carbs_g" in w for w in result["warnings"])
+
+    def test_sat_fat_exceeding_total_fat_rejected(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            {_VALID_EAN_1},Brand,Product,Dairy,PL,,,,none,65,3,10,0,8,5,0,4,0.1,B,1,"milk"
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        result = importer.run()
+
+        assert result["valid_rows"] == 0
+        assert any(
+            "saturated_fat_g" in w and "total_fat_g" in w
+            for w in result["warnings"]
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Dry run mode
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDryRun:
+    """Tests for dry-run mode (validate without writing files)."""
+
+    def test_dry_run_writes_no_files(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            {_VALID_ROW_1}
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out", dry_run=True)
+        result = importer.run()
+
+        assert result["valid_rows"] == 1
+        assert result["files_written"] == []
+        assert result["errors"] == []
+
+    def test_dry_run_still_validates(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            1234567890123,Brand,Product,Dairy,PL,,,,none,,,,,,,,,,,,milk
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out", dry_run=True)
+        result = importer.run()
+
+        assert result["valid_rows"] == 0
+        assert any("Invalid EAN" in w for w in result["warnings"])
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# File-not-found
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestFileNotFound:
+    """Tests for missing input file."""
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        importer = CSVImporter(
+            tmp_path / "nonexistent.csv", output_dir=tmp_path / "out"
+        )
+        with pytest.raises(CSVImportError, match="File not found"):
+            importer.run()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Invalid country
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestInvalidCountry:
+    """Tests for invalid country codes."""
+
+    def test_unknown_country_rejected(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            {_VALID_EAN_1},Brand,Product,Dairy,FR,,,,none,65,3,2,0,8,5,0,4,0.1,B,1,"milk"
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        result = importer.run()
+
+        assert result["valid_rows"] == 0
+        assert any("Invalid country" in w for w in result["warnings"])
+
+    def test_valid_countries(self) -> None:
+        assert frozenset({"PL", "DE"}) == VALID_COUNTRIES
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Invalid prep method
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestInvalidPrepMethod:
+    """Tests for invalid prep_method values."""
+
+    def test_unknown_prep_method_rejected(self, tmp_path: Path) -> None:
+        csv_path = _write_csv(
+            tmp_path,
+            f"""\
+            {_HEADER}
+            {_VALID_EAN_1},Brand,Product,Dairy,PL,,boiled,,none,65,3,2,0,8,5,0,4,0.1,B,1,"milk"
+            """,
+        )
+        importer = CSVImporter(csv_path, output_dir=tmp_path / "out")
+        result = importer.run()
+
+        assert result["valid_rows"] == 0
+        assert any("Invalid prep_method" in w for w in result["warnings"])
+
+    def test_valid_prep_methods_has_15_entries(self) -> None:
+        assert len(VALID_PREP_METHODS) == 15

--- a/ruff.toml
+++ b/ruff.toml
@@ -53,6 +53,7 @@ known-first-party = ["pipeline"]
 "pipeline/test_validator.py" = ["S101"]
 # Pipeline fetch/utility scripts: print() calls are intentional progress indicators
 "pipeline/run.py" = ["T20"]
+"pipeline/csv_import.py" = ["T20"]
 "pipeline/image_importer.py" = ["T20"]
 "fetch_off_category.py" = ["T20"]
 "enrich_ingredients.py" = ["T20", "E501"]


### PR DESCRIPTION
## Summary
CSV bulk import tool for scaling to 10K+ products per country from multi-source data (retailer exports, research datasets, manual curation batches).

## Changes
- **pipeline/csv_importer.py** (~520 lines) — Core module: CSV parsing, validation (EAN checksum, nutrition caps, cross-field checks, formula injection defense), deduplication, SQL generation via `generate_pipeline()`
- **pipeline/csv_import.py** (~85 lines) — CLI entry point with `--file`, `--output-dir`, `--dry-run` flags
- **pipeline/templates/product_import_template.csv** — 21-column template with 3 valid example rows
- **pipeline/test_csv_importer.py** (~330 lines) — 25 pytest tests across 14 test classes

## Validation
- Ruff: All checks passed
- pytest: 25/25 passing
- py_compile: All 3 Python files compile cleanly

## Documentation Updated
- docs/DATA_SOURCES.md — §13 CSV Bulk Import section added
- copilot-instructions.md §3 — Project layout updated
- CHANGELOG.md — Entry added under [Unreleased]

Closes #862