### PR TITLE
ci(repo-verify): wire check_doc_drift.py into push/schedule runs

### DIFF
--- a/.github/workflows/repo-verify.yml
+++ b/.github/workflows/repo-verify.yml
@@ -1,11 +1,11 @@
 name: Repo Hygiene Verify
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
   schedule:
-    - cron: '30 5 * * 1'   # Weekly Monday 05:30 UTC
+    - cron: "30 5 * * 1" # Weekly Monday 05:30 UTC
   workflow_dispatch:
 
 permissions:
@@ -25,11 +25,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - name: Check doc count drift (strict)
         run: python scripts/check_doc_counts.py --strict
       - name: Check migration ordering
         run: python scripts/check_migration_order.py
+      - name: Check doc freshness (90-day threshold)
+        if: github.event_name != 'pull_request'
+        run: python scripts/check_doc_drift.py
       - name: Check migration conventions (changed files only)
         if: github.event_name == 'pull_request'
         shell: bash


### PR DESCRIPTION
## Summary

Wires `scripts/check_doc_drift.py` (90-day freshness threshold) into the `Repo Hygiene Verify` workflow for `push`, `schedule`, and `workflow_dispatch` events. Skipped on `pull_request` — doc age doesn't change meaningfully per PR, and the weekly cron is the appropriate cadence for age-based drift.

## Verification

```powershell
python scripts/check_doc_drift.py
# OK  All 65 documents in docs/ updated within 90 days
# exit=0
```n
## Context

Completes the hygiene-script wiring sweep:

| PR | Script | Trigger |
| --- | --- | --- |
| #1024 | `check_doc_counts.py --strict` | all events |
| #1026 | `check_migration_order.py` | all events |
| #1027 | `check_migration_conventions.py --files` | pull_request |
| **this** | `check_doc_drift.py` | push + schedule + dispatch |