### PR TITLE
fix(frontend): add onKeyDown to dialog elements for accessibility

### DIFF
--- a/frontend/src/components/desktop/CommandPalette.tsx
+++ b/frontend/src/components/desktop/CommandPalette.tsx
@@ -299,6 +299,7 @@ export function CommandPalette({
       ref={dialogRef}
       aria-label={t("commandPalette.placeholder")}
       onClick={handleBackdropClick}
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
       className="fixed inset-0 z-50 m-auto mt-[15vh] mb-auto w-full max-w-lg rounded-2xl bg-surface p-0 shadow-2xl backdrop:bg-black/40"
     >
       {/* Search input */}

--- a/frontend/src/components/desktop/ShortcutsHelp.tsx
+++ b/frontend/src/components/desktop/ShortcutsHelp.tsx
@@ -77,6 +77,7 @@ export function ShortcutsHelp({ open, onClose }: Readonly<ShortcutsHelpProps>) {
       ref={dialogRef}
       aria-labelledby="shortcuts-help-title"
       onClick={handleBackdropClick}
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
       className="fixed inset-0 z-50 m-auto w-full max-w-sm rounded-2xl bg-surface p-6 shadow-xl backdrop:bg-black/30"
     >
       {/* Header */}


### PR DESCRIPTION
## Summary
Fix SonarCloud Quality Gate failure (Reliability Rating B → A).

SonarCloud flagged 2 accessibility bugs:
- **CommandPalette.tsx** L298: dialog with onClick but no onKeyDown
- **ShortcutsHelp.tsx** L76: same issue

## Changes
Added onKeyDown={(e) => e.key === 'Escape' && onClose()} to both dialog elements.

## Verification
- TypeScript: 0 errors
- ESLint: 0 errors on changed files
- 2 files changed, 2 insertions