### PR TITLE
feat(frontend): cross-country product badge in scan result card (#927)

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -352,7 +352,8 @@
     "productFound": "Produkt gefunden!",
     "viewDetails": "Details anzeigen",
     "scanNext": "Nächstes scannen",
-    "pasteBarcode": "Einfügen"
+    "pasteBarcode": "Einfügen",
+    "crossCountryBadge": "Aus dem {country}-Katalog"
   },
   "scannerError": {
     "permissionDenied": "Kamerazugriff verweigert. Erlauben Sie den Kamerazugriff in Ihren Browsereinstellungen und versuchen Sie es erneut.",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -352,7 +352,8 @@
     "productFound": "Product Found!",
     "viewDetails": "View Details",
     "scanNext": "Scan Next",
-    "pasteBarcode": "Paste"
+    "pasteBarcode": "Paste",
+    "crossCountryBadge": "From the {country} catalog"
   },
   "scannerError": {
     "permissionDenied": "Camera permission denied. Allow camera access in your browser settings, then try again.",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -352,7 +352,8 @@
     "productFound": "Produkt znaleziony!",
     "viewDetails": "Zobacz szczegóły",
     "scanNext": "Skanuj następny",
-    "pasteBarcode": "Wklej"
+    "pasteBarcode": "Wklej",
+    "crossCountryBadge": "Z katalogu: {country}"
   },
   "scannerError": {
     "permissionDenied": "Odmowa dostępu do kamery. Zezwól na dostęp do kamery w ustawieniach przeglądarki i spróbuj ponownie.",

--- a/frontend/src/components/scan/ScanResultView.test.tsx
+++ b/frontend/src/components/scan/ScanResultView.test.tsx
@@ -2,10 +2,10 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-    ScanErrorView,
-    ScanFoundView,
-    ScanLookingUpView,
-    ScanNotFoundView,
+  ScanErrorView,
+  ScanFoundView,
+  ScanLookingUpView,
+  ScanNotFoundView,
 } from "./ScanResultView";
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
@@ -85,6 +85,14 @@ vi.mock("@/lib/constants", () => ({
     D: "bg-orange-500",
     E: "bg-red-600",
   },
+  getCountryFlag: (code: string) => {
+    const flags: Record<string, string> = { PL: "🇵🇱", DE: "🇩🇪" };
+    return flags[code] ?? "🌐";
+  },
+  getCountryName: (code: string) => {
+    const names: Record<string, string> = { PL: "Poland", DE: "Germany" };
+    return names[code] ?? code;
+  },
 }));
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────
@@ -102,6 +110,8 @@ const mockFoundProduct = {
   category_icon: "🍟",
   unhealthiness_score: 35,
   nutri_score: "C" as const,
+  product_country: "PL",
+  is_cross_country: false,
 };
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -331,5 +341,38 @@ describe("ScanFoundView", () => {
     );
     await user.click(screen.getByText("scan.scanNext"));
     expect(onReset).toHaveBeenCalledOnce();
+  });
+
+  // ─── Cross-country badge ────────────────────────────────────────────
+
+  it("does not render cross-country badge when is_cross_country is false", () => {
+    render(
+      <ScanFoundView product={mockFoundProduct} onViewDetails={onViewDetails} onReset={onReset} />,
+    );
+    expect(screen.queryByText(/scan\.crossCountryBadge/)).toBeNull();
+  });
+
+  it("renders cross-country badge when is_cross_country is true", () => {
+    const crossCountryProduct = { ...mockFoundProduct, is_cross_country: true, product_country: "DE" };
+    render(
+      <ScanFoundView product={crossCountryProduct} onViewDetails={onViewDetails} onReset={onReset} />,
+    );
+    expect(screen.getByText(/scan\.crossCountryBadge/)).toBeInTheDocument();
+  });
+
+  it("shows correct country name in cross-country badge", () => {
+    const crossCountryProduct = { ...mockFoundProduct, is_cross_country: true, product_country: "DE" };
+    render(
+      <ScanFoundView product={crossCountryProduct} onViewDetails={onViewDetails} onReset={onReset} />,
+    );
+    expect(screen.getByText(/Germany/)).toBeInTheDocument();
+  });
+
+  it("shows country flag emoji in cross-country badge", () => {
+    const crossCountryProduct = { ...mockFoundProduct, is_cross_country: true, product_country: "PL" };
+    render(
+      <ScanFoundView product={crossCountryProduct} onViewDetails={onViewDetails} onReset={onReset} />,
+    );
+    expect(screen.getByText("🇵🇱")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/scan/ScanResultView.tsx
+++ b/frontend/src/components/scan/ScanResultView.tsx
@@ -5,7 +5,7 @@
 import { Button, ButtonLink } from "@/components/common/Button";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { ScanMissSubmitCTA } from "@/components/scan/ScanMissSubmitCTA";
-import { NUTRI_COLORS } from "@/lib/constants";
+import { getCountryFlag, getCountryName, NUTRI_COLORS } from "@/lib/constants";
 import { useTranslation } from "@/lib/i18n";
 import { getScoreBand, toTryVitScore } from "@/lib/score-utils";
 import type {
@@ -182,6 +182,12 @@ export function ScanFoundView({
         {product.brand && (
           <p className="text-sm text-foreground-secondary">
             {product.brand}
+          </p>
+        )}
+        {product.is_cross_country && (
+          <p className="mt-2 inline-flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1 text-xs text-foreground-secondary dark:bg-gray-800">
+            <span aria-hidden="true">{getCountryFlag(product.product_country)}</span>
+            {t("scan.crossCountryBadge", { country: getCountryName(product.product_country) })}
           </p>
         )}
         {band && (

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -24,6 +24,16 @@ export const COUNTRY_DEFAULT_LANGUAGES: Record<string, string> = {
   DE: "de",
 } as const;
 
+/** Get flag emoji for a country code. Falls back to globe for unknown codes. */
+export function getCountryFlag(code: string): string {
+  return COUNTRIES.find((c) => c.code === code)?.flag ?? "🌐";
+}
+
+/** Get English display name for a country code. Falls back to the code itself. */
+export function getCountryName(code: string): string {
+  return COUNTRIES.find((c) => c.code === code)?.name ?? code;
+}
+
 /** Get the available languages for a country: [native, English]. */
 export function getLanguagesForCountry(countryCode: string) {
   const nativeLang = COUNTRY_DEFAULT_LANGUAGES[countryCode] ?? "en";

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1085,6 +1085,8 @@ export interface RecordScanFoundResponse {
   category_icon: string;
   unhealthiness_score: number;
   nutri_score: NutriGrade;
+  product_country: string;
+  is_cross_country: boolean;
 }
 
 export interface RecordScanNotFoundResponse {


### PR DESCRIPTION
## Summary

Adds a cross-country product badge to the scan result card. When a user scans a barcode that matches a product from a different country catalog (e.g., a German user scanning a Polish product), a badge displays the country flag emoji and a localized label like "From the Poland catalog".

Closes #927
Part of epic #920

---

## Changes

### `frontend/src/lib/types.ts`
- Added `product_country: string` and `is_cross_country: boolean` to `RecordScanFoundResponse`

### `frontend/src/lib/constants.ts`
- Added `getCountryFlag(code)` helper — returns flag emoji from `COUNTRIES`, falls back to 🌐
- Added `getCountryName(code)` helper — returns English name from `COUNTRIES`, falls back to the code itself

### `frontend/src/components/scan/ScanResultView.tsx`
- Imported `getCountryFlag` and `getCountryName` from constants
- Added cross-country badge JSX in `ScanFoundView` — renders conditionally when `is_cross_country === true`
- Styled as a pill badge (`rounded-full bg-gray-100 dark:bg-gray-800 text-xs`) positioned after brand, before score band

### `frontend/messages/{en,pl,de}.json`
- Added `scan.crossCountryBadge` key:
  - EN: `"From the {country} catalog"`
  - PL: `"Z katalogu: {country}"`
  - DE: `"Aus dem {country}-Katalog"`

### `frontend/src/components/scan/ScanResultView.test.tsx`
- Extended constants mock with `getCountryFlag` and `getCountryName`
- Added `product_country` and `is_cross_country` to mock fixture
- Added 4 new tests:
  1. Badge hidden when `is_cross_country` is false
  2. Badge visible when `is_cross_country` is true
  3. Correct country name displayed
  4. Country flag emoji displayed

---

## Acceptance Criteria

- [x] Badge appears only when `is_cross_country === true`
- [x] Badge hidden when `is_cross_country === false`
- [x] Shows correct flag emoji + country name
- [x] i18n in all 3 languages (EN, PL, DE)
- [x] Dark mode support (`dark:bg-gray-800`)
- [x] Accessible (`aria-hidden` on decorative flag emoji)
- [x] 4 component tests covering all badge logic

---

## Verification

```
npx tsc --noEmit           → 0 errors
npx vitest run ...test.tsx → 28/28 tests pass (4 new)
```

**7 files changed, +72 / -8 lines**