### PR TITLE
refactor(hooks): use useSyncExternalStore in useReducedMotion

### DIFF
--- a/frontend/src/hooks/use-reduced-motion.test.ts
+++ b/frontend/src/hooks/use-reduced-motion.test.ts
@@ -50,6 +50,7 @@ describe("useReducedMotion", () => {
 
     // Simulate user changing preference
     act(() => {
+      matches = true;
       const onChange = listeners.get("change");
       onChange?.({ matches: true } as MediaQueryListEvent);
     });

--- a/frontend/src/hooks/use-reduced-motion.ts
+++ b/frontend/src/hooks/use-reduced-motion.ts
@@ -6,9 +6,23 @@
 // globals.css; this hook enables JS-driven animations (e.g., Framer Motion,
 // scroll-into-view, requestAnimationFrame) to also respect the preference.
 
-import { useState, useEffect } from "react";
+import { useSyncExternalStore } from "react";
 
 const QUERY = "(prefers-reduced-motion: reduce)";
+
+function subscribe(callback: () => void): () => void {
+  const mql = globalThis.matchMedia(QUERY);
+  mql.addEventListener("change", callback);
+  return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot(): boolean {
+  return globalThis.matchMedia(QUERY).matches;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
 
 /**
  * React hook that tracks the user's `prefers-reduced-motion` media query.
@@ -17,19 +31,5 @@ const QUERY = "(prefers-reduced-motion: reduce)";
  * Safe for SSR — defaults to `false` on the server.
  */
 export function useReducedMotion(): boolean {
-  const [prefersReduced, setPrefersReduced] = useState(false);
-
-  useEffect(() => {
-    const mql = globalThis.matchMedia(QUERY);
-    setPrefersReduced(mql.matches);
-
-    function onChange(e: MediaQueryListEvent) {
-      setPrefersReduced(e.matches);
-    }
-
-    mql.addEventListener("change", onChange);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
-
-  return prefersReduced;
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
## Summary

Replaces `useState`+`useEffect` pattern with React 18+ canonical `useSyncExternalStore` for media-query subscription in `useReducedMotion`.

## Why

- Eliminates React Compiler `set-state-in-effect` warning (24 → 23)
- Removes potential SSR hydration mismatch (snapshot read synchronously during render instead of via post-mount effect)
- Canonical React 18+ pattern for external store subscriptions

## Test impact

Updated test 3 (`responds to media query changes`): the closure `matches` variable now syncs **before** firing the change event, because `useSyncExternalStore` re-reads `getSnapshot()` on each notification (it does not trust the event payload). All 5 existing tests pass.

## Verification

- `npx vitest run src/hooks/use-reduced-motion.test.ts` → 5/5 pass
- `npx tsc --noEmit` → 0 errors
- `npm run lint` → 23 warnings (down from 24)

## Non-Urgent Follow-Ups update

Item #1 of `CURRENT_STATE.md` non-urgent follow-ups: 24 → 23 React Compiler warnings remaining.
