### PR TITLE
chore(frontend): normalize shrink utility in allergen quick badge icon (#1133)

### DIFF
--- a/frontend/src/components/product/AllergenQuickBadges.tsx
+++ b/frontend/src/components/product/AllergenQuickBadges.tsx
@@ -22,7 +22,7 @@ export function AllergenQuickBadges({ allergens }: AllergenQuickBadgesProps) {
     return (
       <div className="card">
         <div className="flex items-center gap-2 text-sm text-score-green-text">
-          <ShieldCheck className="h-4 w-4 flex-shrink-0" aria-hidden />
+          <ShieldCheck className="h-4 w-4 shrink-0" aria-hidden />
           <span>{t("product.noKnownAllergens")}</span>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace one remaining `flex-shrink-0` utility with canonical `shrink-0` in AllergenQuickBadges
- no behavior change

## Verification
- cd frontend && npx tsc --noEmit ✅

Closes #1133
