### PR TITLE
fix(frontend): desktop UX polish — 6 audit fixes across scanner, i18n, and flags

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -393,7 +393,7 @@
     "categoryLabel": "Kategorie",
     "categoryPlaceholder": "Kategorie wählen",
     "photoLabel": "Produktfoto",
-    "photoHint": "Fotografieren Sie die Vorderseite",
+    "photoHint": "Fotografieren Sie die Vorderseite oder die Nährwerttabelle",
     "photoRemove": "Foto entfernen",
     "photoInvalidType": "Bitte wählen Sie eine Bilddatei (JPEG, PNG oder WebP)",
     "photoTooLarge": "Das Foto muss kleiner als 5 MB sein",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -393,7 +393,7 @@
     "categoryLabel": "Category",
     "categoryPlaceholder": "Select a category",
     "photoLabel": "Product Photo",
-    "photoHint": "Take a photo of the front label",
+    "photoHint": "Take a photo of the front label or nutrition table",
     "photoRemove": "Remove photo",
     "photoInvalidType": "Please select an image file (JPEG, PNG, or WebP)",
     "photoTooLarge": "Photo must be smaller than 5 MB",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -393,7 +393,7 @@
     "categoryLabel": "Kategoria",
     "categoryPlaceholder": "Wybierz kategorię",
     "photoLabel": "Zdjęcie produktu",
-    "photoHint": "Zrób zdjęcie przedniej etykiety",
+    "photoHint": "Zrób zdjęcie przedniej etykiety lub tabeli wartości odżywczych",
     "photoRemove": "Usuń zdjęcie",
     "photoInvalidType": "Wybierz plik graficzny (JPEG, PNG lub WebP)",
     "photoTooLarge": "Zdjęcie musi być mniejsze niż 5 MB",

