### PR TITLE
fix(frontend): show Dashboard CTA on landing for logged-in users

### DIFF
--- a/frontend/src/app/LandingSections.test.tsx
+++ b/frontend/src/app/LandingSections.test.tsx
@@ -1,8 +1,23 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LandingSections } from "./LandingSections";
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockGetUser = vi.fn();
+const mockUnsubscribe = vi.fn();
+const mockOnAuthStateChange = vi.fn(() => ({
+  data: { subscription: { unsubscribe: mockUnsubscribe } },
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      getUser: () => mockGetUser(),
+      onAuthStateChange: mockOnAuthStateChange,
+    },
+  }),
+}));
 
 vi.mock("@/components/common/Button", () => ({
   ButtonLink: ({
@@ -38,6 +53,11 @@ vi.mock("lucide-react", () => ({
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe("LandingSections", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+  });
+
   it("renders the hero tagline", () => {
     render(<LandingSections />);
     expect(screen.getByText("landing.tagline")).toBeInTheDocument();
@@ -62,6 +82,22 @@ describe("LandingSections", () => {
     expect(
       signInLinks.some((link) => link.closest("a")?.getAttribute("href") === "/auth/login"),
     ).toBe(true);
+  });
+
+  it("shows Dashboard CTAs linking to /app when authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    render(<LandingSections />);
+
+    // Both CTA clusters (hero + repeat) switch to the Dashboard link.
+    const dashboardLinks = await screen.findAllByText("auth.dashboard");
+    expect(dashboardLinks.length).toBeGreaterThanOrEqual(2);
+    dashboardLinks.forEach((link) => {
+      expect(link.closest("a")).toHaveAttribute("href", "/app");
+    });
+
+    // Public CTAs are hidden for authenticated users.
+    expect(screen.queryByText("landing.getStarted")).not.toBeInTheDocument();
+    expect(screen.queryByText("landing.signIn")).not.toBeInTheDocument();
   });
 
   it("renders features heading and 3 feature cards", () => {

--- a/frontend/src/app/LandingSections.tsx
+++ b/frontend/src/app/LandingSections.tsx
@@ -7,21 +7,69 @@
 import { ButtonLink } from "@/components/common/Button";
 import { Logo } from "@/components/common/Logo";
 import { useTranslation } from "@/lib/i18n";
+import { createClient } from "@/lib/supabase/client";
 import {
-    BarChart3,
-    Camera,
-    ChevronRight,
-    Database,
-    Layers,
-    Search,
-    Shield,
-    ShoppingBasket,
-    type LucideIcon,
+  BarChart3,
+  Camera,
+  ChevronRight,
+  Database,
+  Layers,
+  Search,
+  Shield,
+  ShoppingBasket,
+  type LucideIcon,
 } from "lucide-react";
+import { useEffect, useState } from "react";
+
+// ─── Auth state ─────────────────────────────────────────────────────────────
+// Mirrors the client-side auth pattern in Header.tsx so the landing CTAs can
+// show a Dashboard link to logged-in users while keeping `/` a static page.
+
+function useIsAuthenticated(): boolean {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    try {
+      const client = createClient();
+
+      client.auth.getUser().then(({ data }) => {
+        if (active) {
+          setIsAuthenticated(!!data.user);
+        }
+      });
+
+      const onAuthStateChange = client.auth.onAuthStateChange;
+      if (typeof onAuthStateChange !== "function") {
+        return () => {
+          active = false;
+        };
+      }
+
+      const authListenerResult = onAuthStateChange((_event, session) => {
+        if (active) {
+          setIsAuthenticated(!!session?.user);
+        }
+      });
+
+      return () => {
+        active = false;
+        authListenerResult.data.subscription.unsubscribe();
+      };
+    } catch {
+      return () => {
+        active = false;
+      };
+    }
+  }, []);
+
+  return isAuthenticated;
+}
 
 // ─── Hero ───────────────────────────────────────────────────────────────────
 
-function HeroSection() {
+function HeroSection({ isAuthenticated }: { isAuthenticated: boolean }) {
   const { t } = useTranslation();
   return (
     <section className="relative isolate overflow-hidden bg-linear-to-b from-brand/12 via-surface to-surface pb-16 pt-16 sm:pb-24 sm:pt-20">
@@ -59,22 +107,35 @@ function HeroSection() {
               </p>
 
               <div className="flex flex-col gap-3 sm:flex-row">
-                <ButtonLink
-                  href="/auth/signup"
-                  size="lg"
-                  className="w-full px-8 sm:w-auto"
-                  iconRight={<ChevronRight size={18} aria-hidden="true" />}
-                >
-                  {t("landing.getStarted")}
-                </ButtonLink>
-                <ButtonLink
-                  href="/auth/login"
-                  variant="secondary"
-                  size="lg"
-                  className="w-full px-8 sm:w-auto"
-                >
-                  {t("landing.signIn")}
-                </ButtonLink>
+                {isAuthenticated ? (
+                  <ButtonLink
+                    href="/app"
+                    size="lg"
+                    className="w-full px-8 sm:w-auto"
+                    iconRight={<ChevronRight size={18} aria-hidden="true" />}
+                  >
+                    {t("auth.dashboard")}
+                  </ButtonLink>
+                ) : (
+                  <>
+                    <ButtonLink
+                      href="/auth/signup"
+                      size="lg"
+                      className="w-full px-8 sm:w-auto"
+                      iconRight={<ChevronRight size={18} aria-hidden="true" />}
+                    >
+                      {t("landing.getStarted")}
+                    </ButtonLink>
+                    <ButtonLink
+                      href="/auth/login"
+                      variant="secondary"
+                      size="lg"
+                      className="w-full px-8 sm:w-auto"
+                    >
+                      {t("landing.signIn")}
+                    </ButtonLink>
+                  </>
+                )}
               </div>
             </div>
 
@@ -300,7 +361,7 @@ function DataStatsSection() {
 
 // ─── CTA Repeat ─────────────────────────────────────────────────────────────
 
-function CtaRepeatSection() {
+function CtaRepeatSection({ isAuthenticated }: { isAuthenticated: boolean }) {
   const { t } = useTranslation();
   return (
     <section className="relative isolate overflow-hidden bg-linear-to-b from-brand/10 via-surface to-surface py-16 sm:py-20">
@@ -335,22 +396,35 @@ function CtaRepeatSection() {
           </div>
 
           <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
-            <ButtonLink
-              href="/auth/signup"
-              size="lg"
-              className="w-full px-10 sm:w-auto"
-              iconRight={<ChevronRight size={18} aria-hidden="true" />}
-            >
-              {t("landing.getStarted")}
-            </ButtonLink>
-            <ButtonLink
-              href="/auth/login"
-              variant="secondary"
-              size="lg"
-              className="w-full px-10 sm:w-auto"
-            >
-              {t("landing.signIn")}
-            </ButtonLink>
+            {isAuthenticated ? (
+              <ButtonLink
+                href="/app"
+                size="lg"
+                className="w-full px-10 sm:w-auto"
+                iconRight={<ChevronRight size={18} aria-hidden="true" />}
+              >
+                {t("auth.dashboard")}
+              </ButtonLink>
+            ) : (
+              <>
+                <ButtonLink
+                  href="/auth/signup"
+                  size="lg"
+                  className="w-full px-10 sm:w-auto"
+                  iconRight={<ChevronRight size={18} aria-hidden="true" />}
+                >
+                  {t("landing.getStarted")}
+                </ButtonLink>
+                <ButtonLink
+                  href="/auth/login"
+                  variant="secondary"
+                  size="lg"
+                  className="w-full px-10 sm:w-auto"
+                >
+                  {t("landing.signIn")}
+                </ButtonLink>
+              </>
+            )}
           </div>
         </div>
       </div>
@@ -361,13 +435,14 @@ function CtaRepeatSection() {
 // ─── Combined export ────────────────────────────────────────────────────────
 
 export function LandingSections() {
+  const isAuthenticated = useIsAuthenticated();
   return (
     <>
-      <HeroSection />
+      <HeroSection isAuthenticated={isAuthenticated} />
       <FeaturesSection />
       <HowItWorksSection />
       <DataStatsSection />
-      <CtaRepeatSection />
+      <CtaRepeatSection isAuthenticated={isAuthenticated} />
     </>
   );
 }


### PR DESCRIPTION
Makes the landing-page CTAs auth-aware for logged-in users.

Changes:
- Landing hero CTA now shows Dashboard -> /app for authenticated users.
- Bottom landing CTA now shows Dashboard -> /app for authenticated users.
- Logged-out behavior remains unchanged:
  - Get Started -> /auth/signup
  - Sign In -> /auth/login
- Reuses existing auth.dashboard translation.
- Mirrors the existing Header client-side auth pattern.
- Keeps / as a static page; no server auth or redirects added.

Verification:
- npx tsc --noEmit passed.
- ESLint passed on touched files.
- npx vitest run src/app/LandingSections.test.tsx passed 10/10.
- Browser verified:
  - Authenticated / shows Dashboard in Header, hero CTA, and bottom CTA.
  - Dashboard CTAs link to /app.
  - Public Get Started / Sign In CTAs disappear from landing CTA clusters when authenticated.
  - Logged-out state still shows public CTAs.

Known behavior:
- Same brief client-side auth-resolution flash as Header before getUser() resolves.

Scope:
- No Header refactor.
- No shared auth hook.
- No server-side auth change.
- No redirects.
- No DB/schema/RPC/package/lockfile changes.