### PR TITLE
ci(repo-verify): skip _TEMPLATE.sql and enforce migration ordering

### DIFF
--- a/.github/workflows/repo-verify.yml
+++ b/.github/workflows/repo-verify.yml
@@ -25,3 +25,5 @@ jobs:
           python-version: '3.12'
       - name: Check doc count drift (strict)
         run: python scripts/check_doc_counts.py --strict
+      - name: Check migration ordering
+        run: python scripts/check_migration_order.py

--- a/scripts/check_migration_order.py
+++ b/scripts/check_migration_order.py
@@ -35,7 +35,10 @@ def check_migration_ordering(migrations_dir: str = "supabase/migrations") -> lis
         violations.append(f"Directory not found: {migrations_dir}")
         return violations
 
-    files = sorted(f for f in os.listdir(migrations_dir) if f.endswith(".sql"))
+    files = sorted(
+        f for f in os.listdir(migrations_dir)
+        if f.endswith(".sql") and not f.startswith("_")
+    )
 
     if not files:
         violations.append(f"No .sql files found in {migrations_dir}")


### PR DESCRIPTION
## Problem

`scripts/check_migration_order.py` was failing locally on `_TEMPLATE.sql` — a placeholder in `supabase/migrations/` that is intentionally not a real migration. Because of that false positive the script could not be wired into CI.

## Change

1. **`scripts/check_migration_order.py`** — skip files whose names start with underscore (`_TEMPLATE.sql` etc.) before applying the `YYYYMMDDHHMMSS_description.sql` pattern check. Real migrations always start with a digit.
2. **`.github/workflows/repo-verify.yml`** — add a new step `Check migration ordering` after `Check doc count drift (strict)`, so future timestamp duplicates or out-of-order migrations fail the build immediately.

## Verification

```powershell
python scripts/check_migration_order.py   # OK  All 228 migrations in supabase/migrations/ are properly ordered
```