### PR TITLE
ci(repo-verify): enforce check_doc_counts.py --strict as a gate

### DIFF
--- a/.github/workflows/repo-verify.yml
+++ b/.github/workflows/repo-verify.yml
@@ -19,3 +19,9 @@ jobs:
       - name: Run repo_verify.ps1
         shell: pwsh
         run: ./scripts/repo_verify.ps1
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+      - name: Check doc count drift (strict)
+        run: python scripts/check_doc_counts.py --strict


### PR DESCRIPTION
## Problem

Doc count drift (PR #1022) was undetected for weeks because `check_doc_counts.py` existed but was never wired into CI.

## Fix

Add a Python setup + `--strict` invocation step to the **Repo Hygiene Verify** workflow. Runs on every push, PR, and weekly cron.

## Verification

Script is already clean on main (25 correct / 0 mismatched / strict exit 0 — verified after #1022 + #1023).

## Impact

Future PRs that add migrations, QA suites, or negative tests without updating docs will now fail CI at the Repo Hygiene step.