### PR TITLE
fix(frontend): use useSyncExternalStore for camera support detection (#1063)

### DIFF
--- a/frontend/src/components/ocr/ImageCapture.tsx
+++ b/frontend/src/components/ocr/ImageCapture.tsx
@@ -16,7 +16,21 @@ import { Button } from "@/components/common/Button";
 import { Icon } from "@/components/common/Icon";
 import { useTranslation } from "@/lib/i18n";
 import { Camera, SwitchCamera, Upload, X } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+// Camera support is a static browser capability — no subscription needed.
+// useSyncExternalStore with a noop subscribe is the React-19 hydration-safe
+// pattern for one-time client-only feature detection (#1063).
+const emptySubscribe = () => () => {};
+const getCameraSupportSnapshot = () =>
+  typeof navigator !== "undefined" && !!navigator.mediaDevices?.getUserMedia;
+const getCameraSupportServerSnapshot = () => false;
 
 interface ImageCaptureProps {
   /** Called when user has selected/captured an image. */
@@ -32,17 +46,13 @@ export function ImageCapture({ onCapture, processing }: ImageCaptureProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   const [cameraActive, setCameraActive] = useState(false);
-  const [cameraSupported, setCameraSupported] = useState(false);
+  const cameraSupported = useSyncExternalStore(
+    emptySubscribe,
+    getCameraSupportSnapshot,
+    getCameraSupportServerSnapshot,
+  );
   const [cameraError, setCameraError] = useState<string | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
-
-  // Check camera support on mount
-  useEffect(() => {
-    const supported =
-      typeof navigator !== "undefined" &&
-      !!navigator.mediaDevices?.getUserMedia;
-    setCameraSupported(supported);
-  }, []);
 
   // Cleanup camera stream on unmount
   useEffect(() => {


### PR DESCRIPTION
Phase 2 React Compiler cleanup, continued from #1078.`n`nReplaces ImageCapture's mount useEffect (one of the remaining `react-hooks/set-state-in-effect` violations) with `useSyncExternalStore` `\u2014` the React 19 hydration-safe pattern for one-time browser-feature detection.`n`n- `emptySubscribe`: noop (camera support is static for the page lifetime).`n- `getSnapshot`: returns `navigator.mediaDevices?.getUserMedia` truthiness.`n- `getServerSnapshot`: always `false` `\u2014` matches the initial SSR HTML so no hydration mismatch when the camera button appears post-mount.`n`nValidation: 19/19 ImageCapture tests pass; eslint and tsc clean. Phase 2 cumulative: 16/19.