### PR TITLE
chore(frontend): normalize shrink utility in product detail page (#1127)

### DIFF
--- a/frontend/src/app/app/product/[id]/page.tsx
+++ b/frontend/src/app/app/product/[id]/page.tsx
@@ -695,7 +695,7 @@ function OverviewTab({ profile }: Readonly<{ profile: ProductProfile }>) {
           <div className="flex items-center gap-2 rounded-lg border border-dashed border-info-border bg-info-bg/50 px-3 py-3">
             <Info
               size={18}
-              className="flex-shrink-0 text-info-text"
+              className="shrink-0 text-info-text"
               aria-hidden="true"
             />
             <p className="text-sm text-info-text">


### PR DESCRIPTION
## Summary
- replace `flex-shrink-0` with canonical Tailwind utility `shrink-0` in product detail page
- no behavior change

## Verification
- npx tsc --noEmit ✅

Closes #1127
