### PR TITLE
feat(frontend): user product submission UX with scan-miss CTA and contributor badges (#867)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- User product submission UX: scan-miss CTA (`ScanMissSubmitCTA`) shown when
+  barcode not found, contributor badge (`ContributorBadge`) displaying tier
+  (bronze/silver/gold) based on approved submissions, missing-product CTA on
+  category pages linking to submit flow, TanStack Query hooks for submission
+  history and contributor stats (`useSubmissionHistory`,
+  `useContributorStats`, `useSubmitProduct`). Full i18n coverage (en/pl/de)
+  (#867)
 - Scheduled weekly data refresh orchestrator (`pipeline/orchestrate.py`):
   `PipelineOrchestrator` class sequences OFF API fetch → SQL execution →
   ingredient enrichment → scoring for all categories per country. Supports

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -310,6 +310,7 @@
     "notFoundMessage": "EAN: {ean} ist noch nicht in unserer Datenbank.",
     "alreadySubmitted": "Jemand hat dieses Produkt bereits eingereicht. Es wird gerade überprüft.",
     "helpAdd": "Helfen Sie uns, es hinzuzufügen!",
+    "helpAddHint": "Ihr Beitrag hilft allen, gesündere Optionen zu entdecken.",
     "noCamera": "Keine Kamera auf diesem Gerät gefunden.",
     "permissionDenied": "Kameraberechtigung verweigert. Bitte erlauben Sie den Kamerazugriff in Ihren Browsereinstellungen.",
     "cameraError": "Kamera konnte nicht gestartet werden. Versuchen Sie stattdessen die manuelle Eingabe.",
@@ -587,7 +588,9 @@
     "scoreRange": "TryVit Score Bereich",
     "nutriAB": "Nutri-Score A–B",
     "nova4Pct": "NOVA 4",
-    "bestInCategory": "★ Bester in der Kategorie"
+    "bestInCategory": "★ Bester in der Kategorie",
+    "missingProduct": "Produkt nicht gefunden?",
+    "submitIt": "Einreichen"
   },
   "compare": {
     "title": "Produkte vergleichen",
@@ -1907,5 +1910,10 @@
       "noSourceData": "Quellenangaben sind für dieses Produkt noch nicht verfügbar.",
       "ariaLabel": "Informationen zur Datenquelle"
     }
+  },
+  "contributor": {
+    "bronze": "Bronze-Beiträger",
+    "silver": "Silber-Beiträger",
+    "gold": "Gold-Beiträger"
   }
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -310,6 +310,7 @@
     "notFoundMessage": "EAN: {ean} is not in our database yet.",
     "alreadySubmitted": "Someone has already submitted this product. It's pending review.",
     "helpAdd": "Help us add it!",
+    "helpAddHint": "Your submission helps everyone discover healthier options.",
     "noCamera": "No camera found on this device.",
     "permissionDenied": "Camera permission denied. Please allow camera access in your browser settings.",
     "cameraError": "Could not start camera. Try manual entry instead.",
@@ -587,7 +588,9 @@
     "scoreRange": "TryVit Score Range",
     "nutriAB": "Nutri-Score A–B",
     "nova4Pct": "NOVA 4",
-    "bestInCategory": "★ Best in category"
+    "bestInCategory": "★ Best in category",
+    "missingProduct": "Can't find a product?",
+    "submitIt": "Submit it"
   },
   "compare": {
     "title": "Compare Products",
@@ -1907,5 +1910,10 @@
       "noSourceData": "Source attribution data is not yet available for this product.",
       "ariaLabel": "Data source information"
     }
+  },
+  "contributor": {
+    "bronze": "Bronze Contributor",
+    "silver": "Silver Contributor",
+    "gold": "Gold Contributor"
   }
 }

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -310,6 +310,7 @@
     "notFoundMessage": "EAN: {ean} nie jest jeszcze w naszej bazie danych.",
     "alreadySubmitted": "Ktoś już zgłosił ten produkt. Oczekuje na weryfikację.",
     "helpAdd": "Pomóż nam go dodać!",
+    "helpAddHint": "Twoje zgłoszenie pomaga wszystkim odkrywać zdrowsze opcje.",
     "noCamera": "Nie znaleziono kamery na tym urządzeniu.",
     "permissionDenied": "Brak uprawnień do kamery. Zezwól na dostęp do kamery w ustawieniach przeglądarki.",
     "cameraError": "Nie udało się uruchomić kamery. Spróbuj wpisać kod ręcznie.",
