### PR TITLE
ci(nightly): bump playwright step timeout 10m to 20m

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    timeout-minutes: 20
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: frontend
@@ -109,7 +109,7 @@ jobs:
 
       - name: Full Playwright (all projects including visual)
         run: npx playwright test 2>&1 | tee ../playwright-stdout.log
-        timeout-minutes: 10
+        timeout-minutes: 20
         env:
           # Visual regression disabled until baseline screenshots are generated
           # and committed from a Linux CI run. Re-enable after running:


### PR DESCRIPTION
## Problem

The `Full Playwright (all projects including visual)` step in `nightly.yml` has hit the 10-minute step timeout 2 consecutive nights on main (runs 24646729906, 2026-04-19/20).

## Root cause

Same class as PR #904 — the Next.js 16 upgrade plus subsequent dependency bumps (framework, sentry, supabase, testing groups) slowed the full Playwright suite enough to exceed the prior 10-minute cap. PR #904 applied the same fix to `pr-gate.yml` (5→6m) and `main-gate.yml` (→7m) for vitest.

## Change

- Playwright step: `timeout-minutes: 10` → `20`.
- Containing job: `timeout-minutes: 20` → `30` (headroom for build + unit + playwright install + full suite).

## Verification

Nightly will be re-evaluated on next scheduled run (02:00 UTC). Manual `workflow_dispatch` available if needed.