### PR TITLE
security(rls): revoke PUBLIC EXECUTE from api_submit_product and api_admin_get_submissions

### DIFF
--- a/db/qa/QA__security_posture.sql
+++ b/db/qa/QA__security_posture.sql
@@ -258,7 +258,8 @@ WHERE n.nspname = 'public'
     'api_health_check',                 -- monitoring (service_role only)
     'api_get_pending_notifications',    -- push queue (service_role only)
     'api_mark_notifications_sent',      -- push queue (service_role only)
-    'api_cleanup_push_subscriptions'    -- push cleanup (service_role only)
+    'api_cleanup_push_subscriptions',   -- push cleanup (service_role only)
+    'api_admin_get_submissions'         -- admin submissions review (service_role only)
   )
   AND NOT has_function_privilege('authenticated', p.oid, 'EXECUTE');
 

--- a/supabase/migrations/20260420120000_revoke_public_execute_from_admin_rpcs.sql
+++ b/supabase/migrations/20260420120000_revoke_public_execute_from_admin_rpcs.sql
@@ -1,0 +1,40 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Revoke PUBLIC EXECUTE from privileged write/admin RPCs
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Fixes QA Security Posture check 9 (anon blocked from non-public api_*
+-- functions). The underlying bug: migrations 20260320000300 and
+-- 20260321000100 re-created these functions with DROP + CREATE, which
+-- resets the default ACL to GRANT EXECUTE TO PUBLIC. The subsequent
+-- `REVOKE ... FROM anon` is a no-op because anon inherits from PUBLIC.
+--
+-- Correct pattern: revoke from PUBLIC (the Postgres default grantee) and
+-- grant only to the intended roles.
+--
+-- Idempotent: REVOKE is a no-op if the grant is already absent.
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- api_submit_product — authenticated-only write endpoint
+REVOKE EXECUTE ON FUNCTION public.api_submit_product(
+    text, text, text, text, text, text, text, text
+) FROM PUBLIC;
+
+REVOKE EXECUTE ON FUNCTION public.api_submit_product(
+    text, text, text, text, text, text, text, text
+) FROM anon;
+
+GRANT EXECUTE ON FUNCTION public.api_submit_product(
+    text, text, text, text, text, text, text, text
+) TO authenticated;
+
+-- api_admin_get_submissions — service_role-only admin endpoint
+REVOKE EXECUTE ON FUNCTION public.api_admin_get_submissions(
+    text, integer, integer, text
+) FROM PUBLIC;
+
+REVOKE EXECUTE ON FUNCTION public.api_admin_get_submissions(
+    text, integer, integer, text
+) FROM anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.api_admin_get_submissions(
+    text, integer, integer, text
+) TO service_role;


### PR DESCRIPTION
## Problem

QA Security Posture suite check 9 (`anon blocked from non-public api_* functions`) has been failing on `main` because two API functions are effectively anon-callable:

- `api_submit_product` (authenticated write)
- `api_admin_get_submissions` (service_role admin)

## Root Cause

Migrations `20260320000300_country_aware_scanner_rpcs.sql` and `20260321000100_admin_submissions_country_context.sql` re-created these functions via `DROP FUNCTION` + `CREATE FUNCTION`. In PostgreSQL, dropping a function and re-creating it resets the ACL to the default (`GRANT EXECUTE TO PUBLIC`). The subsequent `REVOKE EXECUTE ... FROM anon` is a **no-op** because `anon` inherits from `PUBLIC`.

ACL before fix:
```
api_submit_product: =X/postgres, postgres=X/postgres, authenticated=X/postgres, service_role=X/postgres
api_admin_get_submissions: =X/postgres, postgres=X/postgres, authenticated=X/postgres, service_role=X/postgres
```
The leading `=X/postgres` = PUBLIC has EXECUTE.

## Fix

New idempotent migration `20260420120000_revoke_public_execute_from_admin_rpcs.sql` that revokes from `PUBLIC` (the correct grantee) and restores the intended grants:

- `api_submit_product` → `authenticated` only
- `api_admin_get_submissions` → `service_role` only

Also updates `QA__security_posture.sql` check 18 allowlist to include `api_admin_get_submissions` (service_role-only, consistent with existing production migration `20260315000600`).

## Verification

ACL after fix:
```
api_submit_product: postgres=X/postgres, authenticated=X/postgres, service_role=X/postgres
api_admin_get_submissions: postgres=X/postgres, service_role=X/postgres
```

- Security Posture check 9: 0 violations ✅
- Security Posture check 18: 0 violations ✅
- Full Suite 16 (Security Posture, 41 checks): PASS ✅

Pre-existing failures on `main` (Suites 20, 21, 32) are unrelated and out of scope for this PR.

## Invariants Preserved

- Additive API change (no signature changes)
- No data mutations
- Idempotent migration (REVOKE is a no-op if grant is absent)
- Authenticated users retain ability to submit products
- service_role retains admin read access