@@ -587,7 +588,9 @@
     "scoreRange": "Zakres wyników TryVit",
     "nutriAB": "Nutri-Score A–B",
     "nova4Pct": "NOVA 4",
-    "bestInCategory": "★ Najlepszy w kategorii"
+    "bestInCategory": "★ Najlepszy w kategorii",
+    "missingProduct": "Nie możesz znaleźć produktu?",
+    "submitIt": "Zgłoś go"
   },
   "compare": {
     "title": "Porównaj produkty",
@@ -1907,5 +1910,10 @@
       "noSourceData": "Dane o źródłach nie są jeszcze dostępne dla tego produktu.",
       "ariaLabel": "Informacje o źródłach danych"
     }
+  },
+  "contributor": {
+    "bronze": "Brązowy Kontrybutor",
+    "silver": "Srebrny Kontrybutor",
+    "gold": "Złoty Kontrybutor"
   }
 }

--- a/frontend/src/app/app/categories/[slug]/page.tsx
+++ b/frontend/src/app/app/categories/[slug]/page.tsx
@@ -274,6 +274,14 @@ export default function CategoryListingPage() {
           </Button>
         </div>
       )}
+
+      {/* Missing product CTA */}
+      <p className="text-center text-xs text-foreground-tertiary pt-2">
+        {t("categories.missingProduct")}{" "}
+        <Link href="/app/scan/submit" className="text-brand hover:text-brand-hover font-medium">
+          {t("categories.submitIt")}
+        </Link>
+      </p>
     </div>
     </PullToRefresh>
   );

--- a/frontend/src/app/app/scan/page.tsx
+++ b/frontend/src/app/app/scan/page.tsx
@@ -9,6 +9,7 @@ import { Button, ButtonLink } from "@/components/common/Button";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { PullToRefresh } from "@/components/common/PullToRefresh";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
+import { ScanMissSubmitCTA } from "@/components/scan/ScanMissSubmitCTA";
 import { useAnalytics } from "@/hooks/use-analytics";
 import { recordScan } from "@/lib/api";
 import { NUTRI_COLORS } from "@/lib/constants";
