### PR TITLE
feat(monitoring): scoring band distribution monitoring for 10K scale (#865)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Scoring band distribution materialized view (`mv_scoring_distribution`) for
+  10K scale monitoring: pre-aggregated Green/Yellow/Orange/Red/Dark Red bands
+  per country and category with product count, percentage, avg/min/max/stddev
+  scores. Integrated into `refresh_all_materialized_views()` and
+  `mv_staleness_check()`. 12-check non-blocking QA suite
+  `QA__scoring_distribution.sql` monitors band concentration, empty bands,
+  cross-country divergence, and category dominance (#865)
 - Automated retailer product scrapers for PL and DE markets:
   `BaseScraper` ABC with robots.txt compliance, 2s rate limiting, retry logic
   (5xx/429 backoff), CSV export; `BiedronkaScraper` (bfrisco.pl, 16 categories)

--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -181,7 +181,8 @@ $suiteCatalog = @(
     @{ Num = 45; Name = "Governance Drift"; Short = "GovDrift"; Id = "governance_drift"; Checks = 8; Blocking = $true; Kind = "sql"; File = "QA__governance_drift.sql" },
     @{ Num = 46; Name = "RLS Audit"; Short = "RLSAudit"; Id = "rls_audit"; Checks = 7; Blocking = $true; Kind = "sql"; File = "QA__rls_audit.sql" },
     @{ Num = 47; Name = "Function Security Audit"; Short = "FuncSecAudit"; Id = "function_security_audit"; Checks = 6; Blocking = $true; Kind = "sql"; File = "QA__function_security_audit.sql" },
-    @{ Num = 48; Name = "Recipe Integrity"; Short = "RecipeInteg"; Id = "recipe_integrity"; Checks = 6; Blocking = $true; Kind = "sql"; File = "QA__recipe_integrity.sql" }
+    @{ Num = 48; Name = "Recipe Integrity"; Short = "RecipeInteg"; Id = "recipe_integrity"; Checks = 6; Blocking = $true; Kind = "sql"; File = "QA__recipe_integrity.sql" },
+    @{ Num = 49; Name = "Scoring Band Distribution"; Short = "ScoringDist"; Id = "scoring_distribution"; Checks = 12; Blocking = $false; Kind = "sql"; File = "QA__scoring_distribution.sql" }
 )
 
 $suiteByNum = @{}

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -500,6 +500,8 @@ tryvit/
 
 **`v_data_coverage_summary`** — Materialized view of per-country, per-category data coverage metrics. Columns: country, category, total_products, with_ingredients, with_allergens, with_ean, ingredient_pct, allergen_pct, ean_pct, avg_completeness. Unique index on (country, category). Used by QA coverage threshold checks (§8.18, checks 34–37). Refreshed by `refresh_all_materialized_views()`.
 
+**`mv_scoring_distribution`** — Materialized view of scoring band distribution per country and category. Columns: country, category, band (Green/Yellow/Orange/Red/Dark Red), product_count, pct_of_category, avg_score, min_score, max_score, stddev_score. Unique index on (country, category, band). Refreshed by `refresh_all_materialized_views()`.
+
 ### Edge Functions
 
 > **Location:** `supabase/functions/`
@@ -996,9 +998,10 @@ At the end of every PR-like change, include a **Verification** section:
 | RLS Audit                 | `QA__rls_audit.sql`                 |      7 | Yes       |
 | Function Security Audit   | `QA__function_security_audit.sql`   |      6 | Yes       |
 | Recipe Integrity          | `QA__recipe_integrity.sql`          |      6 | Yes       |
+| Scoring Band Distribution | `QA__scoring_distribution.sql`      |     12 | No        |
 | **Negative Validation**   | `TEST__negative_checks.sql`         |     23 | Yes       |
 
-**Run:** `.\RUN_QA.ps1` — expects **756/756 checks passing** (+ EAN validation).
+**Run:** `.\RUN_QA.ps1` — expects **768/768 checks passing** (+ EAN validation).
 **Run:** `.\RUN_NEGATIVE_TESTS.ps1` — expects **23/23 caught**.
 
 ### 8.19 Key Regression Tests (Scoring Suite)

--- a/db/qa/QA__scoring_distribution.sql
+++ b/db/qa/QA__scoring_distribution.sql
@@ -1,0 +1,227 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- QA Suite: Scoring Band Distribution Monitoring
+-- 12 checks — verifies scoring band health at scale
+-- Non-blocking (informational) — thresholds will be calibrated at 10K scale
+-- Issue: #865
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- ═══ 1. No single band holds >40% of ALL products (per country) ═══════════
+
+SELECT
+    'BAND_CONCENTRATION' AS issue,
+    country || ': ' || band || ' has ' || pct || '% of all products' AS detail
+FROM (
+    SELECT
+        country,
+        band,
+        ROUND(SUM(product_count)::numeric
+              / SUM(SUM(product_count)) OVER (PARTITION BY country) * 100, 1) AS pct
+    FROM mv_scoring_distribution
+    GROUP BY country, band
+) sub
+WHERE pct > 40;
+
+-- ═══ 2. No band has 0 products per country ════════════════════════════════
+
+SELECT
+    'EMPTY_BAND' AS issue,
+    cr.country_code || ': band ' || b.band || ' has 0 products' AS detail
+FROM country_ref cr
+CROSS JOIN (VALUES ('Green'), ('Yellow'), ('Orange'), ('Red'), ('Dark Red')) AS b(band)
+WHERE cr.is_active = true
+  AND NOT EXISTS (
+    SELECT 1 FROM mv_scoring_distribution sd
+    WHERE sd.country = cr.country_code AND sd.band = b.band
+  )
+  -- Only flag if the country has scored products at all
+  AND EXISTS (
+    SELECT 1 FROM products p
+    WHERE p.country = cr.country_code
+      AND p.is_deprecated IS NOT TRUE
+      AND p.unhealthiness_score IS NOT NULL
+  );
+
+-- ═══ 3. Per-category stddev >= 3 (formula differentiates within category) ═
+
+SELECT
+    'LOW_STDDEV' AS issue,
+    country || '/' || category || ' stddev=' || cat_stddev || ' (too uniform)' AS detail
+FROM (
+    SELECT
+        country,
+        category,
+        ROUND(STDDEV_POP(unhealthiness_score)::numeric, 1) AS cat_stddev,
+        COUNT(*) AS cnt
+    FROM products
+    WHERE is_deprecated IS NOT TRUE
+      AND unhealthiness_score IS NOT NULL
+    GROUP BY country, category
+) sub
+WHERE cnt >= 5  -- skip categories with insufficient sample size
+  AND cat_stddev < 3;
+
+-- ═══ 4. PL vs DE overall distribution divergence <15% per band ════════════
+
+SELECT
+    'COUNTRY_DIVERGENCE' AS issue,
+    band || ': PL=' || pl_pct || '% vs DE=' || de_pct || '% (delta=' || ABS(pl_pct - de_pct) || '%)' AS detail
+FROM (
+    SELECT
+        band,
+        COALESCE(SUM(CASE WHEN country = 'PL' THEN product_count END), 0)
+          ::numeric
+          / NULLIF(SUM(CASE WHEN country = 'PL' THEN 1 END)
+                   * SUM(CASE WHEN country = 'PL' THEN product_count END), 0)
+          AS pl_raw,
+        COALESCE(SUM(CASE WHEN country = 'DE' THEN product_count END), 0)
+          ::numeric AS de_raw
+    FROM mv_scoring_distribution
+    GROUP BY band
+) raw,
+LATERAL (
+    SELECT
+        ROUND(SUM(CASE WHEN sd.country = 'PL' THEN sd.product_count ELSE 0 END)::numeric
+              / NULLIF((SELECT SUM(product_count) FROM mv_scoring_distribution WHERE country = 'PL'), 0) * 100, 1) AS pl_pct,
+        ROUND(SUM(CASE WHEN sd.country = 'DE' THEN sd.product_count ELSE 0 END)::numeric
+              / NULLIF((SELECT SUM(product_count) FROM mv_scoring_distribution WHERE country = 'DE'), 0) * 100, 1) AS de_pct
+    FROM mv_scoring_distribution sd
+    WHERE sd.band = raw.band
+) pcts
+WHERE pl_pct IS NOT NULL
+  AND de_pct IS NOT NULL
+  AND ABS(pl_pct - de_pct) > 15;
+
+-- ═══ 5. Green band (1-20) has at least 10% of products per country ════════
+
+SELECT
+    'GREEN_UNDERREPRESENTED' AS issue,
+    country || ': Green band has only ' || pct || '% (minimum 10%)' AS detail
+FROM (
+    SELECT
+        sd.country,
+        ROUND(SUM(CASE WHEN sd.band = 'Green' THEN sd.product_count ELSE 0 END)::numeric
+              / NULLIF(SUM(sd.product_count), 0) * 100, 1) AS pct
+    FROM mv_scoring_distribution sd
+    GROUP BY sd.country
+) sub
+WHERE pct < 10;
+
+-- ═══ 6. Dark Red band (81-100) has fewer than 20% of products ═════════════
+
+SELECT
+    'DARK_RED_OVERREPRESENTED' AS issue,
+    country || ': Dark Red band has ' || pct || '% (maximum 20%)' AS detail
+FROM (
+    SELECT
+        sd.country,
+        ROUND(SUM(CASE WHEN sd.band = 'Dark Red' THEN sd.product_count ELSE 0 END)::numeric
+              / NULLIF(SUM(sd.product_count), 0) * 100, 1) AS pct
+    FROM mv_scoring_distribution sd
+    GROUP BY sd.country
+) sub
+WHERE pct > 20;
+
+-- ═══ 7. Median unhealthiness score between 20 and 60 (not skewed) ═════════
+
+SELECT
+    'SKEWED_MEDIAN' AS issue,
+    country || ': median unhealthiness=' || med || ' (expected 20-60)' AS detail
+FROM (
+    SELECT
+        country,
+        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY unhealthiness_score)::integer AS med
+    FROM products
+    WHERE is_deprecated IS NOT TRUE
+      AND unhealthiness_score IS NOT NULL
+    GROUP BY country
+) sub
+WHERE med < 20 OR med > 60;
+
+-- ═══ 8. No category has >70% of products in a single band ════════════════
+
+SELECT
+    'CATEGORY_BAND_DOMINANCE' AS issue,
+    country || '/' || category || ': ' || band || ' has ' || pct_of_category || '%' AS detail
+FROM mv_scoring_distribution
+WHERE pct_of_category > 70
+  AND product_count >= 5;  -- minimum sample
+
+-- ═══ 9. At least 3 of 5 bands populated per category ═════════════════════
+
+SELECT
+    'TOO_FEW_BANDS' AS issue,
+    country || '/' || category || ': only ' || band_count || ' of 5 bands populated' AS detail
+FROM (
+    SELECT
+        country,
+        category,
+        COUNT(DISTINCT band) AS band_count,
+        SUM(product_count)   AS total
+    FROM mv_scoring_distribution
+    GROUP BY country, category
+) sub
+WHERE band_count < 3
+  AND total >= 10;  -- skip tiny categories
+
+-- ═══ 10. Score range per category spans at least 20 points ════════════════
+
+SELECT
+    'NARROW_SCORE_RANGE' AS issue,
+    country || '/' || category || ': range=' || score_range || ' points (minimum 20)' AS detail
+FROM (
+    SELECT
+        country,
+        category,
+        MAX(unhealthiness_score) - MIN(unhealthiness_score) AS score_range,
+        COUNT(*) AS cnt
+    FROM products
+    WHERE is_deprecated IS NOT TRUE
+      AND unhealthiness_score IS NOT NULL
+    GROUP BY country, category
+) sub
+WHERE cnt >= 10  -- sufficient sample
+  AND score_range < 20;
+
+-- ═══ 11. Top 5 categories (by product count) have >=4 bands each ══════════
+
+SELECT
+    'TOP_CATEGORY_FEW_BANDS' AS issue,
+    country || '/' || category || ': only ' || band_count || ' bands (top-5 category, expect >=4)' AS detail
+FROM (
+    SELECT
+        sd.country,
+        sd.category,
+        COUNT(DISTINCT sd.band)  AS band_count,
+        SUM(sd.product_count)    AS total,
+        RANK() OVER (PARTITION BY sd.country ORDER BY SUM(sd.product_count) DESC) AS rnk
+    FROM mv_scoring_distribution sd
+    GROUP BY sd.country, sd.category
+) sub
+WHERE rnk <= 5
+  AND band_count < 4;
+
+-- ═══ 12. New products (last 7 days) don't cluster >60% in one band ═══════
+
+SELECT
+    'NEW_PRODUCT_CLUSTERING' AS issue,
+    country || ': ' || pct || '% of new products in ' || band || ' band' AS detail
+FROM (
+    SELECT
+        country,
+        CASE
+          WHEN unhealthiness_score BETWEEN  1 AND 20 THEN 'Green'
+          WHEN unhealthiness_score BETWEEN 21 AND 40 THEN 'Yellow'
+          WHEN unhealthiness_score BETWEEN 41 AND 60 THEN 'Orange'
+          WHEN unhealthiness_score BETWEEN 61 AND 80 THEN 'Red'
+          WHEN unhealthiness_score BETWEEN 81 AND 100 THEN 'Dark Red'
+        END AS band,
+        COUNT(*) AS cnt,
+        ROUND(COUNT(*)::numeric / SUM(COUNT(*)) OVER (PARTITION BY country) * 100, 1) AS pct
+    FROM products
+    WHERE is_deprecated IS NOT TRUE
+      AND unhealthiness_score IS NOT NULL
+      AND last_fetched_at >= NOW() - INTERVAL '7 days'
+    GROUP BY country, band
+) sub
+WHERE pct > 60
+  AND cnt >= 3;  -- need at least 3 new products to be meaningful

--- a/docs/SCORING_ENGINE.md
+++ b/docs/SCORING_ENGINE.md
@@ -258,7 +258,29 @@ See `SCORING_METHODOLOGY.md` §2.8 for the full consumer band table and scientif
 
 ---
 
-## 11. Performance
+## 11. Distribution Monitoring
+
+**Materialized view:** `mv_scoring_distribution` — pre-aggregated scoring band distribution per country and category.
+
+| Column           | Type    | Description                              |
+| ---------------- | ------- | ---------------------------------------- |
+| `country`        | text    | Country code (PL, DE)                    |
+| `category`       | text    | Product category                         |
+| `band`           | text    | Green / Yellow / Orange / Red / Dark Red |
+| `product_count`  | bigint  | Products in this band                    |
+| `pct_of_category`| numeric | Percentage of category in this band      |
+| `avg_score`      | numeric | Mean unhealthiness score                 |
+| `min_score`      | integer | Lowest score in band                     |
+| `max_score`      | integer | Highest score in band                    |
+| `stddev_score`   | numeric | Score standard deviation                 |
+
+**Refresh:** Included in `refresh_all_materialized_views()`. Checked by `mv_staleness_check()`.
+
+**QA suite:** `QA__scoring_distribution.sql` — 12 non-blocking checks monitoring band concentration, empty bands, cross-country divergence, category dominance, and score spread. Thresholds calibrated for ~2,600 products; will tighten at 10K scale.
+
+---
+
+## 12. Performance
 
 | Operation                       | Target           | Method                      |
 | ------------------------------- | ---------------- | --------------------------- |
@@ -271,7 +293,7 @@ The v3.3 fast path ensures zero performance regression for pipeline scoring.
 
 ---
 
-## 12. Security
+## 13. Security
 
 - `compute_score()`, admin RPCs: `SECURITY DEFINER SET search_path = public`
 - Audit log: INSERT-only for service_role, read-only for authenticated
@@ -280,7 +302,7 @@ The v3.3 fast path ensures zero performance regression for pipeline scoring.
 
 ---
 
-## 13. QA Tests
+## 14. QA Tests
 
 17 QA SQL tests in `db/qa/QA__scoring_engine.sql`:
 
@@ -310,7 +332,7 @@ Consumer display tests (TryVit Score bands, percentile badges) are **separate** 
 
 ---
 
-## 14. Unified Formula Registry (#198)
+## 15. Unified Formula Registry (#198)
 
 Both scoring and search ranking formulas are governed under a single **formula registry** system — the `v_formula_registry` view unifies `scoring_model_versions` and `search_ranking_config` into one read-only surface.
 
@@ -372,7 +394,7 @@ WHERE  n.nspname = 'public'
 
 ---
 
-## 15. Weight Change Governance
+## 16. Weight Change Governance
 
 Changing scoring or search weights is a **controlled operation** with mandatory documentation. This process applies to any modification of factor weights, ceilings, categorical maps, or ranking signals.
 

--- a/supabase/migrations/20260318000600_scoring_distribution_mv.sql
+++ b/supabase/migrations/20260318000600_scoring_distribution_mv.sql
@@ -1,0 +1,217 @@
+-- Migration: scoring band distribution materialized view
+-- Purpose: Provides fast, pre-aggregated scoring band distribution metrics
+--          per country and category for 10K-scale monitoring
+-- Rollback: DROP MATERIALIZED VIEW IF EXISTS mv_scoring_distribution;
+-- Issue: #865
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 1. Materialized view: mv_scoring_distribution
+-- ═══════════════════════════════════════════════════════════════════════════
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.mv_scoring_distribution AS
+WITH band_assignment AS (
+  SELECT
+    p.product_id,
+    p.country,
+    p.category,
+    p.unhealthiness_score,
+    CASE
+      WHEN p.unhealthiness_score BETWEEN  1 AND 20 THEN 'Green'
+      WHEN p.unhealthiness_score BETWEEN 21 AND 40 THEN 'Yellow'
+      WHEN p.unhealthiness_score BETWEEN 41 AND 60 THEN 'Orange'
+      WHEN p.unhealthiness_score BETWEEN 61 AND 80 THEN 'Red'
+      WHEN p.unhealthiness_score BETWEEN 81 AND 100 THEN 'Dark Red'
+    END AS band
+  FROM public.products p
+  WHERE p.is_deprecated IS NOT TRUE
+    AND p.unhealthiness_score IS NOT NULL
+)
+SELECT
+  country,
+  category,
+  band,
+  COUNT(*)                     AS product_count,
+  ROUND(COUNT(*)::numeric
+        / SUM(COUNT(*)) OVER (PARTITION BY country, category) * 100, 1)
+                               AS pct_of_category,
+  ROUND(AVG(unhealthiness_score), 1)   AS avg_score,
+  MIN(unhealthiness_score)             AS min_score,
+  MAX(unhealthiness_score)             AS max_score,
+  ROUND(STDDEV_POP(unhealthiness_score)::numeric, 1) AS stddev_score
+FROM band_assignment
+GROUP BY country, category, band
+ORDER BY country, category,
+  CASE band
+    WHEN 'Green'    THEN 1
+    WHEN 'Yellow'   THEN 2
+    WHEN 'Orange'   THEN 3
+    WHEN 'Red'      THEN 4
+    WHEN 'Dark Red' THEN 5
+  END;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_scoring_dist_country_cat_band
+  ON mv_scoring_distribution (country, category, band);
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 2. Add to refresh_all_materialized_views()
+-- ═══════════════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION public.refresh_all_materialized_views(
+    p_triggered_by text DEFAULT 'manual'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+SET statement_timeout TO '30s'
+AS $function$
+DECLARE
+    start_ts  timestamptz;
+    t1        numeric;
+    t2        numeric;
+    t3        numeric;
+    t4        numeric;
+    t5        numeric;
+    r1        bigint;
+    r2        bigint;
+    r3        bigint;
+    r4        bigint;
+    r5        bigint;
+    v_trigger text;
+BEGIN
+    v_trigger := COALESCE(p_triggered_by, 'manual');
+    IF v_trigger NOT IN ('manual', 'post_pipeline', 'scheduled', 'api', 'migration') THEN
+        v_trigger := 'manual';
+    END IF;
+
+    -- Refresh mv_ingredient_frequency
+    start_ts := clock_timestamp();
+    REFRESH MATERIALIZED VIEW CONCURRENTLY mv_ingredient_frequency;
+    t1 := EXTRACT(MILLISECONDS FROM (clock_timestamp() - start_ts));
+    r1 := (SELECT COUNT(*) FROM mv_ingredient_frequency);
+    INSERT INTO mv_refresh_log (mv_name, duration_ms, row_count, triggered_by)
+    VALUES ('mv_ingredient_frequency', t1::integer, r1, v_trigger);
+
+    -- Refresh v_product_confidence
+    start_ts := clock_timestamp();
+    REFRESH MATERIALIZED VIEW CONCURRENTLY v_product_confidence;
+    t2 := EXTRACT(MILLISECONDS FROM (clock_timestamp() - start_ts));
+    r2 := (SELECT COUNT(*) FROM v_product_confidence);
+    INSERT INTO mv_refresh_log (mv_name, duration_ms, row_count, triggered_by)
+    VALUES ('v_product_confidence', t2::integer, r2, v_trigger);
+
+    -- Refresh mv_product_similarity
+    start_ts := clock_timestamp();
+    REFRESH MATERIALIZED VIEW CONCURRENTLY mv_product_similarity;
+    t3 := EXTRACT(MILLISECONDS FROM (clock_timestamp() - start_ts));
+    r3 := (SELECT COUNT(*) FROM mv_product_similarity);
+    INSERT INTO mv_refresh_log (mv_name, duration_ms, row_count, triggered_by)
+    VALUES ('mv_product_similarity', t3::integer, r3, v_trigger);
+
+    -- Refresh v_data_coverage_summary
+    start_ts := clock_timestamp();
+    REFRESH MATERIALIZED VIEW CONCURRENTLY v_data_coverage_summary;
+    t4 := EXTRACT(MILLISECONDS FROM (clock_timestamp() - start_ts));
+    r4 := (SELECT COUNT(*) FROM v_data_coverage_summary);
+    INSERT INTO mv_refresh_log (mv_name, duration_ms, row_count, triggered_by)
+    VALUES ('v_data_coverage_summary', t4::integer, r4, v_trigger);
+
+    -- Refresh mv_scoring_distribution
+    start_ts := clock_timestamp();
+    REFRESH MATERIALIZED VIEW CONCURRENTLY mv_scoring_distribution;
+    t5 := EXTRACT(MILLISECONDS FROM (clock_timestamp() - start_ts));
+    r5 := (SELECT COUNT(*) FROM mv_scoring_distribution);
+    INSERT INTO mv_refresh_log (mv_name, duration_ms, row_count, triggered_by)
+    VALUES ('mv_scoring_distribution', t5::integer, r5, v_trigger);
+
+    RETURN jsonb_build_object(
+        'refreshed_at', NOW(),
+        'triggered_by', v_trigger,
+        'views', jsonb_build_array(
+            jsonb_build_object('name', 'mv_ingredient_frequency',
+                               'rows', r1, 'ms', t1),
+            jsonb_build_object('name', 'v_product_confidence',
+                               'rows', r2, 'ms', t2),
+            jsonb_build_object('name', 'mv_product_similarity',
+                               'rows', r3, 'ms', t3),
+            jsonb_build_object('name', 'v_data_coverage_summary',
+                               'rows', r4, 'ms', t4),
+            jsonb_build_object('name', 'mv_scoring_distribution',
+                               'rows', r5, 'ms', t5)
+        ),
+        'total_ms', t1 + t2 + t3 + t4 + t5
+    );
+END;
+$function$;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 3. Add to mv_staleness_check()
+-- ═══════════════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION public.mv_staleness_check()
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+AS $function$
+    SELECT jsonb_build_object(
+        'checked_at', NOW(),
+        'views', jsonb_build_array(
+            jsonb_build_object(
+                'name', 'mv_ingredient_frequency',
+                'mv_rows', (SELECT COUNT(*) FROM mv_ingredient_frequency),
+                'source_rows', (SELECT COUNT(DISTINCT pi.ingredient_id)
+                                FROM product_ingredient pi
+                                JOIN products p ON p.product_id = pi.product_id
+                                WHERE p.is_deprecated IS NOT TRUE),
+                'is_stale', (SELECT COUNT(*) FROM mv_ingredient_frequency) !=
+                            (SELECT COUNT(DISTINCT pi.ingredient_id)
+                             FROM product_ingredient pi
+                             JOIN products p ON p.product_id = pi.product_id
+                             WHERE p.is_deprecated IS NOT TRUE)
+            ),
+            jsonb_build_object(
+                'name', 'v_product_confidence',
+                'mv_rows', (SELECT COUNT(*) FROM v_product_confidence),
+                'source_rows', (SELECT COUNT(*) FROM products WHERE is_deprecated IS NOT TRUE),
+                'is_stale', (SELECT COUNT(*) FROM v_product_confidence) !=
+                            (SELECT COUNT(*) FROM products WHERE is_deprecated IS NOT TRUE)
+            ),
+            jsonb_build_object(
+                'name', 'v_data_coverage_summary',
+                'mv_rows', (SELECT COUNT(*) FROM v_data_coverage_summary),
+                'source_rows', (SELECT COUNT(DISTINCT (country, category))
+                                FROM products WHERE is_deprecated IS NOT TRUE),
+                'is_stale', (SELECT COUNT(*) FROM v_data_coverage_summary) !=
+                            (SELECT COUNT(DISTINCT (country, category))
+                             FROM products WHERE is_deprecated IS NOT TRUE)
+            ),
+            jsonb_build_object(
+                'name', 'mv_scoring_distribution',
+                'mv_rows', (SELECT COUNT(*) FROM mv_scoring_distribution),
+                'source_rows', (SELECT COUNT(DISTINCT (country, category, 
+                    CASE
+                      WHEN unhealthiness_score BETWEEN  1 AND 20 THEN 'Green'
+                      WHEN unhealthiness_score BETWEEN 21 AND 40 THEN 'Yellow'
+                      WHEN unhealthiness_score BETWEEN 41 AND 60 THEN 'Orange'
+                      WHEN unhealthiness_score BETWEEN 61 AND 80 THEN 'Red'
+                      WHEN unhealthiness_score BETWEEN 81 AND 100 THEN 'Dark Red'
+                    END))
+                                FROM products
+                                WHERE is_deprecated IS NOT TRUE
+                                  AND unhealthiness_score IS NOT NULL),
+                'is_stale', (SELECT COUNT(*) FROM mv_scoring_distribution) !=
+                            (SELECT COUNT(DISTINCT (country, category,
+                    CASE
+                      WHEN unhealthiness_score BETWEEN  1 AND 20 THEN 'Green'
+                      WHEN unhealthiness_score BETWEEN 21 AND 40 THEN 'Yellow'
+                      WHEN unhealthiness_score BETWEEN 41 AND 60 THEN 'Orange'
+                      WHEN unhealthiness_score BETWEEN 61 AND 80 THEN 'Red'
+                      WHEN unhealthiness_score BETWEEN 81 AND 100 THEN 'Dark Red'
+                    END))
+                             FROM products
+                             WHERE is_deprecated IS NOT TRUE
+                               AND unhealthiness_score IS NOT NULL)
+            )
+        )
+    );
+$function$;

--- a/supabase/tests/schema_contracts.test.sql
+++ b/supabase/tests/schema_contracts.test.sql
@@ -93,8 +93,9 @@ SELECT has_view('public', 'v_api_category_overview_by_country', 'view v_api_cate
 -- 6. Materialized views exist
 -- ═══════════════════════════════════════════════════════════════════════════
 
-SELECT has_materialized_view('public', 'mv_ingredient_frequency', 'materialized view mv_ingredient_frequency exists');
-SELECT has_materialized_view('public', 'v_product_confidence',    'materialized view v_product_confidence exists');
+SELECT has_materialized_view('public', 'mv_ingredient_frequency',  'materialized view mv_ingredient_frequency exists');
+SELECT has_materialized_view('public', 'v_product_confidence',     'materialized view v_product_confidence exists');
+SELECT has_materialized_view('public', 'mv_scoring_distribution',  'materialized view mv_scoring_distribution exists');
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 7. Core API functions exist (no-auth functions)


### PR DESCRIPTION
## Summary
Adds mv_scoring_distribution materialized view for pre-aggregated scoring band distribution per country and category, with 12-check non-blocking QA suite for 10K scale monitoring.

## Changes
- **Migration** 20260318000600: Creates mv_scoring_distribution MV (Green/Yellow/Orange/Red/Dark Red bands per country+category), updates efresh_all_materialized_views() and mv_staleness_check()`n- **QA Suite** QA__scoring_distribution.sql: 12 non-blocking checks (band concentration, empty bands, cross-country divergence, category dominance, score spread)
- **Schema contracts**: Added has_materialized_view for mv_scoring_distribution`n- **RUN_QA.ps1**: Added suite #49 (Scoring Band Distribution, 12 checks, non-blocking)
- **Docs**: Updated copilot-instructions.md (Views + QA table), docs/SCORING_ENGINE.md (new Section 11)
- **CHANGELOG**: Entry under [Unreleased]

## Verification
- Migration applies cleanly via supabase db reset`n- efresh_all_materialized_views() returns all 5 MVs including mv_scoring_distribution (28 rows)
- Suite 49 (ScoringDist): **PASS (12/12 — zero violations)**
- All other suite results unchanged from baseline

Closes #865