### PR TITLE
security(frontend): fix ReDoS in Safari UA regex (SonarCloud S5852)

### DIFF
--- a/frontend/src/lib/scanner-errors.ts
+++ b/frontend/src/lib/scanner-errors.ts
@@ -94,7 +94,7 @@ export function getBrowserSummary(): string {
     [/SamsungBrowser\/(\d+)/, "Samsung"],
     [/Firefox\/(\d+)/, "Firefox"],
     [/Chrome\/(\d+)/, "Chrome"],
-    [/Version\/(\d+)[^ ]* Safari/, "Safari"],
+    [/Version\/(\d+)[\d.]* Safari/, "Safari"],
   ];
   for (const [regex, name] of browsers) {
     const match = ua.match(regex);


### PR DESCRIPTION
## Problem\n\nSonarCloud Quality Gate failing on main after PR #948 merge. The `new_security_hotspots_reviewed` condition is at 0% (threshold: 100%).\n\nThe flagged hotspot is rule **S5852** (ReDoS) at `frontend/src/lib/scanner-errors.ts:97` — the Safari UA detection regex `/Version\\/(\\d+)[^ ]* Safari/` where `[^ ]*` can cause super-linear backtracking on adversarial input.\n\n## Fix\n\nReplace `[^ ]*` with `[\\d.]*` — the intermediate part of a Safari version string is always digits and dots (e.g., `17.2.1`), so `[\\d.]*` is both more precise and immune to catastrophic backtracking.\n\n**Before:** `/Version\\/(\\d+)[^ ]* Safari/`\n**After:** `/Version\\/(\\d+)[\\d.]* Safari/`\n\n## Verification\n\n- All 26 scanner-errors tests pass\n- No functional change (regex still matches `Version/17.2.1 Safari` correctly)