### PR TITLE
fix(ci): prevent QA fixtures from seeding production

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -96,16 +96,20 @@ jobs:
 
       - name: Seed QA fixture data
         run: |
-          OUTPUT=$(node tests/quality/seed-fixtures.mjs 2>&1 1>/tmp/qa-ids.txt || true)
-          echo "$OUTPUT"
-          if [ -f /tmp/qa-ids.txt ] && [ -s /tmp/qa-ids.txt ]; then
-            cat /tmp/qa-ids.txt >> "$GITHUB_ENV"
-          else
-            echo "::warning::QA fixture seeding skipped or failed — tests may use fallback IDs"
-          fi
+          set -o pipefail
+          # KEY=VALUE lines go to stdout. No `|| true` — a non-zero exit
+          # (missing staging env in CI, or the in-script production guard
+          # tripping) MUST fail the job rather than run tests with nothing
+          # seeded.
+          node tests/quality/seed-fixtures.mjs | tee /tmp/qa-ids.txt
+          grep -E '^[A-Z_]+=' /tmp/qa-ids.txt >> "$GITHUB_ENV" || true
         env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL_STAGING || secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY_STAGING || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # Staging-only: QA fixtures must NEVER target production. No fallback
+          # to NEXT_PUBLIC_SUPABASE_URL — if the staging secret is unset the
+          # seeder fails in CI (and the in-script production guard would abort
+          # anyway).
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL_STAGING }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY_STAGING }}
 
       - name: Full Playwright (all projects including visual)
         run: npx playwright test 2>&1 | tee ../playwright-stdout.log
@@ -118,6 +122,17 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL_STAGING || secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY_STAGING || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY_STAGING || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+      # Always runs after the fixture-dependent Playwright suite so staging
+      # never accumulates active QA Test Brand rows. Staging-only secrets; the
+      # in-script production guard makes targeting production impossible. In CI
+      # a missing staging secret fails this step rather than leaking fixtures.
+      - name: Teardown QA fixture data
+        if: always()
+        run: node tests/quality/seed-fixtures.mjs --teardown
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL_STAGING }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY_STAGING }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -111,19 +111,21 @@ jobs:
         id: seed
         working-directory: frontend
         run: |
-          # Seed deterministic test products; capture IDs into $GITHUB_ENV
-          OUTPUT=$(node tests/quality/seed-fixtures.mjs 2>&1 1>/tmp/qa-ids.txt || true)
-          echo "$OUTPUT"
-          if [ -f /tmp/qa-ids.txt ] && [ -s /tmp/qa-ids.txt ]; then
-            cat /tmp/qa-ids.txt >> "$GITHUB_ENV"
-            echo "seeded=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "seeded=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::QA fixture seeding skipped or failed — tests may use fallback IDs"
-          fi
+          set -o pipefail
+          # Seed deterministic test products; KEY=VALUE lines go to stdout.
+          # No `|| true` here — a non-zero exit (missing staging env in CI, or
+          # the in-script production guard tripping) MUST fail the job rather
+          # than let the quality gate pass green with nothing seeded.
+          node tests/quality/seed-fixtures.mjs | tee /tmp/qa-ids.txt
+          grep -E '^[A-Z_]+=' /tmp/qa-ids.txt >> "$GITHUB_ENV" || true
+          echo "seeded=true" >> "$GITHUB_OUTPUT"
         env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL_STAGING || secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY_STAGING || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # Staging-only: QA fixtures must NEVER target production. No fallback
+          # to NEXT_PUBLIC_SUPABASE_URL — if the staging secret is unset the
+          # seeder fails in CI (and the in-script production guard would abort
+          # anyway).
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL_STAGING }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY_STAGING }}
 
       # ── Determine mode ───────────────────────────────────────────────────
       - name: Determine mode
