### PR TITLE
fix(compare): clarify demo comparison guidance

### DIFF
--- a/frontend/src/components/compare/ComparisonGrid.test.tsx
+++ b/frontend/src/components/compare/ComparisonGrid.test.tsx
@@ -75,6 +75,7 @@ const productB = makeProduct({
   additives_count: 8,
   allergen_count: 0,
   allergen_tags: null,
+  confidence: "low",
 });
 
 const products = [productA, productB];
@@ -197,6 +198,14 @@ describe("ComparisonGrid", () => {
     expect(n3.length).toBeGreaterThanOrEqual(1);
     const n4 = screen.getAllByText(/N4/);
     expect(n4.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders confidence badges for compared products", () => {
+    render(<ComparisonGrid products={products} />);
+    const verified = screen.getAllByText("Verified");
+    const low = screen.getAllByText("Low");
+    expect(verified.length).toBeGreaterThanOrEqual(1);
+    expect(low.length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders swipe hint on mobile view", () => {

--- a/frontend/src/components/compare/ComparisonGrid.tsx
+++ b/frontend/src/components/compare/ComparisonGrid.tsx
@@ -6,6 +6,7 @@
 // Highlights best/worst values per row with green/red coloring.
 
 import { AvoidBadge } from "@/components/product/AvoidBadge";
+import { ConfidenceBadge } from "@/components/common/ConfidenceBadge";
 import { NUTRI_COLORS, SCORE_BANDS, scoreBandFromScore } from "@/lib/constants";
 import { useTranslation } from "@/lib/i18n";
 import { nutriScoreLabel } from "@/lib/nutri-label";
@@ -221,6 +222,10 @@ function DesktopGrid({
                       {p.brand}
                     </p>
                     <div className="flex items-center justify-center gap-1">
+                      <ConfidenceBadge
+                        level={p.confidence}
+                        percentage={p.data_completeness_pct}
+                      />
                       <span
                         className={`rounded-full px-1.5 py-0.5 text-xs font-bold ${nutriClass}`}
                       >
@@ -583,6 +588,10 @@ function MobileSwipeView({
                 {product.brand}
               </p>
               <div className="mt-1 flex items-center gap-1.5">
+                <ConfidenceBadge
+                  level={product.confidence}
+                  percentage={product.data_completeness_pct}
+                />
                 <span
                   className={`rounded-full px-1.5 py-0.5 text-xs font-bold ${nutriClass}`}
                 >


### PR DESCRIPTION
## Summary
- add confidence badges to compare product headers (desktop and mobile)
- surface data completeness percentage with existing badge component
- add focused compare-grid test assertion for confidence visibility

## Why
During demo rehearsal, compare showed TryVit score/Nutri-Score/NOVA clearly but confidence visibility was weak. This tiny polish improves trust/context without backend changes or redesign.

## Scope
- frontend-only
- no RPC/backend changes
- no migrations
- no package/lockfile changes

## Verification
- npx vitest run src/components/compare/ComparisonGrid.test.tsx
- Frontend Type Check task (npx tsc --noEmit)