### PR TITLE
feat(scanner): country mismatch detection badges in admin review (#929)

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -1093,7 +1093,10 @@
     "approve": "Genehmigen",
     "reject": "Ablehnen",
     "countryLabel": "Land:",
-    "allCountries": "Alle Länder"
+    "allCountries": "Alle Länder",
+    "gs1Mismatch": "GS1-Barcode deutet auf {gs1Country}, aber Einreichung zielt auf {effectiveCountry}",
+    "regionMismatch": "Gescannt in {scanCountry}, aber vorgeschlagen für {suggestedCountry}",
+    "crossCountryProducts": "Gleiche EAN existiert in {countries} ({count} Produkt(e))"
   },
   "monitoring": {
     "title": "Systemüberwachung",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1093,7 +1093,10 @@
     "approve": "Approve",
     "reject": "Reject",
     "countryLabel": "Country:",
-    "allCountries": "All countries"
+    "allCountries": "All countries",
+    "gs1Mismatch": "GS1 barcode suggests {gs1Country} but submission targets {effectiveCountry}",
+    "regionMismatch": "Scanned in {scanCountry} but suggested for {suggestedCountry}",
+    "crossCountryProducts": "Same EAN exists in {countries} ({count} product(s))"
   },
   "monitoring": {
     "title": "System Monitoring",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -1093,7 +1093,10 @@
     "approve": "✅ Zatwierdź",
     "reject": "❌ Odrzuć",
     "countryLabel": "Kraj:",
-    "allCountries": "Wszystkie kraje"
+    "allCountries": "Wszystkie kraje",
+    "gs1Mismatch": "Kod GS1 wskazuje na {gs1Country}, ale zgłoszenie dotyczy {effectiveCountry}",
+    "regionMismatch": "Zeskanowano w {scanCountry}, ale zasugerowano dla {suggestedCountry}",
+    "crossCountryProducts": "Ten sam EAN istnieje w {countries} ({count} produkt(ów))"
   },
   "monitoring": {
     "title": "Monitoring systemu",

--- a/frontend/src/app/app/admin/submissions/page.test.tsx
+++ b/frontend/src/app/app/admin/submissions/page.test.tsx
@@ -68,6 +68,8 @@ const makeSubmission = (overrides: Record<string, unknown> = {}) => ({
   existing_product_match: null,
   scan_country: "PL",
   suggested_country: null,
+  gs1_hint: null,
+  cross_country_products: [],
   ...overrides,
 });
 
@@ -632,5 +634,227 @@ describe("AdminSubmissionsPage", () => {
         expect.objectContaining({ p_country: "PL" }),
       );
     });
