### PR TITLE
feat(pipeline): automated retailer product scrapers for PL and DE markets (#863)

### DIFF
--- a/.github/workflows/scrape-products.yml
+++ b/.github/workflows/scrape-products.yml
@@ -1,0 +1,61 @@
+name: Scrape Products
+
+on:
+  schedule:
+    # Weekly: Monday 3 AM UTC
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+    inputs:
+      retailer:
+        description: 'Retailer to scrape (biedronka, rewe, or all)'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - biedronka
+          - rewe
+      max_products:
+        description: 'Maximum products per retailer'
+        required: false
+        default: '500'
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      matrix:
+        retailer: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.retailer != 'all' && fromJSON(format('["{0}"]', github.event.inputs.retailer)) || fromJSON('["biedronka","rewe"]') }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run scraper
+        run: |
+          python -m pipeline.scrape \
+            --retailer ${{ matrix.retailer }} \
+            --max-products ${{ github.event.inputs.max_products || '500' }} \
+            --output-dir scraped-data/${{ matrix.retailer }}
+
+      - name: Upload scraped CSV
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scraped-${{ matrix.retailer }}-${{ github.run_id }}
+          path: scraped-data/${{ matrix.retailer }}/*.csv
+          retention-days: 30
+          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Automated retailer product scrapers for PL and DE markets:
+  `BaseScraper` ABC with robots.txt compliance, 2s rate limiting, retry logic
+  (5xx/429 backoff), CSV export; `BiedronkaScraper` (bfrisco.pl, 16 categories)
+  and `REWEScraper` (rewe.de, 17 categories); CLI entry point `pipeline/scrape.py`;
+  GitHub Actions weekly workflow; DB migration adds 'scraper' source_type.
+  Includes 35-test pytest suite (#863)
 - Batch SQL generation for 10K scale: pipeline splits large category runs
   (>batch_size products) into multiple batch files per step (01, 03) with
   independent transactions, stale file cleanup, batch progress headers.

--- a/pipeline/scrape.py
+++ b/pipeline/scrape.py
@@ -1,0 +1,107 @@
+"""CLI entry point for the retailer product scrapers.
+
+Usage::
+
+    python -m pipeline.scrape --retailer biedronka --max-products 500
+    python -m pipeline.scrape --retailer rewe --max-products 500 --dry-run
+    python -m pipeline.scrape --retailer biedronka --output-dir db/pipelines/scraper-biedronka
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from pipeline.scrapers.base import BaseScraper
+
+# Registry of available scrapers — import lazily to keep CLI fast.
+SCRAPERS: dict[str, tuple[str, str]] = {
+    "biedronka": ("pipeline.scrapers.biedronka", "BiedronkaScraper"),
+    "rewe": ("pipeline.scrapers.rewe", "REWEScraper"),
+}
+
+
+def _load_scraper(name: str) -> type[BaseScraper]:
+    """Dynamically import and return a scraper class by registry name."""
+    if name not in SCRAPERS:
+        print(f"Unknown retailer: {name!r}", file=sys.stderr)
+        print(f"Available: {', '.join(sorted(SCRAPERS))}", file=sys.stderr)
+        sys.exit(1)
+    module_path, class_name = SCRAPERS[name]
+    import importlib
+
+    module = importlib.import_module(module_path)
+    return getattr(module, class_name)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Scrape retailer websites for product data and export to CSV.",
+    )
+    parser.add_argument(
+        "--retailer",
+        required=True,
+        choices=sorted(SCRAPERS),
+        help="Retailer to scrape.",
+    )
+    parser.add_argument(
+        "--max-products",
+        type=int,
+        default=500,
+        help="Maximum products to scrape (default: 500).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Directory for output CSV (default: db/pipelines/scraper-<retailer>/).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Scrape and validate without writing CSV files.",
+    )
+    args = parser.parse_args()
+
+    scraper_cls = _load_scraper(args.retailer)
+
+    # Infer country from the scraper class
+    country_map = {"biedronka": "PL", "rewe": "DE"}
+    country = country_map.get(args.retailer, "PL")
+
+    output_dir = args.output_dir or f"db/pipelines/scraper-{args.retailer}"
+
+    scraper = scraper_cls(
+        country=country,
+        output_dir=output_dir,
+        max_products=args.max_products,
+        dry_run=args.dry_run,
+    )
+
+    print(f"Scraping {args.retailer} ({country}) — max {args.max_products} products")
+    if args.dry_run:
+        print("  DRY RUN — no files will be written")
+
+    products = scraper.scrape_all()
+
+    print()
+    print("Scrape Summary")
+    print("=" * 40)
+    print(f"  Products scraped:  {len(products)}")
+
+    if not products:
+        print("  No products found.")
+        sys.exit(0)
+
+    if args.dry_run:
+        print("  Dry run complete — no CSV written.")
+        sys.exit(0)
+
+    csv_path = scraper.to_csv(products)
+    print(f"  CSV written:       {csv_path}")
+    print()
+    print("Next step: import this CSV via the pipeline:")
+    print(f"  python -m pipeline.csv_import --file {csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/scrapers/__init__.py
+++ b/pipeline/scrapers/__init__.py
@@ -1,0 +1,1 @@
+"""Automated retailer product scrapers for PL and DE markets."""

--- a/pipeline/scrapers/base.py
+++ b/pipeline/scrapers/base.py
@@ -1,0 +1,328 @@
+"""Abstract base scraper with robots.txt compliance, rate limiting, and CSV export.
+
+All retailer scrapers inherit from BaseScraper, which enforces:
+  - robots.txt checking before any request
+  - Minimum 2-second delay between requests (polite scraping)
+  - User-Agent identification for webmaster transparency
+  - CSV output compatible with the CSVImporter (#862)
+  - Per-run product cap to prevent runaway scraping
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import os
+import time
+import urllib.robotparser
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# CSV columns matching the CSVImporter schema (#862).
+CSV_COLUMNS = [
+    "ean",
+    "brand",
+    "product_name",
+    "category",
+    "country",
+    "calories_kcal",
+    "total_fat_g",
+    "saturated_fat_g",
+    "carbs_g",
+    "sugars_g",
+    "fibre_g",
+    "protein_g",
+    "salt_g",
+    "trans_fat_g",
+    "nutri_score_label",
+    "nova_group",
+    "ingredients_text",
+    "product_type",
+    "prep_method",
+    "store_availability",
+    "controversies",
+]
+
+
+class ScrapingAbortedError(Exception):
+    """Raised when too many consecutive errors occur."""
+
+
+class BaseScraper(ABC):
+    """Abstract base for all retailer product scrapers.
+
+    Subclasses must implement:
+      - get_base_url()       → retailer root URL
+      - get_category_urls()  → list of category page URLs to crawl
+      - parse_product_list() → extract product page URLs from category page
+      - parse_product_page() → extract product data from product detail page
+    """
+
+    DELAY_SECONDS: float = 2.0
+    USER_AGENT: str = "TryVitBot/1.0 (+https://github.com/ericsocrat/tryvit)"
+    MAX_PRODUCTS_PER_RUN: int = 5000
+    MAX_CONSECUTIVE_ERRORS: int = 10
+    MAX_RETRIES: int = 3
+    BACKOFF_429_SECONDS: float = 60.0
+
+    def __init__(
+        self,
+        country: str,
+        output_dir: str = "scraper_output",
+        *,
+        max_products: int | None = None,
+        dry_run: bool = False,
+    ) -> None:
+        if country not in ("PL", "DE"):
+            msg = f"country must be 'PL' or 'DE', got {country!r}"
+            raise ValueError(msg)
+        self.country = country
+        self.output_dir = output_dir
+        self.max_products = min(max_products or self.MAX_PRODUCTS_PER_RUN, self.MAX_PRODUCTS_PER_RUN)
+        self.dry_run = dry_run
+        self._robot_parser: urllib.robotparser.RobotFileParser | None = None
+        self._robots_allowed: bool | None = None
+        self._last_request_time: float = 0.0
+        self._session = requests.Session()
+        self._session.headers.update({"User-Agent": self.USER_AGENT})
+        self.stats = {"fetched": 0, "valid": 0, "skipped": 0, "errors": 0}
+        self._consecutive_errors = 0
+
+    # ── Abstract interface ────────────────────────────────────────────
+
+    @abstractmethod
+    def get_base_url(self) -> str:
+        """Return the retailer's root URL (e.g. 'https://bfrisco.pl')."""
+
+    @abstractmethod
+    def get_category_urls(self) -> list[str]:
+        """Return list of category/listing page URLs to crawl."""
+
+    @abstractmethod
+    def parse_product_list(self, html: str, url: str) -> list[str]:
+        """Extract product detail page URLs from a category/listing page."""
+
+    @abstractmethod
+    def parse_product_page(self, html: str, url: str) -> dict | None:
+        """Parse a single product page into a dict with CSV-compatible keys.
+
+        Must return at minimum: ean, brand, product_name, category
+        The country and source fields are added automatically.
+        Return None to skip the product.
+        """
+
+    # ── robots.txt ────────────────────────────────────────────────────
+
+    def check_robots_txt(self, url: str | None = None) -> bool:
+        """Check robots.txt for the base domain. Returns True if allowed."""
+        if self._robots_allowed is not None:
+            return self._robots_allowed
+
+        base = url or self.get_base_url()
+        robots_url = f"{base.rstrip('/')}/robots.txt"
+        rp = urllib.robotparser.RobotFileParser()
+        rp.set_url(robots_url)
+        try:
+            rp.read()
+        except Exception:
+            logger.warning("Could not fetch robots.txt from %s — assuming allowed", robots_url)
+            self._robots_allowed = True
+            return True
+
+        self._robot_parser = rp
+        self._robots_allowed = rp.can_fetch(self.USER_AGENT, base)
+        if not self._robots_allowed:
+            logger.warning("robots.txt DISALLOWS scraping %s for %s", base, self.USER_AGENT)
+        return self._robots_allowed
+
+    def is_path_allowed(self, url: str) -> bool:
+        """Check if a specific URL path is allowed by robots.txt."""
+        if self._robot_parser is None:
+            return self.check_robots_txt()
+        return self._robot_parser.can_fetch(self.USER_AGENT, url)
+
+    # ── HTTP with rate limiting ───────────────────────────────────────
+
+    def _wait_for_delay(self) -> None:
+        """Enforce minimum delay between requests."""
+        elapsed = time.monotonic() - self._last_request_time
+        if elapsed < self.DELAY_SECONDS:
+            time.sleep(self.DELAY_SECONDS - elapsed)
+
+    def polite_get(self, url: str) -> str | None:
+        """GET a URL with rate limiting, retry on 5xx, robots.txt respect.
+
+        Returns HTML string or None on failure.
+        """
+        if not self.is_path_allowed(url):
+            logger.info("Skipping disallowed URL: %s", url)
+            self.stats["skipped"] += 1
+            return None
+
+        for attempt in range(1, self.MAX_RETRIES + 1):
+            self._wait_for_delay()
+            self._last_request_time = time.monotonic()
+            try:
+                resp = self._session.get(url, timeout=30)
+            except requests.RequestException as exc:
+                logger.warning("Request error on %s (attempt %d): %s", url, attempt, exc)
+                if attempt == self.MAX_RETRIES:
+                    self.stats["errors"] += 1
+                    return None
+                time.sleep(self.DELAY_SECONDS * attempt)
+                continue
+
+            if resp.status_code == 200:
+                self._consecutive_errors = 0
+                return resp.text
+
+            if resp.status_code == 404:
+                logger.debug("404 for %s — skipping", url)
+                self.stats["skipped"] += 1
+                return None
+
+            if resp.status_code == 429:
+                logger.warning("Rate limited (429) on %s — backing off %.0fs", url, self.BACKOFF_429_SECONDS)
+                time.sleep(self.BACKOFF_429_SECONDS)
+                if attempt == self.MAX_RETRIES:
+                    self.stats["errors"] += 1
+                    return None
+                continue
+
+            if resp.status_code >= 500:
+                logger.warning("Server error %d on %s (attempt %d)", resp.status_code, url, attempt)
+                if attempt == self.MAX_RETRIES:
+                    self.stats["errors"] += 1
+                    return None
+                time.sleep(self.DELAY_SECONDS * (2 ** attempt))
+                continue
+
+            # Other client errors (403, etc.)
+            logger.warning("HTTP %d for %s — skipping", resp.status_code, url)
+            self.stats["skipped"] += 1
+            return None
+
+        self.stats["errors"] += 1
+        return None
+
+    # ── Main scrape loop ──────────────────────────────────────────────
+
+    def scrape_all(self) -> list[dict]:
+        """Discover and scrape products from all category pages.
+
+        Returns list of validated product dicts.
+        """
+        if not self.check_robots_txt():
+            logger.error("Aborting: robots.txt disallows scraping %s", self.get_base_url())
+            return []
+
+        products: list[dict] = []
+        category_urls = self.get_category_urls()
+        logger.info(
+            "Scraping %d categories from %s (max %d products)",
+            len(category_urls), self.get_base_url(), self.max_products,
+        )
+
+        for cat_url in category_urls:
+            if len(products) >= self.max_products:
+                break
+
+            html = self.polite_get(cat_url)
+            if html is None:
+                continue
+
+            product_urls = self.parse_product_list(html, cat_url)
+            logger.info("Found %d product URLs on %s", len(product_urls), cat_url)
+
+            for prod_url in product_urls:
+                if len(products) >= self.max_products:
+                    break
+
+                if self._consecutive_errors >= self.MAX_CONSECUTIVE_ERRORS:
+                    logger.error("Aborting: %d consecutive errors", self._consecutive_errors)
+                    raise ScrapingAbortedError(f"{self._consecutive_errors} consecutive errors")
+
+                prod_html = self.polite_get(prod_url)
+                if prod_html is None:
+                    self._consecutive_errors += 1
+                    continue
+
+                self.stats["fetched"] += 1
+                try:
+                    product = self.parse_product_page(prod_html, prod_url)
+                except Exception:
+                    logger.exception("Parse error for %s", prod_url)
+                    self.stats["errors"] += 1
+                    self._consecutive_errors += 1
+                    continue
+
+                if product is None:
+                    self.stats["skipped"] += 1
+                    continue
+
+                if not self._validate_product(product):
+                    self.stats["skipped"] += 1
+                    continue
+
+                # Enrich with country and source provenance
+                product["country"] = self.country
+                product.setdefault("source_url", prod_url)
+                product.setdefault("prep_method", "not-applicable")
+                product.setdefault("controversies", "none")
+
+                products.append(product)
+                self.stats["valid"] += 1
+                self._consecutive_errors = 0
+
+        logger.info(
+            "Scrape complete: %d valid / %d fetched / %d skipped / %d errors",
+            self.stats["valid"],
+            self.stats["fetched"],
+            self.stats["skipped"],
+            self.stats["errors"],
+        )
+        return products
+
+    # ── Validation ────────────────────────────────────────────────────
+
+    @staticmethod
+    def _validate_product(product: dict) -> bool:
+        """Basic validation — EAN and product_name are mandatory."""
+        ean = product.get("ean", "")
+        if not ean or not isinstance(ean, str):
+            logger.debug("Skipping product without EAN")
+            return False
+        if not product.get("product_name"):
+            logger.debug("Skipping product without name")
+            return False
+        if not product.get("brand"):
+            logger.debug("Skipping product without brand")
+            return False
+        return True
+
+    # ── CSV export ────────────────────────────────────────────────────
+
+    def to_csv(self, products: list[dict], filename: str | None = None) -> str:
+        """Export products to CSV compatible with CSVImporter (#862).
+
+        Returns the path to the written CSV file.
+        """
+        if not filename:
+            retailer = type(self).__name__.lower().replace("scraper", "")
+            filename = f"{retailer}_{self.country}_{len(products)}.csv"
+
+        os.makedirs(self.output_dir, exist_ok=True)
+        path = str(Path(self.output_dir) / filename)
+
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS, extrasaction="ignore")
+            writer.writeheader()
+            for p in products:
+                writer.writerow(p)
+
+        logger.info("Wrote %d products to %s", len(products), path)
+        return path

--- a/pipeline/scrapers/biedronka.py
+++ b/pipeline/scrapers/biedronka.py
@@ -1,0 +1,214 @@
+"""Scraper for Biedronka products via bfrisco.pl (Biedronka's online platform).
+
+bfrisco.pl is the online grocery arm of Biedronka (Jeronimo Martins).
+Product pages include EAN barcodes, nutrition tables, and ingredient lists.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from pipeline.scrapers.base import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+# Category slugs on bfrisco.pl → TryVit category mapping.
+BFRISCO_CATEGORIES: dict[str, str] = {
+    "nabiał-jaja-i-masło": "Dairy",
+    "pieczywo": "Bread",
+    "napoje": "Drinks",
+    "słodycze-i-przekąski": "Sweets",
+    "mięso-wędliny-i-drób": "Meat",
+    "mrożonki": "Frozen & Prepared",
+    "płatki-musli-i-otręby": "Cereals",
+    "konserwy-i-przetwory": "Canned Goods",
+    "sosy-i-przyprawy": "Sauces",
+    "oliwy-oleje-i-octy": "Oils & Vinegars",
+    "ryby-i-owoce-morza": "Seafood & Fish",
+    "żywność-dla-dzieci": "Baby",
+    "produkty-instant": "Instant & Frozen",
+    "orzechy-i-bakalie": "Nuts, Seeds & Legumes",
+    "dżemy-miody-i-pasty": "Spreads & Dips",
+    "chipsy-i-krakersy": "Chips",
+}
+
+
+class BiedronkaScraper(BaseScraper):
+    """Scraper for Biedronka products via bfrisco.pl."""
+
+    BASE_URL = "https://www.bfrisco.pl"
+
+    def get_base_url(self) -> str:
+        return self.BASE_URL
+
+    def get_category_urls(self) -> list[str]:
+        """Return category listing URLs for food products."""
+        return [
+            f"{self.BASE_URL}/kategoria/{slug}"
+            for slug in BFRISCO_CATEGORIES
+        ]
+
+    def parse_product_list(self, html: str, url: str) -> list[str]:
+        """Extract product detail page URLs from a category listing page."""
+        try:
+            from bs4 import BeautifulSoup
+        except ImportError:
+            logger.error("beautifulsoup4 is required: pip install beautifulsoup4")
+            return []
+
+        soup = BeautifulSoup(html, "html.parser")
+        urls: list[str] = []
+        for link in soup.select("a.product-card__link, a[data-product-url]"):
+            href = link.get("href", "")
+            if href and "/produkt/" in href:
+                if href.startswith("/"):
+                    href = f"{self.BASE_URL}{href}"
+                urls.append(href)
+        return urls
+
+    def parse_product_page(self, html: str, url: str) -> dict | None:
+        """Extract product data from a bfrisco.pl product detail page."""
+        try:
+            from bs4 import BeautifulSoup
+        except ImportError:
+            return None
+
+        soup = BeautifulSoup(html, "html.parser")
+
+        # --- Product name ---
+        name_el = soup.select_one("h1.product-detail__name, h1[data-product-name]")
+        product_name = name_el.get_text(strip=True) if name_el else None
+        if not product_name:
+            return None
+
+        # --- Brand ---
+        brand_el = soup.select_one("span.product-detail__brand, [data-product-brand]")
+        brand = brand_el.get_text(strip=True) if brand_el else "Biedronka"
+
+        # --- EAN ---
+        ean = self._extract_ean(soup, html)
+        if not ean:
+            return None
+
+        # --- Category ---
+        category = self._detect_category(url)
+
+        # --- Nutrition table ---
+        nutrition = self._extract_nutrition(soup)
+
+        # --- Ingredients ---
+        ingredients = self._extract_ingredients(soup)
+
+        product: dict = {
+            "ean": ean,
+            "brand": brand,
+            "product_name": product_name,
+            "category": category,
+            "store_availability": "Biedronka",
+        }
+        product.update(nutrition)
+        if ingredients:
+            product["ingredients_text"] = ingredients
+
+        return product
+
+    # ── Private helpers ───────────────────────────────────────────────
+
+    def _detect_category(self, url: str) -> str:
+        """Map URL path to TryVit category."""
+        for slug, cat in BFRISCO_CATEGORIES.items():
+            if slug in url:
+                return cat
+        return "Snacks"  # fallback
+
+    @staticmethod
+    def _extract_ean(soup, html: str) -> str | None:
+        """Extract EAN-13 barcode from page metadata or structured data."""
+        # Try meta tags
+        for meta in soup.select("meta[itemprop='gtin13'], meta[property='product:ean']"):
+            val = meta.get("content", "").strip()
+            if val and len(val) in (8, 13) and val.isdigit():
+                return val
+
+        # Try data attributes
+        for el in soup.select("[data-ean], [data-product-ean]"):
+            val = (el.get("data-ean") or el.get("data-product-ean") or "").strip()
+            if val and len(val) in (8, 13) and val.isdigit():
+                return val
+
+        # Try JSON-LD structured data
+        ean_match = re.search(r'"gtin13"\s*:\s*"(\d{13})"', html)
+        if ean_match:
+            return ean_match.group(1)
+
+        return None
+
+    @staticmethod
+    def _extract_nutrition(soup) -> dict:
+        """Extract per-100g nutrition from the product page nutrition table."""
+        result: dict = {}
+        table = soup.select_one("table.nutrition-table, .product-nutrition table")
+        if not table:
+            return result
+
+        nutrient_map = {
+            "wartość energetyczna": "calories_kcal",
+            "energia": "calories_kcal",
+            "tłuszcz": "total_fat_g",
+            "kwasy tłuszczowe nasycone": "saturated_fat_g",
+            "węglowodany": "carbs_g",
+            "cukry": "sugars_g",
+            "błonnik": "fibre_g",
+            "białko": "protein_g",
+            "sól": "salt_g",
+        }
+
+        for row in table.select("tr"):
+            cells = row.select("td, th")
+            if len(cells) < 2:
+                continue
+            label = cells[0].get_text(strip=True).lower()
+            value_text = cells[1].get_text(strip=True)
+
+            for pl_name, csv_key in sorted(
+                nutrient_map.items(), key=lambda x: len(x[0]), reverse=True
+            ):
+                if pl_name in label:
+                    val = _parse_numeric(value_text)
+                    if val is not None:
+                        result[csv_key] = val
+                    break
+
+        return result
+
+    @staticmethod
+    def _extract_ingredients(soup) -> str | None:
+        """Extract ingredients text from the product page."""
+        for selector in (
+            ".product-ingredients",
+            "[data-ingredients]",
+            ".ingredients-list",
+        ):
+            el = soup.select_one(selector)
+            if el:
+                text = el.get_text(strip=True)
+                if text:
+                    return text
+        return None
+
+
+def _parse_numeric(text: str) -> float | None:
+    """Parse a numeric value from text like '12,5 g' or '450 kcal'."""
+    # Remove units and whitespace
+    cleaned = re.sub(r"[a-zA-Zμ%]+", "", text).strip()
+    # Handle Polish decimal separator
+    cleaned = cleaned.replace(",", ".")
+    # Handle ranges like "1200/287" (kJ/kcal) — take last number
+    if "/" in cleaned:
+        parts = cleaned.split("/")
+        cleaned = parts[-1].strip()
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None

--- a/pipeline/scrapers/rewe.py
+++ b/pipeline/scrapers/rewe.py
@@ -1,0 +1,214 @@
+"""Scraper for REWE products via rewe.de.
+
+REWE is one of Germany's largest supermarket chains. Their website
+provides product pages with EAN, nutrition tables, and ingredients.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from pipeline.scrapers.base import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+# REWE category slugs → TryVit category mapping.
+REWE_CATEGORIES: dict[str, str] = {
+    "milch-milchprodukte": "Dairy",
+    "brot-backwaren": "Bread",
+    "getraenke": "Drinks",
+    "suesswaren-knabbereien": "Sweets",
+    "fleisch-wurst": "Meat",
+    "tiefkuehlkost": "Frozen & Prepared",
+    "cerealien-muesli": "Cereals",
+    "konserven": "Canned Goods",
+    "saucen-gewuerze": "Sauces",
+    "oele-essig": "Oils & Vinegars",
+    "fisch-meeresfruechte": "Seafood & Fish",
+    "babynahrung": "Baby",
+    "fertiggerichte": "Instant & Frozen",
+    "nuesse-trockenobst": "Nuts, Seeds & Legumes",
+    "brotaufstriche": "Spreads & Dips",
+    "chips-salzgebaeck": "Chips",
+    "wurstwaren": "Condiments",
+}
+
+
+class REWEScraper(BaseScraper):
+    """Scraper for REWE products via rewe.de."""
+
+    BASE_URL = "https://www.rewe.de"
+
+    def get_base_url(self) -> str:
+        return self.BASE_URL
+
+    def get_category_urls(self) -> list[str]:
+        """Return category listing URLs for food products."""
+        return [
+            f"{self.BASE_URL}/c/{slug}/"
+            for slug in REWE_CATEGORIES
+        ]
+
+    def parse_product_list(self, html: str, url: str) -> list[str]:
+        """Extract product URLs from a REWE category listing page."""
+        try:
+            from bs4 import BeautifulSoup
+        except ImportError:
+            logger.error("beautifulsoup4 is required: pip install beautifulsoup4")
+            return []
+
+        soup = BeautifulSoup(html, "html.parser")
+        urls: list[str] = []
+        for link in soup.select("a.search-service-productDetailsLink, a[href*='/p/']"):
+            href = link.get("href", "")
+            if href and "/p/" in href:
+                if href.startswith("/"):
+                    href = f"{self.BASE_URL}{href}"
+                urls.append(href)
+        return urls
+
+    def parse_product_page(self, html: str, url: str) -> dict | None:
+        """Extract product data from a REWE product detail page."""
+        try:
+            from bs4 import BeautifulSoup
+        except ImportError:
+            return None
+
+        soup = BeautifulSoup(html, "html.parser")
+
+        # --- Product name ---
+        name_el = soup.select_one("h1.rs-qa-product-name, h1[data-qa='product-name']")
+        product_name = name_el.get_text(strip=True) if name_el else None
+        if not product_name:
+            return None
+
+        # --- Brand ---
+        brand_el = soup.select_one(".rs-qa-manufacturer, [data-qa='manufacturer']")
+        brand = brand_el.get_text(strip=True) if brand_el else "REWE"
+
+        # --- EAN ---
+        ean = self._extract_ean(soup, html)
+        if not ean:
+            return None
+
+        # --- Category ---
+        category = self._detect_category(url)
+
+        # --- Nutrition table ---
+        nutrition = self._extract_nutrition(soup)
+
+        # --- Ingredients ---
+        ingredients = self._extract_ingredients(soup)
+
+        product: dict = {
+            "ean": ean,
+            "brand": brand,
+            "product_name": product_name,
+            "category": category,
+            "store_availability": "REWE",
+        }
+        product.update(nutrition)
+        if ingredients:
+            product["ingredients_text"] = ingredients
+
+        return product
+
+    # ── Private helpers ───────────────────────────────────────────────
+
+    def _detect_category(self, url: str) -> str:
+        """Map URL path to TryVit category."""
+        for slug, cat in REWE_CATEGORIES.items():
+            if slug in url:
+                return cat
+        return "Snacks"
+
+    @staticmethod
+    def _extract_ean(soup, html: str) -> str | None:
+        """Extract EAN-13 barcode from page metadata or structured data."""
+        for meta in soup.select("meta[itemprop='gtin13'], meta[property='product:ean']"):
+            val = meta.get("content", "").strip()
+            if val and len(val) in (8, 13) and val.isdigit():
+                return val
+
+        for el in soup.select("[data-ean], [data-product-ean]"):
+            val = (el.get("data-ean") or el.get("data-product-ean") or "").strip()
+            if val and len(val) in (8, 13) and val.isdigit():
+                return val
+
+        ean_match = re.search(r'"gtin13"\s*:\s*"(\d{13})"', html)
+        if ean_match:
+            return ean_match.group(1)
+
+        return None
+
+    @staticmethod
+    def _extract_nutrition(soup) -> dict:
+        """Extract per-100g nutrition from the REWE nutrition table."""
+        result: dict = {}
+        table = soup.select_one(".nutrition-table, .pdd-NutritionTable table")
+        if not table:
+            return result
+
+        nutrient_map = {
+            "brennwert": "calories_kcal",
+            "energie": "calories_kcal",
+            "fett": "total_fat_g",
+            "gesättigte fettsäuren": "saturated_fat_g",
+            "davon gesättigte": "saturated_fat_g",
+            "kohlenhydrate": "carbs_g",
+            "zucker": "sugars_g",
+            "davon zucker": "sugars_g",
+            "ballaststoffe": "fibre_g",
+            "eiweiß": "protein_g",
+            "salz": "salt_g",
+        }
+
+        for row in table.select("tr"):
+            cells = row.select("td, th")
+            if len(cells) < 2:
+                continue
+            label = cells[0].get_text(strip=True).lower()
+            value_text = cells[1].get_text(strip=True)
+
+            for de_name, csv_key in sorted(
+                nutrient_map.items(), key=lambda x: len(x[0]), reverse=True
+            ):
+                if de_name in label:
+                    val = _parse_de_numeric(value_text)
+                    if val is not None:
+                        result[csv_key] = val
+                    break
+
+        return result
+
+    @staticmethod
+    def _extract_ingredients(soup) -> str | None:
+        """Extract ingredients text from the product page."""
+        for selector in (
+            ".pdd-Ingredients",
+            "[data-qa='ingredients']",
+            ".ingredients-section",
+        ):
+            el = soup.select_one(selector)
+            if el:
+                text = el.get_text(strip=True)
+                if text:
+                    return text
+        return None
+
+
+def _parse_de_numeric(text: str) -> float | None:
+    """Parse a numeric value from German-format text like '12,5 g' or '450 kcal'.
+
+    Handles German decimal separator (comma → dot).
+    """
+    cleaned = re.sub(r"[a-zA-Zμ%<>~]+", "", text).strip()
+    cleaned = cleaned.replace(",", ".")
+    if "/" in cleaned:
+        parts = cleaned.split("/")
+        cleaned = parts[-1].strip()
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None

--- a/pipeline/scrapers/test_scrapers.py
+++ b/pipeline/scrapers/test_scrapers.py
@@ -1,0 +1,326 @@
+"""Tests for pipeline.scrapers — retailer product scrapers.
+
+Covers: BaseScraper framework, robots.txt compliance, rate limiting,
+CSV export, product validation, Biedronka HTML parsing, REWE HTML parsing.
+All HTTP calls are mocked — no real network access.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pipeline.scrapers.base import CSV_COLUMNS, BaseScraper
+from pipeline.scrapers.biedronka import BiedronkaScraper, _parse_numeric
+from pipeline.scrapers.rewe import REWEScraper, _parse_de_numeric
+
+# ── Test fixtures ─────────────────────────────────────────────────────
+
+
+class FakeScraper(BaseScraper):
+    """Concrete subclass for testing the abstract BaseScraper."""
+
+    DELAY_SECONDS: float = 0.0  # No delay in tests
+
+    def get_base_url(self) -> str:
+        return "https://example.com"
+
+    def get_category_urls(self) -> list[str]:
+        return ["https://example.com/cat/food"]
+
+    def parse_product_list(self, html: str, url: str) -> list[str]:
+        return ["https://example.com/products/1"]
+
+    def parse_product_page(self, html: str, url: str) -> dict | None:
+        return {
+            "ean": "5901234567893",
+            "brand": "Test",
+            "product_name": "Test Product",
+            "category": "Dairy",
+        }
+
+
+# ── BaseScraper tests ─────────────────────────────────────────────────
+
+
+class TestBaseScraper:
+    def test_init_valid_country(self) -> None:
+        s = FakeScraper(country="PL")
+        assert s.country == "PL"
+        assert s.max_products <= BaseScraper.MAX_PRODUCTS_PER_RUN
+
+    def test_init_invalid_country(self) -> None:
+        with pytest.raises(ValueError, match="country must be"):
+            FakeScraper(country="US")
+
+    def test_max_products_capped(self) -> None:
+        s = FakeScraper(country="PL", max_products=999999)
+        assert s.max_products == BaseScraper.MAX_PRODUCTS_PER_RUN
+
+    def test_validate_product_valid(self) -> None:
+        p = {"ean": "5901234567893", "product_name": "X", "brand": "Y"}
+        assert BaseScraper._validate_product(p) is True
+
+    def test_validate_product_missing_ean(self) -> None:
+        p = {"product_name": "X", "brand": "Y"}
+        assert BaseScraper._validate_product(p) is False
+
+    def test_validate_product_missing_name(self) -> None:
+        p = {"ean": "5901234567893", "brand": "Y"}
+        assert BaseScraper._validate_product(p) is False
+
+    def test_validate_product_missing_brand(self) -> None:
+        p = {"ean": "5901234567893", "product_name": "X"}
+        assert BaseScraper._validate_product(p) is False
+
+
+class TestRobotsTxt:
+    @patch("urllib.robotparser.RobotFileParser.read")
+    @patch("urllib.robotparser.RobotFileParser.can_fetch", return_value=True)
+    def test_robots_allowed(self, mock_can_fetch: MagicMock, mock_read: MagicMock) -> None:
+        s = FakeScraper(country="PL")
+        assert s.check_robots_txt() is True
+        assert s._robots_allowed is True
+
+    @patch("urllib.robotparser.RobotFileParser.read")
+    @patch("urllib.robotparser.RobotFileParser.can_fetch", return_value=False)
+    def test_robots_disallowed(self, mock_can_fetch: MagicMock, mock_read: MagicMock) -> None:
+        s = FakeScraper(country="PL")
+        assert s.check_robots_txt() is False
+
+    @patch("urllib.robotparser.RobotFileParser.read", side_effect=Exception("network"))
+    def test_robots_fetch_error_allows(self, mock_read: MagicMock) -> None:
+        s = FakeScraper(country="PL")
+        assert s.check_robots_txt() is True  # graceful fallback
+
+
+class TestPoliteGet:
+    @patch.object(FakeScraper, "is_path_allowed", return_value=True)
+    def test_successful_get(self, mock_allowed: MagicMock) -> None:
+        s = FakeScraper(country="PL")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = "<html>OK</html>"
+        s._session.get = MagicMock(return_value=mock_resp)
+
+        result = s.polite_get("https://example.com/page")
+        assert result == "<html>OK</html>"
+
+    @patch.object(FakeScraper, "is_path_allowed", return_value=False)
+    def test_disallowed_path_skipped(self, mock_allowed: MagicMock) -> None:
+        s = FakeScraper(country="PL")
+        result = s.polite_get("https://example.com/private")
+        assert result is None
+        assert s.stats["skipped"] == 1
+
+    @patch.object(FakeScraper, "is_path_allowed", return_value=True)
+    def test_404_returns_none(self, mock_allowed: MagicMock) -> None:
+        s = FakeScraper(country="PL")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        s._session.get = MagicMock(return_value=mock_resp)
+
+        result = s.polite_get("https://example.com/missing")
+        assert result is None
+        assert s.stats["skipped"] == 1
+
+
+class TestCSVExport:
+    def test_csv_export_creates_file(self, tmp_path: Path) -> None:
+        s = FakeScraper(country="PL", output_dir=str(tmp_path))
+        products = [
+            {
+                "ean": "5901234567893",
+                "brand": "TestBrand",
+                "product_name": "Test Yogurt",
+                "category": "Dairy",
+                "country": "PL",
+                "calories_kcal": 65,
+                "total_fat_g": 3.2,
+            },
+        ]
+        path = s.to_csv(products, filename="test_out.csv")
+        assert Path(path).exists()
+
+        with open(path, encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+            assert len(rows) == 1
+            assert rows[0]["ean"] == "5901234567893"
+            assert rows[0]["brand"] == "TestBrand"
+
+    def test_csv_has_all_columns(self, tmp_path: Path) -> None:
+        s = FakeScraper(country="PL", output_dir=str(tmp_path))
+        product = {"ean": "1234567890123", "brand": "X", "product_name": "Y", "category": "Dairy", "country": "PL"}
+        path = s.to_csv([product])
+        with open(path, encoding="utf-8") as f:
+            reader = csv.reader(f)
+            header = next(reader)
+            assert header == CSV_COLUMNS
+
+
+class TestScrapeAll:
+    @patch.object(FakeScraper, "check_robots_txt", return_value=False)
+    def test_robots_blocked_returns_empty(self, mock_robots: MagicMock) -> None:
+        s = FakeScraper(country="PL")
+        result = s.scrape_all()
+        assert result == []
+
+    @patch.object(FakeScraper, "check_robots_txt", return_value=True)
+    @patch.object(FakeScraper, "polite_get")
+    def test_scrape_all_collects_products(self, mock_get: MagicMock, mock_robots: MagicMock) -> None:
+        s = FakeScraper(country="PL", max_products=1)
+        # First call = category page, second call = product page
+        mock_get.side_effect = ["<html>list</html>", "<html>product</html>"]
+        result = s.scrape_all()
+        assert len(result) == 1
+        assert result[0]["country"] == "PL"
+        assert result[0]["ean"] == "5901234567893"
+
+
+# ── Biedronka scraper tests ──────────────────────────────────────────
+
+
+class TestBiedronkaScraper:
+    def test_base_url(self) -> None:
+        s = BiedronkaScraper(country="PL")
+        assert "bfrisco.pl" in s.get_base_url()
+
+    def test_category_urls_not_empty(self) -> None:
+        s = BiedronkaScraper(country="PL")
+        urls = s.get_category_urls()
+        assert len(urls) > 0
+        assert all("bfrisco.pl" in u for u in urls)
+
+    def test_parse_product_list_empty_html(self) -> None:
+        s = BiedronkaScraper(country="PL")
+        urls = s.parse_product_list("<html><body></body></html>", "https://bfrisco.pl/cat")
+        assert urls == []
+
+    def test_parse_product_list_with_links(self) -> None:
+        html = """
+        <html><body>
+            <a class="product-card__link" href="/produkt/mleko-2-500ml">Mleko</a>
+            <a class="product-card__link" href="/produkt/jogurt-naturalny">Jogurt</a>
+        </body></html>
+        """
+        s = BiedronkaScraper(country="PL")
+        urls = s.parse_product_list(html, "https://www.bfrisco.pl/kategoria/nabial")
+        assert len(urls) == 2
+        assert all("/produkt/" in u for u in urls)
+
+    def test_parse_product_page_with_nutrition(self) -> None:
+        html = """
+        <html><body>
+            <h1 class="product-detail__name">Jogurt Naturalny 400g</h1>
+            <span class="product-detail__brand">Piątnica</span>
+            <meta itemprop="gtin13" content="5900820000123">
+            <table class="nutrition-table">
+                <tr><td>Wartość energetyczna</td><td>263 kJ / 63 kcal</td></tr>
+                <tr><td>Tłuszcz</td><td>3,2 g</td></tr>
+                <tr><td>Kwasy tłuszczowe nasycone</td><td>2,1 g</td></tr>
+                <tr><td>Węglowodany</td><td>4,6 g</td></tr>
+                <tr><td>Cukry</td><td>4,6 g</td></tr>
+                <tr><td>Białko</td><td>5,5 g</td></tr>
+                <tr><td>Sól</td><td>0,13 g</td></tr>
+            </table>
+        </body></html>
+        """
+        s = BiedronkaScraper(country="PL")
+        p = s.parse_product_page(html, "https://www.bfrisco.pl/produkt/jogurt-naturalny")
+        assert p is not None
+        assert p["product_name"] == "Jogurt Naturalny 400g"
+        assert p["brand"] == "Piątnica"
+        assert p["ean"] == "5900820000123"
+        assert p["calories_kcal"] == 63.0
+        assert p["total_fat_g"] == 3.2
+        assert p["protein_g"] == 5.5
+
+    def test_parse_product_page_no_ean_returns_none(self) -> None:
+        html = """
+        <html><body>
+            <h1 class="product-detail__name">Jogurt</h1>
+            <span class="product-detail__brand">Brand</span>
+        </body></html>
+        """
+        s = BiedronkaScraper(country="PL")
+        assert s.parse_product_page(html, "https://bfrisco.pl/p/x") is None
+
+
+class TestParseNumeric:
+    def test_plain_number(self) -> None:
+        assert _parse_numeric("12.5") == 12.5
+
+    def test_polish_decimal(self) -> None:
+        assert _parse_numeric("3,2 g") == 3.2
+
+    def test_kcal_slash(self) -> None:
+        assert _parse_numeric("263 kJ / 63 kcal") == 63.0
+
+    def test_invalid(self) -> None:
+        assert _parse_numeric("N/A") is None
+
+
+# ── REWE scraper tests ────────────────────────────────────────────────
+
+
+class TestREWEScraper:
+    def test_base_url(self) -> None:
+        s = REWEScraper(country="DE")
+        assert "rewe.de" in s.get_base_url()
+
+    def test_category_urls_not_empty(self) -> None:
+        s = REWEScraper(country="DE")
+        urls = s.get_category_urls()
+        assert len(urls) > 0
+        assert all("rewe.de" in u for u in urls)
+
+    def test_parse_product_list_empty(self) -> None:
+        s = REWEScraper(country="DE")
+        urls = s.parse_product_list("<html></html>", "https://rewe.de/c/x/")
+        assert urls == []
+
+    def test_parse_product_page_with_nutrition(self) -> None:
+        html = """
+        <html><body>
+            <h1 class="rs-qa-product-name">REWE Bio Vollmilch 3,5%</h1>
+            <span class="rs-qa-manufacturer">REWE Bio</span>
+            <meta itemprop="gtin13" content="4388860123456">
+            <table class="nutrition-table">
+                <tr><td>Brennwert</td><td>276 kJ / 66 kcal</td></tr>
+                <tr><td>Fett</td><td>3,5 g</td></tr>
+                <tr><td>davon gesättigte Fettsäuren</td><td>2,3 g</td></tr>
+                <tr><td>Kohlenhydrate</td><td>4,8 g</td></tr>
+                <tr><td>davon Zucker</td><td>4,8 g</td></tr>
+                <tr><td>Eiweiß</td><td>3,3 g</td></tr>
+                <tr><td>Salz</td><td>0,13 g</td></tr>
+            </table>
+        </body></html>
+        """
+        s = REWEScraper(country="DE")
+        p = s.parse_product_page(html, "https://www.rewe.de/p/bio-vollmilch/123")
+        assert p is not None
+        assert p["product_name"] == "REWE Bio Vollmilch 3,5%"
+        assert p["brand"] == "REWE Bio"
+        assert p["ean"] == "4388860123456"
+        assert p["calories_kcal"] == 66.0
+        assert p["total_fat_g"] == 3.5
+        assert p["saturated_fat_g"] == 2.3
+        assert p["protein_g"] == 3.3
+
+
+class TestParseDeNumeric:
+    def test_german_decimal(self) -> None:
+        assert _parse_de_numeric("3,5 g") == 3.5
+
+    def test_kcal_slash(self) -> None:
+        assert _parse_de_numeric("276 kJ / 66 kcal") == 66.0
+
+    def test_less_than(self) -> None:
+        assert _parse_de_numeric("<0,1 g") == 0.1
+
+    def test_invalid(self) -> None:
+        assert _parse_de_numeric("k.A.") is None

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@
 #
 # Do NOT edit requirements.txt directly — it is auto-generated from this file.
 
+beautifulsoup4>=4.12,<5
 requests>=2.31,<3
 tqdm>=4.66,<5
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -54,6 +54,7 @@ known-first-party = ["pipeline"]
 # Pipeline fetch/utility scripts: print() calls are intentional progress indicators
 "pipeline/run.py" = ["T20"]
 "pipeline/csv_import.py" = ["T20"]
+"pipeline/scrape.py" = ["T20"]
 "pipeline/image_importer.py" = ["T20"]
 "fetch_off_category.py" = ["T20"]
 "enrich_ingredients.py" = ["T20", "E501"]

--- a/supabase/migrations/20260318000500_add_scraper_source_type.sql
+++ b/supabase/migrations/20260318000500_add_scraper_source_type.sql
@@ -1,0 +1,14 @@
+-- Migration: add 'scraper' to products.source_type CHECK constraint
+-- Purpose: Enable automated retailer scrapers (#863) to mark their provenance
+-- Rollback: ALTER TABLE products DROP CONSTRAINT chk_products_source_type;
+--           ALTER TABLE products ADD CONSTRAINT chk_products_source_type
+--             CHECK (source_type IS NULL OR source_type IN ('off_api','manual','off_search','csv_import'));
+
+ALTER TABLE public.products
+  DROP CONSTRAINT IF EXISTS chk_products_source_type;
+
+ALTER TABLE public.products
+  ADD CONSTRAINT chk_products_source_type
+  CHECK (source_type IS NULL OR source_type IN (
+    'off_api', 'manual', 'off_search', 'csv_import', 'scraper'
+  ));


### PR DESCRIPTION
Implements #863 — automated retailer product scrapers for PL (Biedronka via bfrisco.pl) and DE (REWE via rewe.de) markets. BaseScraper ABC with robots.txt compliance, 2s rate limiting, retry logic. BiedronkaScraper (16 PL categories), REWEScraper (17 DE categories). CLI entry point, GitHub Actions weekly workflow, DB migration adds scraper source_type. 35-test pytest suite — all passing. Closes #863