### PR TITLE
chore(framework): rename middleware.ts to proxy.ts (Next.js 16 deprecation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Rename `frontend/src/middleware.ts` → `frontend/src/proxy.ts` and
+  exported function `middleware()` → `proxy()` per Next.js 16 deprecation.
+  Eliminates the `middleware.ts` deprecation warning at build time.
+  Behavior is identical; matcher unchanged. The unrelated Supabase SSR
+  helper at `frontend/src/lib/supabase/middleware.ts` is **not** affected
+  (it is a separate `@supabase/ssr` client factory). (#1062)
+
 ### CI
 
 - Wire `scripts/check_doc_drift.py` (90-day freshness threshold) into

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -251,7 +251,7 @@ These are documented follow-ups, not active work items. Address opportunisticall
 
 1. **React Compiler lint warnings cleanup** — 20 locations across 5 rules (`set-state-in-effect` ×17, `preserve-manual-memoization` ×1, `purity` ×1, `refs` ×1, `static-components` ×1). Currently downgraded to `"warn"` in `eslint.config.mjs`. Dedicated cleanup pass when convenient — no urgency.
 2. ~~**Remove `@eslint/eslintrc` and `@eslint/js` from devDependencies**~~ — ✅ Done in PR #1053 (2026-04-30). Restored Linux-only `@emnapi/*` nested lockfile entries to fix cross-platform CI break.
-3. **`middleware.ts` → `proxy.ts` migration** — Next.js 16 deprecated the `middleware.ts` convention in favor of `proxy.ts`. Currently backward-compatible (warning only). Address when Next.js drops support or in next major framework review.
+3. ~~**`middleware.ts` → `proxy.ts` migration**~~ — ✅ Done in #1062. File renamed via `git mv`; exported function renamed `middleware` → `proxy`; deprecation warning eliminated.
 
 ## Staging Environment
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -295,7 +295,7 @@ tryvit/
 ├── fetch_off_category.py            # OFF API → pipeline SQL generator (standalone)
 ├── frontend/
 │   ├── src/
-│   │   ├── middleware.ts                # Next.js middleware (auth redirects)
+│   │   ├── proxy.ts                 # Next.js proxy (auth redirects, was middleware.ts pre-Next.js 16)
 │   │   ├── lib/                     # Shared utilities, API clients, types
 │   │   │   ├── supabase/            # Supabase client (client.ts, server.ts, middleware.ts)
 │   │   │   ├── *.ts                 # Source modules (api, rpc, types, constants, validation, query-keys)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -66,7 +66,7 @@ src/
 │   ├── types.ts              # TypeScript interfaces for API responses
 │   └── constants.ts          # Countries, diet options, allergen tags
 ├── styles/globals.css        # Tailwind base + utility classes
-└── middleware.ts             # Auth-only gate (no onboarding logic here)
+└── proxy.ts                  # Auth-only gate (no onboarding logic here)
 ```
 
 ## Architecture Decisions

--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { middleware } from "./middleware";
+import { proxy } from "./proxy";
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -42,54 +42,54 @@ function createRequest(pathname: string, origin = "http://localhost:3000") {
   return new NextRequest(new URL(pathname, origin));
 }
 
-describe("middleware", () => {
+describe("proxy", () => {
   describe("public paths", () => {
     it("allows unauthenticated access to /", async () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
-      const response = await middleware(createRequest("/"));
+      const response = await proxy(createRequest("/"));
       // Should NOT redirect (status 200)
       expect(response.status).not.toBe(307);
     });
 
     it("allows unauthenticated access to /contact", async () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
-      const response = await middleware(createRequest("/contact"));
+      const response = await proxy(createRequest("/contact"));
       expect(response.status).not.toBe(307);
     });
 
     it("allows unauthenticated access to /privacy", async () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
-      const response = await middleware(createRequest("/privacy"));
+      const response = await proxy(createRequest("/privacy"));
       expect(response.status).not.toBe(307);
     });
 
     it("allows unauthenticated access to /terms", async () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
-      const response = await middleware(createRequest("/terms"));
+      const response = await proxy(createRequest("/terms"));
       expect(response.status).not.toBe(307);
     });
 
     it("allows unauthenticated access to /auth/login", async () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
-      const response = await middleware(createRequest("/auth/login"));
+      const response = await proxy(createRequest("/auth/login"));
       expect(response.status).not.toBe(307);
     });
 
     it("allows unauthenticated access to /auth/signup", async () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
-      const response = await middleware(createRequest("/auth/signup"));
+      const response = await proxy(createRequest("/auth/signup"));
       expect(response.status).not.toBe(307);
     });
 
     it("allows unauthenticated access to /learn", async () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
-      const response = await middleware(createRequest("/learn"));
+      const response = await proxy(createRequest("/learn"));
       expect(response.status).not.toBe(307);
     });
 
     it("allows unauthenticated access to /learn/nutri-score", async () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
-      const response = await middleware(createRequest("/learn/nutri-score"));
+      const response = await proxy(createRequest("/learn/nutri-score"));
       expect(response.status).not.toBe(307);
     });
   });
@@ -99,7 +99,7 @@ describe("middleware", () => {
       mockGetUser.mockResolvedValue({
         data: { user: { id: "u1" } },
       });
-      const response = await middleware(createRequest("/auth/login"));
+      const response = await proxy(createRequest("/auth/login"));
       expect(response.status).toBe(307);
       expect(response.headers.get("location")).toBe(
         "http://localhost:3000/app/search",
@@ -110,7 +110,7 @@ describe("middleware", () => {
       mockGetUser.mockResolvedValue({
         data: { user: { id: "u1" } },
       });
-      const response = await middleware(createRequest("/auth/signup"));
+      const response = await proxy(createRequest("/auth/signup"));
       expect(response.status).toBe(307);
       expect(response.headers.get("location")).toBe(
         "http://localhost:3000/app/search",
@@ -121,7 +121,7 @@ describe("middleware", () => {
       mockGetUser.mockResolvedValue({
         data: { user: { id: "u1" } },
       });
-      const response = await middleware(createRequest("/"));
+      const response = await proxy(createRequest("/"));
       expect(response.status).not.toBe(307);
     });
   });
@@ -129,7 +129,7 @@ describe("middleware", () => {
   describe("protected routes", () => {
     it("redirects unauthenticated user from /app/search to login", async () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
-      const response = await middleware(createRequest("/app/search"));
+      const response = await proxy(createRequest("/app/search"));
       expect(response.status).toBe(307);
       const location = response.headers.get("location") ?? "";
       expect(location).toContain("/auth/login");
@@ -138,7 +138,7 @@ describe("middleware", () => {
 
     it("redirects unauthenticated user from /app/settings to login", async () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
-      const response = await middleware(createRequest("/app/settings"));
+      const response = await proxy(createRequest("/app/settings"));
       expect(response.status).toBe(307);
       const location = response.headers.get("location") ?? "";
       expect(location).toContain("/auth/login");
@@ -146,7 +146,7 @@ describe("middleware", () => {
 
     it("preserves query string in redirect parameter", async () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
-      const response = await middleware(
+      const response = await proxy(
         createRequest("/app/search?q=test&page=2"),
       );
       expect(response.status).toBe(307);
@@ -160,7 +160,7 @@ describe("middleware", () => {
       mockGetUser.mockResolvedValue({
         data: { user: { id: "u1" } },
       });
-      const response = await middleware(createRequest("/app/search"));
+      const response = await proxy(createRequest("/app/search"));
       expect(response.status).not.toBe(307);
     });
   });
@@ -169,7 +169,7 @@ describe("middleware", () => {
 
   describe("rate limiting — API routes", () => {
     it("returns 200 with rate limit headers when under limit", async () => {
-      const response = await middleware(createRequest("/api/health"));
+      const response = await proxy(createRequest("/api/health"));
       expect(response.status).toBe(200);
       expect(response.headers.get("X-RateLimit-Limit")).toBe("60");
       expect(response.headers.get("X-RateLimit-Remaining")).toBe("59");
@@ -184,7 +184,7 @@ describe("middleware", () => {
         reset: Date.now() + 30_000,
       });
 
-      const response = await middleware(createRequest("/api/health"));
+      const response = await proxy(createRequest("/api/health"));
       expect(response.status).toBe(429);
 
       const body = await response.json();
@@ -195,7 +195,7 @@ describe("middleware", () => {
     });
 
     it("does not call Supabase auth for API routes", async () => {
-      await middleware(createRequest("/api/health"));
+      await proxy(createRequest("/api/health"));
       expect(mockGetUser).not.toHaveBeenCalled();
     });
 
@@ -207,13 +207,13 @@ describe("middleware", () => {
         reset: Date.now() + 60_000,
       });
 
-      const response = await middleware(createRequest("/api/health"));
+      const response = await proxy(createRequest("/api/health"));
       expect(response.status).toBe(429);
       expect(response.headers.get("x-request-id")).toBeTruthy();
     });
 
     it("passes through with rate limit headers on success", async () => {
-      const response = await middleware(createRequest("/api/some-endpoint"));
+      const response = await proxy(createRequest("/api/some-endpoint"));
       expect(response.status).toBe(200);
       expect(response.headers.get("X-RateLimit-Limit")).toBeTruthy();
     });
@@ -236,7 +236,7 @@ describe("middleware", () => {
           headers: { "x-rate-limit-bypass": "test-bypass-secret" },
         },
       );
-      const response = await middleware(req);
+      const response = await proxy(req);
       // Should NOT be 429 because bypass token is valid
       expect(response.status).toBe(200);
 
@@ -260,7 +260,7 @@ describe("middleware", () => {
           headers: { "x-rate-limit-bypass": "wrong-secret" },
         },
       );
-      const response = await middleware(req);
+      const response = await proxy(req);
       expect(response.status).toBe(429);
 
       process.env.RATE_LIMIT_BYPASS_TOKEN = originalEnv;
@@ -274,7 +274,7 @@ describe("middleware", () => {
       mockGetUser.mockResolvedValue({
         data: { user: { id: "u1", email: "user@example.com" } },
       });
-      const response = await middleware(
+      const response = await proxy(
         createRequest("/app/admin/submissions"),
       );
       expect(response.status).toBe(303);
@@ -286,7 +286,7 @@ describe("middleware", () => {
       mockGetUser.mockResolvedValue({
         data: { user: { id: "u1", email: "user@example.com" } },
       });
-      const response = await middleware(
+      const response = await proxy(
         createRequest("/app/admin/monitoring"),
       );
       expect(response.status).toBe(303);
@@ -301,7 +301,7 @@ describe("middleware", () => {
       mockGetUser.mockResolvedValue({
         data: { user: { id: "u1", email: "admin@example.com" } },
       });
-      const response = await middleware(
+      const response = await proxy(
         createRequest("/app/admin/submissions"),
       );
       expect(response.status).toBe(303);
@@ -318,7 +318,7 @@ describe("middleware", () => {
       mockGetUser.mockResolvedValue({
         data: { user: { id: "u1", email: "admin@example.com" } },
       });
-      const response = await middleware(
+      const response = await proxy(
         createRequest("/app/admin/submissions"),
       );
       expect(response.status).not.toBe(303);
@@ -334,7 +334,7 @@ describe("middleware", () => {
       mockGetUser.mockResolvedValue({
         data: { user: { id: "u1", email: "admin@example.com" } },
       });
-      const response = await middleware(
+      const response = await proxy(
         createRequest("/app/admin/monitoring"),
       );
       expect(response.status).not.toBe(303);
@@ -349,7 +349,7 @@ describe("middleware", () => {
       mockGetUser.mockResolvedValue({
         data: { user: { id: "u1" } },
       });
-      const response = await middleware(
+      const response = await proxy(
         createRequest("/app/admin/submissions"),
       );
       expect(response.status).toBe(303);
@@ -361,7 +361,7 @@ describe("middleware", () => {
 
     it("redirects unauthenticated user from admin route to login", async () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
-      const response = await middleware(
+      const response = await proxy(
         createRequest("/app/admin/submissions"),
       );
       expect(response.status).toBe(307);
@@ -373,7 +373,7 @@ describe("middleware", () => {
       mockGetUser.mockResolvedValue({
         data: { user: { id: "u1", email: "user@example.com" } },
       });
-      const response = await middleware(
+      const response = await proxy(
         createRequest("/app/admin/submissions"),
       );
       expect(response.status).toBe(303);
@@ -387,12 +387,12 @@ describe("middleware", () => {
   describe("request ID", () => {
     it("generates x-request-id for page requests", async () => {
       mockGetUser.mockResolvedValue({ data: { user: null } });
-      const response = await middleware(createRequest("/"));
+      const response = await proxy(createRequest("/"));
       expect(response.headers.get("x-request-id")).toBeTruthy();
     });
 
     it("generates x-request-id for API requests", async () => {
-      const response = await middleware(createRequest("/api/health"));
+      const response = await proxy(createRequest("/api/health"));
       expect(response.headers.get("x-request-id")).toBeTruthy();
     });
 
@@ -401,7 +401,7 @@ describe("middleware", () => {
       const req = new NextRequest(new URL("/", "http://localhost:3000"), {
         headers: { "x-request-id": "existing-id-123" },
       });
-      const response = await middleware(req);
+      const response = await proxy(req);
       expect(response.headers.get("x-request-id")).toBe("existing-id-123");
     });
   });

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,4 +1,8 @@
-// ─── Middleware: auth enforcement + rate limiting ────────────────────────────
+// ─── Proxy: auth enforcement + rate limiting ─────────────────────────────────
+// Renamed from `middleware.ts` in Next.js 16 (the `middleware.ts` filename and
+// `middleware` function name were deprecated; `proxy.ts` + `proxy` is the new
+// convention). Behavior is identical to the prior middleware.
+//
 // Auth: checks if user is logged in. Does NOT check onboarding_complete.
 //       Onboarding redirect happens in /app/layout.tsx (server component).
 //       Public routes: /, /contact, /privacy, /terms, /auth/*
@@ -118,9 +122,9 @@ async function applyRateLimit(
   return response;
 }
 
-// ─── Main Middleware ─────────────────────────────────────────────────────────
+// ─── Main Proxy ──────────────────────────────────────────────────────────────
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const response = NextResponse.next({ request });
 
   // ── Request ID correlation (#183) ─────────────────────────────────────────


### PR DESCRIPTION
Closes #1062.

## Summary

Next.js 16 deprecated the middleware.ts filename and middleware() function name in favor of proxy.ts + proxy(). This PR completes the rename to eliminate the build-time deprecation warning.

## Changes

- `git mv frontend/src/middleware.ts -> frontend/src/proxy.ts`\n- `git mv frontend/src/middleware.test.ts -> frontend/src/proxy.test.ts`\n- Renamed exported function `middleware()` -> `proxy()` and updated the test file's import + ~30 inline call sites + `describe()` block name.
- Updated `frontend/README.md`, `copilot-instructions.md` ┬º3, `CURRENT_STATE.md` follow-up list, `CHANGELOG.md` `[Unreleased]`.

## Not changed

The unrelated Supabase SSR helper at `frontend/src/lib/supabase/middleware.ts` (`createMiddlewareClient` from `@supabase/ssr`) is **not** affected ΓÇö it's a separate file with a separate purpose.

## Verification

- `npx tsc --noEmit` -> 0 errors
- `npx vitest run src/proxy.test.ts` -> 33/33 pass
- Matcher config unchanged; behavior identical.