### PR TITLE
fix(frontend): derive ProductHeroImage fetch state (#1063)

### DIFF
--- a/frontend/src/components/product/ProductHeroImage.tsx
+++ b/frontend/src/components/product/ProductHeroImage.tsx
@@ -47,19 +47,24 @@ export function ProductHeroImage({
   ean,
 }: ProductHeroImageProps) {
   // ── OFF API fallback state ──────────────────────────────────────────────
+  // Store the fetched result keyed by EAN; derive `offLoading` and `offUrl`
+  // from it so we never call setState synchronously inside the effect
+  // (react-hooks/set-state-in-effect compliance, #1063).
   const needsFallback = !images.has_image || !images.primary;
-  const [offUrl, setOffUrl] = useState<string | null>(null);
-  const [offLoading, setOffLoading] = useState(false);
+  const [fetched, setFetched] = useState<{
+    ean: string | null;
+    url: string | null;
+  }>({ ean: null, url: null });
+  const offLoading = needsFallback && !!ean && fetched.ean !== ean;
+  const offUrl = fetched.ean === ean ? fetched.url : null;
   const [imageLoaded, setImageLoaded] = useState(false);
 
   useEffect(() => {
     if (!needsFallback || !ean) return;
     let cancelled = false;
-    setOffLoading(true);
     fetchOffImageUrl(ean).then((url) => {
       if (!cancelled) {
-        setOffUrl(url);
-        setOffLoading(false);
+        setFetched({ ean, url });
       }
     });
     return () => {


### PR DESCRIPTION
## Summary

Phase 2 micro-fix for #1063. Resolves the last `react-hooks/set-state-in-effect` violation in `ProductHeroImage.tsx` (line 58).

## Violation

The OFF API fallback effect called `setOffLoading(true)` **synchronously** in the effect body before kicking off the async fetch:

```tsx
useEffect(() => {
  if (!needsFallback || !ean) return;
  let cancelled = false;
  setOffLoading(true);                       // ← sync setState in effect
  fetchOffImageUrl(ean).then((url) => {
    if (!cancelled) {
      setOffUrl(url);
      setOffLoading(false);
    }
  });
  ...
}, [needsFallback, ean]);
```

## Migration: derive-during-render

Collapse the two separate state slots (`offUrl`, `offLoading`) into one async-only-updated state `fetched: { ean, url }`. Derive both `offLoading` and `offUrl` during render:

```tsx
const [fetched, setFetched] = useState<{ ean: string | null; url: string | null }>({ ean: null, url: null });
const offLoading = needsFallback && !!ean && fetched.ean !== ean;
const offUrl = fetched.ean === ean ? fetched.url : null;
```

The effect now contains **zero synchronous setState** — only async `setFetched` inside `.then()`, which is allowed by the rule.

## Behavior preserved

- Initial render with `ean` and no image: `offLoading = true` → "Loading image…" skeleton (✓ test `shows loading state then OFF image when ean is provided`)
- After fetch resolves: `fetched.ean === ean`, `fetched.url = mockUrl` → image renders (✓ same test)
- On fetch failure (`fetchOffImageUrl` returns `null`): `fetched.url === null`, `offLoading === false` → CategoryPlaceholder (✓ test `shows placeholder when OFF fetch fails`)
- No `ean`: effect early-returns; `offLoading = false`; CategoryPlaceholder renders (✓ tests `renders CategoryPlaceholder when has_image is false and no ean`, etc.)
- EAN change re-triggers fetch and shows loading skeleton until the new EAN's result lands.

## Verification

- `npx eslint src/components/product/ProductHeroImage.tsx` → 0 warnings (was 1)
- `npx vitest run src/components/product/ProductHeroImage.test.tsx` → 7/7 pass
- `npx tsc --noEmit` → clean

## #1063 progress

- 18/19 set-state-in-effect violations resolved.
- Remaining: `CommandPalette.tsx:197` (open-effect mixing imperative `<dialog>` calls with reset setState). Requires child-key remount refactor — deferred for a dedicated PR.
- `ScanResultView.tsx` violations (lines 34, 216) to follow as the next micro-PR.
