### PR TITLE
fix(frontend): use Edge-compatible @upstash/redis/cloudflare import

### DIFF
--- a/frontend/src/lib/rate-limiter.ts
+++ b/frontend/src/lib/rate-limiter.ts
@@ -6,7 +6,7 @@
 // Development / CI: rate limiting disabled (no Redis configured).
 
 import { Ratelimit, type Duration } from "@upstash/ratelimit";
-import { Redis } from "@upstash/redis";
+import { Redis } from "@upstash/redis/cloudflare";
 
 // ─── Redis Client ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

Next.js build emits an Edge Runtime warning because \@upstash/redis\ (default entry point) resolves to \
odejs.mjs\ which uses \process.version\ — a Node.js API not available in Edge Runtime.

\\\
./node_modules/@upstash/redis/nodejs.mjs
A Node.js API is used (process.version at line: 240) which is not supported in the Edge Runtime.
\\\

Import trace: \middleware.ts\ → \ate-limiter.ts\ → \@upstash/redis/nodejs.mjs\

## Fix

Switch the import in \ate-limiter.ts\ from \@upstash/redis\ to \@upstash/redis/cloudflare\.

The \/cloudflare\ subpath exports the same \Redis\ class with the same \{ url, token }\ constructor API, but uses the Fetch API internally instead of Node.js-specific APIs. This makes it fully compatible with Vercel Edge Runtime.

## Verification

- [x] TypeScript compiles clean (\
px tsc --noEmit\ — 0 errors)
- [x] All 33 rate-limiter tests pass
- [x] \@upstash/redis/cloudflare\ exports \Redis\ class (verified in \cloudflare.d.ts\)
- [x] \cloudflare.mjs\ contains zero \process.\ references (grep confirmed)

## npm Deprecated Warnings (Not Actionable)

All 7 npm deprecated warnings are **transitive dependencies** — not from our code:
- \@lhci/cli@0.15.1\ (latest) → rimraf@2.7.1, rimraf@3.0.2, glob@7.2.3 x2, inflight@1.0.6, source-map@0.6.1
- \@serwist/next@9.5.6\ (latest) → glob@10.5.0, source-map@0.8.0-beta.0

Both upstream packages are at their latest versions. No upgrades available.