### PR TITLE
docs: stabilize TryVit project facts and positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/ericsocrat/tryvit/actions/workflows/pr-gate.yml"><img src="https://img.shields.io/github/actions/workflow/status/ericsocrat/tryvit/pr-gate.yml?style=flat-square&label=build" alt="Build Status" /></a>
-  <img src="https://img.shields.io/badge/QA%20checks-759%20passing-brightgreen?style=flat-square" alt="QA Checks" />
+  <img src="https://img.shields.io/badge/QA%20checks-776%20passing-brightgreen?style=flat-square" alt="QA Checks" />
   <img src="https://img.shields.io/badge/coverage-%E2%89%A588%25-brightgreen?style=flat-square" alt="Coverage" />
   <img src="https://img.shields.io/badge/products-2%2C602-1DB954?style=flat-square" alt="Products" />
   <img src="https://img.shields.io/badge/market-PL%20%2B%20DE-1DB954?style=flat-square" alt="Market" />
@@ -30,6 +30,25 @@
   Every product scored on 9 independent factors. Every number traceable to its source.<br />
   Not a calorie counter. Not a Nutri-Score app. A research-grade scoring engine.
 </p>
+
+<p align="center">
+  <a href="docs/DEMO_SCRIPT.md"><strong>▶ 3-minute demo walkthrough</strong></a> ·
+  <a href="docs/PRODUCT_POSITIONING.md"><strong>Product positioning &amp; non-goals</strong></a>
+</p>
+
+---
+
+<!-- ═══════════════════════════ 3b. WHO IT'S FOR ═════════════════════════ -->
+
+## 🎯 Who It's For
+
+- **Health-conscious shoppers in Poland & Germany** who want to know *why* a product scores the way it does — not just a single letter grade.
+- **Nutrition researchers & data engineers** who need transparent, source-traceable scoring with per-factor breakdowns.
+- **Contributors & reviewers** evaluating a reproducible, fully-tested food-data platform.
+
+**Why it exists:** existing apps reduce nutrition to one opaque grade. TryVit exposes every scoring factor, its weight, and the data confidence behind it — so the score is auditable rather than a black box.
+
+**Non-goals (explicitly out of scope):** TryVit is **not** a medical or dietary-advice tool, **not** a calorie/macro tracker, and makes **no** weight-loss or treatment claims. Markets are currently limited to Poland (primary) and Germany. Monetization is **not yet validated** — see [docs/PRODUCT_POSITIONING.md](docs/PRODUCT_POSITIONING.md).
 
 ---
 
@@ -53,7 +72,7 @@
     </td>
     <td align="center" width="25%">
       <h3>📱 Barcode Scanner</h3>
-      <p>EAN-13 barcode lookup with 99.8% coverage. Scan any product to see its full scoring breakdown instantly.</p>
+      <p>EAN-13 barcode lookup with broad catalog coverage. Scan any product to see its full scoring breakdown instantly.</p>
     </td>
   </tr>
 </table>
@@ -169,20 +188,20 @@ echo "SELECT * FROM v_master LIMIT 5;" | docker exec -i supabase_db_tryvit psql 
 ┌─────────────────┐     ┌──────────────────┐     ┌─────────────────────────┐
 │  Open Food Facts │────▶│  Python Pipeline │────▶│  PostgreSQL (Supabase)  │
 │  API v2          │     │  sql_generator   │     │  228 migrations         │
