### PR TITLE
fix(frontend): resolve set-state-in-effect in MoreDrawer (#1063)

### DIFF
--- a/frontend/src/components/layout/MoreDrawer.tsx
+++ b/frontend/src/components/layout/MoreDrawer.tsx
@@ -92,16 +92,25 @@ export function MoreDrawer({ open, onClose }: Readonly<MoreDrawerProps>) {
   const isAdmin = useAdminStore((s) => s.isAdmin);
   const drawerRef = useRef<HTMLDialogElement>(null);
   const [animating, setAnimating] = useState(false);
+  const [prevOpen, setPrevOpen] = useState(open);
   const touchStartY = useRef(0);
   const touchDeltaY = useRef(0);
 
-  // Track mount animation
+  // Reset animation immediately when the drawer closes — done during render
+  // (https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes)
+  // rather than in an effect to satisfy react-hooks/set-state-in-effect.
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (!open) setAnimating(false);
+  }
+
+  // Defer enabling the animation class to the next frame so CSS transitions
+  // run from the closed state. setState inside requestAnimationFrame is
+  // asynchronous, so it does not violate set-state-in-effect.
   useEffect(() => {
-    if (open) {
-      requestAnimationFrame(() => setAnimating(true));
-    } else {
-      setAnimating(false);
-    }
+    if (!open) return;
+    const id = requestAnimationFrame(() => setAnimating(true));
+    return () => cancelAnimationFrame(id);
   }, [open]);
 
   // Close on Escape


### PR DESCRIPTION
Phase 2 of #1063 — fourth of 19 `react-hooks/set-state-in-effect` violations.

## Change

Splits the `open`-tracking effect in `MoreDrawer` into two parts:

1. Resetting `animating` to `false` on close is moved out of the effect into the canonical [adjust-state-during-render](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) pattern, gated by a `prevOpen` state.
2. Enabling the animation on open stays in an effect, but the `setAnimating(true)` call is inside `requestAnimationFrame`, so it's asynchronous and does not violate the rule. Added a `cancelAnimationFrame` cleanup for safety.

Behaviour is unchanged: the drawer still gets a one-frame delay before the open class is applied (so CSS transitions run from the closed state), and closes immediately reset the animation flag.

## Verification

- `eslint src/components/layout/MoreDrawer.tsx` — clean
- `vitest run src/components/layout/MoreDrawer.test.tsx` — 17/17 pass
- `tsc --noEmit` — clean

## Progress

- Phase 2 violations resolved: 4 of 19 (#1069, #1070, #1071, this PR)
- 15 violations remaining across 10 files