### PR TITLE
fix(frontend): derive ScanResultView animation state (#1063)

### DIFF
--- a/frontend/src/components/scan/ScanResultView.tsx
+++ b/frontend/src/components/scan/ScanResultView.tsx
@@ -31,7 +31,13 @@ export function FadeSlideIn({
 }: Readonly<{ children: React.ReactNode; delay?: number }>) {
   const prefersReduced = useReducedMotion();
   const [visible, setVisible] = useState(false);
-  useEffect(() => { setVisible(true); }, []);
+  useEffect(() => {
+    // Defer setState to next frame so the browser paints the initial
+    // opacity:0 state before the transition runs. Async callback satisfies
+    // react-hooks/set-state-in-effect.
+    const raf = requestAnimationFrame(() => setVisible(true));
+    return () => cancelAnimationFrame(raf);
+  }, []);
 
   if (prefersReduced) return <>{children}</>;
 
@@ -208,25 +214,26 @@ export function ScanFoundView({
   const prefersReduced = useReducedMotion();
   const band = getScoreBand(product.unhealthiness_score);
   const tryVitScore = toTryVitScore(product.unhealthiness_score);
-  const [displayScore, setDisplayScore] = useState(0);
+  const [animatedScore, setAnimatedScore] = useState(0);
+  // Derive: when motion is reduced or score is zero, skip animation entirely
+  // and render the final value. Otherwise show the rAF-driven count-up.
+  const showImmediate = prefersReduced || tryVitScore === 0;
+  const displayScore = showImmediate ? tryVitScore : animatedScore;
 
-  // Animated score count-up
+  // Animated score count-up (rAF-only setState, no sync setState in effect)
   useEffect(() => {
-    if (prefersReduced || tryVitScore === 0) {
-      setDisplayScore(tryVitScore);
-      return;
-    }
+    if (showImmediate) return;
     let frame: number;
     const start = performance.now();
     const duration = 600; // ms
     function tick(now: number) {
       const progress = Math.min((now - start) / duration, 1);
-      setDisplayScore(Math.round(progress * tryVitScore));
+      setAnimatedScore(Math.round(progress * tryVitScore));
       if (progress < 1) frame = requestAnimationFrame(tick);
     }
     frame = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(frame);
-  }, [tryVitScore, prefersReduced]);
+  }, [tryVitScore, showImmediate]);
 
   return (
     <FadeSlideIn>


### PR DESCRIPTION
## Phase 2 React Compiler cleanup (#1063)

Resolves the two remaining `react-hooks/set-state-in-effect` warnings in `ScanResultView.tsx` via the standard Phase 2 patterns (async-only setState + derive-during-render).

### Changes

**`FadeSlideIn`** (was line 37): wrapped `setVisible(true)` in a `requestAnimationFrame` callback. The async setState satisfies the rule and also guarantees the initial `opacity:0` frame paints before the transition fires — so the fade-slide animation actually plays instead of snapping in.

**`ScanFoundView`** (was line 218): switched to derive-during-render. Replaced the early-return `setDisplayScore(tryVitScore)` path with a `showImmediate` flag and `displayScore = showImmediate ? tryVitScore : animatedScore`. The `animatedScore` state now exists solely to drive the `requestAnimationFrame` count-up — no sync setState in any effect body.

### Validation

- `vitest run src/components/scan/ScanResultView.test.tsx` — 33/33 pass
- `eslint src/components/scan/ScanResultView.tsx` — 0 warnings (both `set-state-in-effect` violations gone)
- `tsc --noEmit` — 0 errors

### Phase 2 progress

**18/19 cumulative.** Only `CommandPalette.tsx:197` remains (the open/close effect with mixed imperative dialog DOM + state reset — explicitly deferred per #1067 and #1104 commit notes; needs a child-key remount refactor that's out of scope for an automated micro-PR).

Refs #1063.
