### PR TITLE
fix(scanner): auto-retry camera on transient SPA NotAllowedError

### DIFF
--- a/frontend/src/hooks/__tests__/use-barcode-scanner.test.ts
+++ b/frontend/src/hooks/__tests__/use-barcode-scanner.test.ts
@@ -481,6 +481,43 @@ describe("useBarcodeScanner", () => {
         error_type: "unknown",
       }));
     });
+
+    it("auto-retries when permissions.query returns granted (transient SPA error)", async () => {
+      // First attempt fails with NotAllowedError
+      mockListDevices.mockRejectedValueOnce(
+        new DOMException("NotAllowedError", "NotAllowedError"),
+      );
+      mockClassify.mockReturnValue("permission-denied");
+
+      Object.defineProperty(navigator, "permissions", {
+        value: {
+          query: vi.fn().mockResolvedValue({ state: "granted" }),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() =>
+        useBarcodeScanner(makeOptions()),
+      );
+
+      await act(async () => {
+        await result.current.startScanner();
+      });
+
+      // No error yet — retry is scheduled
+      expect(result.current.cameraError).toBeNull();
+
+      // Retry succeeds (mockRejectedValueOnce only rejects once)
+      mockListDevices.mockResolvedValue([makeDevice("cam1")]);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(700);
+      });
+
+      // Scanner recovered
+      expect(result.current.cameraError).toBeNull();
+    });
   });
 
   // ─── Watchdog timeout ─────────────────────────────────────────────────

--- a/frontend/src/hooks/use-barcode-scanner.ts
+++ b/frontend/src/hooks/use-barcode-scanner.ts
@@ -100,6 +100,7 @@ export function useBarcodeScanner({
   const initStartTimeRef = useRef(0);
   const streamReadyTimeRef = useRef(0);
   const streamReadyFiredRef = useRef(false);
+  const startIdRef = useRef(0);
   const onBarcodeDetectedRef = useRef(onBarcodeDetected);
   onBarcodeDetectedRef.current = onBarcodeDetected;
 
@@ -119,10 +120,11 @@ export function useBarcodeScanner({
     streamReadyFiredRef.current = false;
   }, []);
 
-  const startScanner = useCallback(async () => {
+  const startScanner = useCallback(async (retryAttempt = 0) => {
+    const thisStartId = ++startIdRef.current;
     setCameraError(null);
     initStartTimeRef.current = Date.now();
-    track("scanner_init_start", { browser: getBrowserSummary() });
+    track("scanner_init_start", { browser: getBrowserSummary(), retry_attempt: retryAttempt });
 
     try {
       const { BrowserMultiFormatReader, DecodeHintType, BarcodeFormat } =
@@ -203,7 +205,7 @@ export function useBarcodeScanner({
 
       // Watchdog: if feed is still not active after 5 s, flag camera error
       setTimeout(() => {
-        if (!isMountedRef.current) return;
+        if (!isMountedRef.current || thisStartId !== startIdRef.current) return;
         if (videoEl && (videoEl.readyState < 2 || videoEl.videoWidth === 0)) {
           setCameraError("generic");
           track("scanner_init_error", {
@@ -213,33 +215,53 @@ export function useBarcodeScanner({
         }
       }, 5_000);
     } catch (err: unknown) {
+      if (thisStartId !== startIdRef.current) return; // stale call — discard
+
       const errorType = classifyScannerError(err);
       track("scanner_init_error", {
         error_type: errorType,
         browser: getBrowserSummary(),
+        retry_attempt: retryAttempt,
       });
+
       if (errorType === "permission-denied") {
         // Best-effort permission state detection
-        let permKind: CameraErrorKind = "permission-unknown";
+        let permState: string | null = null;
         try {
           if (navigator.permissions?.query) {
             const result = await navigator.permissions.query({
               name: "camera" as PermissionName,
             });
-            permKind =
-              result.state === "denied"
-                ? "permission-denied"
-                : "permission-prompt";
+            permState = result.state;
           }
         } catch {
           // Permissions API unavailable or 'camera' not supported
         }
-        setCameraError(permKind);
+
+        // Auto-retry only when the Permissions API confirms "granted" —
+        // the NotAllowedError is a transient SPA-navigation artifact
+        // on mobile browsers (especially Android Chrome).
+        if (permState === "granted" && retryAttempt < 2) {
+          setTimeout(() => {
+            if (thisStartId === startIdRef.current && isMountedRef.current) {
+              startScanner(retryAttempt + 1);
+            }
+          }, 600 * (retryAttempt + 1));
+          return;
+        }
+
+        setCameraError(
+          permState === "denied"
+            ? "permission-denied"
+            : permState === "prompt"
+              ? "permission-prompt"
+              : "permission-unknown",
+        );
       } else {
         setCameraError("generic");
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- track is fire-and-forget
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- track is fire-and-forget; self-ref in retry is stable
   }, [stopScanner]);
 
   // ─── Torch ──────────────────────────────────────────────────────────────
@@ -281,6 +303,30 @@ export function useBarcodeScanner({
     }
     return () => stopScanner();
   }, [enabled, startScanner, stopScanner]);
+
+  // Listen for camera-permission state changes — auto-recover from
+  // transient NotAllowedError when the user grants access via settings.
+  useEffect(() => {
+    if (!cameraError) return;
+    let cleanup: (() => void) | null = null;
+    async function listen() {
+      try {
+        if (!navigator.permissions?.query) return;
+        const permStatus = await navigator.permissions.query({
+          name: "camera" as PermissionName,
+        });
+        const onChange = () => {
+          if (permStatus.state === "granted") startScanner();
+        };
+        permStatus.addEventListener("change", onChange);
+        cleanup = () => permStatus.removeEventListener("change", onChange);
+      } catch {
+        /* Permissions API unavailable */
+      }
+    }
+    listen();
+    return () => cleanup?.();
+  }, [cameraError, startScanner]);
 
   // ─── Public API ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

On mobile browsers (especially Android Chrome), SPA navigation causes `getUserMedia()` to throw `NotAllowedError` even when camera permission is already granted. Users see "Camera Access Blocked" and must press **Reload Page** (full page reload) for the camera to work.

## Root Cause

When navigating to the scan page via SPA navigation (client-side route change), the browser's media APIs may temporarily reject camera access. The `NotAllowedError` is transient — the permission IS granted, but the browser hasn't yet associated the new navigation context with the existing permission grant.

## Solution

**Auto-retry when the Permissions API confirms permission is actually granted:**

1. **Stale-call prevention** — `startIdRef` counter ensures old async calls don't overwrite newer state
2. **Targeted retry** — When `NotAllowedError` fires, query the real permission state via `navigator.permissions.query()`. Only retry (up to 2×, exponential backoff: 600ms, 1200ms) when `permState === "granted"` — the specific transient SPA bug scenario
3. **Permission change listener** — New `useEffect` watches `PermissionStatus.onchange` and auto-recovers when user grants access via browser settings while error is displayed

**Key design decision:** Retry is narrowly scoped to `permState === "granted"` only. For `"prompt"`, `"denied"`, or unavailable Permissions API, the error shows immediately — no unnecessary delay.

## Files Changed

- `frontend/src/hooks/use-barcode-scanner.ts` — retry logic + stale-call guard + permission listener
- `frontend/src/hooks/__tests__/use-barcode-scanner.test.ts` — 1 new test (auto-retry recovery) + existing tests verified

## Verification

```
npx tsc --noEmit          → 0 errors
Hook tests (25/25)        → all pass
Page tests (51/51)        → all pass
Full suite (5827/5827)    → all pass, 0 failures
```