### PR TITLE
ci(deps): fix Dependabot title format to pass conventional-commits lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,8 +39,12 @@ updates:
       - "dependencies"
       - "frontend"
     commit-message:
-      prefix: "deps(frontend)"
-      include: "scope"
+      # NOTE: 'deps' is not in .commitlintrc.json type-enum; using 'chore' as the
+      # type and 'deps' as the scope produces titles that pass pr-title-lint.yml.
+      # 'include: scope' is omitted because Dependabot would append the dependency
+      # type (deps/deps-dev) as a second scope, producing 'chore(deps)(deps):' —
+      # which is malformed Conventional Commits.
+      prefix: "chore(deps)"
     # ── Grouped updates to minimise PR flood ──
     # Groups are restricted to minor+patch updates so each major bump
     # arrives as its own PR for individual triage (breaking changes
@@ -151,8 +155,7 @@ updates:
       - "dependencies"
       - "python"
     commit-message:
-      prefix: "deps(python)"
-      include: "scope"
+      prefix: "chore(deps)"
 
   # ── GitHub Actions ────────────────────────────────────────────
   - package-ecosystem: "github-actions"
@@ -189,5 +192,4 @@ updates:
       - "dependencies"
       - "ci"
     commit-message:
-      prefix: "deps(actions)"
-      include: "scope"
+      prefix: "ci(deps)"


### PR DESCRIPTION
## Problem

All 9 currently-open Dependabot PRs (#1042-#1050) fail the `Conventional Commit Title` check because their titles look like:

`deps(frontend)(deps): bump @sentry/nextjs from 10.50.0 to 10.51.0 in /frontend in the sentry group`

Two issues:

1. **`deps` is not a valid type.** `.commitlintrc.json` `type-enum` allows only `feat|fix|schema|data|score|docs|test|ci|refactor|perf|security|chore`.
2. **`include: scope` produces a duplicate scope.** Dependabot appends the dependency type (`deps` / `deps-dev`) as a second scope, so `prefix: 'deps(frontend)'` + `include: scope` becomes `deps(frontend)(deps):` \u2014 malformed.

## Fix

In `.github/dependabot.yml`:

- npm group: `prefix: 'deps(frontend)'` + `include: scope` \u2192 `prefix: 'chore(deps)'` (no `include`)
- pip group: `prefix: 'deps(python)'` + `include: scope` \u2192 `prefix: 'chore(deps)'` (no `include`)
- actions group: `prefix: 'deps(actions)'` + `include: scope` \u2192 `prefix: 'ci(deps)'` (no `include`)

Future Dependabot PRs will produce titles like:

- `chore(deps): bump @sentry/nextjs from 10.50.0 to 10.51.0 in /frontend in the sentry group` \u2705
- `ci(deps): bump SonarSource/sonarqube-scan-action from 7.1.0 to 8.0.0` \u2705

## Existing PR titles

After this PR merges, I'll rename the 9 open Dependabot PR titles to the new format via `gh pr edit`.