### PR TITLE
chore(lint): replace 3 non-null assertions with safe local-variable pattern

### DIFF
--- a/frontend/src/app/onboarding/steps/DoneStep.tsx
+++ b/frontend/src/app/onboarding/steps/DoneStep.tsx
@@ -18,10 +18,8 @@ export function DoneStep({ data, loading, onComplete }: DoneStepProps) {
 
   const countryName =
     COUNTRIES.find((c) => c.code === data.country)?.name ?? data.country;
-  const dietLabel =
-    DIET_OPTIONS.find((d) => d.value === data.diet)
-      ? t(DIET_OPTIONS.find((d) => d.value === data.diet)!.labelKey)
-      : data.diet;
+  const dietOption = DIET_OPTIONS.find((d) => d.value === data.diet);
+  const dietLabel = dietOption ? t(dietOption.labelKey) : data.diet;
   const allergenLabels = data.allergens
     .map((tag) => {
       const found = ALLERGEN_TAGS.find((a) => a.tag === tag);

--- a/frontend/src/components/common/CountryChip.tsx
+++ b/frontend/src/components/common/CountryChip.tsx
@@ -109,7 +109,7 @@ export function CountryChip({
     return (
       <span
         role="img"
-        aria-label={nullLabel!}
+        aria-label={nullLabel ?? ""}
         className={`inline-flex items-center ${cfg.gap} rounded-full border border-border bg-surface-muted ${cfg.px} ${cfg.text} font-medium text-foreground-muted ${className}`}
       >
         <FallbackFlag size={cfg.flag} />

--- a/frontend/src/components/settings/HealthProfileSection.tsx
+++ b/frontend/src/components/settings/HealthProfileSection.tsx
@@ -414,11 +414,10 @@ export function HealthProfileSection() {
                   {profile.health_conditions.length > 0 && (
                     <p className="mt-1 text-xs text-foreground-secondary">
                       {profile.health_conditions
-                        .map(
-                          (c) =>
-                            HEALTH_CONDITIONS.find((hc) => hc.value === c)
-                              ? t(HEALTH_CONDITIONS.find((hc) => hc.value === c)!.labelKey) : c,
-                        )
+                        .map((c) => {
+                          const hc = HEALTH_CONDITIONS.find((h) => h.value === c);
+                          return hc ? t(hc.labelKey) : c;
+                        })
                         .join(", ")}
                     </p>
                   )}


### PR DESCRIPTION
Eliminates the 3 remaining `@typescript-eslint/no-non-null-assertion` warnings (27 to 24 total). All instances followed the same anti-pattern: calling `.find()` twice and using `!` on the second call. Replaced with a single local variable + truthy check.

Files:
- `frontend/src/app/onboarding/steps/DoneStep.tsx` (DIET_OPTIONS lookup)
- `frontend/src/components/common/CountryChip.tsx` (`nullLabel!` -> `nullLabel ?? ''` ; outer guard already ensures truthy)
- `frontend/src/components/settings/HealthProfileSection.tsx` (HEALTH_CONDITIONS lookup)

## Verification

- `npx tsc --noEmit`: 0 errors
- `npm run lint`: 0 errors, 24 warnings (was 27)
- `npx vitest run` on CountryChip + HealthProfileSection: 40/40 passing

Follows CURRENT_STATE.md non-urgent follow-up #1 (lint warnings cleanup). No behavior changes.