### PR TITLE
chore(frontend): normalize shrink utility in alternative score chip (#1131)

### DIFF
--- a/frontend/src/components/alternatives/AlternativeProductCard.tsx
+++ b/frontend/src/components/alternatives/AlternativeProductCard.tsx
@@ -40,7 +40,7 @@ export function AlternativeProductCard({
         {/* Top row: score badge + product info + Nutri-Score */}
         <div className="flex items-start gap-3">
           <div
-            className={`flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg text-lg font-bold ${bandStyle.bg} ${bandStyle.color}`}
+            className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-lg text-lg font-bold ${bandStyle.bg} ${bandStyle.color}`}
           >
             {toTryVitScore(alt.unhealthiness_score)}
           </div>


### PR DESCRIPTION
## Summary
- replace one remaining `flex-shrink-0` utility with canonical `shrink-0` in alternative product score chip
- no behavior change

## Verification
- cd frontend && npx tsc --noEmit ✅

Closes #1131
