### PR TITLE
fix(frontend): resolve set-state-in-effect in useUnsavedChanges (#1063)

### DIFF
--- a/frontend/src/hooks/use-unsaved-changes.ts
+++ b/frontend/src/hooks/use-unsaved-changes.ts
@@ -30,13 +30,21 @@ export interface UnsavedChangesResult {
  */
 export function useUnsavedChanges(isDirty: boolean): UnsavedChangesResult {
   const [pendingHref, setPendingHref] = useState<string | null>(null);
+  const [prevIsDirty, setPrevIsDirty] = useState(isDirty);
   const guardRef = useRef(false);
 
   // Keep ref in sync so event handlers always see the latest value.
   useEffect(() => {
     guardRef.current = isDirty;
-    if (!isDirty) setPendingHref(null);
   }, [isDirty]);
+
+  // Clear any pending navigation when the form transitions back to clean.
+  // Adjusts state during render rather than in an effect — see
+  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  if (isDirty !== prevIsDirty) {
+    setPrevIsDirty(isDirty);
+    if (!isDirty) setPendingHref(null);
+  }
 
   // ─── beforeunload: browser / tab close guard ────────────────────────
   useEffect(() => {


### PR DESCRIPTION
Phase 2 of #1063 — second of 19 `react-hooks/set-state-in-effect` violations.

## Change

In `useUnsavedChanges`, the effect that mirrored `isDirty` into a ref also reset `pendingHref` whenever the form went from dirty to clean. The `setPendingHref(null)` call inside the effect is the violation.

Replaced the state-reset half with the canonical [adjust-state-during-render](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) pattern, comparing `isDirty` against a previous-value state. The ref-sync effect is kept (no `setState` involved).

Behaviour is unchanged: when the form transitions back to clean, any pending navigation is cleared.

## Verification

- `eslint src/hooks/use-unsaved-changes.ts` — clean
- `vitest run src/hooks/use-unsaved-changes.test.ts` — 15/15 pass
- `tsc --noEmit` — clean

## Progress

- Phase 1 (#1067): 4 of 5 React Compiler rules promoted to error
- Phase 2 violations resolved: 2 of 19 (RouteAnnouncer #1069, useUnsavedChanges this PR)
- 17 violations remaining across 13 files