### PR TITLE
test(quality): clean screenshot helper static-analysis findings (#1123)

### DIFF
--- a/frontend/e2e/pr-screenshots.spec.ts
+++ b/frontend/e2e/pr-screenshots.spec.ts
@@ -157,7 +157,7 @@ async function provisionTestUser(): Promise<string> {
     }),
   });
 
-  return testUserId!;
+  return userData.id;
 }
 
 async function signInViaUI(page: Page) {

--- a/frontend/e2e/screenshot-capture.spec.ts
+++ b/frontend/e2e/screenshot-capture.spec.ts
@@ -188,7 +188,7 @@ async function provisionTestUser(): Promise<string> {
     }),
   });
 
-  return testUserId!;
+  return userData.id;
 }
 
 /**

--- a/frontend/tests/quality/helpers/screenshot.test.ts
+++ b/frontend/tests/quality/helpers/screenshot.test.ts
@@ -7,11 +7,11 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Page } from "@playwright/test";
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 // Mock fs before importing the module under test
-vi.mock("fs", () => ({
+vi.mock("node:fs", () => ({
   default: {
     existsSync: vi.fn(),
     rmSync: vi.fn(),

--- a/frontend/tests/quality/helpers/screenshot.ts
+++ b/frontend/tests/quality/helpers/screenshot.ts
@@ -8,8 +8,8 @@
  */
 
 import type { Page } from "@playwright/test";
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 const BASE_DIR = path.join("qa_screenshots", "latest");
 


### PR DESCRIPTION
## Summary
- replace legacy core-module imports in the screenshot helper and its unit test with node: imports
- remove redundant non-null assertions in the two screenshot E2E provisioning helpers
- keep the scope limited to static-analysis cleanup with no behavior changes

## Verification
- npx vitest run tests/quality/helpers/screenshot.test.ts ✅
- npx tsc --noEmit ✅

Closes #1123
