### PR TITLE
fix(scanner): pre-flight getUserMedia retry for transient Android SPA camera errors

### DIFF
--- a/frontend/src/app/app/scan/page.test.tsx
+++ b/frontend/src/app/app/scan/page.test.tsx
@@ -18,6 +18,13 @@ if (typeof globalThis.MediaStream === "undefined") {
   } as unknown as typeof MediaStream;
 }
 
+// Pre-flight getUserMedia stub — delegates to hoisted mock
+Object.defineProperty(navigator, "mediaDevices", {
+  value: { getUserMedia: (...a: unknown[]) => mockGetUserMedia(...a) },
+  writable: true,
+  configurable: true,
+});
+
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
 const {
@@ -27,6 +34,7 @@ const {
   mockListDevices,
   mockDecodeFromDevice,
   mockResetReader,
+  mockGetUserMedia,
 } = vi.hoisted(() => ({
   mockPush: vi.fn(),
   mockRecordScan: vi.fn(),
@@ -34,6 +42,7 @@ const {
   mockListDevices: vi.fn(),
   mockDecodeFromDevice: vi.fn(),
   mockResetReader: vi.fn(),
+  mockGetUserMedia: vi.fn(),
 }));
 
 vi.mock("@/hooks/use-reduced-motion", () => ({
@@ -163,6 +172,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   // Re-establish ZXing defaults (clearAllMocks strips implementations)
   mockListDevices.mockResolvedValue([]);
+  // Pre-flight getUserMedia — resolve by default so camera-mode tests pass
+  mockGetUserMedia.mockResolvedValue({
+    getTracks: () => [{ stop: vi.fn() }],
+  });
 });
 
 describe("ScanPage", () => {

--- a/frontend/src/hooks/__tests__/use-barcode-scanner.test.ts
+++ b/frontend/src/hooks/__tests__/use-barcode-scanner.test.ts
@@ -15,6 +15,7 @@ const {
   mockGetFacing,
   mockShowToast,
   mockIsValidEan,
+  mockGetUserMedia,
 } = vi.hoisted(() => ({
   mockListDevices: vi.fn(),
   mockDecodeFromDevice: vi.fn(),
@@ -24,6 +25,7 @@ const {
   mockGetFacing: vi.fn(),
   mockShowToast: vi.fn(),
   mockIsValidEan: vi.fn(),
+  mockGetUserMedia: vi.fn(),
 }));
 
 // ─── Module mocks ───────────────────────────────────────────────────────────
@@ -70,6 +72,13 @@ if (typeof globalThis.MediaStream === "undefined") {
   } as unknown as typeof MediaStream;
 }
 
+// Pre-flight getUserMedia stub — delegates to hoisted mock
+Object.defineProperty(navigator, "mediaDevices", {
+  value: { getUserMedia: (...a: unknown[]) => mockGetUserMedia(...a) },
+  writable: true,
+  configurable: true,
+});
+
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function makeOptions(overrides: Partial<Parameters<typeof useBarcodeScanner>[0]> = {}) {
@@ -98,6 +107,9 @@ beforeEach(() => {
   mockGetBrowser.mockReturnValue("Chrome/120");
   mockGetFacing.mockReturnValue("environment");
   mockIsValidEan.mockReturnValue(true);
+  mockGetUserMedia.mockResolvedValue({
+    getTracks: () => [{ stop: vi.fn() }],
+  });
 });
 
 afterEach(() => {
@@ -382,7 +394,7 @@ describe("useBarcodeScanner", () => {
 
   describe("permission errors", () => {
     it("sets permission-denied when permissions.query returns denied", async () => {
-      mockListDevices.mockRejectedValue(new DOMException("NotAllowedError", "NotAllowedError"));
+      mockGetUserMedia.mockRejectedValue(new DOMException("NotAllowedError", "NotAllowedError"));
       mockClassify.mockReturnValue("permission-denied");
 
       // Mock permissions API
@@ -406,7 +418,7 @@ describe("useBarcodeScanner", () => {
     });
 
     it("sets permission-prompt when permissions.query returns prompt", async () => {
-      mockListDevices.mockRejectedValue(new DOMException("NotAllowedError", "NotAllowedError"));
+      mockGetUserMedia.mockRejectedValue(new DOMException("NotAllowedError", "NotAllowedError"));
       mockClassify.mockReturnValue("permission-denied");
 
       Object.defineProperty(navigator, "permissions", {
@@ -429,7 +441,7 @@ describe("useBarcodeScanner", () => {
     });
 
     it("sets permission-unknown when permissions API unavailable", async () => {
-      mockListDevices.mockRejectedValue(new DOMException("NotAllowedError", "NotAllowedError"));
+      mockGetUserMedia.mockRejectedValue(new DOMException("NotAllowedError", "NotAllowedError"));
       mockClassify.mockReturnValue("permission-denied");
 
       Object.defineProperty(navigator, "permissions", {
@@ -482,12 +494,15 @@ describe("useBarcodeScanner", () => {
       }));
     });
 
-    it("auto-retries when permissions.query returns granted (transient SPA error)", async () => {
-      // First attempt fails with NotAllowedError
-      mockListDevices.mockRejectedValueOnce(
-        new DOMException("NotAllowedError", "NotAllowedError"),
-      );
-      mockClassify.mockReturnValue("permission-denied");
+    it("pre-flight retries getUserMedia on transient SPA error (permission granted)", async () => {
+      // First getUserMedia call fails, second succeeds
+      mockGetUserMedia
+        .mockRejectedValueOnce(
+          new DOMException("NotAllowedError", "NotAllowedError"),
+        )
+        .mockResolvedValueOnce({ getTracks: () => [{ stop: vi.fn() }] });
+
+      mockListDevices.mockResolvedValue([makeDevice("cam1")]);
 
       Object.defineProperty(navigator, "permissions", {
         value: {
@@ -502,21 +517,15 @@ describe("useBarcodeScanner", () => {
       );
 
       await act(async () => {
-        await result.current.startScanner();
+        const promise = result.current.startScanner();
+        // Advance past the first pre-flight retry delay (250ms)
+        await vi.advanceTimersByTimeAsync(300);
+        await promise;
       });
 
-      // No error yet — retry is scheduled
+      // Scanner recovered via pre-flight — no error shown
       expect(result.current.cameraError).toBeNull();
-
-      // Retry succeeds (mockRejectedValueOnce only rejects once)
-      mockListDevices.mockResolvedValue([makeDevice("cam1")]);
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(700);
-      });
-
-      // Scanner recovered
-      expect(result.current.cameraError).toBeNull();
+      expect(mockGetUserMedia).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/frontend/src/hooks/use-barcode-scanner.ts
+++ b/frontend/src/hooks/use-barcode-scanner.ts
@@ -82,6 +82,48 @@ interface UseBarcodeOptions {
   track: (event: AnalyticsEventName, data?: Record<string, unknown>) => void;
 }
 
+// ─── Pre-flight camera access ───────────────────────────────────────────────
+// On Android Chrome, SPA navigation can cause getUserMedia() to throw a
+// transient NotAllowedError even when the permission is already granted.
+// This helper retries the lightweight getUserMedia call with exponential
+// backoff before we start the heavy ZXing initialization.
+// ────────────────────────────────────────────────────────────────────────────
+
+const PREFLIGHT_MAX_RETRIES = 5;
+const PREFLIGHT_BASE_DELAY_MS = 250;
+
+async function ensureCameraAccess(): Promise<void> {
+  for (let attempt = 0; attempt <= PREFLIGHT_MAX_RETRIES; attempt++) {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+      stream.getTracks().forEach((t) => t.stop());
+      return;
+    } catch (err) {
+      if (attempt === PREFLIGHT_MAX_RETRIES) throw err;
+
+      // Only retry when the Permissions API confirms the user already
+      // granted camera access — the failure is a transient browser bug.
+      let permGranted = false;
+      try {
+        if (navigator.permissions?.query) {
+          const ps = await navigator.permissions.query({
+            name: "camera" as PermissionName,
+          });
+          permGranted = ps.state === "granted";
+        }
+      } catch {
+        /* Permissions API unavailable */
+      }
+
+      if (!permGranted) throw err;
+
+      await new Promise<void>((r) =>
+        setTimeout(r, PREFLIGHT_BASE_DELAY_MS * 2 ** attempt),
+      );
+    }
+  }
+}
+
 // ─── Hook ───────────────────────────────────────────────────────────────────
 
 export function useBarcodeScanner({
@@ -120,13 +162,17 @@ export function useBarcodeScanner({
     streamReadyFiredRef.current = false;
   }, []);
 
-  const startScanner = useCallback(async (retryAttempt = 0) => {
+  const startScanner = useCallback(async () => {
     const thisStartId = ++startIdRef.current;
     setCameraError(null);
     initStartTimeRef.current = Date.now();
-    track("scanner_init_start", { browser: getBrowserSummary(), retry_attempt: retryAttempt });
+    track("scanner_init_start", { browser: getBrowserSummary() });
 
     try {
+      // Pre-flight: ensure camera is accessible before heavy ZXing init.
+      // Handles transient NotAllowedError on Android Chrome SPA navigation.
+      await ensureCameraAccess();
+
       const { BrowserMultiFormatReader, DecodeHintType, BarcodeFormat } =
         await import("@zxing/library");
 
@@ -221,11 +267,10 @@ export function useBarcodeScanner({
       track("scanner_init_error", {
         error_type: errorType,
         browser: getBrowserSummary(),
-        retry_attempt: retryAttempt,
       });
 
       if (errorType === "permission-denied") {
-        // Best-effort permission state detection
+        // Best-effort permission state detection for UI classification
         let permState: string | null = null;
         try {
           if (navigator.permissions?.query) {
@@ -236,18 +281,6 @@ export function useBarcodeScanner({
           }
         } catch {
           // Permissions API unavailable or 'camera' not supported
-        }
-
-        // Auto-retry only when the Permissions API confirms "granted" —
-        // the NotAllowedError is a transient SPA-navigation artifact
-        // on mobile browsers (especially Android Chrome).
-        if (permState === "granted" && retryAttempt < 2) {
-          setTimeout(() => {
-            if (thisStartId === startIdRef.current && isMountedRef.current) {
-              startScanner(retryAttempt + 1);
-            }
-          }, 600 * (retryAttempt + 1));
-          return;
         }
 
         setCameraError(
@@ -261,7 +294,7 @@ export function useBarcodeScanner({
         setCameraError("generic");
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- track is fire-and-forget; self-ref in retry is stable
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- track is fire-and-forget
   }, [stopScanner]);
 
   // ─── Torch ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

PR #954's catch-block retry mechanism (3 full ZXing init retries, ~1800ms total) only partially resolved the Android Chrome camera issue. Users still see the "Camera Access Blocked" error **once** on the first SPA navigation to the scan page, even when camera permission is already granted.

**Root cause:** Android Chrome can throw a transient `NotAllowedError` on `getUserMedia()` during SPA navigation. PR #954 retried the **entire** heavy ZXing initialization (dynamic import + reader creation + device listing + decode start) — each retry was slow and the 1800ms total window was insufficient for longer browser settling times.

## Solution

Replace the catch-block retry with a **pre-flight `getUserMedia` check** that uses exponential backoff before ZXing initialization:

1. **`ensureCameraAccess()`** — lightweight retry of just `getUserMedia({ video: true })`:
   - 6 total attempts (initial + 5 retries)
   - Exponential backoff: 250ms → 500ms → 1000ms → 2000ms → 4000ms
   - ~7.75s maximum wait (vs 1.8s before)
   - Only retries when `navigator.permissions` reports `"granted"` (transient error)
   - Immediately throws if permission is genuinely denied/prompt

2. **Streamlined `startScanner()`** — pre-flight runs first, then ZXing init proceeds once camera access is confirmed. No retry parameter, no catch-block retry logic.

## Changes

| File | Change |
|------|--------|
| `use-barcode-scanner.ts` | Add `ensureCameraAccess()` with exponential backoff; call before ZXing init; remove old catch-block retry |
| `use-barcode-scanner.test.ts` | Add `getUserMedia` jsdom stub; update permission error tests; rewrite auto-retry test for pre-flight mechanism |
| `page.test.tsx` | Add `getUserMedia` jsdom stub (page uses real hook) |

## Verification

```
npx vitest run (scanner tests)  → 157/157 pass (6 files)
npx vitest run (full suite)     → 5,827/5,827 pass (351 files)
npx tsc --noEmit                → 0 errors
```