### PR TITLE
docs: align demo script with auth-gated flow

### DIFF
--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -266,7 +266,7 @@ Epic #920 fully resolved and closed — all 12/12 issues shipped.
 - [x] UX Audit — 74 Playwright screenshots + 20 user screenshots analyzed → 4 issues created (#842-#845)
 - [x] P0 fix: Score display consistency — TryVit Score (100−unhealthiness) for filters/stats (PR #846)
 - [x] P1 fix: Category truncation, product not-found empty state, settings tab overflow (PR #847)
-- [x] P2 fix: Language flags removed, scanner default to manual, QuickWin null guard, 403 page enhanced (PR #848)
+- [x] P2 fix: Language flags removed, scanner default to manual, QuickWin null guard, 403 page enhanced (PR #848) — _superseded: scanner now defaults to camera mode with an always-visible manual entry fallback_
 - [x] P3 fix: Filter skeleton loader, category grid cleanup (PR #849)
 - [x] Fix 7 broken production functions — STABLE→VOLATILE + watchlist alias (PR #854)
 - [x] Configure PRODUCTION_URL secret for health endpoint verification

--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -29,6 +29,13 @@ Confirm before starting:
 
 - Supabase is running and seeded (local DB has product rows; if empty, run `.\RUN_LOCAL.ps1`).
 - `http://localhost:3000` loads the landing page.
+- **You are logged in with a demo account whose onboarding is complete.** All
+  `/app/*` routes (Categories, Product, Scan, Compare) are auth-gated and will
+  redirect to `/auth/login` — and then to `/onboarding` if it is incomplete —
+  so steps 2–4 are not reachable as a logged-out viewer. Sign in and finish
+  onboarding before the audience joins.
+  - Use a pre-created demo account with onboarding completed. Do not include
+    real credentials in this script.
 - Have one known barcode ready as a fallback (see step 3 recovery).
 
 ---
@@ -55,7 +62,8 @@ Confirm before starting:
 ## 3. Barcode scan (~60s)
 
 - Go to **Scan**.
-- **Show:** the camera-based EAN-13 scanner; scan a product barcode.
+- **Show:** the EAN-13 scanner. It defaults to camera mode; the **Manual entry**
+  toggle is always visible as the fallback. Scan a product barcode.
 - **Show:** the matched product and its full scoring breakdown.
 - **Proves:** real-world lookup from barcode to auditable score.
 
@@ -75,8 +83,11 @@ Then continue at step 4 as if the scan succeeded. Do not debug the camera live.
 ## 4. Compare & confidence (~45s)
 
 - Add 2–4 products to **Compare**.
-- **Show:** side-by-side factor comparison; point out differing additive counts and confidence scores.
-- **Say:** "The confidence score tells you how complete the underlying data is, so you know how much to trust each number."
+- **Show:** compare factors side-by-side; point out differing additive counts and
+  per-factor best/worst highlighting. Confidence is shown on each product's
+  detail page, not currently in the compare grid.
+- **Say:** "On each product page, the confidence score tells you how complete the
+  underlying data is, so you know how much to trust each number."
 - **Proves:** transparency and data-quality visibility.
 
 ---


### PR DESCRIPTION
Documentation-only update.

Changes:
- Clarifies that the 3-minute demo requires a logged-in account with onboarding completed.
- Adds a demo-account placeholder without credentials.
- Corrects scanner wording: camera is the default, with manual entry available as fallback.
- Clarifies that confidence is visible on product detail pages, not currently in the compare grid.
- Annotates the historical CURRENT_STATE.md scanner-default note as superseded.

Verification:
- scripts/check_doc_counts.py passed with 25/25 correct and 0 mismatches.

Scope:
- Documentation-only.
- No runtime code changes.
- No auth/proxy/scanner/compare changes.
- No migrations, tests, CI, package files, lockfiles, or production data changed.
