### PR TITLE
ci(security): pin remaining 4 actions to commit SHAs

### DIFF
--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.0.0
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload execution report
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: refresh-report-${{ github.run_id }}
           path: pipeline/reports/refresh_*.json

--- a/.github/workflows/scrape-products.yml
+++ b/.github/workflows/scrape-products.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload scraped CSV
         if: success()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scraped-${{ matrix.retailer }}-${{ github.run_id }}
           path: scraped-data/${{ matrix.retailer }}/*.csv


### PR DESCRIPTION
Pins the last 4 unpinned third-party GitHub Actions references to full commit SHAs for supply-chain hardening. All other workflows in the repo are already SHA-pinned; this brings the workflow directory to 100% coverage.

- actions/checkout v6 -> de0fac2e4500dabe0009e67214ff5f5447ce83dd
- actions/setup-python v6 -> a309ff8b426b58ec0e2a45f0f869d46889d02405
- actions/upload-artifact v7.0.1 -> 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a (x2)

Files touched: .github/workflows/data-refresh.yml, .github/workflows/scrape-products.yml.