### PR TITLE
fix(scan): clarify manual barcode fallback

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -332,6 +332,7 @@
     "cameraUnavailableHint": "Die Kamera konnte nicht gestartet werden. Versuchen Sie es erneut oder geben Sie den Barcode manuell ein.",
     "reloadPage": "Seite neu laden",
     "enterManually": "Barcode manuell eingeben",
+    "manualFallbackReassurance": "Die manuelle Barcode-Eingabe funktioniert sofort, wenn die Kamera nicht verfügbar ist.",
     "retryCamera": "Erneut versuchen",
     "noCameraTitle": "Keine Kamera verfügbar",
     "noCameraHint": "Dieses Gerät hat keine Kamera. Verwenden Sie die manuelle Eingabe, um Produkte nachzuschlagen.",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -332,6 +332,7 @@
     "cameraUnavailableHint": "Could not start the camera. Try again or enter the barcode manually.",
     "reloadPage": "Reload Page",
     "enterManually": "Enter Barcode Manually",
+    "manualFallbackReassurance": "Manual barcode entry works right away if camera access is unavailable.",
     "retryCamera": "Retry Camera",
     "noCameraTitle": "No Camera Available",
     "noCameraHint": "This device does not have a camera. Use manual entry to look up products.",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -332,6 +332,7 @@
     "cameraUnavailableHint": "Nie udało się uruchomić kamery. Spróbuj ponownie lub wpisz kod kreskowy ręcznie.",
     "reloadPage": "Odśwież stronę",
     "enterManually": "Wpisz kod ręcznie",
+    "manualFallbackReassurance": "Ręczne wpisanie kodu kreskowego działa od razu, gdy kamera jest niedostępna.",
     "retryCamera": "Spróbuj ponownie",
     "noCameraTitle": "Brak kamery",
     "noCameraHint": "To urządzenie nie posiada kamery. Użyj trybu ręcznego, aby wyszukać produkty.",

--- a/frontend/src/components/scan/ScannerErrorState.test.tsx
+++ b/frontend/src/components/scan/ScannerErrorState.test.tsx
@@ -145,6 +145,19 @@ describe("ScannerErrorState", () => {
     expect(screen.getByText("scan.cameraBlockedHint")).toBeInTheDocument();
   });
 
+  it("shows manual fallback reassurance for permission-denied", () => {
+    render(
+      <ScannerErrorState
+        error="permission-denied"
+        onRetry={onRetry}
+        onManualEntry={onManualEntry}
+      />,
+    );
+    expect(
+      screen.getByText("scan.manualFallbackReassurance"),
+    ).toBeInTheDocument();
+  });
+
   it("shows cameraPermissionHint for permission-prompt", () => {
     render(
       <ScannerErrorState
@@ -169,6 +182,19 @@ describe("ScannerErrorState", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows manual fallback reassurance for permission-unknown", () => {
+    render(
+      <ScannerErrorState
+        error="permission-unknown"
+        onRetry={onRetry}
+        onManualEntry={onManualEntry}
+      />,
+    );
+    expect(
+      screen.getByText("scan.manualFallbackReassurance"),
+    ).toBeInTheDocument();
+  });
+
   it("shows cameraUnavailableHint for generic", () => {
     render(
       <ScannerErrorState
@@ -178,6 +204,17 @@ describe("ScannerErrorState", () => {
       />,
     );
     expect(screen.getByText("scan.cameraUnavailableHint")).toBeInTheDocument();
+  });
+
+  it("does NOT show manual fallback reassurance for generic", () => {
+    render(
+      <ScannerErrorState
+        error="generic"
+        onRetry={onRetry}
+        onManualEntry={onManualEntry}
+      />,
+    );
+    expect(screen.queryByText("scan.manualFallbackReassurance")).toBeNull();
   });
 
   // ─── CTA Button visibility ─────────────────────────────────────────────

--- a/frontend/src/components/scan/ScannerErrorState.tsx
+++ b/frontend/src/components/scan/ScannerErrorState.tsx
@@ -89,6 +89,11 @@ export function ScannerErrorState({
           {t("scan.enterManually")}
         </Button>
       </div>
+      {(error === "permission-denied" || error === "permission-unknown") && (
+        <p className="mt-2 text-xs text-warning-text/80">
+          {t("scan.manualFallbackReassurance")}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a short reassurance line in scanner error state when camera access is blocked/unknown: manual barcode lookup works immediately.
- Keeps existing scanner flow intact (reload + manual CTA remain unchanged).
- Adds focused component tests for reassurance visibility in blocked/unknown states and absence in generic error state.

## Why
Demo rehearsal showed camera-blocked state is acceptable but can feel uncertain. This change makes manual fallback confidence explicit with minimal UI copy.

## Scope
- Frontend scanner fallback copy only.
- Localized copy update in en/pl/de.
- Focused unit tests in ScannerErrorState.

## Non-goals
- No scanner algorithm or camera handling refactor.
- No backend/RPC changes.
- No migrations.
- No new dependencies.
- No layout redesign.

## Verification
- 
px vitest run src/components/scan/ScannerErrorState.test.tsx (26/26 passed)
- 
px tsc --noEmit (passed)
- Browser spot-check: /app/scan loads and scanner/manual entry UI remains functional in authenticated session; camera-blocked state and manual fallback path were validated in component tests.
