### PR TITLE
fix(frontend): resolve set-state-in-effect in RouteAnnouncer (#1063 Phase 2)

### DIFF
--- a/frontend/src/components/common/RouteAnnouncer.tsx
+++ b/frontend/src/components/common/RouteAnnouncer.tsx
@@ -9,7 +9,7 @@
  */
 
 import { usePathname } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 
 /** Map pathname segments to human-readable page names. */
 function pageTitle(pathname: string): string {
@@ -50,18 +50,19 @@ function pageTitle(pathname: string): string {
 export function RouteAnnouncer() {
   const pathname = usePathname();
   const [announcement, setAnnouncement] = useState("");
-  const isFirstRender = useRef(true);
+  // Track the last announced pathname. Initialised to the current pathname so
+  // the very first render produces no announcement (the browser already
+  // announces initial page load).
+  const [lastPathname, setLastPathname] = useState(pathname);
 
-  useEffect(() => {
-    // Don't announce the initial page load — the browser already handles that.
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return;
-    }
-
-    const title = pageTitle(pathname);
-    setAnnouncement(`Navigated to ${title}`);
-  }, [pathname]);
+  // Adjusting state during render — React's recommended pattern for reacting
+  // to prop changes without an effect. React schedules an immediate re-render
+  // without committing the discarded one. Compatible with React Compiler
+  // (no `set-state-in-effect` violation).
+  if (pathname !== lastPathname) {
+    setLastPathname(pathname);
+    setAnnouncement(`Navigated to ${pageTitle(pathname)}`);
+  }
 
   return (
     <div


### PR DESCRIPTION
## Summary

Resolves 1 of 19 `react-hooks/set-state-in-effect` violations from #1063 Phase 2.

Replaces `useEffect` + `useRef` with React's canonical [adjusting-state-during-render pattern](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes), which the React Compiler accepts.

## Why this is safe

- **Behaviour preserved**: initial render produces no announcement (`lastPathname` initialised to current `pathname`, if-block skipped), pathname change triggers announcement.
- **Tests unchanged**: all 11 existing tests in `RouteAnnouncer.test.tsx` pass — they assert behaviour (aria attributes, announcement text per route), not implementation.
- **Single-file scope**: no API or component contract changes.

## Phase 2 progress

| File | Status |
|------|--------|
| `RouteAnnouncer.tsx` | ✅ this PR |
| 13 other files (18 violations) | ⏸ deferred — each needs per-component review |

## Verification

- `npx eslint src/components/common/RouteAnnouncer.tsx` — clean
- `npx vitest run src/components/common/RouteAnnouncer.test.tsx` — 11/11 pass
- `npx tsc --noEmit` — 0 errors

Closes part of #1063.