@@ -172,6 +174,20 @@ jobs:
           BASE_URL: http://localhost:3000
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY_STAGING || secrets.SUPABASE_SERVICE_ROLE_KEY }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL_STAGING || secrets.NEXT_PUBLIC_SUPABASE_URL }}
+
+      # ── Teardown QA fixtures ─────────────────────────────────────────────
+      # Always runs after the fixture-dependent audits so staging never
+      # accumulates active QA Test Brand rows. Staging-only secrets; the
+      # in-script production guard makes targeting production impossible.
+      # In CI a missing staging secret fails this step (exit 1) rather than
+      # leaving fixtures behind silently.
+      - name: Teardown QA fixture data
+        if: always()
+        working-directory: frontend
+        run: node tests/quality/seed-fixtures.mjs --teardown
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL_STAGING }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY_STAGING }}
 
       # ── Lighthouse CI (Mobile) ─────────────────────────────────────────
       - name: Run Lighthouse CI (Mobile)

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -165,8 +165,13 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL_STAGING || secrets.NEXT_PUBLIC_SUPABASE_URL }}
 
       # ── Desktop Audit ────────────────────────────────────────────────────
+      # No `if: always()` — the quality-desktop project is only registered when
+      # QA_MODE_LEVEL is set (HAS_QUALITY in playwright.config.ts). That value
+      # comes from the "Determine mode" step, which is skipped if seeding fails.
+      # Running this on failure would surface a misleading "project not found"
+      # error instead of the real seed failure, so it mirrors the Mobile Audit
+      # step and only runs when prior steps succeed.
       - name: Run Desktop Audit
-        if: always()
         working-directory: frontend
         run: npx playwright test --project=quality-desktop --reporter=html,list
         env:

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -228,7 +228,7 @@ End-to-end: reconcile → tighten detector → enforce in CI.
 | ------------ | ------ | --------------------------------------------------------------------- |
 | pr-gate      | ✅      | Typecheck, lint, unit tests, build, Playwright smoke                  |
 | main-gate    | ✅      | All passing                                                           |
