### PR TITLE
fix(frontend): resolve set-state-in-effect in ScanResultView (#1063)

### DIFF
--- a/frontend/src/components/scan/ScanResultView.tsx
+++ b/frontend/src/components/scan/ScanResultView.tsx
@@ -31,7 +31,13 @@ export function FadeSlideIn({
 }: Readonly<{ children: React.ReactNode; delay?: number }>) {
   const prefersReduced = useReducedMotion();
   const [visible, setVisible] = useState(false);
-  useEffect(() => { setVisible(true); }, []);
+  // setState inside requestAnimationFrame is asynchronous, so it does not
+  // violate react-hooks/set-state-in-effect while still triggering the
+  // mount-time fade-in transition.
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setVisible(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
 
   if (prefersReduced) return <>{children}</>;
 
@@ -213,8 +219,10 @@ export function ScanFoundView({
   // Animated score count-up
   useEffect(() => {
     if (prefersReduced || tryVitScore === 0) {
-      setDisplayScore(tryVitScore);
-      return;
+      // Defer to next frame so the setState is asynchronous (see
+      // react-hooks/set-state-in-effect). Visual outcome is unchanged.
+      const id = requestAnimationFrame(() => setDisplayScore(tryVitScore));
+      return () => cancelAnimationFrame(id);
     }
     let frame: number;
     const start = performance.now();


### PR DESCRIPTION
Phase 2 of #1063 — fifth of 19 `react-hooks/set-state-in-effect` violations. Resolves two violations in a single file (lines 34 and 216).

## Change

Wraps two synchronous effect `setState` calls in `requestAnimationFrame` so they are asynchronous and no longer violate the rule:

1. `FadeSlideIn` (line 34): mount-time `setVisible(true)` to trigger the fade-in transition.
2. Animated score count-up (line 216): early-return branch when `prefersReduced` or `tryVitScore === 0`.

Both effects now also `cancelAnimationFrame` on unmount. Visual outcome is unchanged — the fade-in still runs from opacity 0 on the next frame, and the no-animation case still snaps the score to its target value.

## Verification

- `eslint src/components/scan/ScanResultView.tsx` — clean
- `vitest run src/components/scan/ScanResultView.test.tsx` — 33/33 pass
- `tsc --noEmit` — clean

## Progress

- Phase 2 violations resolved: 6 of 19 (PRs #1069, #1070, #1071, #1072, this PR resolves 2)
- 13 violations remaining across 9 files