### PR TITLE
fix(scanner): stop false 'Camera Access Blocked' on page load

### DIFF
--- a/frontend/src/hooks/__tests__/use-barcode-scanner.test.ts
+++ b/frontend/src/hooks/__tests__/use-barcode-scanner.test.ts
@@ -434,7 +434,11 @@ describe("useBarcodeScanner", () => {
       );
 
       await act(async () => {
-        await result.current.startScanner();
+        // "prompt" is not "denied", so pre-flight retries — advance timers
+        // to flush all 5 retry delays (250+500+1000+2000+4000 = 7750ms).
+        const promise = result.current.startScanner();
+        await vi.advanceTimersByTimeAsync(8_000);
+        await promise;
       });
 
       expect(result.current.cameraError).toBe("permission-prompt");
@@ -455,7 +459,10 @@ describe("useBarcodeScanner", () => {
       );
 
       await act(async () => {
-        await result.current.startScanner();
+        // Permissions API unavailable → not explicitly denied → retries
+        const promise = result.current.startScanner();
+        await vi.advanceTimersByTimeAsync(8_000);
+        await promise;
       });
 
       expect(result.current.cameraError).toBe("permission-unknown");
@@ -524,6 +531,40 @@ describe("useBarcodeScanner", () => {
       });
 
       // Scanner recovered via pre-flight — no error shown
+      expect(result.current.cameraError).toBeNull();
+      expect(mockGetUserMedia).toHaveBeenCalledTimes(2);
+    });
+
+    it("pre-flight retries getUserMedia when permission state is prompt (not denied)", async () => {
+      // First getUserMedia call fails (transient), second succeeds
+      mockGetUserMedia
+        .mockRejectedValueOnce(
+          new DOMException("NotAllowedError", "NotAllowedError"),
+        )
+        .mockResolvedValueOnce({ getTracks: () => [{ stop: vi.fn() }] });
+
+      mockListDevices.mockResolvedValue([makeDevice("cam1")]);
+
+      // Permission state is "prompt" — should still retry (not bail)
+      Object.defineProperty(navigator, "permissions", {
+        value: {
+          query: vi.fn().mockResolvedValue({ state: "prompt" }),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() =>
+        useBarcodeScanner(makeOptions()),
+      );
+
+      await act(async () => {
+        const promise = result.current.startScanner();
+        await vi.advanceTimersByTimeAsync(300);
+        await promise;
+      });
+
+      // Scanner recovered via pre-flight retry — no error shown
       expect(result.current.cameraError).toBeNull();
       expect(mockGetUserMedia).toHaveBeenCalledTimes(2);
     });

--- a/frontend/src/hooks/use-barcode-scanner.ts
+++ b/frontend/src/hooks/use-barcode-scanner.ts
@@ -108,21 +108,24 @@ async function ensureCameraAccess(): Promise<void> {
 
       if (attempt === PREFLIGHT_MAX_RETRIES) throw err;
 
-      // Only retry when the Permissions API confirms the user already
-      // granted camera access — the failure is a transient browser bug.
-      let permGranted = false;
+      // Only bail when the Permissions API explicitly says "denied" —
+      // that means the user actively blocked camera access and retrying
+      // won't help.  In every other state ("prompt", "granted", or API
+      // unavailable) we retry, because the failure is likely a transient
+      // browser bug during SPA navigation.
+      let permExplicitlyDenied = false;
       try {
         if (navigator.permissions?.query) {
           const ps = await navigator.permissions.query({
             name: "camera" as PermissionName,
           });
-          permGranted = ps.state === "granted";
+          permExplicitlyDenied = ps.state === "denied";
         }
       } catch {
-        /* Permissions API unavailable */
+        /* Permissions API unavailable — retry optimistically */
       }
 
-      if (!permGranted) throw err;
+      if (permExplicitlyDenied) throw err;
 
       await new Promise<void>((r) =>
         setTimeout(r, PREFLIGHT_BASE_DELAY_MS * 2 ** attempt),


### PR DESCRIPTION
## Problem

The scan page shows "Camera Access Blocked" immediately on load even though camera permission is already granted. Users have to click "Reload Page" for the camera to work.

## Root Cause

In `ensureCameraAccess()`, the retry gate was too strict. After a `getUserMedia()` failure, it queried `navigator.permissions.query({ name: "camera" })` and only allowed retries when the result was explicitly `"granted"`:

```ts
const permGranted = ps.state === "granted";
if (!permGranted) throw err; // bails on "prompt" — no retries
```

During SPA navigation, the Permissions API can transiently return `"prompt"` even when the user has already granted camera access. This caused the function to bail immediately with zero retries, surfacing a false "Camera Access Blocked" error.

**Why "Reload Page" fixed it:** A full page reload resets the browser's internal camera permission pipeline, so `getUserMedia()` succeeds on the very first call without needing retries.

## Fix

Inverted the retry gate logic — only bail when permission is explicitly `"denied"` (user actively blocked camera). In all other states (`"prompt"`, `"granted"`, API unavailable), allow retries:

```ts
const permExplicitlyDenied = ps.state === "denied";
if (permExplicitlyDenied) throw err; // only bail on explicit "denied"
```

This is safe because genuinely ungranted permissions will exhaust all 6 retry attempts and then properly propagate the error with the correct permission state.

## Changes

- **`use-barcode-scanner.ts`**: Invert `ensureCameraAccess()` retry gate — `!permGranted` → `permExplicitlyDenied`
- **`use-barcode-scanner.test.ts`**: Update 2 existing tests (advance timers for retries), add 1 new recovery test

## Verification

```
npx tsc --noEmit           → 0 errors
vitest (scanner hook)      → 26/26 pass
```