### PR TITLE
ci(deps): restrict Dependabot groups to minor+patch only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,9 @@ updates:
       prefix: "deps(frontend)"
       include: "scope"
     # ── Grouped updates to minimise PR flood ──
+    # Groups are restricted to minor+patch updates so each major bump
+    # arrives as its own PR for individual triage (breaking changes
+    # cannot be safely batched — see PR #1038 post-mortem).
     groups:
       # Framework core — next + react should upgrade together
       framework:
@@ -50,14 +53,23 @@ updates:
           - "react"
           - "react-dom"
           - "eslint-config-next"
+        update-types:
+          - "minor"
+          - "patch"
       # Sentry SDKs — tightly coupled, upgrade together
       sentry:
         patterns:
           - "@sentry/*"
+        update-types:
+          - "minor"
+          - "patch"
       # Supabase client libs
       supabase:
         patterns:
           - "@supabase/*"
+        update-types:
+          - "minor"
+          - "patch"
       # Testing toolchain
       testing:
         patterns:
@@ -70,6 +82,9 @@ updates:
           - "jsdom"
           - "fake-indexeddb"
           - "vitest-axe"
+        update-types:
+          - "minor"
+          - "patch"
       # Build toolchain
       build-tooling:
         patterns:
@@ -80,10 +95,16 @@ updates:
           - "@tailwindcss/*"
           - "sharp"
           - "@vitejs/*"
-      # Everything else — catch-all for remaining deps
+        update-types:
+          - "minor"
+          - "patch"
+      # Everything else — catch-all for remaining deps (minor/patch only)
       npm-rest:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
         exclude-patterns:
           - "next"
           - "react"
@@ -143,16 +164,22 @@ updates:
       time: "06:00"
       timezone: "Europe/Warsaw"
     groups:
-      # Official GitHub actions — upgrade together
+      # Official GitHub actions — upgrade together (minor/patch only)
       github-official:
         patterns:
           - "actions/*"
           - "github/*"
-      # Third-party actions (Supabase, Sonar, etc.)
+        update-types:
+          - "minor"
+          - "patch"
+      # Third-party actions (Supabase, Sonar, etc.) — minor/patch only
       third-party:
         patterns:
           - "supabase/*"
           - "SonarSource/*"
+        update-types:
+          - "minor"
+          - "patch"
     open-pull-requests-limit: 5
     reviewers:
       - "ericsocrat"


### PR DESCRIPTION
## Problem

PR #1038 grouped 13 npm package updates including 6 MAJOR version bumps (`@eslint/js` 9→10, `@vercel/speed-insights` 1→2, `lucide-react` 0.577→1.11, `sonner` 1→2, `tesseract.js` 5→7, `@types/node` 22→25). All gates failed (Build, Typecheck, Unit Tests, Playwright, Lighthouse, quality_gate, License, Bundle Size, Vercel) and individual breakages cannot be isolated when batched.

## Fix

Add `update-types: [minor, patch]` to every group in `dependabot.yml`. Major bumps now arrive as individual PRs that can be triaged, tested, and merged or pinned one at a time.

## Effect

- Existing minor/patch grouping behavior preserved (low PR noise)
- Future major bumps land individually for proper triage
- PR #1038 will be closed; Dependabot will regenerate ungrouped majors on next run

Follow-up: close #1038 after merge.