### PR TITLE
chore(frontend): normalize shrink utility in categories score chip (#1129)

### DIFF
--- a/frontend/src/app/app/categories/page.tsx
+++ b/frontend/src/app/app/categories/page.tsx
@@ -96,7 +96,7 @@ function CategoryCard({
             </p>
           </div>
           <div
-            className={`flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg text-sm font-bold ${display.bg} ${display.color}`}
+            className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-sm font-bold ${display.bg} ${display.color}`}
           >
             {tryVitScore}
           </div>


### PR DESCRIPTION
## Summary
- replace one remaining `flex-shrink-0` utility with canonical `shrink-0` in categories score chip
- no behavior change

## Verification
- cd frontend && npx tsc --noEmit ✅

Closes #1129
