### PR TITLE
perf(pipeline): batch SQL generation for 10K scale (#864)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Batch SQL generation for 10K scale: pipeline splits large category runs
+  (>batch_size products) into multiple batch files per step (01, 03) with
+  independent transactions, stale file cleanup, batch progress headers.
+  `--batch-size` CLI flag, backward compatible (≤100 products → single file).
+  Includes 26-test pytest suite and structure checker support (#864)
 - CSV bulk import tool (`pipeline/csv_importer.py` + `pipeline/csv_import.py`)
   for multi-source 10K expansion: validates EAN checksums, nutrition caps,
   cross-field constraints, formula injection defense, deduplication by name and

--- a/RUN_LOCAL.ps1
+++ b/RUN_LOCAL.ps1
@@ -154,7 +154,15 @@ $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
 foreach ($file in $allFiles) {
     $relativePath = $file.FullName.Replace($PSScriptRoot, "").TrimStart("\", "/")
-    Write-Host "  RUN  $relativePath" -ForegroundColor Yellow -NoNewline
+    # Show batch progress for batched pipeline files
+    $batchLabel = ""
+    if ($file.Name -match '_batch_(\d{3})_') {
+        $batchNum = $Matches[1]
+        $stepPrefix = ($file.Name -split '_batch_')[0]
+        $totalBatches = @($allFiles | Where-Object { $_.Name -like "$stepPrefix*_batch_*" }).Count
+        $batchLabel = "  [batch $batchNum/$totalBatches]"
+    }
+    Write-Host "  RUN  $relativePath$batchLabel" -ForegroundColor Yellow -NoNewline
 
     $sqlContent = Get-Content $file.FullName -Raw
     $output = $sqlContent | docker exec -i $CONTAINER psql -U $DB_USER -d $DB_NAME --single-transaction -v ON_ERROR_STOP=1 2>&1

--- a/check_pipeline_structure.py
+++ b/check_pipeline_structure.py
@@ -60,15 +60,24 @@ STEP_04_SCORE_CALL = re.compile(
     re.IGNORECASE,
 )
 
+# Batch file step pattern: 01_batch_001_insert_products → base step "01_insert_products"
+_BATCH_STEP_RE = re.compile(r"^(\d{2})_batch_\d{3}_(.+)$")
+
 
 def _check_required_files(category: str, folder: Path) -> list[str]:
     """Check that all required step files exist for a category."""
     violations: list[str] = []
     sql_files = {f.name for f in folder.glob("PIPELINE__*.sql")}
     for step in REQUIRED_STEPS:
-        pattern = f"PIPELINE__{category}__{step}.sql"
-        if pattern not in sql_files:
-            violations.append(f"[{category}] Missing: {pattern}")
+        single = f"PIPELINE__{category}__{step}.sql"
+        if single in sql_files:
+            continue
+        # Accept batch pattern: PIPELINE__{cat}__{prefix}_batch_001_{rest}.sql
+        prefix, rest = step.split("_", 1)
+        batch = f"PIPELINE__{category}__{prefix}_batch_001_{rest}.sql"
+        if batch in sql_files:
+            continue
+        violations.append(f"[{category}] Missing: {single}")
     return violations
 
 
@@ -139,9 +148,11 @@ def check_category(folder: Path) -> list[str]:
         content = sql_file.read_text(encoding="utf-8", errors="replace")
         fname = sql_file.name
 
-        # Extract step identifier
+        # Extract step identifier (handle batch infix)
         parts = fname.replace(".sql", "").split("__")
-        step = parts[-1] if len(parts) >= 3 else ""
+        raw_step = parts[-1] if len(parts) >= 3 else ""
+        m = _BATCH_STEP_RE.match(raw_step)
+        step = f"{m.group(1)}_{m.group(2)}" if m else raw_step
 
         # Check for hardcoded product_id integers in step 01 and 03
         if step in ("01_insert_products", "03_add_nutrition"):

--- a/pipeline/run.py
+++ b/pipeline/run.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import math
 import re
 import sys
 from pathlib import Path
@@ -18,7 +19,7 @@ from tqdm import tqdm
 
 from pipeline.categories import CATEGORY_SEARCH_TERMS, resolve_category
 from pipeline.off_client import extract_product_data, market_score, search_products
-from pipeline.sql_generator import generate_pipeline
+from pipeline.sql_generator import BATCH_SIZE, generate_pipeline
 from pipeline.utils import slug as _slug
 from pipeline.validator import validate_product
 
@@ -180,6 +181,7 @@ def run_pipeline(
     min_completeness: float = 0.0,
     max_warnings: int = 3,
     country: str = "PL",
+    batch_size: int = BATCH_SIZE,
 ) -> None:
     """Execute the full pipeline for a single category.
 
@@ -287,7 +289,7 @@ def run_pipeline(
     print()
 
     # 5. Generate SQL
-    _generate_sql_output(category, unique, output_dir, dry_run, country)
+    _generate_sql_output(category, unique, output_dir, dry_run, country, batch_size)
 
 
 def _generate_sql_output(
@@ -296,24 +298,35 @@ def _generate_sql_output(
     output_dir: str,
     dry_run: bool,
     country: str = "PL",
+    batch_size: int = BATCH_SIZE,
 ) -> None:
     """Phase 5: generate SQL files or print dry-run summary."""
     slug = _slug(category)
+    use_batching = batch_size > 0 and len(products) > batch_size
+
     if dry_run:
-        print("[DRY RUN] Would generate SQL files in:", output_dir)
-        print(f"  PIPELINE__{slug}__01_insert_products.sql ({len(products)} products)")
-        print(f"  PIPELINE__{slug}__03_add_nutrition.sql ({len(products)} nutrition rows)")
+        if use_batching:
+            n_batches = math.ceil(len(products) / batch_size)
+            print(f"[DRY RUN] Would generate batched SQL ({n_batches} batches of {batch_size}) in: {output_dir}")
+            for i in range(1, n_batches + 1):
+                print(f"  PIPELINE__{slug}__01_batch_{i:03d}_insert_products.sql")
+            for i in range(1, n_batches + 1):
+                print(f"  PIPELINE__{slug}__03_batch_{i:03d}_add_nutrition.sql")
+        else:
+            print("[DRY RUN] Would generate SQL files in:", output_dir)
+            print(f"  PIPELINE__{slug}__01_insert_products.sql ({len(products)} products)")
+            print(f"  PIPELINE__{slug}__03_add_nutrition.sql ({len(products)} nutrition rows)")
         print(f"  PIPELINE__{slug}__04_scoring.sql")
         print(f"  PIPELINE__{slug}__05_source_provenance.sql")
         print(f"  PIPELINE__{slug}__06_add_images.sql")
         return
 
     print("Generating SQL files...")
-    files = generate_pipeline(category, products, output_dir, country=country)
+    files = generate_pipeline(category, products, output_dir, country=country, batch_size=batch_size)
     for f in files:
         size_label = ""
-        if "01_insert" in f.name:
-            size_label = f" ({len(products)} products)"
+        if "01_insert" in f.name or "01_batch" in f.name:
+            size_label = f" ({len(products)} products)" if "01_insert" in f.name else ""
         elif "03_add_nutrition" in f.name:
             size_label = f" ({len(products)} nutrition rows)"
         print(f"  OK {f.name}{size_label}")
@@ -371,6 +384,12 @@ def main() -> None:
         default="PL",
         help="ISO 3166-1 alpha-2 country code (default: PL). Supported: PL, DE",
     )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=BATCH_SIZE,
+        help=f"Max products per batch SQL file (default: {BATCH_SIZE}). 0 = no batching.",
+    )
 
     args = parser.parse_args()
 
@@ -387,6 +406,7 @@ def main() -> None:
         min_completeness=args.min_completeness,
         max_warnings=args.max_warnings,
         country=args.country.upper(),
+        batch_size=args.batch_size,
     )
 
 

--- a/pipeline/sql_generator.py
+++ b/pipeline/sql_generator.py
@@ -534,6 +534,205 @@ ON CONFLICT (product_id, store_id) DO NOTHING;
 
 
 # ---------------------------------------------------------------------------
+# Batching support
+# ---------------------------------------------------------------------------
+
+BATCH_SIZE = 100
+
+
+def _chunk(items: list, size: int) -> list[list]:
+    """Split *items* into chunks of at most *size* elements."""
+    return [items[i:i + size] for i in range(0, len(items), size)]
+
+
+def _gen_01_batch(
+    category: str,
+    batch_products: list[dict],
+    all_products: list[dict],
+    today: str,
+    country: str,
+    batch_num: int,
+    total_batches: int,
+    batch_start: int,
+    batch_end: int,
+) -> str:
+    """Generate one batch file for step 01 (insert products).
+
+    Batch 1 includes preamble (deprecation, EAN release, cross-category).
+    Last batch includes postscript (deprecate removed products).
+    All batches include an INSERT with ON CONFLICT.
+    """
+    parts: list[str] = [
+        f"-- PIPELINE ({category}): insert products",
+        f"-- Batch {batch_num}/{total_batches}: products {batch_start}-{batch_end}",
+        "-- Source: Open Food Facts API (automated pipeline)",
+        f"-- Generated: {today}",
+    ]
+
+    # ── Preamble (first batch only) ──────────────────────────────────────
+    if batch_num == 1:
+        parts.append(f"""
+-- 0a. DEPRECATE old products in this category & release their EANs
+update products
+set is_deprecated = true, deprecated_reason = 'Replaced by pipeline refresh', ean = null
+where country = {_sql_text(country)}
+  and category = {_sql_text(category)}
+  and is_deprecated is not true;""")
+
+        eans = [p.get("ean", "") for p in all_products if p.get("ean")]
+        if eans:
+            ean_literals = ", ".join(_sql_text(e) for e in eans)
+            parts.append(f"""
+-- 0b. Release EANs across ALL categories to prevent unique constraint conflicts
+update products set ean = null
+where ean in ({ean_literals})
+  and ean is not null;""")
+
+        keys = sorted({_identity_key(p["brand"], p["product_name"]) for p in all_products})
+        key_literals = ", ".join(_sql_text(k) for k in keys)
+        parts.append(f"""
+-- 0c. Deprecate cross-category products whose identity_key collides with this batch
+update products
+set is_deprecated = true,
+    deprecated_reason = 'Reassigned to {category} by pipeline',
+    ean = null
+where country = {_sql_text(country)}
+  and category != {_sql_text(category)}
+  and identity_key in ({key_literals})
+  and is_deprecated is not true;""")
+
+    # ── INSERT block ─────────────────────────────────────────────────────
+    lines: list[str] = []
+    for i, p in enumerate(batch_products):
+        brand = _sql_text(p["brand"])
+        name = _sql_text(p["product_name"])
+        ean = _sql_text(p.get("ean") or "")
+        product_type = _sql_text(p.get("product_type", "Grocery"))
+        prep = _sql_null_or_text(p.get("prep_method"))
+        store = _sql_null_or_text(_normalize_store(p.get("store_availability")))
+        controversies = _sql_text(p.get("controversies", "none"))
+        comma = "," if i < len(batch_products) - 1 else ""
+        lines.append(
+            f"  ({_sql_text(country)}, {brand}, {product_type}, {_sql_text(category)}, "
+            f"{name}, {prep}, {store}, {controversies}, {ean}){comma}"
+        )
+    values_block = "\n".join(lines)
+
+    parts.append(f"""
+-- 1. INSERT products (batch {batch_num}/{total_batches})
+insert into products (country, brand, product_type, category, product_name, prep_method, store_availability, controversies, ean)
+values
+{values_block}
+on conflict (country, brand, product_name) do update set
+  category = excluded.category,
+  ean = excluded.ean,
+  product_type = excluded.product_type,
+  store_availability = excluded.store_availability,
+  controversies = excluded.controversies,
+  prep_method = excluded.prep_method,
+  is_deprecated = false;""")
+
+    # ── Postscript (last batch only) ─────────────────────────────────────
+    if batch_num == total_batches:
+        name_literals = ", ".join(_sql_text(p["product_name"]) for p in all_products)
+        parts.append(f"""
+-- 2. DEPRECATE removed products
+update products
+set is_deprecated = true, deprecated_reason = 'Removed from pipeline batch'
+where country = {_sql_text(country)} and category = {_sql_text(category)}
+  and is_deprecated is not true
+  and product_name not in ({name_literals});""")
+
+    parts.append("")  # trailing newline
+    return "\n".join(parts)
+
+
+def _gen_03_batch(
+    category: str,
+    batch_products: list[dict],
+    country: str,
+    batch_num: int,
+    total_batches: int,
+    batch_start: int,
+    batch_end: int,
+) -> str:
+    """Generate one batch file for step 03 (add nutrition).
+
+    Batch 1 includes the DELETE (clean existing rows).
+    All batches include an INSERT with ON CONFLICT.
+    """
+    nutrition_lines: list[str] = []
+    for i, p in enumerate(batch_products):
+        brand = _sql_text(p["brand"])
+        name = _sql_text(p["product_name"])
+        vals = ", ".join(
+            _sql_num(p[k])
+            for k in (
+                "calories",
+                "total_fat_g",
+                "saturated_fat_g",
+                "trans_fat_g",
+                "carbs_g",
+                "sugars_g",
+                "fibre_g",
+                "protein_g",
+                "salt_g",
+            )
+        )
+        comma = "," if i < len(batch_products) - 1 else ""
+        nutrition_lines.append(f"    ({brand}, {name}, {vals}){comma}")
+    nutrition_block = "\n".join(nutrition_lines)
+
+    parts: list[str] = [
+        f"-- PIPELINE ({category}): add nutrition facts",
+        f"-- Batch {batch_num}/{total_batches}: products {batch_start}-{batch_end}",
+        "-- Source: Open Food Facts verified per-100g data",
+    ]
+
+    # DELETE existing — only in first batch
+    if batch_num == 1:
+        parts.append(f"""
+-- 1) Remove existing
+delete from nutrition_facts
+where product_id in (
+  select p.product_id
+  from products p
+  where p.country = {_sql_text(country)} and p.category = {_sql_text(category)}
+    and p.is_deprecated is not true
+);""")
+
+    parts.append(f"""
+-- 2) Insert (batch {batch_num}/{total_batches})
+insert into nutrition_facts
+  (product_id, calories, total_fat_g, saturated_fat_g, trans_fat_g,
+   carbs_g, sugars_g, fibre_g, protein_g, salt_g)
+select
+  p.product_id,
+  d.calories, d.total_fat_g, d.saturated_fat_g, d.trans_fat_g,
+  d.carbs_g, d.sugars_g, d.fibre_g, d.protein_g, d.salt_g
+from (
+  values
+{nutrition_block}
+) as d(brand, product_name, calories, total_fat_g, saturated_fat_g, trans_fat_g,
+       carbs_g, sugars_g, fibre_g, protein_g, salt_g)
+join products p on p.country = {_sql_text(country)} and p.brand = d.brand and p.product_name = d.product_name
+  and p.category = {_sql_text(category)} and p.is_deprecated is not true
+on conflict (product_id) do update set
+  calories = excluded.calories,
+  total_fat_g = excluded.total_fat_g,
+  saturated_fat_g = excluded.saturated_fat_g,
+  trans_fat_g = excluded.trans_fat_g,
+  carbs_g = excluded.carbs_g,
+  sugars_g = excluded.sugars_g,
+  fibre_g = excluded.fibre_g,
+  protein_g = excluded.protein_g,
+  salt_g = excluded.salt_g;""")
+
+    parts.append("")  # trailing newline
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -543,8 +742,12 @@ def generate_pipeline(
     products: list[dict],
     output_dir: str,
     country: str = "PL",
+    batch_size: int = BATCH_SIZE,
 ) -> list[Path]:
-    """Generate 6 SQL pipeline files for *category* in *country*.
+    """Generate SQL pipeline files for *category* in *country*.
+
+    When ``len(products) > batch_size``, steps 01 and 03 are split into
+    multiple batch files.  Steps 04--07 always produce a single file.
 
     Parameters
     ----------
@@ -556,11 +759,14 @@ def generate_pipeline(
         Directory to write the SQL files into.
     country:
         ISO 3166-1 alpha-2 country code (default ``"PL"``).
+    batch_size:
+        Maximum products per batch file (default ``BATCH_SIZE``).
+        Set to ``0`` to disable batching.
 
     Returns
     -------
     list[Path]
-        Paths of the six generated files.
+        Paths of the generated files.
     """
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
@@ -572,33 +778,86 @@ def generate_pipeline(
     today = datetime.date.today().isoformat()
 
     files: list[Path] = []
+    use_batching = batch_size > 0 and len(products) > batch_size
 
-    # 01 — insert products
-    path01 = out / f"PIPELINE__{slug}__01_insert_products.sql"
-    path01.write_text(_gen_01_insert_products(category, products, today, country), encoding="utf-8")
-    files.append(path01)
+    if use_batching:
+        chunks = _chunk(products, batch_size)
+        total_batches = len(chunks)
 
-    # 03 — add nutrition
-    path03 = out / f"PIPELINE__{slug}__03_add_nutrition.sql"
-    path03.write_text(_gen_03_add_nutrition(category, products, country), encoding="utf-8")
-    files.append(path03)
+        # Clean up stale single-file or old batch versions
+        for old in out.glob(f"PIPELINE__{slug}__01_insert_products.sql"):
+            old.unlink()
+        for old in out.glob(f"PIPELINE__{slug}__01_batch_*_insert_products.sql"):
+            old.unlink()
+        for old in out.glob(f"PIPELINE__{slug}__03_add_nutrition.sql"):
+            old.unlink()
+        for old in out.glob(f"PIPELINE__{slug}__03_batch_*_add_nutrition.sql"):
+            old.unlink()
 
-    # 04 — scoring
+        # 01 — batched insert products
+        offset = 0
+        for batch_num, chunk in enumerate(chunks, 1):
+            batch_start = offset + 1
+            batch_end = offset + len(chunk)
+            offset += len(chunk)
+            path = out / f"PIPELINE__{slug}__01_batch_{batch_num:03d}_insert_products.sql"
+            path.write_text(
+                _gen_01_batch(
+                    category, chunk, products, today, country,
+                    batch_num, total_batches, batch_start, batch_end,
+                ),
+                encoding="utf-8",
+            )
+            files.append(path)
+
+        # 03 — batched add nutrition
+        offset = 0
+        for batch_num, chunk in enumerate(chunks, 1):
+            batch_start = offset + 1
+            batch_end = offset + len(chunk)
+            offset += len(chunk)
+            path = out / f"PIPELINE__{slug}__03_batch_{batch_num:03d}_add_nutrition.sql"
+            path.write_text(
+                _gen_03_batch(
+                    category, chunk, country,
+                    batch_num, total_batches, batch_start, batch_end,
+                ),
+                encoding="utf-8",
+            )
+            files.append(path)
+    else:
+        # Clean up stale batch files from previous runs
+        for old in out.glob(f"PIPELINE__{slug}__01_batch_*_insert_products.sql"):
+            old.unlink()
+        for old in out.glob(f"PIPELINE__{slug}__03_batch_*_add_nutrition.sql"):
+            old.unlink()
+
+        # 01 — single insert products
+        path01 = out / f"PIPELINE__{slug}__01_insert_products.sql"
+        path01.write_text(_gen_01_insert_products(category, products, today, country), encoding="utf-8")
+        files.append(path01)
+
+        # 03 — single add nutrition
+        path03 = out / f"PIPELINE__{slug}__03_add_nutrition.sql"
+        path03.write_text(_gen_03_add_nutrition(category, products, country), encoding="utf-8")
+        files.append(path03)
+
+    # 04 — scoring (always single file)
     path04 = out / f"PIPELINE__{slug}__04_scoring.sql"
     path04.write_text(_gen_04_scoring(category, products, today, country), encoding="utf-8")
     files.append(path04)
 
-    # 05 — source provenance
+    # 05 — source provenance (always single file)
     path05 = out / f"PIPELINE__{slug}__05_source_provenance.sql"
     path05.write_text(_gen_05_source_provenance(category, products, today, country), encoding="utf-8")
     files.append(path05)
 
-    # 06 — add images
+    # 06 — add images (always single file)
     path06 = out / f"PIPELINE__{slug}__06_add_images.sql"
     path06.write_text(_gen_06_add_images(category, products, today, country), encoding="utf-8")
     files.append(path06)
 
-    # 07 — store availability
+    # 07 — store availability (always single file)
     path07 = out / f"PIPELINE__{slug}__07_store_availability.sql"
     path07.write_text(_gen_07_store_availability(category, products, today, country), encoding="utf-8")
     files.append(path07)

--- a/pipeline/test_batch_sql.py
+++ b/pipeline/test_batch_sql.py
@@ -1,0 +1,310 @@
+"""Tests for batch SQL generation (Issue #864).
+
+Validates that the pipeline correctly splits large product sets into
+multiple batch files while preserving backward compatibility for
+small categories.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pipeline.sql_generator import _chunk, generate_pipeline
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_PRODUCT_TEMPLATE = {
+    "brand": "TestBrand",
+    "product_name": "Product",
+    "ean": "5900000000000",
+    "product_type": "Grocery",
+    "prep_method": "not-applicable",
+    "store_availability": None,
+    "controversies": "none",
+    "calories": 100,
+    "total_fat_g": 5.0,
+    "saturated_fat_g": 2.0,
+    "trans_fat_g": 0.0,
+    "carbs_g": 15.0,
+    "sugars_g": 5.0,
+    "fibre_g": 1.0,
+    "protein_g": 3.0,
+    "salt_g": 0.5,
+    "nutri_score_label": "C",
+    "nutri_score_source": "off_computed",
+    "nova_group": "3",
+    "source_url": "https://world.openfoodfacts.org/product/1234",
+    "image_url": "https://images.openfoodfacts.org/img.jpg",
+}
+
+
+def _make_products(n: int) -> list[dict]:
+    """Create *n* distinct product dicts for testing."""
+    products = []
+    for i in range(1, n + 1):
+        p = dict(_PRODUCT_TEMPLATE)
+        p["brand"] = f"Brand{i}"
+        p["product_name"] = f"Product {i}"
+        p["ean"] = f"{5900000000000 + i}"
+        products.append(p)
+    return products
+
+
+@pytest.fixture()
+def tmp_output(tmp_path: Path) -> Path:
+    """Return a fresh output directory for a fake category."""
+    out = tmp_path / "test-cat"
+    out.mkdir()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# _chunk helper
+# ---------------------------------------------------------------------------
+
+
+class TestChunk:
+    def test_exact_division(self) -> None:
+        result = _chunk(list(range(10)), 5)
+        assert result == [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
+
+    def test_remainder(self) -> None:
+        result = _chunk(list(range(7)), 3)
+        assert len(result) == 3
+        assert result[-1] == [6]
+
+    def test_size_larger_than_items(self) -> None:
+        result = _chunk([1, 2], 100)
+        assert result == [[1, 2]]
+
+    def test_empty(self) -> None:
+        assert _chunk([], 10) == []
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility (≤ batch_size → single files)
+# ---------------------------------------------------------------------------
+
+
+class TestSingleFileMode:
+    """When product count ≤ batch_size, output matches original single-file format."""
+
+    def test_single_files_below_threshold(self, tmp_output: Path) -> None:
+        products = _make_products(50)
+        files = generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        names = [f.name for f in files]
+        assert "PIPELINE__test-cat__01_insert_products.sql" in names
+        assert "PIPELINE__test-cat__03_add_nutrition.sql" in names
+        assert not any("_batch_" in n for n in names)
+
+    def test_single_file_at_exact_threshold(self, tmp_output: Path) -> None:
+        products = _make_products(100)
+        files = generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        names = [f.name for f in files]
+        assert "PIPELINE__test-cat__01_insert_products.sql" in names
+        assert not any("_batch_" in n for n in names)
+
+    def test_unbatched_always_has_six_files(self, tmp_output: Path) -> None:
+        products = _make_products(10)
+        files = generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        assert len(files) == 6
+
+    def test_batch_size_zero_disables_batching(self, tmp_output: Path) -> None:
+        products = _make_products(200)
+        files = generate_pipeline("TestCat", products, str(tmp_output), batch_size=0)
+        names = [f.name for f in files]
+        assert "PIPELINE__test-cat__01_insert_products.sql" in names
+        assert not any("_batch_" in n for n in names)
+
+
+# ---------------------------------------------------------------------------
+# Batched mode (> batch_size → batch files)
+# ---------------------------------------------------------------------------
+
+
+class TestBatchedMode:
+    """When product count > batch_size, steps 01 and 03 are split into batch files."""
+
+    def test_batch_file_count(self, tmp_output: Path) -> None:
+        products = _make_products(250)
+        files = generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        names = [f.name for f in files]
+        # 3 batch files for 01 + 3 batch files for 03 + 4 single files (04-07) = 10
+        assert len(files) == 10
+        batch_01 = [n for n in names if "01_batch" in n]
+        batch_03 = [n for n in names if "03_batch" in n]
+        assert len(batch_01) == 3
+        assert len(batch_03) == 3
+
+    def test_batch_filenames_sort_correctly(self, tmp_output: Path) -> None:
+        products = _make_products(250)
+        files = generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        names = [f.name for f in files]
+        # Verify batch numbering is zero-padded and sorts correctly
+        batch_01 = sorted(n for n in names if "01_batch" in n)
+        assert batch_01 == [
+            "PIPELINE__test-cat__01_batch_001_insert_products.sql",
+            "PIPELINE__test-cat__01_batch_002_insert_products.sql",
+            "PIPELINE__test-cat__01_batch_003_insert_products.sql",
+        ]
+
+    def test_batch_naming_pattern(self, tmp_output: Path) -> None:
+        products = _make_products(150)
+        files = generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        names = [f.name for f in files]
+        assert "PIPELINE__test-cat__01_batch_001_insert_products.sql" in names
+        assert "PIPELINE__test-cat__01_batch_002_insert_products.sql" in names
+        assert "PIPELINE__test-cat__03_batch_001_add_nutrition.sql" in names
+        assert "PIPELINE__test-cat__03_batch_002_add_nutrition.sql" in names
+
+    def test_steps_04_through_07_remain_single(self, tmp_output: Path) -> None:
+        products = _make_products(200)
+        files = generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        names = [f.name for f in files]
+        assert "PIPELINE__test-cat__04_scoring.sql" in names
+        assert "PIPELINE__test-cat__05_source_provenance.sql" in names
+        assert "PIPELINE__test-cat__06_add_images.sql" in names
+        assert "PIPELINE__test-cat__07_store_availability.sql" in names
+
+
+# ---------------------------------------------------------------------------
+# Batch SQL content validation
+# ---------------------------------------------------------------------------
+
+
+class TestBatchContent:
+    """Validate SQL content in batch files."""
+
+    def test_first_batch_has_preamble(self, tmp_output: Path) -> None:
+        products = _make_products(150)
+        generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        batch1 = (tmp_output / "PIPELINE__test-cat__01_batch_001_insert_products.sql").read_text()
+        assert "0a. DEPRECATE old products" in batch1
+        assert "0b. Release EANs" in batch1
+        assert "0c. Deprecate cross-category" in batch1
+
+    def test_middle_batch_no_preamble(self, tmp_output: Path) -> None:
+        products = _make_products(350)
+        generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        batch2 = (tmp_output / "PIPELINE__test-cat__01_batch_002_insert_products.sql").read_text()
+        assert "0a. DEPRECATE" not in batch2
+        assert "0b. Release" not in batch2
+        assert "0c. Deprecate cross-category" not in batch2
+
+    def test_last_batch_has_postscript(self, tmp_output: Path) -> None:
+        products = _make_products(150)
+        generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        batch2 = (tmp_output / "PIPELINE__test-cat__01_batch_002_insert_products.sql").read_text()
+        assert "2. DEPRECATE removed products" in batch2
+
+    def test_postscript_lists_all_products(self, tmp_output: Path) -> None:
+        products = _make_products(150)
+        generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        batch2 = (tmp_output / "PIPELINE__test-cat__01_batch_002_insert_products.sql").read_text()
+        # All 150 product names should be listed in the NOT IN clause
+        for p in products:
+            assert p["product_name"] in batch2
+
+    def test_every_batch_has_on_conflict(self, tmp_output: Path) -> None:
+        products = _make_products(250)
+        generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        for i in range(1, 4):
+            path = tmp_output / f"PIPELINE__test-cat__01_batch_{i:03d}_insert_products.sql"
+            content = path.read_text()
+            assert "on conflict (country, brand, product_name)" in content.lower()
+
+    def test_nutrition_batch_1_has_delete(self, tmp_output: Path) -> None:
+        products = _make_products(150)
+        generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        batch1 = (tmp_output / "PIPELINE__test-cat__03_batch_001_add_nutrition.sql").read_text()
+        assert "delete from nutrition_facts" in batch1.lower()
+
+    def test_nutrition_batch_2_no_delete(self, tmp_output: Path) -> None:
+        products = _make_products(150)
+        generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        batch2 = (tmp_output / "PIPELINE__test-cat__03_batch_002_add_nutrition.sql").read_text()
+        assert "delete from nutrition_facts" not in batch2.lower()
+
+    def test_nutrition_all_batches_have_on_conflict(self, tmp_output: Path) -> None:
+        products = _make_products(250)
+        generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        for i in range(1, 4):
+            path = tmp_output / f"PIPELINE__test-cat__03_batch_{i:03d}_add_nutrition.sql"
+            content = path.read_text()
+            assert "on conflict (product_id)" in content.lower()
+
+    def test_batch_header_comment(self, tmp_output: Path) -> None:
+        products = _make_products(150)
+        generate_pipeline("TestCat", products, str(tmp_output), batch_size=100)
+        batch1 = (tmp_output / "PIPELINE__test-cat__01_batch_001_insert_products.sql").read_text()
+        assert "Batch 1/2: products 1-100" in batch1
+        batch2 = (tmp_output / "PIPELINE__test-cat__01_batch_002_insert_products.sql").read_text()
+        assert "Batch 2/2: products 101-150" in batch2
+
+
+# ---------------------------------------------------------------------------
+# Stale file cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestStaleFileCleanup:
+    """Switching between single-file and batched modes cleans up stale files."""
+
+    def test_single_to_batch_cleans_single_files(self, tmp_output: Path) -> None:
+        # First run: small → single files
+        generate_pipeline("TestCat", _make_products(50), str(tmp_output), batch_size=100)
+        assert (tmp_output / "PIPELINE__test-cat__01_insert_products.sql").exists()
+
+        # Second run: large → batch files (should delete single file)
+        generate_pipeline("TestCat", _make_products(200), str(tmp_output), batch_size=100)
+        assert not (tmp_output / "PIPELINE__test-cat__01_insert_products.sql").exists()
+        assert (tmp_output / "PIPELINE__test-cat__01_batch_001_insert_products.sql").exists()
+
+    def test_batch_to_single_cleans_batch_files(self, tmp_output: Path) -> None:
+        # First run: large → batch files
+        generate_pipeline("TestCat", _make_products(200), str(tmp_output), batch_size=100)
+        assert (tmp_output / "PIPELINE__test-cat__01_batch_001_insert_products.sql").exists()
+
+        # Second run: small → single files (should delete batch files)
+        generate_pipeline("TestCat", _make_products(50), str(tmp_output), batch_size=100)
+        assert (tmp_output / "PIPELINE__test-cat__01_insert_products.sql").exists()
+        assert not (tmp_output / "PIPELINE__test-cat__01_batch_001_insert_products.sql").exists()
+
+    def test_rebatch_cleans_old_batches(self, tmp_output: Path) -> None:
+        # First run: 300 products → 3 batches
+        generate_pipeline("TestCat", _make_products(300), str(tmp_output), batch_size=100)
+        assert (tmp_output / "PIPELINE__test-cat__01_batch_003_insert_products.sql").exists()
+
+        # Second run: 150 products → 2 batches (batch 003 should be deleted)
+        generate_pipeline("TestCat", _make_products(150), str(tmp_output), batch_size=100)
+        assert (tmp_output / "PIPELINE__test-cat__01_batch_002_insert_products.sql").exists()
+        assert not (tmp_output / "PIPELINE__test-cat__01_batch_003_insert_products.sql").exists()
+
+
+# ---------------------------------------------------------------------------
+# check_pipeline_structure.py integration
+# ---------------------------------------------------------------------------
+
+
+class TestStructureCheckerCompat:
+    """Verify check_pipeline_structure.py recognises batch files."""
+
+    def test_batch_files_satisfy_required_steps(self, tmp_output: Path) -> None:
+        from check_pipeline_structure import _check_required_files
+
+        products = _make_products(200)
+        generate_pipeline("test-cat", products, str(tmp_output), batch_size=100)
+        violations = _check_required_files("test-cat", tmp_output)
+        assert violations == []
+
+    def test_single_files_still_recognised(self, tmp_output: Path) -> None:
+        from check_pipeline_structure import _check_required_files
+
+        products = _make_products(50)
+        generate_pipeline("test-cat", products, str(tmp_output), batch_size=100)
+        violations = _check_required_files("test-cat", tmp_output)
+        assert violations == []


### PR DESCRIPTION
## Summary
Splits large category runs (>batch_size products) into multiple batch SQL files per step (01, 03) with independent transactions. Steps 04-07 remain single files.

## Changes
- **sql_generator.py:** Added BATCH_SIZE=100, _chunk(), _gen_01_batch(), _gen_03_batch(), rewrote generate_pipeline() with batch_size parameter
- **run.py:** Added --batch-size CLI argument, BATCH_SIZE import, passthrough to generate_pipeline()
- **check_pipeline_structure.py:** Added _BATCH_STEP_RE regex, updated _check_required_files() and check_category() to recognize batch filenames
- **RUN_LOCAL.ps1:** Added batch detection with [batch NNN/total] progress label
- **test_batch_sql.py:** 26 new tests (chunk, single-file compat, batch mode, content validation, stale cleanup, structure checker)

## Verification
- ruff: 0 errors
- pytest pipeline/: 106/106 pass (26 new + 55 CSV + 25 validator)
- check_pipeline_structure.py: 58 categories verified

Closes #864