### PR TITLE
fix(frontend): prevent category chip clipping under scroll-fade mask (#974)

### DIFF
--- a/frontend/src/components/dashboard/CategoriesBrowse.test.tsx
+++ b/frontend/src/components/dashboard/CategoriesBrowse.test.tsx
@@ -173,4 +173,17 @@ describe("CategoriesBrowse", () => {
       expect(screen.getByTestId("cat-icon-chips")).toBeInTheDocument();
     });
   });
+
+  it("scroll container has padding to prevent clipping under fade mask", async () => {
+    mockGetCategoryOverview.mockResolvedValue({
+      ok: true,
+      data: MOCK_CATEGORIES,
+    });
+    render(<CategoriesBrowse />, { wrapper: createWrapper() });
+    await vi.waitFor(() => {
+      const list = screen.getByRole("list");
+      expect(list.className).toMatch(/px-4/);
+      expect(list.className).toMatch(/-mx-4/);
+    });
+  });
 });

--- a/frontend/src/components/dashboard/CategoriesBrowse.tsx
+++ b/frontend/src/components/dashboard/CategoriesBrowse.tsx
@@ -79,7 +79,7 @@ export function CategoriesBrowse() {
       {isLoading && <CategoriesBrowseSkeleton />}
       {!isLoading && data && data.length > 0 && (
         <ul
-          className="scroll-fade-x scrollbar-hide flex list-none gap-3 overflow-x-auto pb-1 lg:scroll-fade-none lg:grid lg:grid-cols-3 lg:overflow-visible lg:pb-0"
+          className="scroll-fade-x scrollbar-hide -mx-4 flex list-none gap-3 overflow-x-auto px-4 pb-1 lg:scroll-fade-none lg:mx-0 lg:grid lg:grid-cols-3 lg:overflow-visible lg:px-0 lg:pb-0"
           aria-label={t("dashboard.categoriesTitle")}
         >
           {data.map((cat) => (


### PR DESCRIPTION
## Summary

Fixes #974 — the first category chip in the horizontal scroll was being clipped by the `scroll-fade-x` CSS mask gradient on mobile. "Baby Food" appeared as "y Food".

## Root Cause

The `scroll-fade-x` utility applies a `mask-image` gradient that fades from `transparent` → `black` over the first `1.5rem`. Since the `<ul>` had no left padding, the first chip sat directly under this transparent zone and was visually clipped.

## Fix

Add `px-4` (1rem horizontal padding) to the scroll container so content starts **after** the fade zone, with compensating `-mx-4` negative margin so the container still bleeds to screen edges. Both are reset on `lg:` breakpoint (`lg:mx-0 lg:px-0`) where the grid layout replaces horizontal scroll.

**Before:** First category chip cut off under fade mask
**After:** Full chip visible with natural fade-in from edge

## Changes

| File | Change |
|------|--------|
| `CategoriesBrowse.tsx` | Added `-mx-4 px-4 lg:mx-0 lg:px-0` to scroll `<ul>` |
| `CategoriesBrowse.test.tsx` | Added test asserting anti-clipping padding classes |

## Verification

```
npx tsc --noEmit          → 0 errors
npx vitest run            → 5,864 passed | 0 failures | 352 files
CategoriesBrowse tests    → 7/7 passed (6 existing + 1 new)
```

## Test Added

- **"scroll container has padding to prevent clipping under fade mask"** — asserts `px-4` and `-mx-4` classes on the list element

**Part of Epic #972 — Dashboard UI/UX Polish**