### PR TITLE
chore(lint): silence 2 spurious a11y warnings with justification comments

### DIFF
--- a/frontend/src/app/app/scan/submit/page.tsx
+++ b/frontend/src/app/app/scan/submit/page.tsx
@@ -305,6 +305,8 @@ export default function SubmitProductPage() {
             </label>
             {photoPreview && photoPreview.startsWith("blob:") ? (
               <div className="relative inline-block animate-scale-in">
+                {/* blob: URL preview is not eligible for next/image optimization (local memory reference) */}
+                {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   src={photoPreview}
                   alt=""

--- a/frontend/src/components/dashboard/RecentlyViewed.test.tsx
+++ b/frontend/src/components/dashboard/RecentlyViewed.test.tsx
@@ -19,7 +19,7 @@ vi.mock("@/lib/i18n", () => ({
 }));
 
 vi.mock("next/image", () => ({
-  // eslint-disable-next-line @next/next/no-img-element
+  // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text -- alt is forwarded via {...props}
   default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img {...props} />,
 }));
 


### PR DESCRIPTION
Reduces ESLint warnings from 29 to 27 by adding `eslint-disable-next-line` with justification comments to two spurious flags.

## Changes

### 1. `frontend/src/app/app/scan/submit/page.tsx` (line 308)
- `<img>` is used for a `blob:` URL preview of a user-uploaded photo
- `next/image` cannot optimize `blob:` URLs (local memory reference, no CDN/format pipeline applies)
- Added `eslint-disable-next-line @next/next/no-img-element` with explanatory comment

### 2. `frontend/src/components/dashboard/RecentlyViewed.test.tsx` (line 23)
- This is a Vitest mock of `next/image` that forwards all props (including `alt`) via `{...props}`;n- `jsx-a11y/alt-text` cannot statically verify the spread includes `alt`
- Updated the existing `eslint-disable-next-line` to also cover `jsx-a11y/alt-text` with rationale

## Verification

- `npm run lint` → 27 warnings (down from 29), 0 errors
- `npx tsc --noEmit` → 0 errors
- `RecentlyViewed.test.tsx` → 21/21 tests pass

## Out of scope

The remaining 27 warnings are documented as Non-Urgent Follow-Up #1 in `CURRENT_STATE.md` — predominantly React Compiler `set-state-in-effect` (×21) requiring per-component effect-graph analysis. That is a multi-PR refactor and explicitly deferred.