### PR TITLE
ci(repo-verify): enforce migration header conventions on new PRs

### DIFF
--- a/.github/workflows/repo-verify.yml
+++ b/.github/workflows/repo-verify.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Need full history for pull_request diff against base ref.
+          fetch-depth: 0
       - name: Run repo_verify.ps1
         shell: pwsh
         run: ./scripts/repo_verify.ps1
@@ -27,3 +30,17 @@ jobs:
         run: python scripts/check_doc_counts.py --strict
       - name: Check migration ordering
         run: python scripts/check_migration_order.py
+      - name: Check migration conventions (changed files only)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          changed=$(git diff --name-only --diff-filter=AM "$base_sha"...HEAD -- 'supabase/migrations/*.sql' || true)
+          if [ -z "$changed" ]; then
+            echo "No migration files changed in this PR."
+            exit 0
+          fi
+          echo "Changed migration files:"
+          echo "$changed"
+          # shellcheck disable=SC2086
+          python scripts/check_migration_conventions.py --files $changed

--- a/scripts/check_migration_conventions.py
+++ b/scripts/check_migration_conventions.py
@@ -141,14 +141,41 @@ def main() -> None:
     strict = "--strict" in sys.argv
     report_only = "--report" in sys.argv
 
+    # --files FILE1 FILE2 ... restricts the check to an explicit list of paths.
+    # Used by CI to enforce conventions only on migrations added/modified in a PR,
+    # without requiring mass-backfill of legacy headers.
+    files_mode = "--files" in sys.argv
+    explicit_files: list[Path] = []
+    if files_mode:
+        idx = sys.argv.index("--files")
+        for raw in sys.argv[idx + 1 :]:
+            if raw.startswith("--"):
+                break
+            p = Path(raw)
+            # Only check .sql files under supabase/migrations/
+            if p.suffix != ".sql":
+                continue
+            if "supabase/migrations" not in p.as_posix():
+                continue
+            if p.name in SKIP_FILES:
+                continue
+            explicit_files.append(p)
+
     if not MIGRATIONS_ROOT.is_dir():
         print(f"ERROR: Migrations directory not found: {MIGRATIONS_ROOT}")
         sys.exit(1)
 
-    sql_files = sorted(MIGRATIONS_ROOT.glob("*.sql"))
-    sql_files = [f for f in sql_files if f.name not in SKIP_FILES]
+    if files_mode:
+        sql_files = sorted(explicit_files)
+    else:
+        sql_files = sorted(MIGRATIONS_ROOT.glob("*.sql"))
+        sql_files = [f for f in sql_files if f.name not in SKIP_FILES]
 
     if not sql_files:
+        if files_mode:
+            # No migration files in the PR's changeset — treat as clean pass.
+            print("No migration files to check.")
+            sys.exit(0)
         print("ERROR: No migration files found.")
         sys.exit(1)
 


### PR DESCRIPTION
## Problem

`scripts/check_migration_conventions.py` enforces the standard header block (`-- Migration:` and `-- Rollback:` lines in the first 20 lines) documented in docs/MIGRATION_CONVENTIONS.md §3. Locally, ~163 of 227 existing migrations predate the standard and fail the check, so the script cannot be wired into CI without either mass-backfilling legacy headers or accepting a permanently-red gate.

## Change

1. **`scripts/check_migration_conventions.py`** — new `--files FILE [FILE ...]` flag. When passed, the script only checks the listed files, skips non-`.sql` and non-migration paths, skips `_TEMPLATE.sql`, and exits 0 if the resulting list is empty (no migrations in the PR diff → clean pass).
2. **`.github/workflows/repo-verify.yml`** — new pull_request-only step:
    - Checks out with `fetch-depth: 0` so the PR base SHA is available
    - Computes `git diff --name-only --diff-filter=AM <base>...HEAD -- 'supabase/migrations/*.sql'`
    - Invokes the script with the resulting list via `--files`.

## Why this approach

- **Zero mass-backfill risk.** Legacy migrations remain untouched; they are append-only and not runtime-critical for header compliance.
- **Forward-looking only.** Any new migration opened in a PR must either carry the `Migration:` + `Rollback:` header lines or the PR fails.
- **`_TEMPLATE.sql`** already has both header lines, so copying the template yields a compliant migration by default.

## Verification

```powershell
# Compliant template → pass
python scripts/check_migration_conventions.py --files supabase/migrations/_TEMPLATE.sql
# exit 0  'No migration files to check.'  (skip-listed)

# Known-bad legacy migration → fail with specific violation
python scripts/check_migration_conventions.py --files supabase/migrations/20260207000401_remove_unused_columns.sql
# exit 1  ' x [...] Missing 'Rollback:' in header ...'

# Non-migration file → pass (nothing to check)
python scripts/check_migration_conventions.py --files README.md
# exit 0
```