### PR TITLE
docs(demo): add auth readiness check

### DIFF
--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -38,6 +38,13 @@ Confirm before starting:
     real credentials in this script.
 - Have one known barcode ready as a fallback (see step 3 recovery).
 
+### Auth readiness check (30s)
+
+1. Open `/app/compare` (or `/app/search`) before the audience joins.
+2. If you are redirected to `/auth/login`, sign in with the pre-created demo account.
+3. If you are redirected to onboarding, complete or skip onboarding, then return to the same protected route.
+4. Refresh once and confirm the protected page still loads.
+
 ---
 
 ## 1. Landing & positioning (~30s)


### PR DESCRIPTION
## Summary\n- Adds a 30-second pre-demo auth check\n- Helps avoid surprise redirects to /auth/login during demos\n- Docs-only, no runtime/auth/data changes\n- No credentials or secrets added\n\n## Scope\n- Updates docs/DEMO_SCRIPT.md only\n\n## Notes\n- No code, tests, migrations, package files, or generated docs were modified.