-│  (category tags, │     │  validator       │     │  43 pipeline folders    │
+│  (category tags, │     │  validator       │     │  58 pipeline folders    │
 │   countries=PL,DE│     │  off_client      │     │  products + nutrition   │
 └─────────────────┘     └──────────────────┘     │  + ingredients + scores │
                                                   └───────────┬─────────────┘
                                                               │
                                                   ┌───────────▼─────────────┐
                                                   │  API Layer              │
-                                                  │  190+ RPC functions     │
+                                                  │  curated RPC/API layer  │
                                                   │  RLS + SECURITY DEFINER │
                                                   │  pg_trgm search         │
                                                   └───────────┬─────────────┘
                                                               │
                                                   ┌───────────▼─────────────┐
-                                                  │  Next.js 15 Frontend    │
+                                                  │  Next.js 16 Frontend    │
                                                   │  App Router + SSR       │
                                                   │  TanStack Query v5      │
                                                   │  Supabase Auth          │
@@ -242,11 +261,11 @@ Every score is fully explainable via `api_score_explanation()` — returns the 9
 
 <table>
   <tr>
-    <td align="center" width="16%"><strong>759</strong><br />QA Checks</td>
-    <td align="center" width="16%"><strong>48</strong><br />Test Suites</td>
-    <td align="center" width="16%"><strong>23</strong><br />Negative Tests</td>
+    <td align="center" width="16%"><strong>776</strong><br />QA Checks</td>
+    <td align="center" width="16%"><strong>49</strong><br />Test Suites</td>
+    <td align="center" width="16%"><strong>20</strong><br />Negative Tests</td>
     <td align="center" width="16%"><strong>≥88%</strong><br />Line Coverage</td>
-    <td align="center" width="16%"><strong>190+</strong><br />API Functions</td>
+    <td align="center" width="16%"><strong>RPC-first</strong><br />API Layer</td>
     <td align="center" width="16%"><strong>v3.3</strong><br />Scoring Engine</td>
   </tr>
 </table>
@@ -305,7 +324,7 @@ tryvit/
 │   ├── tests/                       # pgTAP integration tests
 │   └── functions/                   # Edge Functions (API gateway, push notifications, CAPTCHA)
 │
-├── frontend/                        # Next.js 15 App Router
+├── frontend/                        # Next.js 16 App Router
 │   ├── src/
 │   │   ├── app/                     # Pages (App Router)
 │   │   ├── components/              # React components
@@ -355,13 +374,13 @@ Every change is validated against **776 automated checks** across 49 QA suites p
   <tr>
     <td>Database QA</td>
     <td>Raw SQL (zero rows = pass)</td>
-    <td>747</td>
+    <td>776</td>
     <td><code>db/qa/QA__*.sql</code></td>
   </tr>
   <tr>
     <td>Negative Tests</td>
     <td>SQL constraint validation</td>
-    <td>23</td>
+    <td>20</td>
     <td><code>db/qa/TEST__*.sql</code></td>
   </tr>
   <tr>
@@ -400,7 +419,7 @@ Every change is validated against **776 automated checks** across 49 QA suites p
 
 1. **PR Gate** — Typecheck → Lint → Build → Unit tests → Playwright smoke E2E
 2. **Main Gate** — Above + Coverage → SonarCloud Quality Gate
-3. **QA Gate** — Schema → Pipelines → 759 QA checks → Sanity → Confidence threshold
+3. **QA Gate** — Schema → Pipelines → 776 QA checks → Sanity → Confidence threshold
 4. **Nightly** — Full Playwright (all projects) + Data Integrity Audit
 
 ---
@@ -415,7 +434,7 @@ Contributions are welcome! Please follow the project conventions:
 2. **Commit messages:** [Conventional Commits](https://www.conventionalcommits.org/) — enforced on PR titles
 3. **Testing:** Every change must include tests. See [copilot-instructions.md](copilot-instructions.md) §8
 4. **Migrations:** Append-only. Never modify existing `supabase/migrations/` files
-5. **QA:** `.\RUN_QA.ps1` must pass (747/747) before merging
+5. **QA:** `.\RUN_QA.ps1` must pass (776/776) before merging
 
 ---
 
@@ -446,7 +465,7 @@ Contributions are welcome! Please follow the project conventions:
 - [COUNTRY_EXPANSION_GUIDE.md](docs/COUNTRY_EXPANSION_GUIDE.md) — Multi-country protocol
 - [MIGRATION_CONVENTIONS.md](docs/MIGRATION_CONVENTIONS.md) — Migration safety & idempotency
 - [BACKFILL_STANDARD.md](docs/BACKFILL_STANDARD.md) — Backfill orchestration
-- [EAN_VALIDATION_STATUS.md](docs/EAN_VALIDATION_STATUS.md) — EAN coverage (99.8%)
+- [EAN_VALIDATION_STATUS.md](docs/EAN_VALIDATION_STATUS.md) — EAN coverage status
 
 </details>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Last audited: 2026-02-14 (vulnerability table below may be stale — re-run `cd 
 
 ### Summary
 
-> **Note:** The project upgraded to **Next.js 15.5.12**. The advisories below were
+> **Note:** The project upgraded to **Next.js 16.2.6**. The advisories below were
 > originally filed against Next.js 14.x. Run `npm audit --omit=dev` to verify
 > which, if any, still apply to the current version.
 
@@ -43,7 +43,7 @@ Last audited: 2026-02-14 (vulnerability table below may be stale — re-run `cd 
 
 ### Remediation Plan
 
-The project is now on **Next.js 15.5.12**. The advisories listed above were filed
+The project is now on **Next.js 16.2.6**. The advisories listed above were filed
 against v14.x and may no longer apply. Re-run `npm audit --omit=dev` and refresh
 this table when vulnerabilities change.
 
@@ -164,7 +164,7 @@ RLS is enabled and forced on all 12 data tables.
 
 ## QA Coverage
 
-Security posture is validated by 22 automated checks (`QA__security_posture.sql`):
+Security posture is validated by the automated security QA suite (`QA__security_posture.sql`):
 
 1. All data tables have RLS enabled
 2. All data tables have FORCE RLS enabled
@@ -189,4 +189,4 @@ Security posture is validated by 22 automated checks (`QA__security_posture.sql`
 21. `resolve_effective_country` is SECURITY DEFINER with `search_path` set
 22. `resolve_effective_country` EXECUTE revoked from `authenticated`
 
-**Total QA coverage:** 421 checks across 30 suites + 29 negative validation tests.
+**Total QA coverage:** 776 checks across 49 suites + 20 negative validation tests.

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -13,6 +13,26 @@
 
 ---
 
+## 0. Top Priority — Strategic Stabilization Mode
+
+> **Read this first.** These rules take precedence over default behavior when the
+> repository is in a stabilization sprint (documentation, truthfulness, and
+> product-positioning cleanup). Full process: `docs/AGENT_REVIEW_WORKFLOW.md`.
+
+- **Do not add new product features** unless explicitly requested.
+- **Prioritize truthfulness, documentation consistency, demoability, and product clarity.**
+- **Treat all counts, versions, QA totals, migration totals, API totals, and product totals as untrusted** until verified from source files/scripts.
+- **Prefer source-of-truth files and commands over narrative markdown** (e.g. `RUN_QA.ps1`, `scripts/repo_verify.ps1`, `scripts/check_doc_counts.py`, `scripts/check_doc_drift.py`, `frontend/package.json`, the `supabase/migrations` / `db/pipelines` / `supabase/tests` inventories, and the `pr-gate` / `main-gate` / `qa` workflows).
+- **Keep changes small, reversible, and reviewable.**
+- **Never weaken** security posture, RLS, RPC-only access, CI gates, API contracts, migrations, or production safety.
+- **If unsure, document the uncertainty instead of guessing** — mark values "Needs verification" with the exact command that would confirm them.
+
+For strategic documentation / product-positioning stabilization sprints, use the
+full four-pass review workflow defined in
+[docs/AGENT_REVIEW_WORKFLOW.md](docs/AGENT_REVIEW_WORKFLOW.md).
+
+---
+
 ## 1. Role & Principles
 
 You are a **food scientist, nutrition researcher, and senior data engineer** maintaining **TryVit** — a multi-axis food health scoring platform.

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -43,7 +43,7 @@ You are a **food scientist, nutrition researcher, and senior data engineer** mai
 - **Never guess Nutri-Score.** Compute from nutrition or cite official sources.
 - **Idempotent everything.** Every SQL file safe to run 1× or 100×.
 - **Reproducible setup.** `supabase db reset` + pipelines = full rebuild.
-- **Country-scoped.** PL is primary; DE at full parity (1,066 products across 19 categories). All queries are country-filtered. See `docs/COUNTRY_EXPANSION_GUIDE.md`.
+- **Country-scoped.** PL is primary; DE at full parity (1,222 products across 21 categories). All queries are country-filtered. See `docs/COUNTRY_EXPANSION_GUIDE.md`.
 - **Every change must be tested.** No code ships without corresponding tests. See §8.
 
 ---

--- a/docs/AGENT_REVIEW_WORKFLOW.md
+++ b/docs/AGENT_REVIEW_WORKFLOW.md
@@ -1,0 +1,163 @@
+# TryVit — Agent Review Workflow (Strategic Stabilization)
+
+> **Last updated:** 2026-05-31
+> **Status:** Active
+> **Owner issue:** —
+> **Authority:** `copilot-instructions.md` §0 (Top Priority — Strategic Stabilization Mode) is the primary rule. This doc defines the full multi-pass process referenced there.
+
+---
+
+## Purpose
+
+This document defines the four-pass workflow used for **strategic documentation,
+truthfulness, and product-positioning stabilization sprints**. It is intentionally
+stored separately from `copilot-instructions.md` so the instructions file stays
+short and authoritative, and so agents do not treat review-workflow text as
+permanent project law (and over-focus on docs forever).
+
+Use this workflow **only** for stabilization sprints — not for routine feature work.
+
+---
+
+## Governing Principles (apply to every pass)
+
+- **Scope is documentation-only** unless explicitly stated otherwise: no feature
+  code, no migrations, no CI logic, no package files, no tests, no production data.
+- **Source-of-truth hierarchy** (highest first):
+  1. Scripts / workflows — `RUN_QA.ps1`, `RUN_NEGATIVE_TESTS.ps1`,
+     `scripts/repo_verify.ps1`, `scripts/check_doc_counts.py`,
+     `scripts/check_doc_drift.py`
+  2. Runtime / config / file inventory — `frontend/package.json`,
+     `supabase/migrations`, `db/pipelines`, `supabase/tests`,
+     `pr-gate` / `main-gate` / `qa` workflow files
+  3. `CURRENT_STATE.md`
+  4. Narrative markdown docs
+- **Never invent a count.** If a number is required and not source-backed, run the
+  verifying command. If it still cannot be confirmed, mark it "Needs verification"
+  with the exact command.
+- **Markdown is not current truth.** A markdown file may carry historical context,
+  but it cannot be the final source of truth for a current count unless it clearly
+  labels the value as historical (e.g. "as of YYYY-MM-DD").
+- **Reversibility.** Every change must be revertable with zero runtime impact.
+
+---
+
+## Pass 1 — Claude Opus 4.8: Audit Only (No Edits)
+
+**Goal:** Produce an evidence-backed audit of documentation/positioning drift. No
+files are modified in this pass.
+
+**Rules:**
+- Read-only. Do not edit any file.
+- For every numeric/version claim found, classify it against the source-of-truth
+  hierarchy: Verified / Needs-verification / Wrong.
+- Record an **uncertainty register**: each unconfirmed value plus the exact command
+  that would confirm it.
+- Document concrete drift (e.g. QA badge vs scripts, Next.js version vs
+  `package.json`, API function-count mismatches, product totals across docs).
+
+**Output:**
+- Drift inventory (file → claim → classification → source/command).
+- Uncertainty register.
+- A prioritized list of contradictions to resolve in Pass 2.
+
+---
+
+## Pass 2 — Claude Opus 4.8: Documentation Stabilization (Docs-Only Execution)
+
+**Goal:** Apply the corrections identified in Pass 1, plus author the agreed
+positioning artifacts, as a documentation-only diff.
+
+**Rules:**
+- Documentation-only. No runtime code, migrations, CI logic, package files, tests,
+  or production data.
+- Every corrected number must be source-backed; otherwise label it "Needs
+  verification" with the command.
+- Keep edits minimal and reversible. Do not rewrite unrelated sections for style.
+- Fix contradictions in **all** affected files — do not correct one file while
+  leaving the same stale value elsewhere.
+
+**Typical artifacts:**
+- `README.md` rewrite — product-first (what / who / why) before architecture.
+- `PROJECT_SNAPSHOT.md` — current, source-backed snapshot of key counts.
+- `docs/PRODUCT_POSITIONING.md` — honest positioning, non-goals, unvalidated
+  monetization clearly labeled.
+- `docs/DEMO_SCRIPT.md` — a 3–5 minute runnable demo with a recovery branch.
+
+**Output (final report):**
+- Files changed.
+- Contradictions fixed (with sources).
+- Residual uncertainty register.
+
+---
+
+## Pass 3 — ChatGPT GPT-5.5 Thinking: Strict Reviewer Mode
+
+**Goal:** Aggressively challenge the Pass 2 diff and decide merge / change / reject
+per file, with explicit criteria.
+
+**Inputs to provide:**
+1. The Pass 1 audit output.
+2. The Pass 2 final report.
+3. The actual changed files / GitHub PR diff.
+4. Any verification logs run during Pass 2.
+
+**Rules:**
+- Treat every number as guilty until proven by a source (hierarchy above).
+- Any new number not in the uncertainty register and not source-backed →
+  automatic Change-Required.
+- Any scope creep beyond docs (feature code, migrations, CI, production data) →
+  automatic Reject for that hunk.
+- Do not punish a historical doc for being historical — but require it be clearly
+  labeled so it cannot be mistaken for current truth.
+- If the reviewer cannot inspect the actual diff/source, it must say the review is
+  **limited** and not pretend full verification occurred (mark affected rulings
+  "Conditional — diff not inspected").
+
+**Output:**
+- Verdict summary: MERGE / MERGE-WITH-CHANGES / REJECT (state full vs limited review).
+- Per-file rulings table.
+- Fact-integrity findings.
+- Contradiction-closure table.
+- **Must-fix-before-merge** list (ordered, blocking).
+- Nice-to-have list (non-blocking).
+- If MERGE-WITH-CHANGES: minimal, copy-pasteable correction tasks for Pass 2.1.
+
+---
+
+## Pass 2.1 — Claude Opus 4.8: Blocker-Only Correction Round
+
+**Goal:** Resolve **only** the reviewer's "Must-fix-before-merge" items. Nothing else.
+
+**Rules:**
+- Touch only files in the blocking list; touch the minimum lines required.
+- Do not add new claims, numbers, sections, or positioning unless the reviewer
+  explicitly requested it.
+- Do not rewrite accepted sections for style; do not broaden scope.
+- No runtime code, migrations, CI logic, package files, tests, or production data.
+- If a blocker is ambiguous or cannot be fixed within scope, stop and record it
+  under "remaining uncertainties" — do not guess.
+
+**Output:**
+- Blocker checklist (# → blocker → file:lines → fix → source/command).
+- Patch summary (one bullet per file).
+- Verification commands run (command → result).
+- Reversibility confirmation.
+- Remaining uncertainties.
+
+---
+
+## Loop Summary
+
+```
+Pass 1  (Opus)   audit only, no edits
+   ↓
+Pass 2  (Opus)   docs-only stabilization + positioning artifacts
+   ↓
+Pass 3  (GPT-5.5) strict review → merge / change / reject
+   ↓
+Pass 2.1 (Opus)  blocker-only correction (only if MERGE-WITH-CHANGES)
+```
+
+This keeps agents from endlessly polishing the repo and drives the project toward a
+clean, truthful, mergeable state.

--- a/docs/API_CONTRACTS.md
+++ b/docs/API_CONTRACTS.md
@@ -4,7 +4,7 @@
 > **Stability:** Stable — these surfaces are safe for frontend consumption.
 > **Versioning & Deprecation:** See [API_VERSIONING.md](API_VERSIONING.md) for breaking change protocol, sunset windows, and version strategy.
 > **Naming Conventions:** See [API_CONVENTIONS.md](API_CONVENTIONS.md) for RPC naming patterns, parameter standards, and security requirements.
-> **Canonical Registry:** See [api-registry.yaml](api-registry.yaml) for structured, machine-readable registry of all 107 functions.
+> **Canonical Registry:** See [api-registry.yaml](api-registry.yaml) — the structured, machine-readable registry that is the source of truth for the public API function inventory.
 
 ---
 

--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -1,0 +1,96 @@
+# Demo Script — TryVit (3–5 minutes)
+
+> **Last updated:** 2026-05-31
+> **Status:** Active
+> **Owner issue:** —
+
+A runnable walkthrough for demoing TryVit locally. Target length: 3–5 minutes.
+Each step lists what to show and the point it proves. A recovery branch is
+included in case the live scanner fails.
+
+For environment details see [`VIEWING_AND_TESTING.md`](VIEWING_AND_TESTING.md) and
+[`../CURRENT_STATE.md`](../CURRENT_STATE.md).
+
+---
+
+## 0. Pre-flight (before the audience joins)
+
+```powershell
+Set-Location c:/Users/ericsocrat/Desktop/tryvit
+
+# Start the database and confirm it is healthy
+supabase status
+
+# Start the frontend dev server (separate terminal)
+cd frontend; npm run dev   # http://localhost:3000
+```
+
+Confirm before starting:
+
+- Supabase is running and seeded (local DB has product rows; if empty, run `.\RUN_LOCAL.ps1`).
+- `http://localhost:3000` loads the landing page.
+- Have one known barcode ready as a fallback (see step 3 recovery).
+
+---
+
+## 1. Landing & positioning (~30s)
+
+- Open `http://localhost:3000`.
+- **Say:** "TryVit scores food products on multiple independent health axes — not a single letter grade."
+- **Show:** the hero and the multi-axis pitch.
+- **Proves:** clear positioning vs. single-grade apps.
+
+---
+
+## 2. Category browse & scoring (~60s)
+
+- Navigate to **Categories** → pick a category (e.g. Chips or Dairy).
+- **Show:** products ranked, each with a health score and band color.
+- Open one product detail page.
+- **Show:** the score breakdown — the 9 weighted factors, each with its contribution, plus Nutri-Score, NOVA, and the confidence score.
+- **Proves:** explainability and multi-axis scoring.
+
+---
+
+## 3. Barcode scan (~60s)
+
+- Go to **Scan**.
+- **Show:** the camera-based EAN-13 scanner; scan a product barcode.
+- **Show:** the matched product and its full scoring breakdown.
+- **Proves:** real-world lookup from barcode to auditable score.
+
+### Recovery branch — if the scanner fails
+
+Cameras and permissions are the most fragile part of any live demo. If the feed is
+black or no permission is granted:
+
+1. Switch the scanner to **manual entry** and type a known EAN, **or**
+2. Use the **Search** flow to open the same product by name, **or**
+3. Open the product detail page directly by ID.
+
+Then continue at step 4 as if the scan succeeded. Do not debug the camera live.
+
+---
+
+## 4. Compare & confidence (~45s)
+
+- Add 2–4 products to **Compare**.
+- **Show:** side-by-side factor comparison; point out differing additive counts and confidence scores.
+- **Say:** "The confidence score tells you how complete the underlying data is, so you know how much to trust each number."
+- **Proves:** transparency and data-quality visibility.
+
+---
+
+## 5. Wrap-up (~30s)
+
+- **Say:** "Every number you saw is traceable to its source and validated by 776 automated QA checks before it ever reaches the app."
+- Point to [`PRODUCT_POSITIONING.md`](PRODUCT_POSITIONING.md) for scope and non-goals.
+
+---
+
+## Reset after the demo
+
+```powershell
+# Stop the dev server with Ctrl+C in its terminal.
+# The local database can be left running for the next session.
+```

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,29 +2,29 @@
 
 > **Last updated:** 2026-05-31
 > **Status:** Active — update when adding, renaming, or archiving docs
-> **Total documents:** 66 in `docs/` + 11 in `docs/decisions/` + 25 in `docs/assets/logo/` + 7 in `docs/assets/banners/` + 7 elsewhere in repo
+> **Total documents:** 68 in `docs/` + 11 in `docs/decisions/` + 25 in `docs/assets/logo/` + 7 in `docs/assets/banners/` + 7 elsewhere in repo
 > **Reference:** Issue [#200](https://github.com/ericsocrat/tryvit/issues/200), [#201](https://github.com/ericsocrat/tryvit/issues/201)
 
 ---
 
 ## Quick Navigation
 
-| Domain                                                   | Count | Documents                                                                                                                                                  |
-| -------------------------------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Architecture & Design](#architecture--design)           | 8     | Governance blueprint, domain boundaries, feature flags, scoring engine, search architecture, CI proposal, health-goal personalization                      |
-| [Diagrams](#diagrams)                                    | 13    | Architecture, ERDs, pipeline flow, QA overview, CI/CD, confidence, concern tiers, country expansion, scoring infographic + headers                         |
-| [Brand Assets](#brand-assets)                            | 17    | Logomark SVG variants + PNG exports, wordmark, lockup variants (horizontal + stacked, light + dark)                                                        |
-| [Banners](#banners)                                      | 5     | Social preview, README hero banner (SVG + PNG), badges reference                                                                                           |
-| [API](#api)                                              | 6     | Contracts, conventions, versioning, frontend mapping, contract testing, registry                                                                           |
-| [Scoring](#scoring)                                      | 2     | Methodology (formula), engine (architecture)                                                                                                               |
-| [Data & Provenance](#data--provenance)                   | 5     | Sources, provenance, integrity audits, EAN validation, production data                                                                                     |
-| [Security & Compliance](#security--compliance)           | 5     | Root policy, audit report, access audit, privacy checklist, rate limiting                                                                                  |
-| [Observability & Operations](#observability--operations) | 9     | Monitoring, observability, log schema, alerts, on-call policy, SLOs, metrics, incident response, disaster drill                                            |
-| [DevOps & Environment](#devops--environment)             | 3     | Environment strategy, staging setup, Sonar config                                                                                                          |
-| [Frontend & UX](#frontend--ux)                           | 7     | UX/UI design, UX impact metrics, brand guidelines, name candidates, design system, frontend README, design refresh spec                                    |
-| [Process & Workflow](#process--workflow)                 | 8     | Agent workflow reference, agent review workflow, research workflow, viewing & testing, backfill standard, migration conventions, labels, country expansion |
-| [Governance & Policy](#governance--policy)               | 6     | Feature sunsetting, performance report, performance guardrails, doc governance, repo governance, this index                                                |
-| [Architecture Decisions](#architecture-decisions-adrs)   | 10    | MADR template + 9 ADRs (stack, scoring, country isolation, pipeline, API versioning, migrations, ingredients, nutrient density, ingredient language model) |
+| Domain                                                   | Count | Documents                                                                                                                                                               |
+| -------------------------------------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Architecture & Design](#architecture--design)           | 8     | Governance blueprint, domain boundaries, feature flags, scoring engine, search architecture, CI proposal, health-goal personalization                                   |
+| [Diagrams](#diagrams)                                    | 13    | Architecture, ERDs, pipeline flow, QA overview, CI/CD, confidence, concern tiers, country expansion, scoring infographic + headers                                      |
+| [Brand Assets](#brand-assets)                            | 17    | Logomark SVG variants + PNG exports, wordmark, lockup variants (horizontal + stacked, light + dark)                                                                     |
+| [Banners](#banners)                                      | 5     | Social preview, README hero banner (SVG + PNG), badges reference                                                                                                        |
+| [API](#api)                                              | 6     | Contracts, conventions, versioning, frontend mapping, contract testing, registry                                                                                        |
+| [Scoring](#scoring)                                      | 2     | Methodology (formula), engine (architecture)                                                                                                                            |
+| [Data & Provenance](#data--provenance)                   | 5     | Sources, provenance, integrity audits, EAN validation, production data                                                                                                  |
+| [Security & Compliance](#security--compliance)           | 5     | Root policy, audit report, access audit, privacy checklist, rate limiting                                                                                               |
+| [Observability & Operations](#observability--operations) | 9     | Monitoring, observability, log schema, alerts, on-call policy, SLOs, metrics, incident response, disaster drill                                                         |
+| [DevOps & Environment](#devops--environment)             | 3     | Environment strategy, staging setup, Sonar config                                                                                                                       |
+| [Frontend & UX](#frontend--ux)                           | 8     | UX/UI design, UX impact metrics, brand guidelines, name candidates, design system, frontend README, design refresh spec, product positioning                            |
+| [Process & Workflow](#process--workflow)                 | 9     | Agent workflow reference, agent review workflow, research workflow, viewing & testing, backfill standard, migration conventions, labels, country expansion, demo script |
+| [Governance & Policy](#governance--policy)               | 6     | Feature sunsetting, performance report, performance guardrails, doc governance, repo governance, this index                                                             |
+| [Architecture Decisions](#architecture-decisions-adrs)   | 10    | MADR template + 9 ADRs (stack, scoring, country isolation, pipeline, API versioning, migrations, ingredients, nutrient density, ingredient language model)              |
 
 ---
 
@@ -201,6 +201,7 @@
 | [../frontend/docs/DESIGN_SYSTEM.md](../frontend/docs/DESIGN_SYSTEM.md) | Frontend design system — Tailwind tokens, component patterns                                                           | Frontend domain                                         | 2026-02-17   |
 | [../frontend/README.md](../frontend/README.md)                         | Frontend project overview — setup, scripts, architecture                                                               | Frontend domain                                         | 2026-02-24   |
 | [DESIGN_REFRESH_SPEC.md](DESIGN_REFRESH_SPEC.md)                       | Mobile-first design system & UX refresh spec — component redesign rules, layout principles, implementation order       | Frontend domain                                         | 2026-03-14   |
+| [PRODUCT_POSITIONING.md](PRODUCT_POSITIONING.md)                       | Product positioning — audience, problem, MVP scope, explicit non-goals, unvalidated assumptions                        | Product domain                                          | 2026-05-31   |
 
 ## Process & Workflow
 
@@ -214,6 +215,7 @@
 | [COUNTRY_EXPANSION_GUIDE.md](COUNTRY_EXPANSION_GUIDE.md) | Multi-country expansion protocol — PL active, DE micro-pilot                                                   | [#148](https://github.com/ericsocrat/tryvit/issues/148)                                                          | 2026-02-24   |
 | [AGENT_WORKFLOW.md](AGENT_WORKFLOW.md)                   | Agent/AI workflow reference — execution protocol, command quick-reference, domain matrix, priority definitions | [#200](https://github.com/ericsocrat/tryvit/issues/200)                                                          | 2026-03-02   |
 | [AGENT_REVIEW_WORKFLOW.md](AGENT_REVIEW_WORKFLOW.md)     | Strategic stabilization review workflow — 4-pass audit, execution, strict review, blocker-only correction      | —                                                                                                                | 2026-05-31   |
+| [DEMO_SCRIPT.md](DEMO_SCRIPT.md)                         | Runnable 3–5 minute demo walkthrough with scanner-failure recovery branch                                      | —                                                                                                                | 2026-05-31   |
 
 > **Repo root script:** [`setup-env.ps1`](../setup-env.ps1) — `.env` → PowerShell session loader with `-Verify` connectivity checks and `-ShowValues` masked display. Dot-source with `. .\setup-env.ps1`.
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,45 +1,45 @@
 # Documentation Index
 
-> **Last updated:** 2026-05-26
+> **Last updated:** 2026-05-31
 > **Status:** Active — update when adding, renaming, or archiving docs
-> **Total documents:** 65 in `docs/` + 11 in `docs/decisions/` + 25 in `docs/assets/logo/` + 7 in `docs/assets/banners/` + 7 elsewhere in repo
+> **Total documents:** 66 in `docs/` + 11 in `docs/decisions/` + 25 in `docs/assets/logo/` + 7 in `docs/assets/banners/` + 7 elsewhere in repo
 > **Reference:** Issue [#200](https://github.com/ericsocrat/tryvit/issues/200), [#201](https://github.com/ericsocrat/tryvit/issues/201)
 
 ---
 
 ## Quick Navigation
 
-| Domain                                                   | Count | Documents                                                                                                                           |
-| -------------------------------------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| [Architecture & Design](#architecture--design)           | 8     | Governance blueprint, domain boundaries, feature flags, scoring engine, search architecture, CI proposal, health-goal personalization |
-| [Diagrams](#diagrams)                                    | 13    | Architecture, ERDs, pipeline flow, QA overview, CI/CD, confidence, concern tiers, country expansion, scoring infographic + headers  |
-| [Brand Assets](#brand-assets)                            | 17    | Logomark SVG variants + PNG exports, wordmark, lockup variants (horizontal + stacked, light + dark)                                 |
-| [Banners](#banners)                                      | 5     | Social preview, README hero banner (SVG + PNG), badges reference                                                                    |
-| [API](#api)                                              | 6     | Contracts, conventions, versioning, frontend mapping, contract testing, registry                                                    |
-| [Scoring](#scoring)                                      | 2     | Methodology (formula), engine (architecture)                                                                                        |
-| [Data & Provenance](#data--provenance)                   | 5     | Sources, provenance, integrity audits, EAN validation, production data                                                              |
-| [Security & Compliance](#security--compliance)           | 5     | Root policy, audit report, access audit, privacy checklist, rate limiting                                                           |
-| [Observability & Operations](#observability--operations) | 9     | Monitoring, observability, log schema, alerts, on-call policy, SLOs, metrics, incident response, disaster drill                     |
-| [DevOps & Environment](#devops--environment)             | 3     | Environment strategy, staging setup, Sonar config                                                                                   |
-| [Frontend & UX](#frontend--ux)                           | 7     | UX/UI design, UX impact metrics, brand guidelines, name candidates, design system, frontend README, design refresh spec             |
-| [Process & Workflow](#process--workflow)                 | 7     | Agent workflow reference, research workflow, viewing & testing, backfill standard, migration conventions, labels, country expansion |
-| [Governance & Policy](#governance--policy)               | 6     | Feature sunsetting, performance report, performance guardrails, doc governance, repo governance, this index                         |
+| Domain                                                   | Count | Documents                                                                                                                                                  |
+| -------------------------------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Architecture & Design](#architecture--design)           | 8     | Governance blueprint, domain boundaries, feature flags, scoring engine, search architecture, CI proposal, health-goal personalization                      |
+| [Diagrams](#diagrams)                                    | 13    | Architecture, ERDs, pipeline flow, QA overview, CI/CD, confidence, concern tiers, country expansion, scoring infographic + headers                         |
+| [Brand Assets](#brand-assets)                            | 17    | Logomark SVG variants + PNG exports, wordmark, lockup variants (horizontal + stacked, light + dark)                                                        |
+| [Banners](#banners)                                      | 5     | Social preview, README hero banner (SVG + PNG), badges reference                                                                                           |
+| [API](#api)                                              | 6     | Contracts, conventions, versioning, frontend mapping, contract testing, registry                                                                           |
+| [Scoring](#scoring)                                      | 2     | Methodology (formula), engine (architecture)                                                                                                               |
+| [Data & Provenance](#data--provenance)                   | 5     | Sources, provenance, integrity audits, EAN validation, production data                                                                                     |
+| [Security & Compliance](#security--compliance)           | 5     | Root policy, audit report, access audit, privacy checklist, rate limiting                                                                                  |
+| [Observability & Operations](#observability--operations) | 9     | Monitoring, observability, log schema, alerts, on-call policy, SLOs, metrics, incident response, disaster drill                                            |
+| [DevOps & Environment](#devops--environment)             | 3     | Environment strategy, staging setup, Sonar config                                                                                                          |
+| [Frontend & UX](#frontend--ux)                           | 7     | UX/UI design, UX impact metrics, brand guidelines, name candidates, design system, frontend README, design refresh spec                                    |
+| [Process & Workflow](#process--workflow)                 | 8     | Agent workflow reference, agent review workflow, research workflow, viewing & testing, backfill standard, migration conventions, labels, country expansion |
+| [Governance & Policy](#governance--policy)               | 6     | Feature sunsetting, performance report, performance guardrails, doc governance, repo governance, this index                                                |
 | [Architecture Decisions](#architecture-decisions-adrs)   | 10    | MADR template + 9 ADRs (stack, scoring, country isolation, pipeline, API versioning, migrations, ingredients, nutrient density, ingredient language model) |
 
 ---
 
 ## Architecture & Design
 
-| Document                                                   | Purpose                                                                                                              | Owner Issue                                                                                                      | Last Updated |
-| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------ |
-| [GOVERNANCE_BLUEPRINT.md](GOVERNANCE_BLUEPRINT.md)         | Execution governance blueprint — master plan for all GOV-* issues                                                    | [#195](https://github.com/ericsocrat/tryvit/issues/195)                                                          | 2026-02-24   |
-| [DOMAIN_BOUNDARIES.md](DOMAIN_BOUNDARIES.md)               | Domain boundary enforcement, 13 domains, ownership mapping, interface contracts                                      | [#196](https://github.com/ericsocrat/tryvit/issues/196)                                                          | 2026-02-24   |
-| [FEATURE_FLAGS.md](FEATURE_FLAGS.md)                       | Feature flag architecture — toggle registry, rollout strategy                                                        | [#191](https://github.com/ericsocrat/tryvit/issues/191)                                                          | 2026-02-24   |
-| [SCORING_ENGINE.md](SCORING_ENGINE.md)                     | Scoring engine architecture — versioned function design, formula registry, weight governance, drift detection        | [#189](https://github.com/ericsocrat/tryvit/issues/189), [#198](https://github.com/ericsocrat/tryvit/issues/198) | 2026-02-28   |
-| [DRIFT_DETECTION.md](DRIFT_DETECTION.md)                   | Automated drift detection — 8-check catalog, severity levels, CI integration plan, doc freshness, migration ordering | [#199](https://github.com/ericsocrat/tryvit/issues/199)                                                          | 2026-03-01   |
-| [SEARCH_ARCHITECTURE.md](SEARCH_ARCHITECTURE.md)           | Search architecture — pg_trgm, tsvector, ranking, synonym management                                                 | [#192](https://github.com/ericsocrat/tryvit/issues/192)                                                          | 2026-02-24   |
-| [CI_ARCHITECTURE_PROPOSAL.md](CI_ARCHITECTURE_PROPOSAL.md) | CI pipeline design proposal                                                                                          | —                                                                                                                | 2026-05-25   |
-| [HEALTH_GOAL_PERSONALIZATION.md](HEALTH_GOAL_PERSONALIZATION.md) | Health-goal personalization design — goal taxonomy, personalization model, MVP scope, privacy, copy safety            | [#892](https://github.com/ericsocrat/tryvit/issues/892)                                                          | 2026-03-16   |
+| Document                                                         | Purpose                                                                                                              | Owner Issue                                                                                                      | Last Updated |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------ |
+| [GOVERNANCE_BLUEPRINT.md](GOVERNANCE_BLUEPRINT.md)               | Execution governance blueprint — master plan for all GOV-* issues                                                    | [#195](https://github.com/ericsocrat/tryvit/issues/195)                                                          | 2026-02-24   |
+| [DOMAIN_BOUNDARIES.md](DOMAIN_BOUNDARIES.md)                     | Domain boundary enforcement, 13 domains, ownership mapping, interface contracts                                      | [#196](https://github.com/ericsocrat/tryvit/issues/196)                                                          | 2026-02-24   |
+| [FEATURE_FLAGS.md](FEATURE_FLAGS.md)                             | Feature flag architecture — toggle registry, rollout strategy                                                        | [#191](https://github.com/ericsocrat/tryvit/issues/191)                                                          | 2026-02-24   |
+| [SCORING_ENGINE.md](SCORING_ENGINE.md)                           | Scoring engine architecture — versioned function design, formula registry, weight governance, drift detection        | [#189](https://github.com/ericsocrat/tryvit/issues/189), [#198](https://github.com/ericsocrat/tryvit/issues/198) | 2026-02-28   |
+| [DRIFT_DETECTION.md](DRIFT_DETECTION.md)                         | Automated drift detection — 8-check catalog, severity levels, CI integration plan, doc freshness, migration ordering | [#199](https://github.com/ericsocrat/tryvit/issues/199)                                                          | 2026-03-01   |
+| [SEARCH_ARCHITECTURE.md](SEARCH_ARCHITECTURE.md)                 | Search architecture — pg_trgm, tsvector, ranking, synonym management                                                 | [#192](https://github.com/ericsocrat/tryvit/issues/192)                                                          | 2026-02-24   |
+| [CI_ARCHITECTURE_PROPOSAL.md](CI_ARCHITECTURE_PROPOSAL.md)       | CI pipeline design proposal                                                                                          | —                                                                                                                | 2026-05-25   |
+| [HEALTH_GOAL_PERSONALIZATION.md](HEALTH_GOAL_PERSONALIZATION.md) | Health-goal personalization design — goal taxonomy, personalization model, MVP scope, privacy, copy safety           | [#892](https://github.com/ericsocrat/tryvit/issues/892)                                                          | 2026-03-16   |
 
 ## Diagrams
 
@@ -133,10 +133,10 @@
 
 ## Scoring
 
-| Document                                         | Purpose                                                               | Owner Issue                                             | Last Updated |
-| ------------------------------------------------ | --------------------------------------------------------------------- | ------------------------------------------------------- | ------------ |
+| Document                                         | Purpose                                                                            | Owner Issue                                             | Last Updated |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------- | ------------------------------------------------------- | ------------ |
 | [SCORING_METHODOLOGY.md](SCORING_METHODOLOGY.md) | v3.3 scoring formula — 9 factors, weights, ceilings, bands, nutrient density bonus | [#189](https://github.com/ericsocrat/tryvit/issues/189) | 2026-02-12   |
-| [SCORING_ENGINE.md](SCORING_ENGINE.md)           | Scoring engine architecture — function versioning, regression testing | [#189](https://github.com/ericsocrat/tryvit/issues/189) | 2026-02-24   |
+| [SCORING_ENGINE.md](SCORING_ENGINE.md)           | Scoring engine architecture — function versioning, regression testing              | [#189](https://github.com/ericsocrat/tryvit/issues/189) | 2026-02-24   |
 
 > **Relationship:** SCORING_METHODOLOGY.md defines the **formula** (what is computed). SCORING_ENGINE.md defines the **architecture** (how it is maintained, versioned, and tested). No redundancy — they serve different audiences.
 
@@ -213,6 +213,7 @@
 | [LABELS.md](LABELS.md)                                   | GitHub labeling conventions — issue/PR label taxonomy                                                          | Process domain                                                                                                   | 2026-05-25   |
 | [COUNTRY_EXPANSION_GUIDE.md](COUNTRY_EXPANSION_GUIDE.md) | Multi-country expansion protocol — PL active, DE micro-pilot                                                   | [#148](https://github.com/ericsocrat/tryvit/issues/148)                                                          | 2026-02-24   |
 | [AGENT_WORKFLOW.md](AGENT_WORKFLOW.md)                   | Agent/AI workflow reference — execution protocol, command quick-reference, domain matrix, priority definitions | [#200](https://github.com/ericsocrat/tryvit/issues/200)                                                          | 2026-03-02   |
+| [AGENT_REVIEW_WORKFLOW.md](AGENT_REVIEW_WORKFLOW.md)     | Strategic stabilization review workflow — 4-pass audit, execution, strict review, blocker-only correction      | —                                                                                                                | 2026-05-31   |
 
 > **Repo root script:** [`setup-env.ps1`](../setup-env.ps1) — `.env` → PowerShell session loader with `-Verify` connectivity checks and `-ShowValues` masked display. Dot-source with `. .\setup-env.ps1`.
 

--- a/docs/PRODUCTION_DATA.md
+++ b/docs/PRODUCTION_DATA.md
@@ -4,6 +4,11 @@
 > **Status:** Comprehensive audit of production data infrastructure
 > **Project:** tryvit (Supabase project `uskvezwftkkudvksmken`)
 
+> ⚠️ **Historical snapshot.** This document reflects the production data picture
+> as of 2026-02-28 (Phase 6 audit). Counts, totals, and migration numbers below
+> may have drifted. For live project status, see
+> [`CURRENT_STATE.md`](../CURRENT_STATE.md).
+
 ---
 
 ## Table of Contents

--- a/docs/PRODUCT_POSITIONING.md
+++ b/docs/PRODUCT_POSITIONING.md
@@ -1,0 +1,86 @@
+# Product Positioning — TryVit
+
+> **Last updated:** 2026-05-31
+> **Status:** Active
+> **Owner issue:** —
+
+This document defines who TryVit is for, the problem it solves, what is explicitly
+in and out of scope for the current MVP, and which assumptions remain unvalidated.
+It is the canonical reference for product framing. For live project status see
+[`../CURRENT_STATE.md`](../CURRENT_STATE.md).
+
+---
+
+## 1. One-line positioning
+
+TryVit is a research-grade, multi-axis food health scoring platform for Poland and
+Germany that makes every score **auditable** — exposing the factors, weights, and
+data confidence behind each number instead of a single opaque grade.
+
+---
+
+## 2. Who it's for
+
+| Audience                              | What they get                                                                                           |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Health-conscious shoppers (PL/DE)** | A clear, explainable health score per product, with the reasons behind it and how complete the data is. |
+| **Nutrition researchers**             | Transparent, source-traceable scoring on 9 weighted factors plus Nutri-Score, NOVA, and confidence.     |
+| **Data engineers / contributors**     | A reproducible, fully-tested PostgreSQL-first platform with idempotent pipelines and CI gates.          |
+
+---
+
+## 3. The problem
+
+Mainstream food apps reduce nutrition to a single letter or a calorie count. That
+hides *why* a product is rated the way it is, ignores processing level and additive
+concerns, and gives no signal about how trustworthy the underlying data is.
+
+TryVit's thesis: a health score is only useful if it is **explainable and
+auditable**. Every factor, its weight, its ceiling, and the data confidence should
+be visible.
+
+---
+
+## 4. What makes it different
+
+- **Multi-axis, not single-grade** — unhealthiness (1–100), Nutri-Score, NOVA, and a data-confidence score are computed and shown independently.
+- **9 weighted factors** — saturated fat, sugars, salt, calories, trans fat, additives, prep method, controversies, and EFSA ingredient-concern tiers, minus a nutrient-density bonus.
+- **Confidence transparency** — every product carries a 0–100 completeness/confidence score.
+- **Full explainability** — score breakdowns expose each factor's raw value, weight, and contribution.
+
+---
+
+## 5. MVP scope (in scope now)
+
+- Poland (primary) and Germany (full parity) product catalogs.
+- Scan / search / compare / score flows with per-factor explanations.
+- Confidence scoring and data-provenance surfacing.
+- Authenticated user features: preferences, health profiles, lists, comparisons, saved searches, scan history, submissions.
+
+---
+
+## 6. Explicit non-goals
+
+TryVit is **not**, and the MVP does not attempt to be:
+
+- A medical, clinical, or dietary-advice tool. It makes **no** treatment or diagnosis claims.
+- A weight-loss program or calorie/macro tracker.
+- A global product database — markets are limited to **PL and DE** today.
+- A replacement for reading the legal product label. `product_name` and label text are treated as authoritative and never modified.
+- A real-time price or availability tracker.
+
+---
+
+## 7. Unvalidated assumptions
+
+These are documented as open questions, **not** established facts:
+
+| Assumption                                             | Status      |
+| ------------------------------------------------------ | ----------- |
+| Monetization model (subscription, B2B data, affiliate) | Unvalidated |
+| Target market size / willingness to pay                | Unvalidated |
+| Demand for DE beyond PL                                | Unvalidated |
+| Retention impact of confidence/explainability features | Unvalidated |
+
+Update this table as assumptions are tested. Do not present any row as validated
+without evidence.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,12 @@
 # TryVit Frontend
 
-Next.js 15 (App Router) + TypeScript + Tailwind CSS frontend for the TryVit.
+Next.js 16 (App Router) + TypeScript + Tailwind CSS frontend for the TryVit.
 
 ## Tech Stack
 
 | Layer         | Choice                                          |
 | ------------- | ----------------------------------------------- |
-| Framework     | Next.js 15 (App Router)                         |
+| Framework     | Next.js 16 (App Router)                         |
 | Language      | TypeScript (strict)                             |
 | Styling       | Tailwind CSS (custom `brand` palette)           |
 | Auth          | `@supabase/ssr` (browser + server + middleware) |


### PR DESCRIPTION
Documentation-only stabilization pass for TryVit.

Changes included:
- Added strategic agent review workflow documentation.
- Added top-priority strategic stabilization rules to copilot instructions.
- Reconciled stale README/SECURITY/frontend README facts:
  - QA checks: 776
  - QA suites: 49
  - negative tests: 20
  - Next.js: 16 / 16.2.6 where applicable
- Removed unverifiable live API/EAN count claims from main docs.
- Added historical snapshot banner to PRODUCTION_DATA.md.
- Added PRODUCT_POSITIONING.md.
- Added DEMO_SCRIPT.md.
- Updated docs index/counts.
- Created follow-up issue #1147 for lower-priority stale documentation references.

Verification:
- scripts/check_doc_counts.py passed with 25/25 correct and 0 mismatches.
- check_doc_drift.py still flags pre-existing stale docs, now tracked in #1147.

Scope:
- Documentation-only.
- No runtime code changes.
- No migrations changed.
- No CI logic changed.
- No package files, tests, scripts, production data, or lockfiles changed.