### PR TITLE
schema(scanner): add scan_country to scan_history (#921)

### DIFF
--- a/supabase/migrations/20260320000100_scan_history_country.sql
+++ b/supabase/migrations/20260320000100_scan_history_country.sql
@@ -1,0 +1,18 @@
+-- Migration: Add scan_country to scan_history
+-- Purpose: Captures user's catalog region at scan time (from user_preferences.country).
+--          Enables country-scoped scan analytics and downstream country-aware features.
+-- Nullable: Existing rows have no country context; old API callers still work.
+-- Rollback: ALTER TABLE public.scan_history DROP COLUMN IF EXISTS scan_country;
+-- Issue: #921 | Epic: #920
+
+ALTER TABLE public.scan_history
+  ADD COLUMN IF NOT EXISTS scan_country text
+  REFERENCES public.country_ref(country_code);
+
+-- Partial index for country-scoped analytics queries
+CREATE INDEX IF NOT EXISTS idx_sh_country
+  ON public.scan_history (scan_country)
+  WHERE scan_country IS NOT NULL;
+
+COMMENT ON COLUMN public.scan_history.scan_country IS
+  'User catalog region at scan time (from user_preferences.country). NULL for legacy rows.';

--- a/supabase/tests/schema_contracts.test.sql
+++ b/supabase/tests/schema_contracts.test.sql
@@ -7,7 +7,7 @@
 -- ─────────────────────────────────────────────────────────────────────────────
 
 BEGIN;
-SELECT plan(288);
+SELECT plan(297);
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- 1. Core data tables exist
@@ -420,6 +420,13 @@ SELECT has_function('public', 'api_watch_product',                           'fu
 SELECT has_function('public', 'api_unwatch_product',                         'function api_unwatch_product exists');
 SELECT has_function('public', 'api_get_watchlist',                           'function api_get_watchlist exists');
 SELECT has_trigger('products', 'trg_record_score_change',                    'trigger trg_record_score_change exists on products');
+
+-- ─── scan_history.scan_country (#921, epic #920) ─────────────────────────────
+SELECT has_column('public', 'scan_history', 'scan_country',       'scan_history has scan_country column');
+SELECT col_is_null('public', 'scan_history', 'scan_country',      'scan_history.scan_country is nullable');
+SELECT fk_ok('public', 'scan_history', 'scan_country',
+             'public', 'country_ref', 'country_code',
+             'scan_history.scan_country references country_ref(country_code)');
 
 SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
## Summary

Adds a nullable `scan_country` column to `scan_history` with FK to `country_ref(country_code)`. This captures the user's catalog region at scan time, enabling downstream country-aware scanner features.

**Part of epic #920. Closes #921.**

---

## Changes

### Migration: `20260320000100_scan_history_country.sql`

- `ALTER TABLE scan_history ADD COLUMN IF NOT EXISTS scan_country text REFERENCES country_ref(country_code)` — nullable for backward compat
- Partial index `idx_sh_country` on `scan_country WHERE scan_country IS NOT NULL` — for country-scoped analytics
- Column comment documenting purpose and NULL semantics

### pgTAP: `schema_contracts.test.sql`

- 3 new tests: `has_column`, `col_is_null`, `fk_ok` for `scan_history.scan_country`
- Plan count corrected from 288 → 297 (pre-existing drift of 6 tests + 3 new)

---

## Files Changed

| File | Change |
|---|---|
| `supabase/migrations/20260320000100_scan_history_country.sql` | New migration |
| `supabase/tests/schema_contracts.test.sql` | +3 pgTAP tests, plan 288→297 |

**2 files changed, +26 / -1 lines**

---

## Acceptance Criteria

- [x] `scan_history` has `scan_country text REFERENCES country_ref(country_code)` column
- [x] Column is nullable (existing rows remain NULL)
- [x] Partial index `idx_sh_country` exists on `scan_country WHERE NOT NULL`
- [x] pgTAP: `has_column('scan_history', 'scan_country')` passes
- [x] Migration is idempotent (`ADD COLUMN IF NOT EXISTS`)
- [x] `supabase db reset` succeeds cleanly
- [x] `.\RUN_QA.ps1` — no new failures introduced

---

## Verification

```powershell
supabase db reset                → ✅ All 210 migrations applied cleanly
supabase test db                 → schema_contracts: 297 tests, 296 pass, 1 pre-existing failure
                                   (test 294: trg_record_score_change — unrelated)
                                   My 3 new tests (295-297) all pass.
.\RUN_QA.ps1                     → 45/49 suites pass. 4 failures are pre-existing
                                   data-dependent (Confidence, Diet, Allergen,
                                   MultiCountry — caused by db reset clearing
                                   pipeline product data, not by this migration).
```

### Column verification

```
scan_country | text | YES (nullable)
idx_sh_country index exists
FK to country_ref(country_code) confirmed
```

---

## Wording Corrections

Issue #921 body says `WHERE NOT NULL` in the acceptance criteria but `WHERE scan_country IS NOT NULL` in the SQL block. The migration uses the technically correct `WHERE scan_country IS NOT NULL` syntax (standard SQL).

---

## Scope

This PR adds **only** the schema column — no API changes, no frontend changes, no data backfill. Those are handled by downstream issues in the #920 epic.

## Next Issue

Recommend: **#922** — `schema(scanner): add scan_country + suggested_country to product_submissions`