+  });
+
+  // ─── Mismatch Badge Tests (#929) ──────────────────────────────────────────
+
+  it("shows GS1 mismatch badge when countries differ", async () => {
+    mockCallRpc.mockImplementation((_client: unknown, fnName: string) => {
+      if (fnName === "api_admin_get_submissions") {
+        return Promise.resolve({
+          ok: true,
+          data: {
+            submissions: [
+              makeSubmission({
+                scan_country: "PL",
+                suggested_country: null,
+                gs1_hint: { code: "DE", name: "Germany", confidence: "high", prefix: "400" },
+                product_name: "GS1 Mismatch Product",
+              }),
+            ],
+            page: 1,
+            pages: 1,
+            total: 1,
+          },
+        });
+      }
+      return Promise.resolve({ ok: true, data: {} });
+    });
+    render(<AdminSubmissionsPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByTestId("gs1-mismatch-badge")).toBeInTheDocument();
+    });
+  });
+
+  it("hides GS1 badge when GS1 hint matches effective country", async () => {
+    mockCallRpc.mockImplementation((_client: unknown, fnName: string) => {
+      if (fnName === "api_admin_get_submissions") {
+        return Promise.resolve({
+          ok: true,
+          data: {
+            submissions: [
+              makeSubmission({
+                scan_country: "PL",
+                gs1_hint: { code: "PL", name: "Poland", confidence: "high", prefix: "590" },
+                product_name: "Matching GS1",
+              }),
+            ],
+            page: 1,
+            pages: 1,
+            total: 1,
+          },
+        });
+      }
+      return Promise.resolve({ ok: true, data: {} });
+    });
+    render(<AdminSubmissionsPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("Matching GS1")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("gs1-mismatch-badge")).not.toBeInTheDocument();
+  });
+
+  it("hides GS1 badge when hint is UNKNOWN", async () => {
+    mockCallRpc.mockImplementation((_client: unknown, fnName: string) => {
+      if (fnName === "api_admin_get_submissions") {
+        return Promise.resolve({
+          ok: true,
+          data: {
+            submissions: [
+              makeSubmission({
+                gs1_hint: { code: "UNKNOWN", name: "Unknown", confidence: "none" },
+                product_name: "Unknown GS1",
+              }),
+            ],
+            page: 1,
+            pages: 1,
+            total: 1,
+          },
+        });
+      }
+      return Promise.resolve({ ok: true, data: {} });
+    });
+    render(<AdminSubmissionsPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("Unknown GS1")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("gs1-mismatch-badge")).not.toBeInTheDocument();
+  });
+
+  it("hides GS1 badge when hint is STORE", async () => {
+    mockCallRpc.mockImplementation((_client: unknown, fnName: string) => {
+      if (fnName === "api_admin_get_submissions") {
+        return Promise.resolve({
+          ok: true,
+          data: {
+            submissions: [
+              makeSubmission({
+                gs1_hint: { code: "STORE", name: "Store/internal", confidence: "high" },
+                product_name: "Store EAN",
+              }),
+            ],
+            page: 1,
+            pages: 1,
+            total: 1,
+          },
+        });
+      }
+      return Promise.resolve({ ok: true, data: {} });
+    });
+    render(<AdminSubmissionsPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("Store EAN")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("gs1-mismatch-badge")).not.toBeInTheDocument();
+  });
+
+  it("shows region mismatch when scan and suggested countries differ", async () => {
+    mockCallRpc.mockImplementation((_client: unknown, fnName: string) => {
+      if (fnName === "api_admin_get_submissions") {
+        return Promise.resolve({
+          ok: true,
+          data: {
+            submissions: [
+              makeSubmission({
+                scan_country: "PL",
+                suggested_country: "DE",
+                product_name: "Region Mismatch",
+              }),
+            ],
+            page: 1,
+            pages: 1,
+            total: 1,
+          },
+        });
+      }
+      return Promise.resolve({ ok: true, data: {} });
+    });
+    render(<AdminSubmissionsPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByTestId("region-mismatch-badge")).toBeInTheDocument();
+    });
+  });
+
+  it("hides region badge when scan equals suggested", async () => {
+    mockCallRpc.mockImplementation((_client: unknown, fnName: string) => {
+      if (fnName === "api_admin_get_submissions") {
+        return Promise.resolve({
+          ok: true,
+          data: {
+            submissions: [
+              makeSubmission({
+                scan_country: "DE",
+                suggested_country: "DE",
+                product_name: "Same Region",
+              }),
+            ],
+            page: 1,
+            pages: 1,
+            total: 1,
+          },
+        });
+      }
+      return Promise.resolve({ ok: true, data: {} });
+    });
+    render(<AdminSubmissionsPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("Same Region")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("region-mismatch-badge")).not.toBeInTheDocument();
+  });
+
+  it("shows cross-country badge when products exist in other countries", async () => {
+    mockCallRpc.mockImplementation((_client: unknown, fnName: string) => {
+      if (fnName === "api_admin_get_submissions") {
+        return Promise.resolve({
+          ok: true,
+          data: {
+            submissions: [
+              makeSubmission({
+                cross_country_products: [
+                  { product_id: 42, product_name: "Same Chips DE", country: "DE" },
+                ],
+                product_name: "Cross Country",
+              }),
+            ],
+            page: 1,
+            pages: 1,
+            total: 1,
+          },
+        });
+      }
+      return Promise.resolve({ ok: true, data: {} });
+    });
+    render(<AdminSubmissionsPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByTestId("cross-country-badge")).toBeInTheDocument();
+    });
+  });
+
+  it("hides cross-country badge when no products in other countries", async () => {
+    mockCallRpc.mockImplementation((_client: unknown, fnName: string) => {
+      if (fnName === "api_admin_get_submissions") {
+        return Promise.resolve({
+          ok: true,
+          data: {
+            submissions: [
+              makeSubmission({
+                cross_country_products: [],
+                product_name: "No Cross Country",
+              }),
+            ],
+            page: 1,
+            pages: 1,
+            total: 1,
+          },
+        });
+      }
+      return Promise.resolve({ ok: true, data: {} });
+    });
+    render(<AdminSubmissionsPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("No Cross Country")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("cross-country-badge")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/app/admin/submissions/page.tsx
+++ b/frontend/src/app/app/admin/submissions/page.tsx
@@ -466,6 +466,47 @@ function AdminSubmissionCard({
           </p>
         )}
 
+        {/* GS1 country mismatch badge (#929) */}
+        {submission.gs1_hint &&
+          submission.gs1_hint.code !== "UNKNOWN" &&
+          submission.gs1_hint.code !== "STORE" &&
+          (submission.suggested_country ?? submission.scan_country) &&
+          submission.gs1_hint.code !==
+            (submission.suggested_country ?? submission.scan_country) && (
+            <p className="text-xs text-warning-text" data-testid="gs1-mismatch-badge">
+              ⚠ {t("admin.gs1Mismatch", {
+                gs1Country: submission.gs1_hint.name,
+                effectiveCountry:
+                  (submission.suggested_country ?? submission.scan_country)!,
+              })}
+            </p>
+          )}
+
+        {/* Region mismatch badge (#929) */}
+        {submission.scan_country &&
+          submission.suggested_country &&
+          submission.scan_country !== submission.suggested_country && (
+            <p className="text-xs text-info-text" data-testid="region-mismatch-badge">
+              ℹ {t("admin.regionMismatch", {
+                scanCountry: submission.scan_country,
+                suggestedCountry: submission.suggested_country,
+              })}
+            </p>
+          )}
+
+        {/* Cross-country product badge (#929) */}
+        {submission.cross_country_products.length > 0 && (
+          <p className="text-xs text-info-text" data-testid="cross-country-badge">
+            ℹ {t("admin.crossCountryProducts", {
+              count: submission.cross_country_products.length,
+              countries: submission.cross_country_products
+                .map((p) => p.country)
+                .filter((v, i, a) => a.indexOf(v) === i)
+                .join(", "),
+            })}
+          </p>
+        )}
+
         {submission.review_notes && (
           <p className="rounded-md bg-warning-bg p-2 text-xs text-warning-text">
             <ShieldAlert size={14} aria-hidden="true" className="mr-1 inline" />

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1170,6 +1170,18 @@ export interface AdminSubmission extends Submission {
     product_id: number;
     product_name: string;
   } | null;
+  // Mismatch detection (#929)
+  gs1_hint: {
+    code: string;
+    name: string;
+    confidence: string;
+    prefix?: string;
+  } | null;
+  cross_country_products: {
+    product_id: number;
+    product_name: string;
+    country: string;
+  }[];
 }
 
 export interface AdminSubmissionsResponse {

--- a/supabase/migrations/20260321000400_admin_mismatch_badges.sql
+++ b/supabase/migrations/20260321000400_admin_mismatch_badges.sql
@@ -1,0 +1,131 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Migration: 20260321000400_admin_mismatch_badges.sql
+-- Ticket:    #929 — Country mismatch detection badges in admin review
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Extends api_admin_get_submissions with two new fields per submission:
+--   • gs1_hint            — GS1 prefix → country hint via gs1_country_hint()
+--   • cross_country_products — products with same EAN in OTHER countries
+--
+-- Backward compatible: new keys are additive, no param changes.
+-- ═══════════════════════════════════════════════════════════════════════════
+-- To roll back: redeploy api_admin_get_submissions from 20260321000100
+-- ═══════════════════════════════════════════════════════════════════════════
+
+
+CREATE OR REPLACE FUNCTION public.api_admin_get_submissions(
+  p_status    text    DEFAULT 'pending',
+  p_page      integer DEFAULT 1,
+  p_page_size integer DEFAULT 20,
+  p_country   text    DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_offset  integer;
+  v_total   bigint;
+  v_items   jsonb;
+BEGIN
+  v_offset := (GREATEST(p_page, 1) - 1) * LEAST(p_page_size, 50);
+
+  SELECT COUNT(*) INTO v_total
+    FROM public.product_submissions
+   WHERE (p_status = 'all' OR status = p_status)
+     AND (p_country IS NULL
+          OR scan_country = p_country
+          OR suggested_country = p_country);
+
+  SELECT COALESCE(jsonb_agg(row_obj ORDER BY rn), '[]'::jsonb)
+    INTO v_items
+    FROM (
+      SELECT
+        ROW_NUMBER() OVER (ORDER BY ps.created_at ASC) AS rn,
+        jsonb_build_object(
+          'id',               ps.id,
+          'ean',              ps.ean,
+          'product_name',     ps.product_name,
+          'brand',            ps.brand,
+          'category',         ps.category,
+          'photo_url',        ps.photo_url,
+          'notes',            ps.notes,
+          'status',           ps.status,
+          'user_id',          ps.user_id,
+          'merged_product_id', ps.merged_product_id,
+          'created_at',       ps.created_at,
+          'updated_at',       ps.updated_at,
+          'reviewed_at',      ps.reviewed_at,
+          -- ── Country context (#925) ─────────────────────────
+          'scan_country',         ps.scan_country,
+          'suggested_country',    ps.suggested_country,
+          -- ── GS1 prefix hint (#929) ─────────────────────────
+          'gs1_hint',             public.gs1_country_hint(ps.ean),
+          -- ── Cross-country products (#929) ──────────────────
+          'cross_country_products', (
+            SELECT COALESCE(jsonb_agg(
+              jsonb_build_object(
+                'product_id',   p.product_id,
+                'product_name', p.product_name,
+                'country',      p.country
+              )
+            ), '[]'::jsonb)
+            FROM public.products p
+            WHERE p.ean = ps.ean
+              AND p.ean IS NOT NULL
+              AND p.is_deprecated IS NOT TRUE
+              AND p.country != COALESCE(ps.suggested_country, ps.scan_country)
+          ),
+          -- ── Trust & quality enrichment (#474) ──────────────
+          'user_trust_score',       COALESCE(uts.trust_score, 50),
+          'user_total_submissions', COALESCE(uts.total_submissions, 0),
+          'user_approved_pct',      CASE
+            WHEN COALESCE(uts.total_submissions, 0) > 0
+            THEN round(100.0 * uts.approved_submissions / uts.total_submissions)
+            ELSE NULL
+          END,
+          'user_flagged',           (uts.flagged_at IS NOT NULL),
+          'review_notes',           ps.review_notes,
+          'existing_product_match', (
+            SELECT jsonb_build_object(
+              'product_id', p.product_id,
+              'product_name', p.product_name
+            )
+            FROM public.products p
+            WHERE p.ean = ps.ean AND p.is_deprecated IS NOT TRUE
+            LIMIT 1
+          )
+        ) AS row_obj
+      FROM public.product_submissions ps
+      LEFT JOIN public.user_trust_scores uts ON uts.user_id = ps.user_id
+      WHERE (p_status = 'all' OR ps.status = p_status)
+        AND (p_country IS NULL
+             OR ps.scan_country = p_country
+             OR ps.suggested_country = p_country)
+      ORDER BY ps.created_at ASC
+      OFFSET v_offset
+      LIMIT LEAST(p_page_size, 50)
+    ) sub;
+
+  RETURN jsonb_build_object(
+    'api_version', '1.0',
+    'total',       v_total,
+    'page',        GREATEST(p_page, 1),
+    'pages',       GREATEST(CEIL(v_total::numeric / LEAST(p_page_size, 50)), 1),
+    'page_size',   LEAST(p_page_size, 50),
+    'status_filter', p_status,
+    'country_filter', p_country,
+    'submissions', v_items
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.api_admin_get_submissions(text, integer, integer, text) IS
+  'Purpose: List product submissions with trust enrichment, country context, and mismatch detection
+   Auth: authenticated (SECURITY DEFINER)
+   Params: p_status (default pending), p_page (default 1), p_page_size (default 20, max 50), p_country (optional)
+   Returns: JSONB {api_version, total, page, pages, page_size, status_filter, country_filter, submissions: [...]}
+   New in #929: gs1_hint (GS1 prefix country hint), cross_country_products (same EAN in other countries)
+   Country filter: matches scan_country OR suggested_country
+   Backward compatible: new keys are additive, no parameter changes';


### PR DESCRIPTION
## Summary
Adds country mismatch detection badges to the admin submission review page, helping reviewers spot cross-country data discrepancies.

**3 mismatch badges:**
1. **GS1 mismatch** (amber) — EAN barcode prefix suggests a different country than the submission target
2. **Region mismatch** (info) — Scan country differs from suggested country
3. **Cross-country** (info) — Same EAN exists as a product in another country

Closes #929

## Changes
- **Migration** `20260321000400` — extends `api_admin_get_submissions` with `gs1_hint` (via `gs1_country_hint()`) and `cross_country_products` subquery
- **Types** — added `gs1_hint` and `cross_country_products` to `AdminSubmission` interface
- **UI** — 3 conditional badge sections in `AdminSubmissionCard` with `data-testid` attributes
- **i18n** — 3 keys added to en/pl/de (`admin.gs1Mismatch`, `admin.regionMismatch`, `admin.crossCountryProducts`)
- **Tests** — 8 new Vitest tests covering show/hide logic for all 3 badges (40/40 total)

## Verification
- `npx tsc --noEmit` — 0 errors
- `npx vitest run page.test.tsx` — 40/40 pass (32 existing + 8 new)