### PR TITLE
fix(frontend): round distribution bar segment edges + add dashboard to page-map (#975)

### DIFF
--- a/frontend/e2e/helpers/page-map.ts
+++ b/frontend/e2e/helpers/page-map.ts
@@ -69,7 +69,7 @@ export const PAGE_MAP: PageEntry[] = [
 
   // ── Authenticated pages ─────────────────────────────────────────────────
   {
-    patterns: ["src/app/app/page.tsx", "src/components/layout/"],
+    patterns: ["src/app/app/page.tsx", "src/components/layout/", "src/components/dashboard/"],
     url: "/app",
     label: "dashboard",
     auth: true,

--- a/frontend/src/components/dashboard/HealthSummary.test.tsx
+++ b/frontend/src/components/dashboard/HealthSummary.test.tsx
@@ -131,6 +131,22 @@ describe("HealthSummary", () => {
     expect(bar.children).toHaveLength(1);
   });
 
+  it("applies rounded corners to first and last distribution bar segments", () => {
+    const products = [
+      makeProduct({ product_id: 1, unhealthiness_score: 10 }), // green
+      makeProduct({ product_id: 2, unhealthiness_score: 30 }), // yellow
+      makeProduct({ product_id: 3, unhealthiness_score: 50 }), // orange
+    ];
+    render(<HealthSummary products={products} />);
+
+    const bar = screen.getByTestId("health-distribution-bar");
+    const firstSegment = bar.children[0] as HTMLElement;
+    const lastSegment = bar.children[bar.children.length - 1] as HTMLElement;
+
+    expect(firstSegment.className).toContain("first:rounded-l-full");
+    expect(lastSegment.className).toContain("last:rounded-r-full");
+  });
+
   it("has correct aria-label on section", () => {
     const products = [makeProduct({ unhealthiness_score: 30 })];
     render(<HealthSummary products={products} />);

--- a/frontend/src/components/dashboard/HealthSummary.tsx
+++ b/frontend/src/components/dashboard/HealthSummary.tsx
@@ -98,7 +98,7 @@ export function HealthSummary({ products }: Readonly<HealthSummaryProps>) {
           d.count > 0 ? (
             <div
               key={d.band}
-              className="transition-all duration-300"
+              className="transition-all duration-300 first:rounded-l-full last:rounded-r-full"
               style={{
                 width: `${(d.count / total) * 100}%`,
                 backgroundColor:


### PR DESCRIPTION
# Fix: Distribution bar segment edges + page-map dashboard coverage (#975)

Closes #975

## Changes

### 1. Distribution bar rounded corners (`HealthSummary.tsx`)
The distribution bar container had `rounded-full` but child segment `<div>` elements had no border-radius, causing hard color transitions at the first and last segment edges.

**Fix:** Added `first:rounded-l-full last:rounded-r-full` to segment divs so the outer segments match the container's rounding.

### 2. Page-map dashboard pattern (`page-map.ts`)
The PR screenshot infrastructure's page-map entry for the dashboard page only matched `src/app/app/page.tsx` and `src/components/layout/`. Changes to dashboard components in `src/components/dashboard/` (like CategoriesBrowse, HealthSummary, QuickActions) would not trigger screenshot capture.

**Fix:** Added `\"src/components/dashboard/\"` to the dashboard entry patterns array.

### 3. Test coverage
Added test asserting `first:rounded-l-full` and `last:rounded-r-full` classes are present on distribution bar segments.

## Verification

- TypeScript: `npx tsc --noEmit` → 0 errors
- HealthSummary tests: **12/12 passed**
- Full suite: `npx vitest run` → **5,865 passed | 19 skipped | 0 failures**

## Files Changed (3)

| File | Change |
|------|--------|
| `frontend/src/components/dashboard/HealthSummary.tsx` | Add rounding classes to bar segments |
| `frontend/src/components/dashboard/HealthSummary.test.tsx` | Add segment rounding test |
| `frontend/e2e/helpers/page-map.ts` | Add `src/components/dashboard/` to dashboard patterns |"