### PR TITLE
fix(dashboard): critical fixes — href bug, displayName, nudge chip, skeleton (#961)

### DIFF
--- a/frontend/src/app/app/page.test.tsx
+++ b/frontend/src/app/app/page.test.tsx
@@ -10,7 +10,18 @@ const mockGetDashboardData = vi.fn();
 const mockGetCategoryOverview = vi.fn();
 
 vi.mock("@/lib/supabase/client", () => ({
-  createClient: () => ({}),
+  createClient: () => ({
+    auth: {
+      getUser: () =>
+        Promise.resolve({
+          data: {
+            user: {
+              user_metadata: { full_name: "Jan Kowalski" },
+            },
+          },
+        }),
+    },
+  }),
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -168,6 +179,14 @@ describe("DashboardPage", () => {
       expect(greetingEl.textContent).toMatch(
         /Good morning|Good afternoon|Good evening|Good night/,
       );
+    });
+  });
+
+  it("passes display name from auth to greeting", async () => {
+    render(<DashboardPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      const greetingEl = screen.getByRole("heading", { level: 1 });
+      expect(greetingEl.textContent).toContain("Jan Kowalski");
     });
   });
 

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -15,7 +15,7 @@ import { getDashboardData } from "@/lib/api";
 import { queryKeys, staleTimes } from "@/lib/query-keys";
 import { createClient } from "@/lib/supabase/client";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 // ─── Main Page ──────────────────────────────────────────────────────────────
 
@@ -23,6 +23,7 @@ export default function DashboardPage() {
   const supabase = createClient();
   const queryClient = useQueryClient();
   const { track } = useAnalytics();
+  const [displayName, setDisplayName] = useState<string | null>(null);
 
   const { data, isLoading, isError } = useQuery({
     queryKey: queryKeys.dashboard,
@@ -38,6 +39,16 @@ export default function DashboardPage() {
     track("dashboard_viewed");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      const name =
+        user?.user_metadata?.full_name ??
+        user?.user_metadata?.name ??
+        null;
+      setDisplayName(typeof name === "string" ? name : null);
+    });
+  }, [supabase]);
 
   const handleRefresh = useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
@@ -78,7 +89,7 @@ export default function DashboardPage() {
   return (
     <PullToRefresh onRefresh={handleRefresh}>
     <div className="space-y-6 lg:space-y-8">
-      <DashboardGreeting />
+      <DashboardGreeting displayName={displayName} />
 
       {/* Health summary — average score + band distribution */}
       <HealthSummary products={dashboard.recently_viewed} />

--- a/frontend/src/components/common/skeletons/DashboardSkeleton.test.tsx
+++ b/frontend/src/components/common/skeletons/DashboardSkeleton.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DashboardSkeleton } from "./DashboardSkeleton";
+
+// ─── DashboardSkeleton ─────────────────────────────────────────────────────
+
+describe("DashboardSkeleton", () => {
+  it("renders with accessible loading status", () => {
+    render(<DashboardSkeleton />);
+    const container = screen.getByRole("status");
+    expect(container).toHaveAttribute("aria-busy", "true");
+    expect(container).toHaveAttribute("aria-label", "Loading dashboard");
+  });
+
+  it("uses vertical space-y layout (not grid)", () => {
+    render(<DashboardSkeleton />);
+    const container = screen.getByRole("status");
+    expect(container.className).toContain("space-y-6");
+    expect(container.className).not.toContain("grid-cols-12");
+  });
+
+  it("renders greeting skeleton with pill chip", () => {
+    render(<DashboardSkeleton />);
+    const container = screen.getByRole("status");
+    // Greeting section: first child has rounded-full chip skeleton
+    const firstSection = container.firstElementChild;
+    expect(firstSection).toBeInTheDocument();
+    const chip = firstSection?.querySelector('[class*="rounded-full"]');
+    expect(chip).toBeInTheDocument();
+  });
+
+  it("renders 3 recently viewed placeholder rows", () => {
+    render(<DashboardSkeleton />);
+    const container = screen.getByRole("status");
+    // Card rows inside recently viewed section (4th child)
+    const cards = container.querySelectorAll(".card.flex.items-center.gap-3");
+    expect(cards.length).toBe(3);
+  });
+
+  it("renders 4 quick action placeholders", () => {
+    render(<DashboardSkeleton />);
+    const container = screen.getByRole("status");
+    const grid = container.querySelector(".grid.grid-cols-2");
+    expect(grid).toBeInTheDocument();
+    expect(grid?.children.length).toBe(4);
+  });
+});

--- a/frontend/src/components/common/skeletons/DashboardSkeleton.tsx
+++ b/frontend/src/components/common/skeletons/DashboardSkeleton.tsx
@@ -1,94 +1,74 @@
 /**
  * DashboardSkeleton — shimmer placeholder for the /app dashboard page.
- * Mirrors: greeting, quick actions, categories, stats bar, sections + product rows.
+ * Mirrors actual composition: greeting → health summary → quick win → recently viewed → quick actions.
  */
 
 import { Skeleton, SkeletonContainer } from "@/components/common/Skeleton";
-import { ProductCardSkeleton } from "./ProductCardSkeleton";
 
 export function DashboardSkeleton() {
   return (
     <SkeletonContainer
       label="Loading dashboard"
-      className="space-y-6 lg:grid lg:grid-cols-12 lg:gap-6 lg:space-y-0"
+      className="space-y-6 lg:space-y-8"
     >
-      {/* Row 1 — Greeting (full width) */}
-      <div className="lg:col-span-12 space-y-1">
-        <Skeleton variant="text" width="14rem" height={28} />
-        <Skeleton variant="text" width="10rem" height={14} />
+      {/* Greeting */}
+      <div className="space-y-2">
+        <Skeleton variant="text" width="16rem" height={28} />
+        <Skeleton variant="text" width="10rem" height={16} />
+        <Skeleton variant="rect" width="6rem" height={22} className="rounded-full!" />
       </div>
 
-      {/* Row 2 — Quick Actions (8) + Stats (4) */}
-      <div className="lg:col-span-8">
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          {Array.from({ length: 4 }, (_, i) => (
-            <div
-              key={i}
-              className="card flex flex-col items-center gap-2 py-3 lg:py-6"
-            >
-              <Skeleton variant="rect" width={32} height={32} />
-              <Skeleton variant="text" width="3rem" height={12} />
-            </div>
-          ))}
-        </div>
-      </div>
-      <div className="lg:col-span-4">
-        <div className="grid grid-cols-2 gap-3">
-          {Array.from({ length: 4 }, (_, i) => (
-            <div key={i} className="card flex flex-col items-center gap-1 py-3">
-              <Skeleton
-                variant="rect"
-                width={32}
-                height={32}
-                className="rounded-md!"
-              />
-              <Skeleton variant="text" width="3rem" height={20} />
-              <Skeleton variant="text" width="4rem" height={12} />
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* Row 3 — Categories (6) + Tip (6) */}
-      <div className="lg:col-span-6 space-y-2">
-        <div className="flex items-center justify-between">
-          <Skeleton variant="text" width="8rem" height={20} />
-          <Skeleton variant="text" width="4rem" height={14} />
-        </div>
-        <div className="flex gap-3 overflow-hidden lg:grid lg:grid-cols-3">
-          {Array.from({ length: 6 }, (_, i) => (
-            <div
-              key={i}
-              className="flex shrink-0 flex-col items-center gap-1.5 rounded-xl border bg-surface px-3 py-3"
-              style={{ minWidth: "5rem" }}
-            >
-              <Skeleton variant="rect" width={32} height={32} />
-              <Skeleton variant="text" width="3.5rem" height={12} />
-            </div>
-          ))}
-        </div>
-      </div>
-      <div className="lg:col-span-6">
-        <div className="card flex items-start gap-3">
-          <Skeleton variant="rect" width={32} height={32} />
-          <div className="min-w-0 flex-1 space-y-1">
-            <Skeleton variant="text" width="6rem" height={14} />
-            <Skeleton variant="text" width="100%" height={14} />
+      {/* Health summary */}
+      <div className="card space-y-3">
+        <Skeleton variant="text" width="10rem" height={18} />
+        <div className="flex items-center gap-4">
+          <Skeleton variant="rect" width={64} height={64} className="rounded-full!" />
+          <div className="flex-1 space-y-2">
+            <Skeleton variant="text" width="100%" height={12} />
+            <Skeleton variant="text" width="80%" height={12} />
           </div>
         </div>
       </div>
 
-      {/* Row 4 — Recently viewed (8) + Favorites (4) */}
-      <div className="lg:col-span-8 space-y-2">
-        <Skeleton variant="text" width="12rem" height={20} />
-        <ProductCardSkeleton count={3} />
-      </div>
-      <div className="lg:col-span-4 space-y-2">
-        <div className="flex items-center justify-between">
-          <Skeleton variant="text" width="8rem" height={20} />
-          <Skeleton variant="text" width="4rem" height={14} />
+      {/* Quick win card */}
+      <div className="card space-y-3">
+        <Skeleton variant="text" width="8rem" height={18} />
+        <div className="flex items-center gap-3">
+          <Skeleton variant="rect" width={32} height={32} className="rounded-full!" />
+          <Skeleton variant="text" width="60%" height={14} />
+          <Skeleton variant="rect" width={32} height={32} className="rounded-full!" />
         </div>
-        <ProductCardSkeleton count={2} />
+        <Skeleton variant="text" width="12rem" height={14} />
+      </div>
+
+      {/* Recently viewed */}
+      <div className="space-y-2">
+        <Skeleton variant="text" width="10rem" height={18} />
+        <div className="space-y-2">
+          {Array.from({ length: 3 }, (_, i) => (
+            <div key={i} className="card flex items-center gap-3">
+              <Skeleton variant="rect" width={40} height={40} className="rounded-lg!" />
+              <div className="min-w-0 flex-1 space-y-1">
+                <Skeleton variant="text" width="70%" height={14} />
+                <Skeleton variant="text" width="40%" height={12} />
+              </div>
+              <Skeleton variant="rect" width={32} height={32} className="rounded-full!" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Quick actions */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div
+            key={i}
+            className="card flex flex-col items-center gap-2 py-3 lg:py-5"
+          >
+            <Skeleton variant="rect" width={28} height={28} className="rounded-md!" />
+            <Skeleton variant="text" width="3.5rem" height={12} />
+          </div>
+        ))}
       </div>
     </SkeletonContainer>
   );

--- a/frontend/src/components/dashboard/DashboardGreeting.test.tsx
+++ b/frontend/src/components/dashboard/DashboardGreeting.test.tsx
@@ -4,6 +4,7 @@ import {
   DashboardGreeting,
   getTimeOfDay,
   getSeasonKey,
+  SEASON_STYLE,
 } from "./DashboardGreeting";
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
@@ -117,9 +118,20 @@ describe("DashboardGreeting", () => {
     expect(screen.getByText("dashboard.subtitle")).toBeInTheDocument();
   });
 
-  it("shows seasonal nudge", () => {
+  it("shows seasonal nudge as a styled chip", () => {
     render(<DashboardGreeting />);
-    expect(screen.getByTestId("seasonal-nudge")).toBeInTheDocument();
+    const nudge = screen.getByTestId("seasonal-nudge");
+    expect(nudge).toBeInTheDocument();
+    expect(nudge.tagName).toBe("SPAN");
+    expect(nudge.className).toContain("rounded-full");
+  });
+
+  it("renders seasonal emoji matching the current season", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T12:00:00")); // summer
+    render(<DashboardGreeting />);
+    const nudge = screen.getByTestId("seasonal-nudge");
+    expect(nudge.textContent).toContain(SEASON_STYLE.summer.emoji);
   });
 
   it("includes display name when provided", () => {

--- a/frontend/src/components/dashboard/DashboardGreeting.tsx
+++ b/frontend/src/components/dashboard/DashboardGreeting.tsx
@@ -24,6 +24,16 @@ function getSeasonKey(): "spring" | "summer" | "autumn" | "winter" {
   return "winter";
 }
 
+const SEASON_STYLE: Record<
+  ReturnType<typeof getSeasonKey>,
+  { emoji: string; className: string }
+> = {
+  spring: { emoji: "🌱", className: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300" },
+  summer: { emoji: "☀️", className: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300" },
+  autumn: { emoji: "🍂", className: "bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300" },
+  winter: { emoji: "❄️", className: "bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-300" },
+};
+
 interface DashboardGreetingProps {
   displayName?: string | null;
 }
@@ -39,23 +49,25 @@ export function DashboardGreeting({
     ? t(`dashboard.greeting.${timeOfDay}Named`, { name: displayName })
     : t(`dashboard.greeting.${timeOfDay}`);
 
+  const { emoji, className: seasonClass } = SEASON_STYLE[season];
+
   return (
-    <div className="space-y-1">
+    <div className="space-y-2">
       <h1 className="text-xl font-bold text-foreground sm:text-2xl md:text-3xl lg:text-4xl">
         {greeting}
       </h1>
       <p className="text-sm text-foreground-secondary lg:text-base">
         {t("dashboard.subtitle")}
       </p>
-      <p
-        className="text-xs text-foreground-muted lg:text-sm"
+      <span
+        className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${seasonClass}`}
         data-testid="seasonal-nudge"
       >
-        {t(`dashboard.season.${season}`)}
-      </p>
+        {emoji} {t(`dashboard.season.${season}`)}
+      </span>
     </div>
   );
 }
 
 /** Export for testing */
-export { getTimeOfDay, getSeasonKey };
+export { getTimeOfDay, getSeasonKey, SEASON_STYLE };

--- a/frontend/src/components/dashboard/QuickWinCard.test.tsx
+++ b/frontend/src/components/dashboard/QuickWinCard.test.tsx
@@ -176,12 +176,13 @@ describe("QuickWinCard", () => {
     );
   });
 
-  it("links to product page", () => {
+  it("links to the alternative product page (not the worst product)", () => {
     const products = [makeProduct({ product_id: 42 })];
     render(<QuickWinCard products={products} />, { wrapper: createWrapper() });
 
     const link = screen.getByRole("link", { name: /View swap/ });
-    expect(link).toHaveAttribute("href", "/app/product/42");
+    // Alternative product_id is 99 (from mockAlternativesData)
+    expect(link).toHaveAttribute("href", "/app/product/99");
   });
 
   it("has correct section aria-label", () => {

--- a/frontend/src/components/dashboard/QuickWinCard.tsx
+++ b/frontend/src/components/dashboard/QuickWinCard.tsx
@@ -101,7 +101,7 @@ export function QuickWinCard({ products }: Readonly<QuickWinCardProps>) {
           </div>
 
           <Link
-            href={`/app/product/${worstProduct.product_id}`}
+            href={`/app/product/${alternative.product_id}`}
             className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
           >
             {t("dashboard.quickWinViewSwap")}


### PR DESCRIPTION
## Summary

Implements all 4 critical dashboard fixes from Issue #961 (P0).

### Changes

| Fix | What | File(s) |
|-----|------|---------|
| 1 | **QuickWinCard href bug** — linked to worst product instead of alternative | QuickWinCard.tsx |
| 2 | **displayName pass** — fetch user metadata via \supabase.auth.getUser()\ and pass to DashboardGreeting | page.tsx |
| 3 | **Seasonal nudge elevation** — replace muted \<p>\ with colored chip + emoji per season (spring/summer/autumn/winter with dark mode) | DashboardGreeting.tsx |
| 4 | **DashboardSkeleton rebuild** — mirrors actual page composition (greeting → health summary → quick win → recently viewed → quick actions) | DashboardSkeleton.tsx |

### Tests

- QuickWinCard.test.tsx — updated assertion for alternative product href
- DashboardGreeting.test.tsx — 2 new tests (chip structure + seasonal emoji)
- DashboardSkeleton.test.tsx — **new file**, 5 tests (a11y, layout, chip, rows, grid)
- page.test.tsx — updated supabase mock + new displayName integration test

### Verification

\\\
npx tsc --noEmit           → 0 errors
npx vitest run             → 5,837 passed | 0 failed (352 files)
\\\

**8 files changed, +164 / -82 lines**

Closes #961
Part of Epic #960