### PR TITLE
fix(frontend): resolve set-state-in-effect in SearchAutocomplete (#1063)

### DIFF
--- a/frontend/src/components/search/SearchAutocomplete.tsx
+++ b/frontend/src/components/search/SearchAutocomplete.tsx
@@ -135,12 +135,18 @@ export function SearchAutocomplete({
   const debouncedQuery = useDebounce(query, 200);
   const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const [recentSearches, setRecentSearches] = useState<string[]>(() =>
+    show ? getRecentSearches() : [],
+  );
 
-  // Load recent searches when dropdown opens
-  useEffect(() => {
+  // Refresh recent searches each time the dropdown transitions from closed → open.
+  // Adjusted during render (avoids react-hooks/set-state-in-effect):
+  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const [prevShow, setPrevShow] = useState(show);
+  if (show !== prevShow) {
+    setPrevShow(show);
     if (show) setRecentSearches(getRecentSearches());
-  }, [show]);
+  }
 
   const { data, isFetching } = useQuery({
     queryKey: queryKeys.autocomplete(debouncedQuery),
@@ -174,10 +180,14 @@ export function SearchAutocomplete({
   const getOptionId = (index: number) =>
     index >= 0 ? `search-autocomplete-option-${index}` : undefined;
 
-  // Reset active index when suggestions change
-  useEffect(() => {
+  // Reset active index when suggestions or query mode change.
+  // Adjusted during render to avoid react-hooks/set-state-in-effect.
+  const resetKey = `${suggestions.length}|${debouncedQuery}|${isQueryMode}`;
+  const [prevResetKey, setPrevResetKey] = useState(resetKey);
+  if (resetKey !== prevResetKey) {
+    setPrevResetKey(resetKey);
     setActiveIndex(-1);
-  }, [suggestions.length, debouncedQuery, isQueryMode]);
+  }
 
   // Report active ID to parent for aria-activedescendant
   useEffect(() => {


### PR DESCRIPTION
Phase 2 of #1063 — ninth PR, resolves 11 + 12 of 19 violations.

Two `react-hooks/set-state-in-effect` warnings in `SearchAutocomplete.tsx` resolved by adjusting state during render instead of inside `useEffect`:

1. **Refresh recent-searches on dropdown open** — replaced `[show]` effect with a `prevShow` render-phase tracker. Added a lazy initializer so `recentSearches` hydrates on mount when `show` is already true (preserves existing test expectations around initial render).
2. **Reset activeIndex when suggestions/query mode change** — replaced the multi-dep effect with a composite `resetKey`/`prevResetKey` tracker.

Pattern reference: <https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes>

Behaviour unchanged. 32/32 vitest pass, eslint and tsc clean.

Cross-references prior Phase 2 PRs: #1067, #1069, #1070, #1071, #1072, #1073, #1074, #1075, #1076.