### PR TITLE
docs: reconcile count drift (49 suites, 776 checks, 20 neg tests, 228 migrations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ supabase db reset                        # Full rebuild (migrations + seed)
 .\RUN_SEED.ps1                           # Seed reference data only
 
 # ── Testing ──
-.\RUN_QA.ps1                             # 759 QA checks across 48 suites
-.\RUN_NEGATIVE_TESTS.ps1                 # 23 constraint violation tests
+.\RUN_QA.ps1                             # 776 QA checks across 49 suites
+.\RUN_NEGATIVE_TESTS.ps1                 # 20 constraint violation tests
 .\RUN_SANITY.ps1 -Env local              # Row-count + schema assertions
 python validate_eans.py                  # EAN checksum validation
 python check_pipeline_structure.py       # Pipeline folder/file structure
@@ -168,7 +168,7 @@ echo "SELECT * FROM v_master LIMIT 5;" | docker exec -i supabase_db_tryvit psql 
 ```
 ┌─────────────────┐     ┌──────────────────┐     ┌─────────────────────────┐
 │  Open Food Facts │────▶│  Python Pipeline │────▶│  PostgreSQL (Supabase)  │
-│  API v2          │     │  sql_generator   │     │  227 migrations         │
+│  API v2          │     │  sql_generator   │     │  228 migrations         │
 │  (category tags, │     │  validator       │     │  43 pipeline folders    │
 │   countries=PL,DE│     │  off_client      │     │  products + nutrition   │
 └─────────────────┘     └──────────────────┘     │  + ingredients + scores │
@@ -296,11 +296,11 @@ tryvit/
 │   │   ├── chips-pl/                # Reference PL implementation
 │   │   ├── chips-de/                # DE Chips (51 products)
 │   │   └── ... (21 more PL + 20 DE) # Variable product counts per category
-│   ├── qa/                          # 48 test suites (759 checks)
+│   ├── qa/                          # 49 test suites (776 checks)
 │   └── views/                       # Reference view definitions
 │
 ├── supabase/
-│   ├── migrations/                  # 227 append-only schema migrations
+│   ├── migrations/                  # 228 append-only schema migrations
 │   ├── seed/                        # Reference data seeds
 │   ├── tests/                       # pgTAP integration tests
 │   └── functions/                   # Edge Functions (API gateway, push notifications, CAPTCHA)
@@ -327,8 +327,8 @@ tryvit/
 ├── monitoring/                      # Alert definitions
 │
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
-├── RUN_QA.ps1                       # QA test runner (759 checks)
-├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (23 tests)
+├── RUN_QA.ps1                       # QA test runner (776 checks)
+├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (20 tests)
 ├── RUN_SANITY.ps1                   # Sanity checks
 ├── CHANGELOG.md                     # Structured changelog
 ├── DEPLOYMENT.md                    # Deployment procedures & rollback
@@ -343,7 +343,7 @@ tryvit/
 
 ## 🧪 Testing
 
-Every change is validated against **747 automated checks** across 48 QA suites plus 23 negative validation tests. No data enters the database without verification.
+Every change is validated against **776 automated checks** across 49 QA suites plus 20 negative validation tests. No data enters the database without verification.
 
 <table>
   <tr>

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -9,7 +9,7 @@
 > **Servings:** removed as separate table — all nutrition data is per-100g on nutrition_facts
 > **Ingredient analytics:** 5,340 unique ingredients (all clean ASCII English), 2,691 allergen declarations, 2,702 trace declarations
 > **Ingredient concerns:** EFSA-based 4-tier additive classification (0=none, 1=low, 2=moderate, 3=high)
-> **QA:** 759 checks across 48 suites + 23 negative validation tests — all passing
+> **QA:** 776 checks across 49 suites + 20 negative validation tests — all passing
 
 ---
 
@@ -137,7 +137,7 @@ tryvit/
 │   │   ├── QA__event_intelligence.sql    # 18 event intelligence checks
 │   │   ├── QA__source_coverage.sql  # 8 informational reports (non-blocking)
 │   │   ├── QA__recipe_integrity.sql      # 6 recipe data integrity checks
-│   │   └── TEST__negative_checks.sql     # 23 negative validation tests
+│   │   └── TEST__negative_checks.sql     # 20 negative validation tests
 │   └── views/
 │       └── VIEW__master_product_view.sql  # v_master definition (reference copy)
 ├── supabase/
@@ -169,7 +169,7 @@ tryvit/
 │   │   ├── api-gateway/             # Write-path gateway (rate limiting, validation) (#478)
 │   │   └── send-push-notification/  # Push notification handler
 │   ├── dr-drill/                    # Disaster recovery drill artifacts
-│   └── migrations/                  # 227 append-only schema migrations
+│   └── migrations/                  # 228 append-only schema migrations
 │       ├── 20260207000100_create_schema.sql
 │       ├── 20260207000200_baseline.sql
 │       ├── 20260207000300_add_chip_metadata.sql
@@ -283,8 +283,8 @@ tryvit/
 │       ├── 006-append-only-migrations.md
 │       └── 007-english-canonical-ingredients.md
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
-├── RUN_QA.ps1                       # QA test runner (759 checks across 48 suites)
-├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (23 injection tests)
+├── RUN_QA.ps1                       # QA test runner (776 checks across 49 suites)
+├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (20 injection tests)
 ├── RUN_SANITY.ps1                   # Sanity checks (16) — row counts, schema assertions
 ├── RUN_REMOTE.ps1                   # Remote deployment (requires confirmation)
 ├── RUN_SEED.ps1                     # Seed data runner
@@ -678,7 +678,7 @@ a mix of `'baked'`, `'fried'`, and `'none'`.
 
 ## 7. Migrations
 
-**Location:** `supabase/migrations/` — managed by Supabase CLI. Currently **227 migrations**.
+**Location:** `supabase/migrations/` — managed by Supabase CLI. Currently **228 migrations**.
 
 **Rules:**
 
@@ -750,7 +750,7 @@ A change is **not done** unless relevant tests were added/updated, every suite i
 | Component tests     | **Testing Library React** + Vitest                | `frontend/src/components/**/*.test.tsx`      | same as above                        |
 | E2E smoke           | **Playwright 1.58** (Chromium)                    | `frontend/e2e/smoke.spec.ts`                 | `cd frontend && npx playwright test` |
 | E2E auth            | Playwright (requires `SUPABASE_SERVICE_ROLE_KEY`) | `frontend/e2e/authenticated.spec.ts`         | same (CI auto-detects key)           |
-| DB QA (759 checks)  | Raw SQL (zero rows = pass)                        | `db/qa/QA__*.sql` (48 suites)                | `.\RUN_QA.ps1`                       |
+| DB QA (776 checks)  | Raw SQL (zero rows = pass)                        | `db/qa/QA__*.sql` (49 suites)                | `.\RUN_QA.ps1`                       |
 | Negative validation | SQL injection/constraint tests                    | `db/qa/TEST__negative_checks.sql`            | `.\RUN_NEGATIVE_TESTS.ps1`           |
 | DB sanity           | Row-count + schema assertions                     | via `RUN_SANITY.ps1`                         | `.\RUN_SANITY.ps1 -Env local`        |
 | Pipeline structure  | Python validator                                  | `check_pipeline_structure.py`                | `python check_pipeline_structure.py` |
@@ -891,7 +891,7 @@ E2E tests are the **only** exception — they run against a live dev server but 
   - **`pr-title-lint.yml`**: PR title conventional-commit validation (all PRs)
   - **`main-gate.yml`**: Typecheck → Lint → Build → Unit tests with coverage → Playwright smoke E2E → SonarCloud scan + BLOCKING Quality Gate → Sentry sourcemap upload
   - **`nightly.yml`**: Full Playwright (all projects incl. visual regression) + Data Integrity Audit (parallel)
-  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (759 checks) → Sanity (17 checks) → Confidence threshold
+  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (776 checks) → Sanity (17 checks) → Confidence threshold
   - **`deploy.yml`**: Manual trigger → Schema diff → Approval gate (production) → Pre-deploy backup → `supabase db push` → Post-deploy sanity
   - **`sync-cloud-db.yml`**: Auto-sync migrations to production on merge to `main`
 - **Required (merge-blocking) checks:** `Unit Tests`, `Playwright Smoke`, `Typecheck & Lint`, `Build`. These four must pass before a PR can merge.
@@ -928,7 +928,7 @@ If adding/changing DB schema or SQL functions:
 - For rollback procedures, see `DEPLOYMENT.md` → **Rollback Procedures** (5 scenarios + emergency checklist).
 - Add a QA check that verifies the migration outcome (row counts, constraint behavior).
 - Ensure idempotency (`IF NOT EXISTS`, `ON CONFLICT`, `DO UPDATE SET`).
-- Run `.\RUN_QA.ps1` to verify all 759 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 23 injection tests.
+- Run `.\RUN_QA.ps1` to verify all 776 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 20 injection tests.
 
 ### 8.14 Snapshots Are Not Enough
 
@@ -1023,8 +1023,8 @@ At the end of every PR-like change, include a **Verification** section:
 | Scoring Band Distribution | `QA__scoring_distribution.sql`      |     12 | No        |
 | **Negative Validation**   | `TEST__negative_checks.sql`         |     23 | Yes       |
 
-**Run:** `.\RUN_QA.ps1` — expects **771/771 checks passing** (+ EAN validation).
-**Run:** `.\RUN_NEGATIVE_TESTS.ps1` — expects **23/23 caught**.
+**Run:** `.\RUN_QA.ps1` — expects **776/776 checks passing** (+ EAN validation).
+**Run:** `.\RUN_NEGATIVE_TESTS.ps1` — expects **20/20 caught**.
 
 ### 8.19 Key Regression Tests (Scoring Suite)
 
@@ -2022,8 +2022,8 @@ Else → fallback Z (always safe, always returns a value)
 ## Verification Checklist (Definition of Done)
 
 - [ ] `python check_pipeline_structure.py` — 0 errors
-- [ ] `.\RUN_QA.ps1` — all 759 checks pass
-- [ ] `.\RUN_NEGATIVE_TESTS.ps1` — 23/23 caught
+- [ ] `.\RUN_QA.ps1` — all 776 checks pass
+- [ ] `.\RUN_NEGATIVE_TESTS.ps1` — 20/20 caught
 - [ ] `supabase test db` — all pgTAP pass
 - [ ] `cd frontend && npx tsc --noEmit` — 0 errors
 - [ ] `cd frontend && npx vitest run` — all pass, coverage ≥ baseline
@@ -2466,8 +2466,8 @@ Execute every command. Record output. Do not skip.
 ```powershell
 # ── Database layer ───────────────────────────────────────────────────
 supabase test db                               # All pgTAP tests pass
-.\RUN_QA.ps1                                   # All 759+ QA checks pass
-.\RUN_NEGATIVE_TESTS.ps1                       # All 23 negative tests caught
+.\RUN_QA.ps1                                   # All 776+ QA checks pass
+.\RUN_NEGATIVE_TESTS.ps1                       # All 20 negative tests caught
 python check_pipeline_structure.py            # 0 errors
 python validate_eans.py                       # 0 EAN failures
 python check_enrichment_identity.py           # 0 violations
@@ -2516,7 +2516,7 @@ After implementation, update ALL of these that apply (per §18.1):
 
 ```powershell
 supabase test db                  → XX/XX pgTAP tests pass
-.\RUN_QA.ps1                      → 759/759 checks pass (0 failures)
+.\RUN_QA.ps1                      → 776/776 checks pass (0 failures)
 .\RUN_NEGATIVE_TESTS.ps1          → 23/23 caught
 npx tsc --noEmit                  → 0 errors
 npx vitest run                    → XXX/XXX tests pass

--- a/docs/PRODUCTION_DATA.md
+++ b/docs/PRODUCTION_DATA.md
@@ -40,7 +40,7 @@
 
 ### 1.2 Migration Inventory
 
-**Location:** `supabase/migrations/` — **185 migration files**, append-only.
+**Location:** `supabase/migrations/` — **228 migration files**, append-only.
 
 **Naming convention:** `YYYYMMDDHHMMSS_description.sql` (Supabase CLI timestamps). Files are applied in lexicographic sort order.
 
@@ -324,7 +324,7 @@ There is no standalone `init_db_structure.py` script. Database initialization fo
 
 ```
 supabase db reset
-  → Applies all 185 migrations in order (supabase/migrations/*.sql)
+  → Applies all 228 migrations in order (supabase/migrations/*.sql)
   → Runs seed.sql (empty — no-op)
   → Schema is ready
 
@@ -460,7 +460,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
 
 - **EAN coverage:** 997/1,025 (97.3%)
 - **Scoring version:** v3.2 — 9-factor weighted formula
-- **QA checks:** 733 checks across 48 suites — all passing
+- **QA checks:** 776 checks across 49 suites — all passing
 - **Negative tests:** 20 injection tests — all caught
 - **Confidence threshold (CI):** ≤5% low-confidence products allowed
 - **CHECK constraints:** 24 domain constraints enforced at DB level
@@ -506,7 +506,7 @@ Backup = supabase/migrations/*.sql + db/pipelines/*.sql
 ```
 
 Since the database can be fully reconstructed from:
-1. 185 migration files (schema + functions + views)
+1. 228 migration files (schema + functions + views)
 2. 25 × 4 pipeline SQL files (all product data)
 3. `ci_post_pipeline.sql` (data fixups)
 


### PR DESCRIPTION
## Problem

`scripts/check_doc_counts.py` reported 23 mismatched count references across 3 files. Root cause: docs weren't updated after recent additions (cross-country views expanded QA from 759->776, today's security migration bumped count to 228, RUN_QA.ps1 actually runs 49 suites including ScoringDist).

## Fix

Updated hard-coded counts in:
- **copilot-instructions.md** (13 locations): 759->776 checks, 48->49 suites, 23->20 neg tests, 227->228 migrations, 771/771->776/776
- **README.md** (5 locations): same normalization
- **docs/PRODUCTION_DATA.md** (4 locations): 185->228 migrations, 733->776 checks, 48->49 suites

## Verification

```n`scripts/check_doc_counts.py`` -> 25 correct / 1 mismatch (false positive: governance_drift_check doc line 487 says '8 checks' re: its own internal checks)
```n
## Notes

No code or schema changes. Safe docs-only PR. The 1 remaining 'mismatch' is the `governance_drift_check()` function description referring to its 8 internal checks -- distinct from QA total. Regex in check_doc_counts.py could be tightened in a follow-up.