--- a/frontend/src/app/app/scan/page.test.tsx
+++ b/frontend/src/app/app/scan/page.test.tsx
@@ -412,12 +412,17 @@ describe("ScanPage", () => {
   });
 
   it("supports barcode format info text", async () => {
+    mockListDevices.mockResolvedValue([
+      { deviceId: "cam1", label: "Front Camera" } as MediaDeviceInfo,
+    ]);
     const user = userEvent.setup();
     render(<ScanPage />, { wrapper: createWrapper() });
     await user.click(screen.getByText("Camera"));
-    expect(
-      screen.getByText(/Supports EAN-13, EAN-8, UPC-A, UPC-E/),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Supports EAN-13, EAN-8, UPC-A, UPC-E/),
+      ).toBeInTheDocument();
+    });
   });
 
   it("enables batch mode checkbox", async () => {
@@ -556,11 +561,9 @@ describe("ScanPage", () => {
 
     render(<ScanPage />, { wrapper: createWrapper() });
 
-    // Enable batch mode
-    await user.click(screen.getByLabelText(/Batch mode/));
-
-    // Switch to manual and scan
+    // Switch to manual first (avoids camera-error hiding batch toggle)
     await user.click(screen.getByText("Manual"));
+    await user.click(screen.getByLabelText(/Batch mode/));
     await user.type(
       screen.getByPlaceholderText("Enter barcode"),
       "5901234123457",
@@ -592,8 +595,8 @@ describe("ScanPage", () => {
     const user = userEvent.setup();
 
     render(<ScanPage />, { wrapper: createWrapper() });
-    await user.click(screen.getByLabelText(/Batch mode/));
     await user.click(screen.getByText("Manual"));
+    await user.click(screen.getByLabelText(/Batch mode/));
     await user.type(
       screen.getByPlaceholderText("Enter barcode"),
       "5901234123457",
@@ -622,8 +625,8 @@ describe("ScanPage", () => {
     const user = userEvent.setup();
 
     render(<ScanPage />, { wrapper: createWrapper() });
-    await user.click(screen.getByLabelText(/Batch mode/));
     await user.click(screen.getByText("Manual"));
+    await user.click(screen.getByLabelText(/Batch mode/));
     await user.type(
       screen.getByPlaceholderText("Enter barcode"),
       "5901234123457",
@@ -654,8 +657,8 @@ describe("ScanPage", () => {
     const user = userEvent.setup();
 
     render(<ScanPage />, { wrapper: createWrapper() });
-    await user.click(screen.getByLabelText(/Batch mode/));
     await user.click(screen.getByText("Manual"));
+    await user.click(screen.getByLabelText(/Batch mode/));
     await user.type(
       screen.getByPlaceholderText("Enter barcode"),
       "5901234123457",
@@ -671,12 +674,17 @@ describe("ScanPage", () => {
   });
 
   it("shows camera info text in camera mode", async () => {
+    mockListDevices.mockResolvedValue([
+      { deviceId: "cam1", label: "Front Camera" } as MediaDeviceInfo,
+    ]);
     const user = userEvent.setup();
     render(<ScanPage />, { wrapper: createWrapper() });
     await user.click(screen.getByText("Camera"));
-    expect(
-      screen.getByText(/Supports EAN-13, EAN-8, UPC-A, UPC-E/),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Supports EAN-13, EAN-8, UPC-A, UPC-E/),
+      ).toBeInTheDocument();
+    });
   });
 
   it("mutation error sets scan state to error", async () => {
@@ -871,8 +879,8 @@ describe("ScanPage", () => {
     const user = userEvent.setup();
 
     render(<ScanPage />, { wrapper: createWrapper() });
-    await user.click(screen.getByLabelText(/Batch mode/));
     await user.click(screen.getByText("Manual"));
+    await user.click(screen.getByLabelText(/Batch mode/));
     await user.type(
       screen.getByPlaceholderText("Enter barcode"),
       "5901234123457",

--- a/frontend/src/app/app/scan/page.tsx
+++ b/frontend/src/app/app/scan/page.tsx
@@ -187,42 +187,11 @@ export default function ScanPage() {
     await queryClient.invalidateQueries({ queryKey: ["scan-history"] });
   }, [queryClient]);
 
-  // ─── Early-return result states ─────────────────────────────────────────────
-
-  if (scanState === "error") {
-    return (
-      <ScanErrorView
-        ean={ean}
-        onRetry={() => { setScanState("looking-up"); scanMutation.mutate(ean); }}
-        onReset={() => handleReset()}
-      />
-    );
-  }
-
-  if (scanState === "not-found" && scanResult && !scanResult.found) {
-    return (
-      <ScanNotFoundView
-        ean={ean}
-        scanResult={scanResult as RecordScanNotFoundResponse}
-        onReset={() => handleReset()}
-        country={userCountry}
-      />
-    );
-  }
-
-  if (scanState === "looking-up" && scanMutation.isPending) {
-    return <ScanLookingUpView ean={ean} />;
-  }
-
-  if (scanState === "found" && foundProduct) {
-    return (
-      <ScanFoundView
-        product={foundProduct}
-        onViewDetails={() => router.push(`/app/scan/result/${foundProduct.product_id}`)}
-        onReset={() => handleReset()}
-      />
-    );
-  }
+  // ─── Idle-state flag — scanState is "idle" and not transitioning ────────────
+  const isIdle =
+    scanState === "idle" ||
+    (scanState === "looking-up" && !scanMutation.isPending) ||
+    (scanState === "found" && !foundProduct);
 
   return (
     <PullToRefresh onRefresh={handleRefresh}>
@@ -259,7 +228,44 @@ export default function ScanPage() {
         </div>
       </div>
 
-      {/* Batch mode toggle */}
+      {/* ── Result states ─────────────────────────────────────────────────── */}
+
+      {scanState === "error" && (
+        <ScanErrorView
+          ean={ean}
+          onRetry={() => { setScanState("looking-up"); scanMutation.mutate(ean); }}
+          onReset={() => handleReset()}
+        />
+      )}
+
+      {scanState === "not-found" && scanResult && !scanResult.found && (
+        <ScanNotFoundView
+          ean={ean}
+          scanResult={scanResult as RecordScanNotFoundResponse}
+          onReset={() => handleReset()}
+          country={userCountry}
+        />
+      )}
+
+      {scanState === "looking-up" && scanMutation.isPending && (
+        <ScanLookingUpView ean={ean} />
+      )}
+
+      {scanState === "found" && foundProduct && (
+        <ScanFoundView
+          product={foundProduct}
+          onViewDetails={() => router.push(`/app/scan/result/${foundProduct.product_id}`)}
+          onReset={() => handleReset()}
+        />
+      )}
+
+      {/* ── Idle scanner UI ───────────────────────────────────────────────── */}
+
+      {isIdle && (
+        <>
+
+      {/* Batch mode toggle (hidden when camera has an error) */}
+      {!(mode === "camera" && cameraError) && (
       <label className="touch-target flex cursor-pointer items-center gap-2 rounded-lg border border-border px-3 py-2.5">
         <input
           type="checkbox"
@@ -272,6 +278,7 @@ export default function ScanPage() {
         />
         <span className="text-sm text-foreground">{t("scan.batchMode")}</span>
       </label>
+      )}
 
       {/* Mode toggle */}
       <div className="flex gap-1 rounded-lg bg-surface-muted p-1">
@@ -391,11 +398,11 @@ export default function ScanPage() {
                   </p>
                 </div>
               )}
+              <p className="text-center text-xs text-foreground-muted">
+                {t("scan.cameraHint")}
+              </p>
             </>
           )}
-          <p className="text-center text-xs text-foreground-muted">
-            {t("scan.cameraHint")}
-          </p>
         </div>
       ) : (
         <form onSubmit={handleManualSubmit} className="space-y-3">
@@ -498,6 +505,8 @@ export default function ScanPage() {
             {t("scan.doneScan")}
           </Button>
         </div>
+      )}
+        </>
       )}
     </div>
     </PullToRefresh>

--- a/frontend/src/app/app/scan/submit/page.test.tsx
+++ b/frontend/src/app/app/scan/submit/page.test.tsx
@@ -214,7 +214,7 @@ describe("SubmitProductPage", () => {
 
   it("shows photo upload prompt initially", () => {
     render(<SubmitProductPage />, { wrapper: createWrapper() });
-    expect(screen.getByText("Take a photo of the front label")).toBeInTheDocument();
+    expect(screen.getByText("Take a photo of the front label or nutrition table")).toBeInTheDocument();
   });
 
   it("shows photo preview and remove button after selecting a valid photo", async () => {
@@ -242,7 +242,7 @@ describe("SubmitProductPage", () => {
       expect.objectContaining({ type: "error", messageKey: "submit.photoInvalidType" }),
     );
     // Photo prompt should still be shown (no preview)
-    expect(screen.getByText("Take a photo of the front label")).toBeInTheDocument();
+    expect(screen.getByText("Take a photo of the front label or nutrition table")).toBeInTheDocument();
   });
 
   it("rejects files exceeding 5 MB", async () => {
@@ -272,7 +272,7 @@ describe("SubmitProductPage", () => {
     });
 
     await user.click(screen.getByRole("button", { name: "Remove photo" }));
-    expect(screen.getByText("Take a photo of the front label")).toBeInTheDocument();
+    expect(screen.getByText("Take a photo of the front label or nutrition table")).toBeInTheDocument();
   });
 
   // ─── GS1 country hint ─────────────────────────────────────────────────────

--- a/frontend/src/app/app/scan/submit/page.tsx
+++ b/frontend/src/app/app/scan/submit/page.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "@/lib/i18n";
 import { createClient } from "@/lib/supabase/client";
 import { showToast } from "@/lib/toast";
 import type { FormSubmitEvent } from "@/lib/types";
+import { isValidEan, isValidEanChecksum } from "@/lib/validation";
 import { useMutation } from "@tanstack/react-query";
 import { Camera, FileText, X } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -37,6 +38,7 @@ export default function SubmitProductPage() {
   const [notes, setNotes] = useState("");
   const [photoFile, setPhotoFile] = useState<File | null>(null);
   const [photoPreview, setPhotoPreview] = useState<string | null>(null);
+  const [checksumWarn, setChecksumWarn] = useState(false);
   const { t } = useTranslation();
   const gs1Hint = ean.length >= 8 ? gs1CountryHint(ean) : null;
   const photoPreviewRef = useRef(photoPreview);
@@ -159,9 +161,11 @@ export default function SubmitProductPage() {
               id="ean"
               type="text"
               value={ean}
-              onChange={(e) =>
-                setEan(e.target.value.replaceAll(/\D/g, "").slice(0, 13))
-              }
+              onChange={(e) => {
+                const v = e.target.value.replaceAll(/\D/g, "").slice(0, 13);
+                setEan(v);
+                setChecksumWarn(v.length >= 8 && isValidEan(v) && !isValidEanChecksum(v));
+              }}
               className="input-field font-mono tracking-widest"
               placeholder={t("submit.eanPlaceholder")}
               inputMode="numeric"
@@ -169,6 +173,11 @@ export default function SubmitProductPage() {
               required
               readOnly={!!prefillEan}
             />
+            {checksumWarn && (
+              <p className="mt-1 text-xs text-warning-text">
+                {t("scan.checksumWarning")}
+              </p>
+            )}
           </div>
 
           {/* Product name */}

--- a/frontend/src/lib/constants.test.ts
+++ b/frontend/src/lib/constants.test.ts
@@ -4,6 +4,7 @@ import {
     COUNTRIES,
     DIET_OPTIONS,
     FEATURES,
+    getCountryFlag,
     getScoreInterpretation,
     HEALTH_CONDITIONS,
     NUTRI_COLORS,
@@ -239,5 +240,33 @@ describe("TRAFFIC_LIGHT_NUTRIENTS", () => {
 describe("FEATURES", () => {
   it("has ECO_SCORE set to false by default", () => {
     expect(FEATURES.ECO_SCORE).toBe(false);
+  });
+});
+
+// ─── getCountryFlag ─────────────────────────────────────────────────────────
+
+describe("getCountryFlag", () => {
+  it("returns 🇵🇱 for PL", () => {
+    expect(getCountryFlag("PL")).toBe("🇵🇱");
+  });
+
+  it("returns 🇩🇪 for DE", () => {
+    expect(getCountryFlag("DE")).toBe("🇩🇪");
+  });
+
+  it("returns 🇺🇸 for US (not in COUNTRIES array)", () => {
+    expect(getCountryFlag("US")).toBe("🇺🇸");
+  });
+
+  it("handles lowercase codes", () => {
+    expect(getCountryFlag("pl")).toBe("🇵🇱");
+    expect(getCountryFlag("us")).toBe("🇺🇸");
+  });
+
+  it("returns 🌐 for invalid codes", () => {
+    expect(getCountryFlag("")).toBe("🌐");
+    expect(getCountryFlag("X")).toBe("🌐");
+    expect(getCountryFlag("USA")).toBe("🌐");
+    expect(getCountryFlag("12")).toBe("🌐");
   });
 });

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -24,9 +24,13 @@ export const COUNTRY_DEFAULT_LANGUAGES: Record<string, string> = {
   DE: "de",
 } as const;
 
-/** Get flag emoji for a country code. Falls back to globe for unknown codes. */
+/** Get flag emoji for any ISO 3166-1 alpha-2 country code via regional indicator symbols. */
 export function getCountryFlag(code: string): string {
-  return COUNTRIES.find((c) => c.code === code)?.flag ?? "🌐";
+  if (!/^[A-Z]{2}$/i.test(code)) return "🌐";
+  const upper = code.toUpperCase();
+  return String.fromCodePoint(
+    ...([...upper].map((c) => 0x1f1e6 + c.charCodeAt(0) - 65)),
+  );
 }
 
 /** Get English display name for a country code. Falls back to the code itself. */


### PR DESCRIPTION
## Summary

Desktop UX audit at 175% & 150% zoom identified 7 issues (3 P2, 4 P3). This PR implements 6 of them; P3-3 (weight/packaging fields) is deferred as it requires DB schema changes.

**9 files changed, +124 / −65 lines.**

---

## Changes

### P2-1 — Layout Bypass on Scan Page (High)

**Problem:** Four early `return` blocks bypassed the shared layout shell — breadcrumbs, header, and `<PullToRefresh>` wrapper disappeared when scanner showed results or loading states.

**Fix:** Removed all early returns. Single `return` with layout shell always renders. Result states (found, not-found, looking-up) shown conditionally inside the shared layout. Idle scanner UI wrapped in `{isIdle && (<>...</>)}`.

**Files:** `frontend/src/app/app/scan/page.tsx`

### P2-2 — Camera Hint Shown During Error (High)

**Problem:** The "Point your camera at a barcode" hint stayed visible alongside the camera error message, creating contradictory UI.

**Fix:** Moved `<p>{t("scan.cameraHint")}</p>` inside the non-error branch of the `cameraError` ternary so it only renders when the camera is operational.

**Files:** `frontend/src/app/app/scan/page.tsx`

### P2-3 — Incomplete Photo Hint Copy (Medium)

**Problem:** Photo hint said "Take a photo of the front label" but didn't mention the nutrition table — users may not know both are useful.

**Fix:** Updated all 3 locales to "Take a photo of the front label or nutrition table" (EN/DE/PL).

**Files:** `frontend/messages/en.json`, `frontend/messages/de.json`, `frontend/messages/pl.json`

### P3-1 — Globe Fallback for Country Flags (Low)

**Problem:** `getCountryFlag()` used a static `COUNTRIES.find()` lookup with a 🌐 fallback — any code outside the lookup returned a generic globe.

**Fix:** Rewrote to compute Unicode regional indicator symbols from ISO 3166-1 alpha-2 codes. Now supports all 676 two-letter combinations — no static map needed. Input-validated with `/^[A-Z]{2}$/i` regex; invalid inputs still return 🌐.

**Files:** `frontend/src/lib/constants.ts`, `frontend/src/lib/constants.test.ts` (6 new tests)

### P3-2 — No Checksum Warning on Submission Page (Low)

**Problem:** Users could submit product barcodes with invalid GS1 check digits — no feedback until server rejection.

**Fix:** Added client-side EAN checksum validation using existing `isValidEan`/`isValidEanChecksum` utilities. Shows amber warning when barcode fails check digit (non-blocking — user can still submit).

**Files:** `frontend/src/app/app/scan/submit/page.tsx`

### P3-4 — Batch Toggle Visible During Camera Error (Low)

**Problem:** Batch mode toggle was visible when camera had an error but was non-functional (clicking it did nothing useful).

**Fix:** Wrapped batch toggle in `{!(mode === "camera" && cameraError) && (...)}` guard — hidden when camera mode has an error. Visible in manual mode or when camera is working.

**Files:** `frontend/src/app/app/scan/page.tsx`

### P3-3 — Weight/Packaging Fields (Deferred)

Requires `weight_g`, `packaging_type`, `serving_suggestion` columns on `product_submissions` table + migration. Out of scope for this PR.

---

## Test Updates

| Category | Count | Description |
|----------|-------|-------------|
| New tests | 6 | `getCountryFlag()` — PL 🇵🇱, DE 🇩🇪, US 🇺🇸, lowercase, invalid, empty |
| Fixed tests | 3 | Updated photo hint text assertions to match new i18n copy |
| Fixed tests | 2 | Added camera device mocks for hint visibility tests (camera hint now inside non-error branch) |
| Fixed tests | 5 | Swapped batch toggle click order (Manual first, then batch) to avoid camera error race condition |

**Total: 5798/5798 tests pass, 0 TypeScript errors.**

---

## Verification

```
npx tsc --noEmit              → 0 errors
npx vitest run                → 5798/5798 pass (349 files, 0 failures)
```