### PR TITLE
fix(admin): clarify legacy null-country submissions in review UI

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -1096,7 +1096,10 @@
     "allCountries": "Alle Länder",
     "gs1Mismatch": "GS1-Barcode deutet auf {gs1Country}, aber Einreichung zielt auf {effectiveCountry}",
     "regionMismatch": "Gescannt in {scanCountry}, aber vorgeschlagen für {suggestedCountry}",
-    "crossCountryProducts": "Gleiche EAN existiert in {countries} ({count} Produkt(e))"
+    "crossCountryProducts": "Gleiche EAN existiert in {countries} ({count} Produkt(e))",
+    "noCountry": "Kein Land",
+    "noCountryHint": "Eingereicht vor der Länder-Erfassung",
+    "gs1InfoHint": "GS1-Barcode registriert in {gs1Country} (informativ)"
   },
   "monitoring": {
     "title": "Systemüberwachung",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1096,7 +1096,10 @@
     "allCountries": "All countries",
     "gs1Mismatch": "GS1 barcode suggests {gs1Country} but submission targets {effectiveCountry}",
     "regionMismatch": "Scanned in {scanCountry} but suggested for {suggestedCountry}",
-    "crossCountryProducts": "Same EAN exists in {countries} ({count} product(s))"
+    "crossCountryProducts": "Same EAN exists in {countries} ({count} product(s))",
+    "noCountry": "No country",
+    "noCountryHint": "Submitted before country tracking was added",
+    "gs1InfoHint": "GS1 barcode registered in {gs1Country} (informational)"
   },
   "monitoring": {
     "title": "System Monitoring",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -1096,7 +1096,10 @@
     "allCountries": "Wszystkie kraje",
     "gs1Mismatch": "Kod GS1 wskazuje na {gs1Country}, ale zgłoszenie dotyczy {effectiveCountry}",
     "regionMismatch": "Zeskanowano w {scanCountry}, ale zasugerowano dla {suggestedCountry}",
-    "crossCountryProducts": "Ten sam EAN istnieje w {countries} ({count} produkt(ów))"
+    "crossCountryProducts": "Ten sam EAN istnieje w {countries} ({count} produkt(ów))",
+    "noCountry": "Brak kraju",
+    "noCountryHint": "Zgłoszone przed dodaniem śledzenia krajów",
+    "gs1InfoHint": "Kod GS1 zarejestrowany w {gs1Country} (informacyjnie)"
   },
   "monitoring": {
     "title": "Monitoring systemu",

--- a/frontend/src/app/app/admin/submissions/page.test.tsx
+++ b/frontend/src/app/app/admin/submissions/page.test.tsx
@@ -26,8 +26,12 @@ vi.mock("@/components/common/skeletons", () => ({
 }));
 
 vi.mock("@/components/common/CountryChip", () => ({
-  CountryChip: ({ country }: { country: string | null }) =>
-    country ? <span data-testid="country-chip">{country}</span> : null,
+  CountryChip: ({ country, nullLabel }: { country: string | null; nullLabel?: string }) =>
+    country ? (
+      <span data-testid="country-chip">{country}</span>
+    ) : nullLabel ? (
+      <span data-testid="country-chip" data-null-country="">{nullLabel}</span>
+    ) : null,
 }));
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -581,7 +585,7 @@ describe("AdminSubmissionsPage", () => {
     expect(chip).toHaveTextContent("DE");
   });
 
-  it("does not render country chip when both countries are null", async () => {
+  it("shows fallback country chip when both countries are null", async () => {
     mockCallRpc.mockImplementation((_client: unknown, fnName: string) => {
       if (fnName === "api_admin_get_submissions") {
         return Promise.resolve({
@@ -606,7 +610,9 @@ describe("AdminSubmissionsPage", () => {
     await waitFor(() => {
       expect(screen.getByText("Unknown Origin")).toBeInTheDocument();
     });
-    expect(screen.queryByTestId("country-chip")).not.toBeInTheDocument();
+    const chip = screen.getByTestId("country-chip");
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveAttribute("data-null-country");
   });
 
   it("renders country filter dropdown", async () => {
@@ -856,5 +862,120 @@ describe("AdminSubmissionsPage", () => {
       expect(screen.getByText("No Cross Country")).toBeInTheDocument();
     });
     expect(screen.queryByTestId("cross-country-badge")).not.toBeInTheDocument();
+  });
+
+  // ─── Legacy Null-Country UX Tests ─────────────────────────────────────────
+
+  it("shows legacy help text for null-country submission", async () => {
+    mockCallRpc.mockImplementation((_client: unknown, fnName: string) => {
+      if (fnName === "api_admin_get_submissions") {
+        return Promise.resolve({
+          ok: true,
+          data: {
+            submissions: [
+              makeSubmission({
+                scan_country: null,
+                suggested_country: null,
+                product_name: "Legacy Product",
+              }),
+            ],
+            page: 1,
+            pages: 1,
+            total: 1,
+          },
+        });
+      }
+      return Promise.resolve({ ok: true, data: {} });
+    });
+    render(<AdminSubmissionsPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByTestId("no-country-info")).toBeInTheDocument();
+    });
+  });
+
+  it("shows GS1 informational hint when country is null but gs1_hint exists", async () => {
+    mockCallRpc.mockImplementation((_client: unknown, fnName: string) => {
+      if (fnName === "api_admin_get_submissions") {
+        return Promise.resolve({
+          ok: true,
+          data: {
+            submissions: [
+              makeSubmission({
+                scan_country: null,
+                suggested_country: null,
+                gs1_hint: { code: "DE", name: "Germany", confidence: "high", prefix: "400" },
+                product_name: "GS1 Hint Legacy",
+              }),
+            ],
+            page: 1,
+            pages: 1,
+            total: 1,
+          },
+        });
+      }
+      return Promise.resolve({ ok: true, data: {} });
+    });
+    render(<AdminSubmissionsPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByTestId("gs1-info-hint")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("gs1-mismatch-badge")).not.toBeInTheDocument();
+  });
+
+  it("renders No country option in country filter", async () => {
+    render(<AdminSubmissionsPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByTestId("country-filter")).toBeInTheDocument();
+    });
+    expect(screen.getByText("No country")).toBeInTheDocument();
+  });
+
+  it("sends p_country __none__ when No country filter is selected", async () => {
+    render(<AdminSubmissionsPage />, { wrapper: createWrapper() });
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("country-filter")).toBeInTheDocument();
+    });
+
+    await user.selectOptions(screen.getByTestId("country-filter"), "__none__");
+
+    await waitFor(() => {
+      expect(mockCallRpc).toHaveBeenCalledWith(
+        expect.anything(),
+        "api_admin_get_submissions",
+        expect.objectContaining({ p_country: "__none__" }),
+      );
+    });
+  });
+
+  it("suppresses mismatch badges for null-country submissions", async () => {
+    mockCallRpc.mockImplementation((_client: unknown, fnName: string) => {
+      if (fnName === "api_admin_get_submissions") {
+        return Promise.resolve({
+          ok: true,
+          data: {
+            submissions: [
+              makeSubmission({
+                scan_country: null,
+                suggested_country: null,
+                gs1_hint: { code: "DE", name: "Germany", confidence: "high", prefix: "400" },
+                product_name: "No Mismatch Legacy",
+              }),
+            ],
+            page: 1,
+            pages: 1,
+            total: 1,
+          },
+        });
+      }
+      return Promise.resolve({ ok: true, data: {} });
+    });
+    render(<AdminSubmissionsPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("No Mismatch Legacy")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("gs1-mismatch-badge")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("region-mismatch-badge")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/app/admin/submissions/page.tsx
+++ b/frontend/src/app/app/admin/submissions/page.tsx
@@ -9,31 +9,31 @@ import { CountryChip } from "@/components/common/CountryChip";
 import { EmptyStateIllustration } from "@/components/common/EmptyStateIllustration";
 import { SubmissionsSkeleton } from "@/components/common/skeletons";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
-import { useTranslation } from "@/lib/i18n";
 import { COUNTRIES } from "@/lib/constants";
+import { useTranslation } from "@/lib/i18n";
 import { callRpc } from "@/lib/rpc";
 import { createClient } from "@/lib/supabase/client";
 import { showToast } from "@/lib/toast";
 import type {
-    AdminBatchRejectResponse,
-    AdminReviewResponse,
-    AdminSubmission,
-    AdminSubmissionsResponse,
-    AdminVelocityResponse,
-    RpcResult,
+  AdminBatchRejectResponse,
+  AdminReviewResponse,
+  AdminSubmission,
+  AdminSubmissionsResponse,
+  AdminVelocityResponse,
+  RpcResult,
 } from "@/lib/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-    Activity,
-    Ban,
-    CheckCircle,
-    Clock,
-    FileText,
-    Link2,
-    RefreshCw,
-    ShieldAlert,
-    ShieldCheck,
-    XCircle,
+  Activity,
+  Ban,
+  CheckCircle,
+  Clock,
+  FileText,
+  Link2,
+  RefreshCw,
+  ShieldAlert,
+  ShieldCheck,
+  XCircle,
 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 
@@ -284,6 +284,7 @@ export default function AdminSubmissionsPage() {
               {c.code}
             </option>
           ))}
+          <option value="__none__">{t("admin.noCountry")}</option>
         </select>
       </div>
 
@@ -408,6 +409,7 @@ function AdminSubmissionCard({
   const { t } = useTranslation();
   const date = new Date(submission.created_at).toLocaleString();
   const canReview = submission.status === "pending";
+  const effectiveCountry = submission.suggested_country ?? submission.scan_country;
 
   return (
     <li className="card">
@@ -432,10 +434,9 @@ function AdminSubmissionCard({
           </div>
           <div className="flex items-center gap-2">
             <CountryChip
-              country={
-                submission.suggested_country ?? submission.scan_country
-              }
+              country={effectiveCountry}
               size="sm"
+              nullLabel={t("admin.noCountry")}
             />
             {submission.user_trust_score !== null &&
               submission.user_trust_score !== undefined && (
@@ -459,6 +460,13 @@ function AdminSubmissionCard({
           </p>
         )}
 
+        {/* Legacy help text for null-country submissions */}
+        {!effectiveCountry && (
+          <p className="text-xs italic text-foreground-muted" data-testid="no-country-info">
+            ℹ {t("admin.noCountryHint")}
+          </p>
+        )}
+
         {submission.existing_product_match && (
           <p className="text-xs text-warning-text">
             ⚠ Possible duplicate — existing product #{submission.existing_product_match.product_id}{" "}
@@ -470,15 +478,23 @@ function AdminSubmissionCard({
         {submission.gs1_hint &&
           submission.gs1_hint.code !== "UNKNOWN" &&
           submission.gs1_hint.code !== "STORE" &&
-          (submission.suggested_country ?? submission.scan_country) &&
-          submission.gs1_hint.code !==
-            (submission.suggested_country ?? submission.scan_country) && (
+          effectiveCountry &&
+          submission.gs1_hint.code !== effectiveCountry && (
             <p className="text-xs text-warning-text" data-testid="gs1-mismatch-badge">
               ⚠ {t("admin.gs1Mismatch", {
                 gs1Country: submission.gs1_hint.name,
-                effectiveCountry:
-                  (submission.suggested_country ?? submission.scan_country)!,
+                effectiveCountry: effectiveCountry,
               })}
+            </p>
+          )}
+
+        {/* GS1 informational hint for legacy null-country submissions */}
+        {!effectiveCountry &&
+          submission.gs1_hint &&
+          submission.gs1_hint.code !== "UNKNOWN" &&
+          submission.gs1_hint.code !== "STORE" && (
+            <p className="text-xs text-foreground-secondary" data-testid="gs1-info-hint">
+              ℹ {t("admin.gs1InfoHint", { gs1Country: submission.gs1_hint.name })}
             </p>
           )}
 

--- a/frontend/src/components/common/CountryChip.test.tsx
+++ b/frontend/src/components/common/CountryChip.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { CountryChip } from "./CountryChip";
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
@@ -22,6 +22,14 @@ describe("CountryChip", () => {
   it("renders null when country is null", () => {
     const { container } = render(<CountryChip country={null} />);
     expect(container.innerHTML).toBe("");
+  });
+
+  it("renders fallback chip with nullLabel when country is null", () => {
+    render(<CountryChip country={null} nullLabel="No country" />);
+    const chip = screen.getByRole("img");
+    expect(chip).toBeTruthy();
+    expect(chip.getAttribute("aria-label")).toBe("No country");
+    expect(screen.getByText("No country")).toBeTruthy();
   });
 
   // ─── SVG flag rendering ────────────────────────────────────────────────

--- a/frontend/src/components/common/CountryChip.tsx
+++ b/frontend/src/components/common/CountryChip.tsx
@@ -10,12 +10,14 @@ import { useTranslation } from "@/lib/i18n";
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 interface CountryChipProps {
-  /** ISO 3166-1 alpha-2 country code. Null → render nothing. */
+  /** ISO 3166-1 alpha-2 country code. Null → render nothing (unless nullLabel provided). */
   country: string | null;
   /** Show full country name instead of 2-letter code. */
   showLabel?: boolean;
   /** Badge size variant. */
   size?: "sm" | "md";
+  /** Label to show when country is null. If omitted, null renders nothing. */
+  nullLabel?: string;
   className?: string;
 }
 
@@ -95,11 +97,26 @@ export function CountryChip({
   country,
   showLabel = false,
   size = "md",
+  nullLabel,
   className = "",
 }: Readonly<CountryChipProps>) {
   const { t } = useTranslation();
 
-  if (!country) return null;
+  if (!country && !nullLabel) return null;
+
+  if (!country) {
+    const cfg = SIZE_CONFIG[size];
+    return (
+      <span
+        role="img"
+        aria-label={nullLabel!}
+        className={`inline-flex items-center ${cfg.gap} rounded-full border border-border bg-surface-muted ${cfg.px} ${cfg.text} font-medium text-foreground-muted ${className}`}
+      >
+        <FallbackFlag size={cfg.flag} />
+        <span>{nullLabel}</span>
+      </span>
+    );
+  }
 
   const meta = COUNTRIES.find((c) => c.code === country);
   const name = meta?.name ?? country;


### PR DESCRIPTION
## Problem

Production smoke test after epic #920 deployment revealed 3 legacy submissions (Coca-Cola, Kellogg's Krave, PG Tips — all from Feb 2026) with **zero country context** in the admin review UI. Both `scan_country` and `suggested_country` are NULL for these rows because they were submitted before country tracking was added in epic #920.

**Root cause:** Missing feature / scope gap — NOT a regression. Epic #920 correctly implemented country-aware features for **new** submissions only. No fallback UX was designed for pre-existing null-country rows.

## Changes

### CountryChip.tsx
- Added `nullLabel?: string` prop — backward compatible (existing callers unaffected)
- When `country` is null AND `nullLabel` is provided → renders muted chip with `FallbackFlag` + label text
- When `country` is null AND no `nullLabel` → still returns null (existing behavior preserved)

### Admin Submissions Page (page.tsx)
- Extracted `effectiveCountry` variable (replaces inline `suggested_country ?? scan_country`)
- CountryChip now passes `nullLabel={t("admin.noCountry")}` → shows "No country" chip for legacy rows
- Added **legacy help text**: "Submitted before country tracking was added" (italic, muted, with ℹ icon)
- Added **GS1 informational hint**: "GS1 barcode registered in {country} (informational)" — shown only when country is null but GS1 hint exists, clearly labeled as informational (not proof of origin)
- Added **"No country" filter option** with `__none__` sentinel value in country dropdown
- Simplified GS1 mismatch badge to use `effectiveCountry` variable

### i18n (3 locales)
- Added `admin.noCountry` / `admin.noCountryHint` / `admin.gs1InfoHint` to en.json, pl.json, de.json

### Tests
- **1 modified test**: "does not render country chip when null" → "shows fallback country chip when null" (asserts chip IS present with `data-null-country` attribute)
- **6 new tests**: legacy help text visible, GS1 info hint for null-country, "No country" filter exists, filter sends `__none__`, mismatch badges suppressed for null-country, CountryChip `nullLabel` rendering

### Hard Rules Followed
- ❌ No historical data guessing — NULL values preserved as-is
- ❌ No auto-backfill of legacy rows
- ❌ GS1 prefix NOT treated as proof of product origin — labeled "informational" only

## Verification

```powershell
npx tsc --noEmit                  → 0 errors
npx vitest run (2 files)          → 63/63 tests pass
npx vitest run (i18n)             → 45/45 tests pass (dictionary parity confirmed)
```

### New/Updated Tests
- `CountryChip.test.tsx` — 1 new test (nullLabel rendering)
- `page.test.tsx` — 1 modified + 5 new tests (legacy UX coverage)

## File Impact

**7 files changed, +206 / -35 lines**
- 1 component modified (CountryChip.tsx — nullLabel prop)
- 1 page modified (page.tsx — effectiveCountry, legacy text, GS1 hint, filter)
- 3 i18n files (3 new keys each)
- 2 test files (1 modified test + 6 new tests)

## Follow-Up (Not in Scope)

Backend `api_admin_get_submissions` does not yet handle the `__none__` sentinel for NULL-country filtering. The frontend sends it correctly; backend handling can be added as a separate issue.