@@ -31,7 +32,6 @@ import {
     CheckCircle,
     ClipboardList,
     ClipboardPaste,
-    Clock,
     FileText,
     Flashlight,
     Keyboard,
@@ -372,24 +372,7 @@ export default function ScanPage() {
           </p>
         </div>
 
-        {hasPending ? (
-          <div className="card border-warning-border bg-warning-bg">
-            <p className="text-sm text-warning-text">
-              <span className="inline-flex items-center gap-1">
-                <Clock size={16} aria-hidden="true" />{" "}
-                {t("scan.alreadySubmitted")}
-              </span>
-            </p>
-          </div>
-        ) : (
-          <ButtonLink
-            href={`/app/scan/submit?ean=${ean}`}
-            fullWidth
-            icon={<FileText size={16} aria-hidden="true" />}
-          >
-            {t("scan.helpAdd")}
-          </ButtonLink>
-        )}
+        <ScanMissSubmitCTA ean={ean} hasPendingSubmission={hasPending} />
 
         <div className="flex gap-2">
           <Button

--- a/frontend/src/app/app/scan/submissions/page.tsx
+++ b/frontend/src/app/app/scan/submissions/page.tsx
@@ -11,6 +11,7 @@ import { queryKeys, staleTimes } from "@/lib/query-keys";
 import { createClient } from "@/lib/supabase/client";
 import type { Submission } from "@/lib/types";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { ContributorBadge } from "@/components/scan/ContributorBadge";
 import {
     CheckCircle,
     Clock,
@@ -96,6 +97,7 @@ export default function MySubmissionsPage() {
           <p className="text-sm text-foreground-secondary">
             {t("scan.submissionsSubtitle")}
           </p>
+          <ContributorBadge />
         </div>
         <Link
           href="/app/scan"

--- a/frontend/src/components/scan/ContributorBadge.test.tsx
+++ b/frontend/src/components/scan/ContributorBadge.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ContributorBadge } from "./ContributorBadge";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockUseContributorStats = vi.fn();
+
+vi.mock("@/hooks/use-submissions", () => ({
+  useContributorStats: () => mockUseContributorStats(),
+  // Re-export type to satisfy the import
+}));
+
+vi.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("ContributorBadge", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // ─── Null rendering cases ──────────────────────────────────────────────
+
+  it("renders nothing when loading", () => {
+    mockUseContributorStats.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    const { container } = render(<ContributorBadge />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when stats is null", () => {
+    mockUseContributorStats.mockReturnValue({
+      data: null,
+      isLoading: false,
+    });
+    const { container } = render(<ContributorBadge />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when tier is none", () => {
+    mockUseContributorStats.mockReturnValue({
+      data: { tier: "none", approved: 0, total: 0, pending: 0, rejected: 0, merged: 0 },
+      isLoading: false,
+    });
+    const { container } = render(<ContributorBadge />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  // ─── Badge rendering ──────────────────────────────────────────────────
+
+  it("renders bronze badge with approved count", () => {
+    mockUseContributorStats.mockReturnValue({
+      data: { tier: "bronze", approved: 3, total: 5, pending: 2, rejected: 0, merged: 0 },
+      isLoading: false,
+    });
+    render(<ContributorBadge />);
+    expect(screen.getByText(/contributor\.bronze/)).toBeTruthy();
+    expect(screen.getByText(/3/)).toBeTruthy();
+  });
+
+  it("renders silver badge", () => {
+    mockUseContributorStats.mockReturnValue({
+      data: { tier: "silver", approved: 15, total: 20, pending: 3, rejected: 2, merged: 0 },
+      isLoading: false,
+    });
+    render(<ContributorBadge />);
+    expect(screen.getByText(/contributor\.silver/)).toBeTruthy();
+  });
+
+  it("renders gold badge", () => {
+    mockUseContributorStats.mockReturnValue({
+      data: { tier: "gold", approved: 55, total: 60, pending: 3, rejected: 2, merged: 0 },
+      isLoading: false,
+    });
+    render(<ContributorBadge />);
+    expect(screen.getByText(/contributor\.gold/)).toBeTruthy();
+    expect(screen.getByText(/55/)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/scan/ContributorBadge.tsx
+++ b/frontend/src/components/scan/ContributorBadge.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useContributorStats, type ContributorTier } from "@/hooks/use-submissions";
+import { useTranslation } from "@/lib/i18n";
+import { Award } from "lucide-react";
+
+const TIER_STYLES: Record<
+  Exclude<ContributorTier, "none">,
+  { bg: string; text: string; labelKey: string }
+> = {
+  bronze: {
+    bg: "bg-amber-100 dark:bg-amber-900/30",
+    text: "text-amber-700 dark:text-amber-400",
+    labelKey: "contributor.bronze",
+  },
+  silver: {
+    bg: "bg-slate-100 dark:bg-slate-700/40",
+    text: "text-slate-600 dark:text-slate-300",
+    labelKey: "contributor.silver",
+  },
+  gold: {
+    bg: "bg-yellow-100 dark:bg-yellow-900/30",
+    text: "text-yellow-700 dark:text-yellow-400",
+    labelKey: "contributor.gold",
+  },
+};
+
+/** Inline badge showing the user's contributor tier based on approved submissions. */
+export function ContributorBadge() {
+  const { data: stats, isLoading } = useContributorStats();
+  const { t } = useTranslation();
+
+  if (isLoading || !stats || stats.tier === "none") return null;
+
+  const style = TIER_STYLES[stats.tier];
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${style.bg} ${style.text}`}
+    >
+      <Award size={12} aria-hidden="true" />
+      {t(style.labelKey)} · {stats.approved}
+    </span>
+  );
+}

--- a/frontend/src/components/scan/ScanMissSubmitCTA.test.tsx
+++ b/frontend/src/components/scan/ScanMissSubmitCTA.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ScanMissSubmitCTA } from "./ScanMissSubmitCTA";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/components/common/Button", () => ({
+  ButtonLink: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("ScanMissSubmitCTA", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // ─── Submit CTA (default state) ─────────────────────────────────────────
+
+  it("renders submit button when hasPendingSubmission is false", () => {
+    render(<ScanMissSubmitCTA ean="5901234123457" />);
+    expect(screen.getByText("scan.helpAdd")).toBeTruthy();
+  });
+
+  it("links to submit page with ean in query string", () => {
+    render(<ScanMissSubmitCTA ean="5901234123457" />);
+    const link = screen.getByRole("link");
+    expect(link.getAttribute("href")).toBe(
+      "/app/scan/submit?ean=5901234123457"
+    );
+  });
+
+  it("renders hint text below the button", () => {
+    render(<ScanMissSubmitCTA ean="5901234123457" />);
+    expect(screen.getByText("scan.helpAddHint")).toBeTruthy();
+  });
+
+  // ─── Pending submission warning ─────────────────────────────────────────
+
+  it("renders already-submitted warning when hasPendingSubmission is true", () => {
+    render(
+      <ScanMissSubmitCTA ean="5901234123457" hasPendingSubmission={true} />
+    );
+    expect(screen.getByText("scan.alreadySubmitted")).toBeTruthy();
+  });
+
+  it("does not render submit button when hasPendingSubmission is true", () => {
+    render(
+      <ScanMissSubmitCTA ean="5901234123457" hasPendingSubmission={true} />
+    );
+    expect(screen.queryByText("scan.helpAdd")).toBeNull();
+  });
+});

--- a/frontend/src/components/scan/ScanMissSubmitCTA.tsx
+++ b/frontend/src/components/scan/ScanMissSubmitCTA.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { ButtonLink } from "@/components/common/Button";
+import { useTranslation } from "@/lib/i18n";
+import { Clock, FileText } from "lucide-react";
+
+interface ScanMissSubmitCTAProps {
+  ean: string;
+  hasPendingSubmission?: boolean;
+}
+
+/** CTA shown when a scanned barcode is not found in the database. */
+export function ScanMissSubmitCTA({
+  ean,
+  hasPendingSubmission = false,
+}: ScanMissSubmitCTAProps) {
+  const { t } = useTranslation();
+
+  if (hasPendingSubmission) {
+    return (
+      <div className="card border-warning-border bg-warning-bg">
+        <p className="text-sm text-warning-text">
+          <span className="inline-flex items-center gap-1">
+            <Clock size={16} aria-hidden="true" />{" "}
+            {t("scan.alreadySubmitted")}
+          </span>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <ButtonLink
+        href={`/app/scan/submit?ean=${ean}`}
+        fullWidth
+        icon={<FileText size={16} aria-hidden="true" />}
+      >
+        {t("scan.helpAdd")}
+      </ButtonLink>
+      <p className="text-center text-xs text-foreground-muted">
+        {t("scan.helpAddHint")}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/hooks/use-submissions.test.tsx
+++ b/frontend/src/hooks/use-submissions.test.tsx
@@ -1,0 +1,226 @@
+import {
+  useContributorStats,
+  useSubmissionHistory,
+  useSubmitProduct,
+} from "@/hooks/use-submissions";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockGetMySubmissions = vi.fn();
+const mockSubmitProduct = vi.fn();
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({}),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getMySubmissions: (...args: unknown[]) => mockGetMySubmissions(...args),
+  submitProduct: (...args: unknown[]) => mockSubmitProduct(...args),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  showToast: vi.fn(),
+}));
+
+vi.mock("@/lib/events", () => ({
+  eventBus: { emit: vi.fn().mockResolvedValue(undefined) },
+}));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function makeSubmission(status: string) {
+  return {
+    submission_id: Math.random(),
+    ean: "5901234123457",
+    product_name: "Test Product",
+    brand: "Test Brand",
+    status,
+    created_at: new Date().toISOString(),
+  };
+}
+
+// ─── useSubmissionHistory ───────────────────────────────────────────────────
+
+describe("useSubmissionHistory", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches paginated submissions", async () => {
+    const data = { submissions: [makeSubmission("pending")], total: 1 };
+    mockGetMySubmissions.mockResolvedValue({ ok: true, data });
+
+    const { result } = renderHook(() => useSubmissionHistory(1, 20), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(data);
+    expect(mockGetMySubmissions).toHaveBeenCalledWith(expect.anything(), 1, 20);
+  });
+
+  it("throws on API error", async () => {
+    mockGetMySubmissions.mockResolvedValue({
+      ok: false,
+      error: { message: "Unauthorized" },
+    });
+
+    const { result } = renderHook(() => useSubmissionHistory(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe("Unauthorized");
+  });
+});
+
+// ─── useContributorStats ────────────────────────────────────────────────────
+
+describe("useContributorStats", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns none tier with no approved submissions", async () => {
+    const subs = [makeSubmission("pending"), makeSubmission("rejected")];
+    mockGetMySubmissions.mockResolvedValue({
+      ok: true,
+      data: { submissions: subs, total: 2 },
+    });
+
+    const { result } = renderHook(() => useContributorStats(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.tier).toBe("none");
+    expect(result.current.data?.approved).toBe(0);
+    expect(result.current.data?.pending).toBe(1);
+    expect(result.current.data?.rejected).toBe(1);
+  });
+
+  it("returns bronze tier with 1+ approved", async () => {
+    const subs = [makeSubmission("approved"), makeSubmission("pending")];
+    mockGetMySubmissions.mockResolvedValue({
+      ok: true,
+      data: { submissions: subs, total: 2 },
+    });
+
+    const { result } = renderHook(() => useContributorStats(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.tier).toBe("bronze");
+    expect(result.current.data?.approved).toBe(1);
+  });
+
+  it("returns silver tier with 10+ approved", async () => {
+    const subs = Array.from({ length: 10 }, () => makeSubmission("approved"));
+    mockGetMySubmissions.mockResolvedValue({
+      ok: true,
+      data: { submissions: subs, total: 10 },
+    });
+
+    const { result } = renderHook(() => useContributorStats(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.tier).toBe("silver");
+  });
+
+  it("returns gold tier with 50+ approved", async () => {
+    const subs = Array.from({ length: 50 }, () => makeSubmission("approved"));
+    mockGetMySubmissions.mockResolvedValue({
+      ok: true,
+      data: { submissions: subs, total: 50 },
+    });
+
+    const { result } = renderHook(() => useContributorStats(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.tier).toBe("gold");
+    expect(result.current.data?.approved).toBe(50);
+  });
+
+  it("counts merged as approved for tier calculation", async () => {
+    const subs = [makeSubmission("merged")];
+    mockGetMySubmissions.mockResolvedValue({
+      ok: true,
+      data: { submissions: subs, total: 1 },
+    });
+
+    const { result } = renderHook(() => useContributorStats(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.tier).toBe("bronze");
+    expect(result.current.data?.approved).toBe(1);
+    expect(result.current.data?.merged).toBe(1);
+  });
+});
+
+// ─── useSubmitProduct ───────────────────────────────────────────────────────
+
+describe("useSubmitProduct", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls submitProduct API and shows success toast", async () => {
+    mockSubmitProduct.mockResolvedValue({
+      ok: true,
+      data: { submission_id: 42 },
+    });
+
+    const { result } = renderHook(() => useSubmitProduct(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.mutate({
+        ean: "5901234123457",
+        productName: "New Product",
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockSubmitProduct).toHaveBeenCalledWith(expect.anything(), {
+      ean: "5901234123457",
+      productName: "New Product",
+    });
+  });
+
+  it("throws on API error", async () => {
+    mockSubmitProduct.mockResolvedValue({
+      ok: false,
+      error: { message: "Rate limited" },
+    });
+
+    const { result } = renderHook(() => useSubmitProduct(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.mutate({
+        ean: "5901234123457",
+        productName: "New Product",
+      });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe("Rate limited");
+  });
+});

--- a/frontend/src/hooks/use-submissions.ts
+++ b/frontend/src/hooks/use-submissions.ts
@@ -1,0 +1,121 @@
+// ─── TanStack Query hooks for Product Submissions ───────────────────────────
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import { getMySubmissions, submitProduct } from "@/lib/api";
+import { queryKeys, staleTimes } from "@/lib/query-keys";
+import { showToast } from "@/lib/toast";
+import { eventBus } from "@/lib/events";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type ContributorTier = "none" | "bronze" | "silver" | "gold";
+
+export interface ContributorStats {
+  total: number;
+  approved: number;
+  pending: number;
+  rejected: number;
+  merged: number;
+  tier: ContributorTier;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function computeTier(approvedCount: number): ContributorTier {
+  if (approvedCount >= 50) return "gold";
+  if (approvedCount >= 10) return "silver";
+  if (approvedCount >= 1) return "bronze";
+  return "none";
+}
+
+// ─── Queries ────────────────────────────────────────────────────────────────
+
+/** Paginated submission history. */
+export function useSubmissionHistory(page: number = 1, pageSize: number = 20) {
+  const supabase = createClient();
+
+  return useQuery({
+    queryKey: queryKeys.mySubmissions(page),
+    queryFn: async () => {
+      const result = await getMySubmissions(supabase, page, pageSize);
+      if (!result.ok) throw new Error(result.error.message);
+      return result.data;
+    },
+    staleTime: staleTimes.mySubmissions,
+  });
+}
+
+/**
+ * Contributor stats — fetches ALL submissions (page 1, large page size)
+ * and derives approved/pending/rejected/merged counts + tier badge.
+ */
+export function useContributorStats() {
+  const supabase = createClient();
+
+  return useQuery({
+    queryKey: queryKeys.contributorStats,
+    queryFn: async () => {
+      // Fetch a large page to get total + submission statuses
+      const result = await getMySubmissions(supabase, 1, 200);
+      if (!result.ok) throw new Error(result.error.message);
+
+      const subs = result.data.submissions;
+      const approved = subs.filter((s) => s.status === "approved").length;
+      const merged = subs.filter((s) => s.status === "merged").length;
+      const approvedTotal = approved + merged;
+
+      const stats: ContributorStats = {
+        total: result.data.total,
+        approved: approvedTotal,
+        pending: subs.filter((s) => s.status === "pending").length,
+        rejected: subs.filter((s) => s.status === "rejected").length,
+        merged,
+        tier: computeTier(approvedTotal),
+      };
+
+      return stats;
+    },
+    staleTime: staleTimes.contributorStats,
+  });
+}
+
+// ─── Mutations ──────────────────────────────────────────────────────────────
+
+/** Submit a new product. Invalidates submission caches on success. */
+export function useSubmitProduct() {
+  const supabase = createClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (params: {
+      ean: string;
+      productName: string;
+      brand?: string;
+      category?: string;
+      photoUrl?: string;
+      notes?: string;
+    }) => {
+      const result = await submitProduct(supabase, params);
+      if (!result.ok) throw new Error(result.error.message);
+      if (result.data.error) throw new Error(result.data.error);
+      return result.data;
+    },
+    onSuccess: (_data, variables) => {
+      showToast({ type: "success", messageKey: "submit.successToast" });
+      void eventBus.emit({
+        type: "product.submitted",
+        payload: { ean: variables.ean },
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["my-submissions"],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.contributorStats,
+      });
+    },
+    onError: (error: Error) => {
+      showToast({ type: "error", message: error.message });
+    },
+  });
+}

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -165,6 +165,9 @@ export const queryKeys = {
 
   /** Push subscriptions (#143) */
   pushSubscriptions: ["push-subscriptions"] as const,
+
+  /** Contributor stats (approved submission count for badges) (#867) */
+  contributorStats: ["contributor-stats"] as const,
 } as const;
 
 // ─── Stale time constants (ms) ──────────────────────────────────────────────
@@ -304,4 +307,7 @@ export const staleTimes = {
 
   /** Push subscriptions — 10 min (changes on user action) */
   pushSubscriptions: 10 * 60 * 1000,
+
+  /** Contributor stats — 10 min (changes only on approval) */
+  contributorStats: 10 * 60 * 1000,
 } as const;


### PR DESCRIPTION
## Summary
User product submission UX improvements for Issue #867:

- **ScanMissSubmitCTA** — CTA shown when scanned barcode not found; handles pending-submission warning vs submit link
- **ContributorBadge** — Inline badge showing contributor tier (bronze/silver/gold) based on approved submissions
- **Category page CTA** — Missing product prompt on category listing pages linking to submit flow
- **TanStack Query hooks** — useSubmissionHistory, useContributorStats, useSubmitProduct with cache keys and stale times
- **i18n** — Full coverage in en/pl/de for all new strings

## Files Changed
- 6 new files (2 components + 1 hook + 3 test files)
- 8 modified files (3 pages + 3 locale files + query-keys + CHANGELOG)

## Verification
- tsc --noEmit — 0 errors
- vitest run — 343/343 test files pass (5613 tests)
- npm run lint — 0 warnings or errors

Closes #867