-| qa.yml       | ✅      | 776/776 checks passing (49 suites)                                    |
+| qa.yml       | ✅      | 777/777 checks passing (49 suites)                                    |
 | deploy.yml   | ⚠️      | 209/227 migrations on production — 18 pending deploy (epic #920)      |
 | dep-audit    | ✅      | 0 high/critical vulnerabilities                                       |
 | python-lint  | ✅      | 0 ruff errors                                                         |
@@ -301,7 +301,7 @@ These are documented follow-ups, not active work items. Address opportunisticall
 
 - **Products (local DB):** 2,602 active (1,380 PL + 1,222 DE across 21 active + 1 deactivated category)
 - **Deprecated products:** 58
-- **QA checks:** 776 total (49 suites) — view_consistency +3 checks for cross-country analytics views
+- **QA checks:** 777 total (49 suites) — view_consistency +3 checks for cross-country analytics views
 - **Negative tests:** 20/20 caught
 - **EAN coverage:** 2,261/2,264 with EAN (99.9%) — local DB
 - **Ingredient refs:** 3,100 (local, after orphan cleanup from 6,279)

--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -10,7 +10,7 @@
         4. validate_eans.py (EAN-8/EAN-13 checksum validation — blocking)
         5. QA__api_surfaces.sql (18 API contract validation checks — blocking)
         6. QA__confidence_scoring.sql (14 confidence scoring checks — blocking)
-        7. QA__data_quality.sql (29 data quality & plausibility checks — blocking)
+        7. QA__data_quality.sql (30 data quality & plausibility checks — blocking)
         8. QA__referential_integrity.sql (18 referential integrity checks — blocking)
         9. QA__view_consistency.sql (13 view & function consistency checks — blocking)
        10. QA__naming_conventions.sql (12 naming/formatting convention checks — blocking)
@@ -139,7 +139,7 @@ $suiteCatalog = @(
     @{ Num = 4; Name = "EAN Checksum Validation"; Short = "EAN"; Id = "ean"; Checks = 1; Blocking = $true; Kind = "python"; File = "validate_eans.py" },
     @{ Num = 5; Name = "API Surface Validation"; Short = "API"; Id = "api"; Checks = 18; Blocking = $true; Kind = "sql"; File = "QA__api_surfaces.sql" },
     @{ Num = 6; Name = "Confidence Scoring"; Short = "Confidence"; Id = "confidence"; Checks = 14; Blocking = $true; Kind = "sql"; File = "QA__confidence_scoring.sql" },
-    @{ Num = 7; Name = "Data Quality & Plausibility"; Short = "DataQuality"; Id = "data_quality"; Checks = 29; Blocking = $true; Kind = "sql"; File = "QA__data_quality.sql" },
+    @{ Num = 7; Name = "Data Quality & Plausibility"; Short = "DataQuality"; Id = "data_quality"; Checks = 30; Blocking = $true; Kind = "sql"; File = "QA__data_quality.sql" },
     @{ Num = 8; Name = "Referential Integrity"; Short = "RefInteg"; Id = "referential"; Checks = 18; Blocking = $true; Kind = "sql"; File = "QA__referential_integrity.sql" },
     @{ Num = 9; Name = "View & Function Consistency"; Short = "Views"; Id = "views"; Checks = 13; Blocking = $true; Kind = "sql"; File = "QA__view_consistency.sql" },
     @{ Num = 10; Name = "Naming Conventions"; Short = "Naming"; Id = "naming"; Checks = 12; Blocking = $true; Kind = "sql"; File = "QA__naming_conventions.sql" },

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -9,7 +9,7 @@
 > **Servings:** removed as separate table — all nutrition data is per-100g on nutrition_facts
 > **Ingredient analytics:** 5,340 unique ingredients (all clean ASCII English), 2,691 allergen declarations, 2,702 trace declarations
 > **Ingredient concerns:** EFSA-based 4-tier additive classification (0=none, 1=low, 2=moderate, 3=high)
-> **QA:** 776 checks across 49 suites + 20 negative validation tests — all passing
+> **QA:** 777 checks across 49 suites + 20 negative validation tests — all passing
 
 ---
 
@@ -303,7 +303,7 @@ tryvit/
 │       ├── 006-append-only-migrations.md
 │       └── 007-english-canonical-ingredients.md
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
-├── RUN_QA.ps1                       # QA test runner (776 checks across 49 suites)
+├── RUN_QA.ps1                       # QA test runner (777 checks across 49 suites)
 ├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (20 injection tests)
 ├── RUN_SANITY.ps1                   # Sanity checks (16) — row counts, schema assertions
 ├── RUN_REMOTE.ps1                   # Remote deployment (requires confirmation)
@@ -377,7 +377,7 @@ tryvit/
 │   ├── pr-gate.yml                  # Lint → Typecheck → Build → Playwright E2E
 │   ├── pr-title-lint.yml            # PR title conventional-commit validation (all PRs)
 │   ├── main-gate.yml                # Build → Unit tests + coverage → SonarCloud
-│   ├── qa.yml                       # Schema → Pipelines → QA (776) → Sanity
+│   ├── qa.yml                       # Schema → Pipelines → QA (777) → Sanity
 │   ├── nightly.yml                  # Full Playwright (all projects) + Data Integrity Audit
 │   ├── deploy.yml                   # Manual trigger → Schema diff → Approval → db push
 │   ├── sync-cloud-db.yml            # Remote DB sync
@@ -770,7 +770,7 @@ A change is **not done** unless relevant tests were added/updated, every suite i
 | Component tests     | **Testing Library React** + Vitest                | `frontend/src/components/**/*.test.tsx`      | same as above                        |
 | E2E smoke           | **Playwright 1.58** (Chromium)                    | `frontend/e2e/smoke.spec.ts`                 | `cd frontend && npx playwright test` |
 | E2E auth            | Playwright (requires `SUPABASE_SERVICE_ROLE_KEY`) | `frontend/e2e/authenticated.spec.ts`         | same (CI auto-detects key)           |
-| DB QA (776 checks)  | Raw SQL (zero rows = pass)                        | `db/qa/QA__*.sql` (49 suites)                | `.\RUN_QA.ps1`                       |
+| DB QA (777 checks)  | Raw SQL (zero rows = pass)                        | `db/qa/QA__*.sql` (49 suites)                | `.\RUN_QA.ps1`                       |
 | Negative validation | SQL injection/constraint tests                    | `db/qa/TEST__negative_checks.sql`            | `.\RUN_NEGATIVE_TESTS.ps1`           |
 | DB sanity           | Row-count + schema assertions                     | via `RUN_SANITY.ps1`                         | `.\RUN_SANITY.ps1 -Env local`        |
 | Pipeline structure  | Python validator                                  | `check_pipeline_structure.py`                | `python check_pipeline_structure.py` |
@@ -911,7 +911,7 @@ E2E tests are the **only** exception — they run against a live dev server but 
   - **`pr-title-lint.yml`**: PR title conventional-commit validation (all PRs)
   - **`main-gate.yml`**: Typecheck → Lint → Build → Unit tests with coverage → Playwright smoke E2E → SonarCloud scan + BLOCKING Quality Gate → Sentry sourcemap upload
   - **`nightly.yml`**: Full Playwright (all projects incl. visual regression) + Data Integrity Audit (parallel)
-  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (776 checks) → Sanity (17 checks) → Confidence threshold
+  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (777 checks) → Sanity (17 checks) → Confidence threshold
   - **`deploy.yml`**: Manual trigger → Schema diff → Approval gate (production) → Pre-deploy backup → `supabase db push` → Post-deploy sanity
   - **`sync-cloud-db.yml`**: Auto-sync migrations to production on merge to `main`
 - **Required (merge-blocking) checks:** `Unit Tests`, `Playwright Smoke`, `Typecheck & Lint`, `Build`. These four must pass before a PR can merge.
@@ -948,7 +948,7 @@ If adding/changing DB schema or SQL functions:
 - For rollback procedures, see `DEPLOYMENT.md` → **Rollback Procedures** (5 scenarios + emergency checklist).
 - Add a QA check that verifies the migration outcome (row counts, constraint behavior).
 - Ensure idempotency (`IF NOT EXISTS`, `ON CONFLICT`, `DO UPDATE SET`).
-- Run `.\RUN_QA.ps1` to verify all 776 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 20 injection tests.
+- Run `.\RUN_QA.ps1` to verify all 777 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 20 injection tests.
 
 ### 8.14 Snapshots Are Not Enough
 
@@ -1000,7 +1000,7 @@ At the end of every PR-like change, include a **Verification** section:
 | API Contract              | `QA__api_contract.sql`              |     33 | Yes       |
 | Confidence Scoring        | `QA__confidence_scoring.sql`        |     14 | Yes       |
 | Confidence Reporting      | `QA__confidence_reporting.sql`      |      7 | Yes       |
-| Data Quality              | `QA__data_quality.sql`              |     29 | Yes       |
+| Data Quality              | `QA__data_quality.sql`              |     30 | Yes       |
 | Ref. Integrity            | `QA__referential_integrity.sql`     |     18 | Yes       |
 | View Consistency          | `QA__view_consistency.sql`          |     16 | Yes       |
 | Naming Conventions        | `QA__naming_conventions.sql`        |     12 | Yes       |
@@ -1043,7 +1043,7 @@ At the end of every PR-like change, include a **Verification** section:
 | Scoring Band Distribution | `QA__scoring_distribution.sql`      |     12 | No        |
 | **Negative Validation**   | `TEST__negative_checks.sql`         |     20 | Yes       |
 
-**Run:** `.\RUN_QA.ps1` — expects **776/776 checks passing** (+ EAN validation).
+**Run:** `.\RUN_QA.ps1` — expects **777/777 checks passing** (+ EAN validation).
 **Run:** `.\RUN_NEGATIVE_TESTS.ps1` — expects **20/20 caught**.
 
 ### 8.19 Key Regression Tests (Scoring Suite)
@@ -1201,7 +1201,7 @@ security(rls): lock down product_submissions to authenticated users
 
 **Pre-commit checklist:**
 
-1. `.\RUN_QA.ps1` — 776/776 pass
+1. `.\RUN_QA.ps1` — 777/777 pass
 2. No credentials in committed files
 3. No modifications to existing `supabase/migrations/`
 4. Docs updated if schema or methodology changed
@@ -1575,7 +1575,7 @@ Before a feature is considered complete, verify against all CI gates:
 | Gate                | Command                               | Expected                        |
 | ------------------- | ------------------------------------- | ------------------------------- |
 | Pipeline structure  | `python check_pipeline_structure.py`  | 0 errors                        |
-| DB QA               | `.\RUN_QA.ps1`                        | All checks pass (currently 776) |
+| DB QA               | `.\RUN_QA.ps1`                        | All checks pass (currently 777) |
 | Negative tests      | `.\RUN_NEGATIVE_TESTS.ps1`            | All caught (currently 23)       |
 | pgTAP tests         | `supabase test db`                    | All pass                        |
 | TypeScript          | `cd frontend && npx tsc --noEmit`     | 0 errors                        |
@@ -1721,7 +1721,7 @@ Produce **exactly this structure** — fill every section with real data:
 | Metric                    | Current Value   | Target / Baseline       | Status   |
 | ------------------------- | --------------- | ----------------------- | -------- |
 | Active products (PL+DE)   | ~X,XXX          | ≥2,602                  | ✅/⚠️/❌ |
-| QA checks passing         | XXX/776         | 776/776                 | ✅/⚠️/❌ |
+| QA checks passing         | XXX/777         | 777/777                 | ✅/⚠️/❌ |
 | Negative tests passing    | 23/23           | 23/23                   | ✅/⚠️/❌ |
 | Migrations committed      | XXX             | ≥227                    | ✅/⚠️/❌ |
 | Vitest coverage (lines)   | XX%             | ≥88%                    | ✅/⚠️/❌ |
@@ -2042,7 +2042,7 @@ Else → fallback Z (always safe, always returns a value)
 ## Verification Checklist (Definition of Done)
 
 - [ ] `python check_pipeline_structure.py` — 0 errors
-- [ ] `.\RUN_QA.ps1` — all 776 checks pass
+- [ ] `.\RUN_QA.ps1` — all 777 checks pass
 - [ ] `.\RUN_NEGATIVE_TESTS.ps1` — 20/20 caught
 - [ ] `supabase test db` — all pgTAP pass
 - [ ] `cd frontend && npx tsc --noEmit` — 0 errors
@@ -2486,7 +2486,7 @@ Execute every command. Record output. Do not skip.
 ```powershell
 # ── Database layer ───────────────────────────────────────────────────
 supabase test db                               # All pgTAP tests pass
-.\RUN_QA.ps1                                   # All 776+ QA checks pass
+.\RUN_QA.ps1                                   # All 777+ QA checks pass
 .\RUN_NEGATIVE_TESTS.ps1                       # All 20 negative tests caught
 python check_pipeline_structure.py            # 0 errors
 python validate_eans.py                       # 0 EAN failures
@@ -2536,7 +2536,7 @@ After implementation, update ALL of these that apply (per §18.1):
 
 ```powershell
 supabase test db                  → XX/XX pgTAP tests pass
-.\RUN_QA.ps1                      → 776/776 checks pass (0 failures)
+.\RUN_QA.ps1                      → 777/777 checks pass (0 failures)
 .\RUN_NEGATIVE_TESTS.ps1          → 20/20 caught
 npx tsc --noEmit                  → 0 errors
 npx vitest run                    → XXX/XXX tests pass

--- a/db/qa/QA__data_quality.sql
+++ b/db/qa/QA__data_quality.sql
@@ -1,5 +1,5 @@
 -- ============================================================
--- QA: Data Quality & Plausibility Checks (39 checks)
+-- QA: Data Quality & Plausibility Checks (40 checks)
 -- Validates data hygiene, plausibility bounds, cross-field
 -- consistency, and coverage regression thresholds.
 -- All checks are BLOCKING unless marked informational.
@@ -378,4 +378,20 @@ WHERE p.is_deprecated IS NOT TRUE
   AND p.brand IS NOT NULL
 GROUP BY normalize_brand(p.brand)
 HAVING COUNT(DISTINCT p.brand) > 1;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 40. No active QA fixture products in the live catalog
+--     QA fixtures (brand = 'QA Test Brand') are synthetic Dairy products
+--     seeded by frontend/tests/quality/seed-fixtures.mjs for Playwright
+--     quality-gate runs. They must ONLY exist on a staging/test instance.
+--     In June 2026 four leaked into production because the CI seed step fell
+--     back to the production URL when the staging secret was unset. This
+--     check fails if any such product is active (is_deprecated IS NOT TRUE),
+--     guaranteeing fixtures never surface in any user-facing surface again.
+-- ═══════════════════════════════════════════════════════════════════════════
+SELECT '40. no active QA fixture products' AS check_name,
+       COUNT(*) AS violations
+FROM products p
+WHERE p.brand = 'QA Test Brand'
+  AND p.is_deprecated IS NOT TRUE;
 

--- a/docs/PRODUCTION_DATA.md
+++ b/docs/PRODUCTION_DATA.md
@@ -465,7 +465,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
 
 - **EAN coverage:** 997/1,025 (97.3%)
 - **Scoring version:** v3.2 — 9-factor weighted formula
-- **QA checks:** 776 checks across 49 suites — all passing
+- **QA checks:** 777 checks across 49 suites — all passing
 - **Negative tests:** 20 injection tests — all caught
 - **Confidence threshold (CI):** ≤5% low-confidence products allowed
 - **CHECK constraints:** 24 domain constraints enforced at DB level

--- a/frontend/tests/quality/seed-fixtures.mjs
+++ b/frontend/tests/quality/seed-fixtures.mjs
@@ -5,10 +5,16 @@
  * data so the quality-gate Playwright tests have real rendered DOM to audit.
  *
  * Usage:
- *   node tests/quality/seed-fixtures.mjs
+ *   node tests/quality/seed-fixtures.mjs              # seed fixtures
+ *   node tests/quality/seed-fixtures.mjs --teardown   # soft-deprecate fixtures
  *
  * Outputs KEY=VALUE lines to stdout for CI to capture into $GITHUB_ENV.
- * Requires NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY env vars.
+ * Requires NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY env vars,
+ * which MUST point at a staging/local/test instance. The seeder refuses to
+ * run against the production project (hard guard) — see PRODUCTION_PROJECT_REF.
+ *
+ * Missing env: skips with exit 0 locally, but FAILS with exit 1 in CI
+ * (CI=true) so a misconfigured staging secret can never pass silently.
  *
  * Idempotent — safe to run multiple times (upserts on unique constraints).
  *
@@ -22,11 +28,57 @@ import { createClient } from "@supabase/supabase-js";
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
+// Canonical brand used by all QA fixtures. Centralised so the teardown path
+// and any future tooling reference a single source of truth.
+const QA_FIXTURE_BRAND = "QA Test Brand";
+
+// Hard safety guard. These QA fixtures must NEVER be written to the production
+// Supabase project. In June 2026 four fixtures leaked into the production
+// catalog because the CI seed step fell back to the production URL when the
+// staging secret was unset. The seeder now refuses to run against production,
+// regardless of how the URL was resolved.
+const PRODUCTION_PROJECT_REF = "uskvezwftkkudvksmken";
+
+// Are we running inside CI? GitHub Actions (and most CI providers) set CI=true.
+// In CI, missing fixture env is a hard failure — a silent skip would let the
+// quality-gate/nightly workflow pass green while seeding (or teardown) did
+// nothing, masking misconfigured staging secrets. Locally, a missing env is a
+// legitimate "I just want to run the app" case, so we skip safely.
+const IS_CI = process.env.CI === "true" || process.env.CI === "1";
+
 if (!SUPABASE_URL || !SERVICE_KEY) {
+  if (IS_CI) {
+    console.error(
+      "❌ Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in CI."
+    );
+    console.error(
+      "    QA fixture seeding/teardown requires the *_STAGING secrets. " +
+        "Failing instead of silently skipping — configure " +
+        "SUPABASE_URL_STAGING / SUPABASE_SERVICE_ROLE_KEY_STAGING."
+    );
+    process.exit(1);
+  }
   console.warn(
     "⚠️  Skipping QA fixture seeding — missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY"
   );
+  console.warn(
+    "    QA fixtures require an explicit staging/local/test target. " +
+      "Set the *_STAGING secrets — do not fall back to production."
+  );
   process.exit(0);
+}
+
+if (SUPABASE_URL.includes(PRODUCTION_PROJECT_REF)) {
+  console.error(
+    `❌ Refusing to seed QA fixtures against the production project ` +
+      `(${PRODUCTION_PROJECT_REF}). QA fixtures must only target a ` +
+      `staging, local, or test Supabase instance.`
+  );
+  console.error(
+    "    Resolved NEXT_PUBLIC_SUPABASE_URL points at production. " +
+      "Provide SUPABASE_URL_STAGING / SUPABASE_SERVICE_ROLE_KEY_STAGING instead."
+  );
+  process.exit(1);
 }
 
 const supabase = createClient(SUPABASE_URL, SERVICE_KEY, {
@@ -427,7 +479,54 @@ async function main() {
   console.error("\n🎉 QA fixture seeding complete!\n");
 }
 
-main().catch((err) => {
-  console.error(`\n❌ QA fixture seeding failed: ${err.message}`);
+/* ── Teardown ────────────────────────────────────────────────────────────── */
+
+/**
+ * Soft-deprecate all QA fixture products instead of hard-deleting them.
+ *
+ * Soft-deprecation (is_deprecated = true) is reversible and matches the
+ * project's "deprecate, never DELETE" data policy. v_master and the public
+ * API filter out is_deprecated rows, so deprecated fixtures stop appearing in
+ * any user-facing surface while remaining auditable in the table.
+ *
+ * Invoke with: node tests/quality/seed-fixtures.mjs --teardown
+ *           or: QA_FIXTURE_TEARDOWN=1 node tests/quality/seed-fixtures.mjs
+ */
+async function teardown() {
+  console.error(
+    `🧹 Soft-deprecating QA fixture products (brand="${QA_FIXTURE_BRAND}")...\n`
+  );
+
+  const { data, error } = await supabase
+    .from("products")
+    .update({
+      is_deprecated: true,
+      deprecated_reason: "qa-fixture teardown",
+    })
+    .eq("brand", QA_FIXTURE_BRAND)
+    .eq("is_deprecated", false)
+    .select("product_id");
+
+  if (error) {
+    throw new Error(`Teardown failed: ${error.message}`);
+  }
+
+  const count = data?.length ?? 0;
+  console.error(
+    `  ✅ Soft-deprecated ${count} QA fixture product(s) (reversible)\n`
+  );
+}
+
+/* ── Entry point ─────────────────────────────────────────────────────────── */
+
+const isTeardown =
+  process.argv.includes("--teardown") ||
+  process.env.QA_FIXTURE_TEARDOWN === "1";
+
+const run = isTeardown ? teardown : main;
+
+run().catch((err) => {
+  const action = isTeardown ? "teardown" : "seeding";
+  console.error(`\n❌ QA fixture ${action} failed: ${err.message}`);
   process.exit(1);
 });

--- a/frontend/tests/quality/seed-fixtures.mjs
+++ b/frontend/tests/quality/seed-fixtures.mjs
@@ -22,6 +22,7 @@
  */
 
 import { createClient } from "@supabase/supabase-js";
+import ws from "ws";
 
 /* ── Environment ─────────────────────────────────────────────────────────── */
 
@@ -81,8 +82,16 @@ if (SUPABASE_URL.includes(PRODUCTION_PROJECT_REF)) {
   process.exit(1);
 }
 
+// The seeder only performs REST queries (upsert/select) — it never opens a
+// realtime channel. However, @supabase/supabase-js still constructs a
+// RealtimeClient eagerly, and on Node 20 (no native global WebSocket) that
+// throws "Node.js 20 detected without native WebSocket support". Passing the
+// `ws` package as the realtime transport satisfies the constructor without
+// changing any query behaviour. Node 22+ has a global WebSocket and ignores
+// this, so the fix is forward-compatible.
 const supabase = createClient(SUPABASE_URL, SERVICE_KEY, {
   auth: { autoRefreshToken: false, persistSession: false },
+  realtime: { transport: ws },
 });
 
 /* ── Helpers ──────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Prevents QA fixture products from being seeded into production/demo again.

Changes:
- Adds a hard production-project guard to seed-fixtures.mjs.
- Makes missing fixture env fail in CI but skip safely locally.
- Removes production fallback from QA fixture seed workflows.
- Adds teardown mode using soft-deprecation, not hard delete.
- Runs teardown with if: always() in quality-gate and nightly workflows.
- Adds QA data-quality check 40 for zero active QA Test Brand rows.
- Updates QA count truthfully from 776 to 777.

Verification:
- node --check frontend/tests/quality/seed-fixtures.mjs passed.
- scripts/check_doc_counts.py --strict passed with 25/25 correct and 0 mismatches.
- Workflow YAML parsed successfully.
- Production QA fixture violation check returned 0.

Scope:
- No production data changes in this PR.
- No RPC/v_master changes.
- No frontend UI changes.
- No package or lockfile changes.

Remaining manual follow-up:
- Staging project rxtaicdpnaqigowdbmsb should be checked/cleaned once credentials are available.
