### PR TITLE
fix(frontend): resolve set-state-in-effect in NutritionSettingsPage (#1063)

### DIFF
--- a/frontend/src/app/app/settings/nutrition/page.tsx
+++ b/frontend/src/app/app/settings/nutrition/page.tsx
@@ -15,7 +15,7 @@ import { createClient } from "@/lib/supabase/client";
 import { showToast } from "@/lib/toast";
 import { useLanguageStore } from "@/stores/language-store";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export default function NutritionSettingsPage() {
   const supabase = createClient();
@@ -42,8 +42,12 @@ export default function NutritionSettingsPage() {
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
 
-  // Populate from fetched prefs
-  useEffect(() => {
+  // Populate from fetched prefs — adjust state during render when the
+  // upstream query result changes (avoids react-hooks/set-state-in-effect).
+  // See https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const [prevPrefs, setPrevPrefs] = useState(prefs);
+  if (prefs !== prevPrefs) {
+    setPrevPrefs(prefs);
     if (prefs) {
       setDiet(prefs.diet_preference ?? "none");
       setAllergens(prefs.avoid_allergens ?? []);
@@ -51,7 +55,7 @@ export default function NutritionSettingsPage() {
       setStrictAllergen(prefs.strict_allergen);
       setTreatMayContain(prefs.treat_may_contain_as_unsafe);
     }
-  }, [prefs]);
+  }
 
   function markDirty() {
     setDirty(true);


### PR DESCRIPTION
Phase 2 of #1063 - seventh PR, eighth violation of 19. Resolves `src/app/app/settings/nutrition/page.tsx:48`.

## Change

Replaces a `useEffect` that synced 5 form fields (`diet`, `allergens`, `strictDiet`, `strictAllergen`, `treatMayContain`) from a `useQuery` `prefs` result with the React 19 'adjust state during render' pattern (https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes).

A `prevPrefs` state variable tracks the last seen query result; when the `prefs` reference changes, the new values are written before render completes.

The `useEffect` import is removed since the file no longer uses it.

Behaviour is unchanged - the form still populates after the query resolves and after refetches.

## Verification

- `eslint` - clean
- `vitest run src/app/app/settings/nutrition/page.test.tsx` - 16/16 pass
- `tsc --noEmit` - clean

## Progress

- Phase 2 violations resolved: 8 of 19 (PRs #1069, #1070, #1071, #1072, #1073, #1074, this)
- 11 violations remaining across 7 files