### PR TITLE
fix(frontend): ESLint config override for OG image + upgrade @upstash/redis

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -68,6 +68,14 @@ const eslintConfig = [
     },
   },
 
+  // OG image generators — Satori requires plain <img>, not next/image
+  {
+    files: ["**/opengraph-image.tsx"],
+    rules: {
+      "@next/next/no-img-element": "off",
+    },
+  },
+
   // Logger & metrics utilities — intentional console usage
   {
     files: ["**/logger.ts", "**/monitoring/**", "**/web-vitals.ts"],

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "@supabase/supabase-js": "^2.99.0",
         "@tanstack/react-query": "^5.62.0",
         "@upstash/ratelimit": "^2.0.8",
-        "@upstash/redis": "^1.36.4",
+        "@upstash/redis": "^1.37.0",
         "@vercel/speed-insights": "^1.3.1",
         "@zxing/browser": "^0.1.5",
         "@zxing/library": "^0.21.3",
@@ -6072,9 +6072,9 @@
       }
     },
     "node_modules/@upstash/redis": {
-      "version": "1.36.4",
-      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.36.4.tgz",
-      "integrity": "sha512-w4s/msmyMqxOxaVhC8TQ2whJ77+Zd8YaSFokXL4mULQopaYb4xNJcm/PedtFQyLJn65nneySw9IwYnlMBBmFHg==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
+      "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
     "@supabase/supabase-js": "^2.99.0",
     "@tanstack/react-query": "^5.62.0",
     "@upstash/ratelimit": "^2.0.8",
-    "@upstash/redis": "^1.36.4",
+    "@upstash/redis": "^1.37.0",
     "@vercel/speed-insights": "^1.3.1",
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",

--- a/frontend/src/app/app/product/[id]/opengraph-image.tsx
+++ b/frontend/src/app/app/product/[id]/opengraph-image.tsx
@@ -176,7 +176,6 @@ export default async function OGImage({
           }}
         >
           {heroUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element -- Satori renderer requires plain <img>, not next/image
             <img
               src={heroUrl}
               alt=""


### PR DESCRIPTION
## Changes

- **ESLint config override:** Added file-level override in \slint.config.mjs\ to disable \@next/next/no-img-element\ for \**/opengraph-image.tsx\ files (Satori/ImageResponse requires plain \<img>\, not \
ext/image\). Resolves CI/local ESLint discrepancy where CI reported the inline directive as unused.
- **Remove inline directive:** Removed \slint-disable-next-line\ from \opengraph-image.tsx\ — now handled by config override.
- **Upgrade @upstash/redis:** 1.36.4 → 1.37.0 (latest patch).

## Non-actionable warnings (remaining after this PR)

| Warning | Source | Why non-actionable |
|---------|--------|--------------------|
| \@upstash/redis\ Edge Runtime | Next.js build | Package v1.x exports \
odejs.mjs\ unconditionally — no edge entry point exists. \process.version\ usage is safely guarded with \	ypeof process === 'object'\. Works at runtime. |
| 4× webpack cache serialization | Next.js build | Internal webpack behavior for large string chunks |
| 7× npm deprecated | \
pm ci\ | Transitive deps (inflight, rimraf, glob, source-map) — not directly upgradable |
| SonarCloud Node.js 20 deprecation | sonarqube-scan-action v7.0.0 | Latest release; requires SonarSource to ship v8 |
| Buffer() deprecation | SonarCloud scanner | Internal scanner binary — not our code |
| bash template lines | CI infrastructure | GitHub Actions runner templates |
| git checkout hints | GitHub Actions | Standard git advice output |

## Verification

- \
px tsc --noEmit\ → 0 errors
- \
px eslint src/\ → 0 warnings, 0 errors
- \
px vitest run\ → 5,613 passed, 19 skipped (343 files)