### PR TITLE
docs: refresh CHANGELOG + CURRENT_STATE for #1021-#1024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### CI
+
+- Enforce `scripts/check_doc_counts.py --strict` as a CI gate in the
+  **Repo Hygiene Verify** workflow so future doc count drift fails the build
+  (#1024)
+- Tighten `check_doc_counts.py` QA check regex with a `MIN_QA_CHECK_TOTAL = 100`
+  threshold to skip per-function sub-counts (e.g., `governance_drift_check`'s
+  "8 checks across…"), eliminating false positives (#1023)
+
+### Security
+
+- Revoke `PUBLIC EXECUTE` from `api_submit_product` and
+  `api_admin_get_submissions` — write-path + admin functions now require
+  `authenticated` or `service_role` (#1021)
+
+### Documentation
+
+- Reconcile count drift across repo — 49 QA suites, 776 QA checks, 20 negative
+  tests, 228 migrations aligned between filesystem, `copilot-instructions.md`,
+  `CURRENT_STATE.md`, `RUN_QA.ps1`, and `qa.yml` (#1022)
+
 ### Added
 
 - Epic #920 — Country-Aware Scanner & Submission Pipeline: 12 issues (#921–#932),

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # CURRENT_STATE.md
 
-> **Last updated:** 2026-03-21 by GitHub Copilot (epic #920 closeout)
+> **Last updated:** 2026-04-20 by GitHub Copilot (doc-count-drift workstream close)
 > **Purpose:** Volatile project status for AI agent context recovery. Read this FIRST at session start.
 
 ---
@@ -8,9 +8,22 @@
 ## Active Branch & PR
 
 - **Branch:** `main`
-- **Latest SHA (main):** `dbe06364` (feat(scanner): cross-country analytics views (#932) (#945))
-- **Open PRs:** 1 (Dependabot #941 — Next.js 16.1.6→16.1.7 security patch, 5 CVEs)
+- **Latest SHA (main):** `fe5dfd3e` (ci(repo-verify): enforce check_doc_counts.py --strict as a gate (#1024))
+- **Open PRs:** 0
+- **Open issues:** 1 (#212 — GOV-G1 Infrastructure Cost Attribution, deferred)
 - **Mode:** 🟢 Clean — no active work
+
+## Recently Shipped (Doc-Count-Drift Hardening Workstream)
+
+End-to-end: reconcile → tighten detector → enforce in CI.
+
+| PR    | Summary                                                                              |
+| ----- | ------------------------------------------------------------------------------------ |
+| #1024 | ci(repo-verify): enforce check_doc_counts.py --strict as a gate                      |
+| #1023 | chore(scripts): tighten QA check regex (`MIN_QA_CHECK_TOTAL = 100`)                  |
+| #1022 | docs: reconcile count drift (49 suites, 776 checks, 20 neg tests, 228 migrations)    |
+| #1021 | security(rls): revoke PUBLIC EXECUTE from api_submit_product + api_admin_get_submissions |
+| #1020 | ci(nightly): bump playwright step timeout 10m→20m                                    |
 
 ## Recently Shipped (Epic #920 — Country-Aware Scanner & Submission Pipeline)
 


### PR DESCRIPTION
## Context

CHANGELOG.md and CURRENT_STATE.md were stale relative to the recent workstream. This PR reconciles both.

## Changes

**CHANGELOG.md ([Unreleased])** — add three sections for recently-merged work:
- **CI** — #1024 (enforce `check_doc_counts.py --strict`), #1023 (regex tightening)
- **Security** — #1021 (revoke PUBLIC EXECUTE from submission + admin RPCs)
- **Documentation** — #1022 (reconcile count drift)

**CURRENT_STATE.md** — bump last-updated to 2026-04-20, latest SHA to `fe5dfd3e`, update open PR count to 0, add "Doc-Count-Drift Hardening Workstream" section covering #1020-#1024.

## Verification

- `check_doc_counts.py --strict` exits 0 (25 correct / 0 mismatched)
- No code changes, documentation-only