### PR TITLE
feat(frontend): wire dormant dashboard components (#963)

### DIFF
--- a/frontend/src/app/app/page.test.tsx
+++ b/frontend/src/app/app/page.test.tsx
@@ -1,4 +1,4 @@
-import type { DashboardData } from "@/lib/types";
+import type { DashboardData, DashboardInsights } from "@/lib/types";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import { useState } from "react";
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetDashboardData = vi.fn();
 const mockGetCategoryOverview = vi.fn();
+const mockGetDashboardInsights = vi.fn();
 
 vi.mock("@/lib/supabase/client", () => ({
   createClient: () => ({
@@ -27,10 +28,11 @@ vi.mock("@/lib/supabase/client", () => ({
 vi.mock("@/lib/api", () => ({
   getDashboardData: (...args: unknown[]) => mockGetDashboardData(...args),
   getCategoryOverview: (...args: unknown[]) => mockGetCategoryOverview(...args),
+  getDashboardInsights: (...args: unknown[]) => mockGetDashboardInsights(...args),
 }));
 
 vi.mock("next/link", () => ({
-   
+
   default: ({ href, children, className, ...rest }: any) => (
     <a href={href} className={className} {...rest}>
       {children}
@@ -150,6 +152,16 @@ const mockDashboard: DashboardData = {
 
 // ─── Import page after mocks ────────────────────────────────────────────────
 
+const mockInsights: DashboardInsights = {
+  api_version: "1.0",
+  avg_score: 42,
+  score_trend: "improving",
+  nova_distribution: { "1": 2, "2": 3, "3": 4, "4": 1 },
+  category_diversity: { explored: 5, total: 20 },
+  allergen_alerts: { count: 0, products: [] },
+  recent_comparisons: [],
+};
+
 import DashboardPage from "./page";
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -159,6 +171,7 @@ describe("DashboardPage", () => {
     vi.clearAllMocks();
     mockGetDashboardData.mockResolvedValue({ ok: true, data: mockDashboard });
     mockGetCategoryOverview.mockResolvedValue({ ok: true, data: [] });
+    mockGetDashboardInsights.mockResolvedValue({ ok: true, data: mockInsights });
   });
 
   it("shows skeleton loading state initially", () => {
@@ -305,6 +318,51 @@ describe("DashboardPage", () => {
     });
   });
 
+  it("renders HealthInsightsPanel when insights data is available", async () => {
+    render(<DashboardPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("health-insights-panel"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders NutritionTip section", async () => {
+    render(<DashboardPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("💡")).toBeInTheDocument();
+    });
+  });
+
+  it("renders CategoriesBrowse section", async () => {
+    mockGetCategoryOverview.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          category: "Dairy",
+          display_name: "Dairy",
+          product_count: 10,
+          avg_score: 25,
+          min_score: 5,
+          max_score: 50,
+        },
+      ],
+    });
+    render(<DashboardPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("Dairy")).toBeInTheDocument();
+    });
+  });
+
+  it("still renders other sections when HealthInsightsPanel fails", async () => {
+    mockGetDashboardInsights.mockRejectedValue(new Error("fail"));
+    render(<DashboardPage />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByTestId("health-summary")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("quick-actions")).toBeInTheDocument();
+  });
+
   it("applies staggered fade-in-up animations to dashboard sections", async () => {
     const { container } = render(<DashboardPage />, {
       wrapper: createWrapper(),
@@ -313,7 +371,7 @@ describe("DashboardPage", () => {
       expect(screen.getByTestId("health-summary")).toBeInTheDocument();
     });
     const animated = container.querySelectorAll(".animate-fade-in-up");
-    expect(animated.length).toBeGreaterThanOrEqual(5);
+    expect(animated.length).toBeGreaterThanOrEqual(8);
     // First section (greeting) has no delay; subsequent have staggered delays
     const delays = Array.from(animated).map(
       (el) => (el as HTMLElement).style.animationDelay,
@@ -323,5 +381,8 @@ describe("DashboardPage", () => {
     expect(delays[2]).toBe("100ms");
     expect(delays[3]).toBe("150ms");
     expect(delays[4]).toBe("200ms");
+    expect(delays[5]).toBe("250ms");
+    expect(delays[6]).toBe("300ms");
+    expect(delays[7]).toBe("350ms");
   });
 });

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -4,9 +4,12 @@ import { EmptyState } from "@/components/common/EmptyState";
 import { ErrorBoundary } from "@/components/common/ErrorBoundary";
 import { PullToRefresh } from "@/components/common/PullToRefresh";
 import { DashboardSkeleton } from "@/components/common/skeletons";
+import { CategoriesBrowse } from "@/components/dashboard/CategoriesBrowse";
 import { DashboardGreeting } from "@/components/dashboard/DashboardGreeting";
+import { HealthInsightsPanel } from "@/components/dashboard/HealthInsightsPanel";
 import { HealthSummary } from "@/components/dashboard/HealthSummary";
 import { NewUserWelcome } from "@/components/dashboard/NewUserWelcome";
+import { NutritionTip } from "@/components/dashboard/NutritionTip";
 import { QuickActions } from "@/components/dashboard/QuickActions";
 import { QuickWinCard } from "@/components/dashboard/QuickWinCard";
 import { RecentlyViewed } from "@/components/dashboard/RecentlyViewed";
@@ -98,16 +101,28 @@ export default function DashboardPage() {
         <HealthSummary products={dashboard.recently_viewed} />
       </div>
 
-      {/* Quick win — swap suggestion for worst product */}
+      {/* Health insights — trends, NOVA, allergens, diversity, comparisons */}
       <div className="animate-fade-in-up" style={{ animationDelay: "100ms" }}>
+        <ErrorBoundary level="section" context={{ section: "health-insights" }}>
+          <HealthInsightsPanel />
+        </ErrorBoundary>
+      </div>
+
+      {/* Quick win — swap suggestion for worst product */}
+      <div className="animate-fade-in-up" style={{ animationDelay: "150ms" }}>
         <ErrorBoundary level="section" context={{ section: "quick-win" }}>
           <QuickWinCard products={dashboard.recently_viewed} />
         </ErrorBoundary>
       </div>
 
+      {/* Nutrition tip — daily rotating health tip */}
+      <div className="animate-fade-in-up" style={{ animationDelay: "200ms" }}>
+        <NutritionTip />
+      </div>
+
       {/* Recently viewed — compact card list */}
       {dashboard.recently_viewed.length > 0 && (
-        <div className="animate-fade-in-up" style={{ animationDelay: "150ms" }}>
+        <div className="animate-fade-in-up" style={{ animationDelay: "250ms" }}>
           <ErrorBoundary
             level="section"
             context={{ section: "recently-viewed" }}
@@ -117,8 +132,15 @@ export default function DashboardPage() {
         </div>
       )}
 
+      {/* Browse categories — horizontal scrollable chips */}
+      <div className="animate-fade-in-up" style={{ animationDelay: "300ms" }}>
+        <ErrorBoundary level="section" context={{ section: "categories-browse" }}>
+          <CategoriesBrowse />
+        </ErrorBoundary>
+      </div>
+
       {/* Quick actions */}
-      <div className="animate-fade-in-up" style={{ animationDelay: "200ms" }}>
+      <div className="animate-fade-in-up" style={{ animationDelay: "350ms" }}>
         <QuickActions />
       </div>
     </div>

--- a/frontend/src/components/common/skeletons/DashboardSkeleton.test.tsx
+++ b/frontend/src/components/common/skeletons/DashboardSkeleton.test.tsx
@@ -44,4 +44,29 @@ describe("DashboardSkeleton", () => {
     expect(grid).toBeInTheDocument();
     expect(grid?.children.length).toBe(4);
   });
+
+  it("renders health insights skeleton with 3 rounded-xl blocks", () => {
+    render(<DashboardSkeleton />);
+    const container = screen.getByRole("status");
+    // Insights section: 3rd child (after greeting and health summary)
+    const insightsSection = container.children[2];
+    expect(insightsSection).toBeInTheDocument();
+    const blocks = insightsSection.querySelectorAll('[class*="rounded-xl"]');
+    expect(blocks.length).toBe(3);
+  });
+
+  it("renders nutrition tip skeleton with bordered card", () => {
+    render(<DashboardSkeleton />);
+    const container = screen.getByRole("status");
+    const tipCard = container.querySelector(".rounded-xl.border.bg-surface");
+    expect(tipCard).toBeInTheDocument();
+  });
+
+  it("renders categories browse skeleton with 6 chip placeholders", () => {
+    render(<DashboardSkeleton />);
+    const container = screen.getByRole("status");
+    const chipContainer = container.querySelector(".flex.gap-3.overflow-hidden");
+    expect(chipContainer).toBeInTheDocument();
+    expect(chipContainer?.children.length).toBe(6);
+  });
 });

--- a/frontend/src/components/common/skeletons/DashboardSkeleton.tsx
+++ b/frontend/src/components/common/skeletons/DashboardSkeleton.tsx
@@ -30,6 +30,13 @@ export function DashboardSkeleton() {
         </div>
       </div>
 
+      {/* Health insights panel */}
+      <div className="space-y-3">
+        <Skeleton variant="rect" width="100%" height={80} className="rounded-xl!" />
+        <Skeleton variant="rect" width="100%" height={112} className="rounded-xl!" />
+        <Skeleton variant="rect" width="100%" height={40} className="rounded-xl!" />
+      </div>
+
       {/* Quick win card */}
       <div className="card space-y-3">
         <Skeleton variant="text" width="8rem" height={18} />
@@ -39,6 +46,18 @@ export function DashboardSkeleton() {
           <Skeleton variant="rect" width={32} height={32} className="rounded-full!" />
         </div>
         <Skeleton variant="text" width="12rem" height={14} />
+      </div>
+
+      {/* Nutrition tip */}
+      <div className="rounded-xl border bg-surface p-4 space-y-2">
+        <div className="flex items-start gap-3">
+          <Skeleton variant="rect" width={28} height={28} className="rounded-md!" />
+          <div className="flex-1 space-y-1.5">
+            <Skeleton variant="text" width="6rem" height={14} />
+            <Skeleton variant="text" width="90%" height={12} />
+            <Skeleton variant="text" width="60%" height={12} />
+          </div>
+        </div>
       </div>
 
       {/* Recently viewed */}
@@ -53,6 +72,23 @@ export function DashboardSkeleton() {
                 <Skeleton variant="text" width="40%" height={12} />
               </div>
               <Skeleton variant="rect" width={32} height={32} className="rounded-full!" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Categories browse */}
+      <div className="space-y-2">
+        <Skeleton variant="text" width="10rem" height={18} />
+        <div className="flex gap-3 overflow-hidden">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div
+              key={i}
+              className="flex shrink-0 flex-col items-center gap-1.5 rounded-xl border bg-surface px-3 py-3"
+              style={{ minWidth: "5rem" }}
+            >
+              <Skeleton variant="rect" width={32} height={32} />
+              <Skeleton variant="text" width="3.5rem" height={12} />
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
Wires three dormant dashboard components into the main dashboard page:
- **HealthInsightsPanel** — score trends, NOVA distribution, allergen alerts, category diversity
- **NutritionTip** — daily rotating nutrition tips with i18n
- **CategoriesBrowse** — category overview browse grid

## Changes
- **page.tsx**: Added 3 imports + 3 new sections with ErrorBoundary wrappers. Updated animation sequence from 5→8 sections with staggered delays (0/50/100/150/200/250/300/350ms).
- **DashboardSkeleton.tsx**: Added 3 matching skeleton sections (insights panel, nutrition tip, categories browse).
- **page.test.tsx**: Added mock for `getDashboardInsights`, 4 new test cases (HealthInsightsPanel render, NutritionTip render, CategoriesBrowse render, ErrorBoundary graceful degradation), updated animation delay test from 5→8 sections.
- **DashboardSkeleton.test.tsx**: Added 3 tests for new skeleton sections.

## Verification
- `npx tsc --noEmit` → 0 errors
- `npx vitest run` → 18/18 tests pass (page.test.tsx + DashboardSkeleton.test.tsx)
- `npx eslint` → 0 errors on all 4 changed files

Closes #963