### PR TITLE
fix(frontend): resolve set-state-in-effect in SettingsPage (#1063)

### DIFF
--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -51,13 +51,17 @@ export default function ProfileSettingsPage() {
   const { showConfirmDialog, confirmNavigation, cancelNavigation } =
     useUnsavedChanges(dirty);
 
-  // Populate from fetched prefs
-  useEffect(() => {
+  // Populate from fetched prefs — adjust state during render when the
+  // upstream query result changes (avoids react-hooks/set-state-in-effect).
+  // See https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const [prevPrefs, setPrevPrefs] = useState(prefs);
+  if (prefs !== prevPrefs) {
+    setPrevPrefs(prefs);
     if (prefs) {
       setCountry(prefs.country ?? "");
       setLanguage((prefs.preferred_language ?? "en") as SupportedLanguage);
     }
-  }, [prefs]);
+  }
 
   function markDirty() {
     setDirty(true);


### PR DESCRIPTION
Phase 2 of #1063 - sixth PR, seventh violation of 19. Resolves `src/app/app/settings/page.tsx:57`.

## Change

Replaces a `useEffect` that synced `country`/`language` state from a `useQuery` `prefs` result with the React 19 'adjust state during render' pattern (https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes).

A `prevPrefs` state variable tracks the last seen query result; when the `prefs` reference changes, the new values are written before render completes.

Behaviour is unchanged - the form still populates after the query resolves and after refetches.

## Verification

- `eslint src/app/app/settings/page.tsx` - clean
- `vitest run src/app/app/settings/page.test.tsx` - 14/14 pass
- `tsc --noEmit` - clean

## Progress

- Phase 2 violations resolved: 7 of 19 (PRs #1069, #1070, #1071, #1072, #1073, this)
- 12 violations remaining across 8 files