### PR TITLE
fix(scanner): address 4 Copilot review suggestions from PR #955

### DIFF
--- a/frontend/src/app/app/scan/page.test.tsx
+++ b/frontend/src/app/app/scan/page.test.tsx
@@ -18,13 +18,6 @@ if (typeof globalThis.MediaStream === "undefined") {
   } as unknown as typeof MediaStream;
 }
 
-// Pre-flight getUserMedia stub — delegates to hoisted mock
-Object.defineProperty(navigator, "mediaDevices", {
-  value: { getUserMedia: (...a: unknown[]) => mockGetUserMedia(...a) },
-  writable: true,
-  configurable: true,
-});
-
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
 const {
@@ -44,6 +37,14 @@ const {
   mockResetReader: vi.fn(),
   mockGetUserMedia: vi.fn(),
 }));
+
+// Pre-flight getUserMedia stub — delegates to hoisted mock (placed after
+// vi.hoisted so the reference is explicit in source order).
+Object.defineProperty(navigator, "mediaDevices", {
+  value: { getUserMedia: (...a: unknown[]) => mockGetUserMedia(...a) },
+  writable: true,
+  configurable: true,
+});
 
 vi.mock("@/hooks/use-reduced-motion", () => ({
   useReducedMotion: () => true,

--- a/frontend/src/hooks/use-barcode-scanner.ts
+++ b/frontend/src/hooks/use-barcode-scanner.ts
@@ -99,6 +99,13 @@ async function ensureCameraAccess(): Promise<void> {
       stream.getTracks().forEach((t) => t.stop());
       return;
     } catch (err) {
+      // NotFoundError / OverconstrainedError = genuinely no camera hardware.
+      // Don't retry — let the caller handle it as a real no-camera error.
+      const errName = err instanceof DOMException ? err.name : "";
+      if (errName === "NotFoundError" || errName === "OverconstrainedError") {
+        throw err;
+      }
+
       if (attempt === PREFLIGHT_MAX_RETRIES) throw err;
 
       // Only retry when the Permissions API confirms the user already
@@ -146,9 +153,14 @@ export function useBarcodeScanner({
   const onBarcodeDetectedRef = useRef(onBarcodeDetected);
   onBarcodeDetectedRef.current = onBarcodeDetected;
 
+  const trackRef = useRef(track);
+  trackRef.current = track;
+
   // ─── Lifecycle ──────────────────────────────────────────────────────────
 
   const stopScanner = useCallback(() => {
+    // Invalidate any in-flight startScanner() so it bails after pre-flight
+    startIdRef.current++;
     if (readerRef.current) {
       readerRef.current.reset();
       readerRef.current = null;
@@ -166,12 +178,16 @@ export function useBarcodeScanner({
     const thisStartId = ++startIdRef.current;
     setCameraError(null);
     initStartTimeRef.current = Date.now();
-    track("scanner_init_start", { browser: getBrowserSummary() });
+    trackRef.current("scanner_init_start", { browser: getBrowserSummary() });
 
     try {
       // Pre-flight: ensure camera is accessible before heavy ZXing init.
       // Handles transient NotAllowedError on Android Chrome SPA navigation.
       await ensureCameraAccess();
+
+      // Bail if the start was invalidated during pre-flight (e.g. user
+      // navigated away or stopScanner was called).
+      if (thisStartId !== startIdRef.current || !isMountedRef.current) return;
 
       const { BrowserMultiFormatReader, DecodeHintType, BarcodeFormat } =
         await import("@zxing/library");
@@ -190,7 +206,7 @@ export function useBarcodeScanner({
       const devices = await reader.listVideoInputDevices();
       if (devices.length === 0) {
         setCameraError("no-camera");
-        track("scanner_init_error", {
+        trackRef.current("scanner_init_error", {
           error_type: "no-camera",
           browser: getBrowserSummary(),
         });
@@ -220,7 +236,7 @@ export function useBarcodeScanner({
           if (videoEl.srcObject instanceof MediaStream) {
             streamRef.current = videoEl.srcObject;
             const videoTrack = streamRef.current.getVideoTracks()[0];
-            track("scanner_stream_ready", {
+              trackRef.current("scanner_stream_ready", {
               camera_count: devices.length,
               has_multiple_cameras: devices.length > 1,
               facing_mode: videoTrack
@@ -254,7 +270,7 @@ export function useBarcodeScanner({
         if (!isMountedRef.current || thisStartId !== startIdRef.current) return;
         if (videoEl && (videoEl.readyState < 2 || videoEl.videoWidth === 0)) {
           setCameraError("generic");
-          track("scanner_init_error", {
+          trackRef.current("scanner_init_error", {
             error_type: "feed-timeout",
             browser: getBrowserSummary(),
           });
@@ -264,7 +280,7 @@ export function useBarcodeScanner({
       if (thisStartId !== startIdRef.current) return; // stale call — discard
 
       const errorType = classifyScannerError(err);
-      track("scanner_init_error", {
+      trackRef.current("scanner_init_error", {
         error_type: errorType,
         browser: getBrowserSummary(),
       });
@@ -294,7 +310,7 @@ export function useBarcodeScanner({
         setCameraError("generic");
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- track is fire-and-forget
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- trackRef is stable
   }, [stopScanner]);
 
   // ─── Torch ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Addresses all 4 Copilot code review suggestions from merged PR #955 (pre-flight camera fix).

## Changes

| # | Suggestion | File | Fix |
|---|-----------|------|-----|
| 1 | **Stale `track` closure** — `useCallback` omits `track` from deps; identity changes when `deviceType` detected | `use-barcode-scanner.ts` | Added `trackRef` pattern (same as existing `onBarcodeDetectedRef`); all `track()` calls inside `startScanner` use `trackRef.current()` |
| 2 | **Page test stub ordering** — `Object.defineProperty` references `mockGetUserMedia` before `vi.hoisted` in source order | `page.test.tsx` | Moved `Object.defineProperty` block after the `vi.hoisted` block |
| 3 | **Cancel in-flight starts** — stale `startScanner` could proceed after navigation during `ensureCameraAccess()` backoff | `use-barcode-scanner.ts` | `startIdRef.current++` in `stopScanner()` + bail check after `await ensureCameraAccess()` |
| 4 | **No-camera pre-flight** — `NotFoundError`/`OverconstrainedError` retried as transient errors | `use-barcode-scanner.ts` | Early throw for these error names — no backoff retry for genuine hardware absence |

## Verification

```
npx tsc --noEmit                → 0 errors
npx vitest run (scanner tests)  → 237/237 pass (11 files)
npx vitest run (full suite)     → 5,827/5,827 pass (351 files)
```