### PR TITLE
fix(frontend): derive clamped activeIndex in CommandPalette (#1063)

### DIFF
--- a/frontend/src/components/desktop/CommandPalette.tsx
+++ b/frontend/src/components/desktop/CommandPalette.tsx
@@ -189,6 +189,14 @@ export function CommandPalette({
     return items;
   }, [query, navItems, recentItems, t]);
 
+  // Clamp activeIndex during render so it never points past the filtered list.
+  // (Replaces a prior useEffect that called setActiveIndex(...) on shrink —
+  // forbidden by react-hooks/set-state-in-effect. Issue #1063.)
+  const safeActiveIndex =
+    filteredItems.length === 0
+      ? 0
+      : Math.min(activeIndex, filteredItems.length - 1);
+
   // Reset state when opening/closing
   useEffect(() => {
     const el = dialogRef.current;
@@ -204,20 +212,13 @@ export function CommandPalette({
     }
   }, [open]);
 
-  // Keep active index in bounds
-  useEffect(() => {
-    if (activeIndex >= filteredItems.length) {
-      setActiveIndex(Math.max(0, filteredItems.length - 1));
-    }
-  }, [filteredItems.length, activeIndex]);
-
   // Scroll active item into view
   useEffect(() => {
     const list = listRef.current;
     if (!list) return;
     const activeEl = list.querySelector("[data-active='true']");
     activeEl?.scrollIntoView({ block: "nearest" });
-  }, [activeIndex]);
+  }, [safeActiveIndex]);
 
   // Handle native dialog cancel (Escape)
   const handleCancel = useCallback(() => {
@@ -254,13 +255,13 @@ export function CommandPalette({
           break;
         case "Enter":
           e.preventDefault();
-          if (filteredItems[activeIndex]) {
-            selectItem(filteredItems[activeIndex]);
+          if (filteredItems[safeActiveIndex]) {
+            selectItem(filteredItems[safeActiveIndex]);
           }
           break;
       }
     },
-    [filteredItems, activeIndex, selectItem],
+    [filteredItems, safeActiveIndex, selectItem],
   );
 
   // Click on backdrop closes
@@ -339,7 +340,7 @@ export function CommandPalette({
 
         {filteredItems.map((item, index) => {
           const sectionLabel = getSectionLabel(item, index);
-          const isActive = index === activeIndex;
+          const isActive = index === safeActiveIndex;
 
           return (
             <div key={item.id}>


### PR DESCRIPTION
## Summary

Resolves 1 of 2 `react-hooks/set-state-in-effect` warnings in `CommandPalette.tsx` (Phase 2 of #1063).

The "keep active index in bounds" effect called `setActiveIndex(...)` whenever the filtered list shrank below the stored index — a classic store-then-correct pattern. Replaced with a render-time derivation:

```ts
const safeActiveIndex =
  filteredItems.length === 0
    ? 0
    : Math.min(activeIndex, filteredItems.length - 1);
```

All read sites (Enter handler, `isActive` comparison, scroll-into-view dep) now use `safeActiveIndex`. Setters (`setActiveIndex(0)`, `setActiveIndex((i) => ...)`, etc.) are unchanged — the stored value may drift past the list end, but consumers always see the clamped value.

## Deferred

The remaining warning at line 197 (open/close effect: mixed imperative `<dialog>.showModal()` + `setQuery("")` + `setActiveIndex(0)` on `open` transitions) requires a child-key remount refactor and is left for a dedicated PR.

## Phase 2 progress on #1063

| Status | Count |
| --- | ---: |
| Resolved | 16 |
| Remaining | 3 |

Remaining targets: `CommandPalette.tsx:197`, `ProductHeroImage.tsx:58`, `ScanResultView.tsx:34,216`.

## Verification

- `npx eslint src/components/desktop/CommandPalette.tsx` — file now reports 1 warning (was 2)
- `npx vitest run src/components/desktop` — 39/39 pass (3 files)
- `npx tsc --noEmit` — clean

Closes part of #1063.
