### PR TITLE
docs: reconcile stale project references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- Reconcile stale documentation references across project docs: update outdated QA/check-count references to current documented values, switch API registry references in `API_CONVENTIONS.md` and `FRONTEND_API_MAP.md` to count-neutral wording, clarify pipeline folder terminology in `copilot-instructions.md`, and mark the stale Next.js upgrade note in `SECURITY.md` as resolved (#1147)
+
 ### Fixed
 
 - Resolve 6 React Compiler violations (Phase 1 of 2): `static-components`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ Last audited: 2026-02-14 (vulnerability table below may be stale — re-run `cd 
 - Requires "insecure React Server Components" usage patterns.
 - Our RSC usage is standard (data fetching via Supabase client).
 - Vercel's infrastructure provides additional request-level protections.
-- **Low practical risk.** Will be resolved on Next.js 15/16 upgrade.
+- **Low practical risk.** Resolved — project is now on Next.js 16.
 
 **GHSA-5j98-mcp5-4vw2 — glob CLI injection:**
 - The `glob` CLI (`--cmd` flag) allows command injection.

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -629,7 +629,7 @@ All categories have **variable product counts** (28–95 active products). Categ
 | Desserts & Ice Cream | `desserts-ice-cream` |
 | Spices & Seasonings  | `spices-seasonings`  |
 
-**43 pipeline folders** (22 PL + 21 DE). Category-to-OFF tag mappings live in `pipeline/categories.py`. Each category has multiple OFF tags and search terms for comprehensive coverage. 7 new categories defined in `category_ref` but not yet added to the pipeline (see Issue #859).
+**58 pipeline folders** (22 PL active + 21 DE active + 7 new PL + 7 new DE + 1 legacy `chips` folder superseded by `chips-pl`). Category-to-OFF tag mappings live in `pipeline/categories.py`. Each category has multiple OFF tags and search terms for comprehensive coverage. The 7 new categories (pasta-rice, soups, coffee-tea, frozen-vegetables, ready-meals, desserts-ice-cream, spices-seasonings) have folders but are not yet populated with product data (see Issue #859).
 
 ---
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -629,7 +629,7 @@ All categories have **variable product counts** (28–95 active products). Categ
 | Desserts & Ice Cream | `desserts-ice-cream` |
 | Spices & Seasonings  | `spices-seasonings`  |
 
-**58 pipeline folders** (22 PL active + 21 DE active + 7 new PL + 7 new DE + 1 legacy `chips` folder superseded by `chips-pl`). Category-to-OFF tag mappings live in `pipeline/categories.py`. Each category has multiple OFF tags and search terms for comprehensive coverage. The 7 new categories (pasta-rice, soups, coffee-tea, frozen-vegetables, ready-meals, desserts-ice-cream, spices-seasonings) have folders but are not yet populated with product data (see Issue #859).
+**58 pipeline folders** (22 PL active + 21 DE active + 7 new PL + 7 new DE + 1 legacy `chips` folder superseded by `chips-pl`). Category-to-OFF tag mappings live in `pipeline/categories.py`. Each category has multiple OFF tags and search terms for comprehensive coverage. The 7 new categories (pasta-rice, soups, coffee-tea, frozen-vegetables, ready-meals, desserts-ice-cream, spices-seasonings) already have pipeline folders and generated SQL assets on disk; verify database population separately from the pipeline inventory.
 
 ---
 

--- a/docs/API_CONVENTIONS.md
+++ b/docs/API_CONVENTIONS.md
@@ -16,52 +16,52 @@ All public schema functions follow a strict naming pattern:
 
 ### 1.1 Visibility Prefixes
 
-| Prefix        | Meaning                                    | Auth Requirement     | Example                          |
-| ------------- | ------------------------------------------ | -------------------- | -------------------------------- |
-| `api_`        | Public-facing, called by frontend          | `authenticated`      | `api_search_products`            |
-| `api_admin_`  | Admin-only, called by admin panel          | `authenticated` + admin check | `api_admin_get_submissions` |
-| `admin_`      | Admin/ops tooling (not exposed via PostgREST) | Direct DB access  | `admin_rescore_batch`            |
-| `metric_`     | Analytics/metrics aggregation              | Direct DB access     | `metric_dau`                     |
-| `trg_`        | Trigger functions (not callable directly)  | N/A (trigger-fired)  | `trg_set_updated_at`             |
-| _(none/internal)_ | Internal helpers, not exposed as RPC   | N/A                  | `compute_unhealthiness_v32`      |
+| Prefix            | Meaning                                       | Auth Requirement              | Example                     |
+| ----------------- | --------------------------------------------- | ----------------------------- | --------------------------- |
+| `api_`            | Public-facing, called by frontend             | `authenticated`               | `api_search_products`       |
+| `api_admin_`      | Admin-only, called by admin panel             | `authenticated` + admin check | `api_admin_get_submissions` |
+| `admin_`          | Admin/ops tooling (not exposed via PostgREST) | Direct DB access              | `admin_rescore_batch`       |
+| `metric_`         | Analytics/metrics aggregation                 | Direct DB access              | `metric_dau`                |
+| `trg_`            | Trigger functions (not callable directly)     | N/A (trigger-fired)           | `trg_set_updated_at`        |
+| _(none/internal)_ | Internal helpers, not exposed as RPC          | N/A                           | `compute_unhealthiness_v32` |
 
 ### 1.2 Domain Names
 
-| Domain         | Scope                                               | Examples                                                |
-| -------------- | --------------------------------------------------- | ------------------------------------------------------- |
-| `products`     | Product identity, detail, listing, alternatives      | `api_product_detail`, `api_better_alternatives`         |
-| `category`     | Category listing, overview, statistics               | `api_category_listing`, `api_category_overview`         |
-| `scoring`      | Score computation, explanation, history               | `api_score_explanation`, `api_score_history`             |
-| `search`       | Full-text search, autocomplete, filters               | `api_search_products`, `api_search_autocomplete`        |
-| `health`       | Health profiles, warnings, daily values               | `api_create_health_profile`, `api_product_health_warnings` |
-| `lists`        | User product lists (CRUD, sharing)                    | `api_create_list`, `api_get_lists`, `api_add_to_list`   |
-| `compare`      | Product comparisons                                   | `api_get_products_for_compare`, `api_save_comparison`   |
-| `scanner`      | Barcode scanning, scan history                        | `api_record_scan`, `api_get_scan_history`               |
-| `preferences`  | User preferences, onboarding                          | `api_get_user_preferences`, `api_complete_onboarding`   |
-| `submissions`  | User product submissions                              | `api_submit_product`, `api_get_my_submissions`          |
-| `telemetry`    | Event tracking, analytics                             | `api_track_event`, `api_admin_get_event_summary`        |
-| `dashboard`    | Dashboard data, recently viewed                       | `api_get_dashboard_data`, `api_get_recently_viewed`     |
-| `confidence`   | Data confidence scoring                               | `api_data_confidence`                                   |
-| `provenance`   | Data source tracking, cross-validation                | `admin_provenance_dashboard`                            |
-| `infrastructure` | MV refresh, staleness, search vectors               | `refresh_all_materialized_views`, `mv_staleness_check`  |
-| `flags`        | Feature flags, rollout                                | `admin_toggle_flag`, `expire_stale_flags`               |
+| Domain           | Scope                                           | Examples                                                   |
+| ---------------- | ----------------------------------------------- | ---------------------------------------------------------- |
+| `products`       | Product identity, detail, listing, alternatives | `api_product_detail`, `api_better_alternatives`            |
+| `category`       | Category listing, overview, statistics          | `api_category_listing`, `api_category_overview`            |
+| `scoring`        | Score computation, explanation, history         | `api_score_explanation`, `api_score_history`               |
+| `search`         | Full-text search, autocomplete, filters         | `api_search_products`, `api_search_autocomplete`           |
+| `health`         | Health profiles, warnings, daily values         | `api_create_health_profile`, `api_product_health_warnings` |
+| `lists`          | User product lists (CRUD, sharing)              | `api_create_list`, `api_get_lists`, `api_add_to_list`      |
+| `compare`        | Product comparisons                             | `api_get_products_for_compare`, `api_save_comparison`      |
+| `scanner`        | Barcode scanning, scan history                  | `api_record_scan`, `api_get_scan_history`                  |
+| `preferences`    | User preferences, onboarding                    | `api_get_user_preferences`, `api_complete_onboarding`      |
+| `submissions`    | User product submissions                        | `api_submit_product`, `api_get_my_submissions`             |
+| `telemetry`      | Event tracking, analytics                       | `api_track_event`, `api_admin_get_event_summary`           |
+| `dashboard`      | Dashboard data, recently viewed                 | `api_get_dashboard_data`, `api_get_recently_viewed`        |
+| `confidence`     | Data confidence scoring                         | `api_data_confidence`                                      |
+| `provenance`     | Data source tracking, cross-validation          | `admin_provenance_dashboard`                               |
+| `infrastructure` | MV refresh, staleness, search vectors           | `refresh_all_materialized_views`, `mv_staleness_check`     |
+| `flags`          | Feature flags, rollout                          | `admin_toggle_flag`, `expire_stale_flags`                  |
 
 ### 1.3 Action Naming
 
 Actions use descriptive verb-noun or verb patterns:
 
-| Pattern          | Usage                       | Examples                                        |
-| ---------------- | --------------------------- | ----------------------------------------------- |
-| `get_*`          | Retrieve single/list        | `api_get_lists`, `api_get_scan_history`          |
-| `create_*`       | Insert new record           | `api_create_list`, `api_create_health_profile`   |
-| `update_*`       | Modify existing record      | `api_update_list`, `api_update_health_profile`   |
-| `delete_*`       | Remove record               | `api_delete_list`, `api_delete_comparison`        |
-| `search_*`       | Full-text/fuzzy search      | `api_search_products`, `api_search_autocomplete` |
-| `record_*`       | Log an event/action         | `api_record_scan`, `api_record_product_view`     |
-| `toggle_*`       | Flip boolean state          | `api_toggle_share`, `admin_toggle_flag`          |
-| `compute_*`      | Calculate derived value     | `compute_unhealthiness_v32`, `compute_score`     |
-| `find_*`         | Discovery/similarity        | `find_better_alternatives`, `find_similar_products` |
-| `resolve_*`      | Multi-tier resolution       | `resolve_effective_country`, `resolve_language`   |
+| Pattern     | Usage                   | Examples                                            |
+| ----------- | ----------------------- | --------------------------------------------------- |
+| `get_*`     | Retrieve single/list    | `api_get_lists`, `api_get_scan_history`             |
+| `create_*`  | Insert new record       | `api_create_list`, `api_create_health_profile`      |
+| `update_*`  | Modify existing record  | `api_update_list`, `api_update_health_profile`      |
+| `delete_*`  | Remove record           | `api_delete_list`, `api_delete_comparison`          |
+| `search_*`  | Full-text/fuzzy search  | `api_search_products`, `api_search_autocomplete`    |
+| `record_*`  | Log an event/action     | `api_record_scan`, `api_record_product_view`        |
+| `toggle_*`  | Flip boolean state      | `api_toggle_share`, `admin_toggle_flag`             |
+| `compute_*` | Calculate derived value | `compute_unhealthiness_v32`, `compute_score`        |
+| `find_*`    | Discovery/similarity    | `find_better_alternatives`, `find_similar_products` |
+| `resolve_*` | Multi-tier resolution   | `resolve_effective_country`, `resolve_language`     |
 
 ### 1.4 Version Suffix
 
@@ -84,31 +84,31 @@ Do **not** use version suffixes for new endpoints or non-breaking changes.
 
 ### 2.1 Standard Prefixes
 
-| Prefix | Usage                    | Example                        |
-| ------ | ------------------------ | ------------------------------ |
-| `p_`   | Function parameters      | `p_product_id`, `p_query`      |
-| `v_`   | Local variables (plpgsql)| `v_total`, `v_rows`            |
+| Prefix | Usage                     | Example                   |
+| ------ | ------------------------- | ------------------------- |
+| `p_`   | Function parameters       | `p_product_id`, `p_query` |
+| `v_`   | Local variables (plpgsql) | `v_total`, `v_rows`       |
 
 ### 2.2 Common Parameters
 
 These parameters appear across multiple functions and must use consistent names:
 
-| Parameter              | Type      | Default | Description                    |
-| ---------------------- | --------- | ------- | ------------------------------ |
-| `p_product_id`         | `bigint`  | —       | Product identifier             |
-| `p_ean`                | `text`    | —       | EAN-13 barcode                 |
-| `p_category`           | `text`    | `NULL`  | Category filter                |
-| `p_country`            | `text`    | `NULL`  | Country code (auto-resolved)   |
-| `p_limit`              | `integer` | `20`    | Result page size               |
-| `p_offset`             | `integer` | `0`     | Result page offset             |
-| `p_query`              | `text`    | —       | Search query text              |
-| `p_sort_by`            | `text`    | `'score'` | Sort column key              |
-| `p_sort_dir`           | `text`    | `'asc'` | Sort direction (asc/desc)      |
-| `p_diet_preference`    | `text`    | `NULL`  | Diet filter                    |
-| `p_avoid_allergens`    | `text[]`  | `NULL`  | Allergen exclusion list        |
-| `p_strict_diet`        | `boolean` | `false` | Strict diet matching           |
-| `p_strict_allergen`    | `boolean` | `false` | Strict allergen matching       |
-| `p_treat_may_contain`  | `boolean` | `false` | Treat traces as contains       |
+| Parameter             | Type      | Default   | Description                  |
+| --------------------- | --------- | --------- | ---------------------------- |
+| `p_product_id`        | `bigint`  | —         | Product identifier           |
+| `p_ean`               | `text`    | —         | EAN-13 barcode               |
+| `p_category`          | `text`    | `NULL`    | Category filter              |
+| `p_country`           | `text`    | `NULL`    | Country code (auto-resolved) |
+| `p_limit`             | `integer` | `20`      | Result page size             |
+| `p_offset`            | `integer` | `0`       | Result page offset           |
+| `p_query`             | `text`    | —         | Search query text            |
+| `p_sort_by`           | `text`    | `'score'` | Sort column key              |
+| `p_sort_dir`          | `text`    | `'asc'`   | Sort direction (asc/desc)    |
+| `p_diet_preference`   | `text`    | `NULL`    | Diet filter                  |
+| `p_avoid_allergens`   | `text[]`  | `NULL`    | Allergen exclusion list      |
+| `p_strict_diet`       | `boolean` | `false`   | Strict diet matching         |
+| `p_strict_allergen`   | `boolean` | `false`   | Strict allergen matching     |
+| `p_treat_may_contain` | `boolean` | `false`   | Treat traces as contains     |
 
 ### 2.3 Pagination Clamping
 
@@ -155,12 +155,12 @@ When `auth.uid()` is `NULL`.
 
 All score-related responses use consistent band labels:
 
-| Band         | Score Range | Key Value     |
-| ------------ | ----------- | ------------- |
-| Low risk     | 1–25        | `"low"`       |
-| Moderate     | 26–50       | `"moderate"`  |
-| High         | 51–75       | `"high"`      |
-| Very high    | 76–100      | `"very_high"` |
+| Band      | Score Range | Key Value     |
+| --------- | ----------- | ------------- |
+| Low risk  | 1–25        | `"low"`       |
+| Moderate  | 26–50       | `"moderate"`  |
+| High      | 51–75       | `"high"`      |
+| Very high | 76–100      | `"very_high"` |
 
 ### 3.4 Boolean Conversion
 
@@ -268,19 +268,19 @@ and 7 `trg_*` functions follow the naming convention correctly.
 These internal functions predate the convention but are **not exposed as RPCs**,
 so renaming is unnecessary:
 
-| Function                        | Domain         | Notes                              |
-| ------------------------------- | -------------- | ---------------------------------- |
-| `compute_unhealthiness_v32`     | scoring        | Active scoring function            |
-| `assign_confidence`             | confidence     | Called by `score_category()`       |
-| `find_better_alternatives`      | products       | Called by `api_better_alternatives` |
-| `find_similar_products`         | products       | Similarity engine                  |
-| `build_search_vector`           | search         | Trigger helper                     |
-| `expand_search_query`           | search         | Query expansion                    |
-| `search_rank`                   | search         | Ranking function                   |
-| `resolve_effective_country`     | preferences    | Country resolution                 |
-| `resolve_language`              | preferences    | Language resolution                |
-| `score_category` (PROCEDURE)    | scoring        | Batch scoring orchestrator         |
-| `compute_score`                 | scoring        | Config-driven scoring              |
+| Function                     | Domain      | Notes                               |
+| ---------------------------- | ----------- | ----------------------------------- |
+| `compute_unhealthiness_v32`  | scoring     | Active scoring function             |
+| `assign_confidence`          | confidence  | Called by `score_category()`        |
+| `find_better_alternatives`   | products    | Called by `api_better_alternatives` |
+| `find_similar_products`      | products    | Similarity engine                   |
+| `build_search_vector`        | search      | Trigger helper                      |
+| `expand_search_query`        | search      | Query expansion                     |
+| `search_rank`                | search      | Ranking function                    |
+| `resolve_effective_country`  | preferences | Country resolution                  |
+| `resolve_language`           | preferences | Language resolution                 |
+| `score_category` (PROCEDURE) | scoring     | Batch scoring orchestrator          |
+| `compute_score`              | scoring     | Config-driven scoring               |
 
 These are all internal helpers that follow implicit domain conventions.
 No renaming action needed — the `api_*` / `admin_*` / `metric_*` / `trg_*`
@@ -290,18 +290,18 @@ prefix system provides sufficient clarity for the RPC surface.
 
 ## 8. Function Count Summary
 
-| Visibility     | Count | Description                              |
-| -------------- | ----: | ---------------------------------------- |
-| `api_*`        |    57 | Public frontend-facing (incl. `api_admin_*`) |
-| `api_admin_*`  |     7 | Admin panel (subset of `api_*`)          |
-| `admin_*`      |     7 | Ops tooling (not RPC-exposed)            |
-| `metric_*`     |    10 | Analytics aggregation                    |
-| `trg_*`        |     7 | Trigger functions                        |
-| _(internal)_   |    26 | Internal helpers, compute, resolve       |
-| **Total**      | **107** |                                        |
+| Visibility    |   Count | Description                                  |
+| ------------- | ------: | -------------------------------------------- |
+| `api_*`       |      57 | Public frontend-facing (incl. `api_admin_*`) |
+| `api_admin_*` |       7 | Admin panel (subset of `api_*`)              |
+| `admin_*`     |       7 | Ops tooling (not RPC-exposed)                |
+| `metric_*`    |      10 | Analytics aggregation                        |
+| `trg_*`       |       7 | Trigger functions                            |
+| _(internal)_  |      26 | Internal helpers, compute, resolve           |
+| **Total**     | **107** |                                              |
 
 ---
 
 > **Canonical registry:** See [api-registry.yaml](api-registry.yaml) for the structured,
-> machine-readable registry of all 107 functions with parameters, return types,
+> machine-readable registry that currently lists public-schema functions with parameters, return types,
 > auth requirements, domain classification, and performance targets.

--- a/docs/CI_ARCHITECTURE_PROPOSAL.md
+++ b/docs/CI_ARCHITECTURE_PROPOSAL.md
@@ -72,7 +72,7 @@
 | Run all category pipelines    | Loop over `db/pipelines/*/PIPELINE__*.sql` | 60-120s      |
 | Schema drift detection        | SQL query                                  | 5s           |
 | Post-pipeline fixup           | `db/ci_post_pipeline.sql`                  | 5s           |
-| QA (421 checks)               | `RUN_QA.ps1`                               | 30-60s       |
+| QA (777 checks)               | `RUN_QA.ps1`                               | 30-60s       |
 | Sanity (17 checks)            | `RUN_SANITY.ps1`                           | 10-20s       |
 | Confidence coverage threshold | SQL check                                  | 5s           |
 | QA summary + fail gate        |                                            | 5s           |
@@ -127,7 +127,7 @@ PW run          ✓ (dead)     ✓ (real) + ✓ (preview)
 Event: pull_request
 ├── build.yml        ← lint + type-check + build + unit tests + PW (dead) + Sonar
 ├── ci.yml           ← lint + type-check + build → PW (real) + PW (preview)
-└── qa.yml           ← full DB pipeline + 421 QA checks (even for frontend-only PRs!)
+└── qa.yml           ← full DB pipeline + 777 QA checks (even for frontend-only PRs!)
 
 Event: push to main
 ├── build.yml        ← everything again
@@ -224,7 +224,7 @@ flowchart TD
         direction TB
         D1[Postgres Service] --> D2[Schema Migrations]
         D2 --> D3[Pipeline Execution]
-        D3 --> D4[421 QA Checks]
+        D3 --> D4[777 QA Checks]
         D4 --> D5[17 Sanity Checks]
         D5 --> D6[Confidence Threshold]
     end
@@ -839,7 +839,7 @@ These checks MUST pass before merge is allowed:
 
 1. `PR Gate / Lint → Type-check → Build → Test` — core frontend gate
 2. `PR Gate / Playwright Smoke` — basic E2E sanity
-3. `QA / Pipeline + QA (421 checks) + Sanity (17 checks)` — only when `db/**` or `supabase/**` paths are touched (use path-based required check or use `paths-ignore` + `if` guard)
+3. `QA / Pipeline + QA (777 checks) + Sanity (17 checks)` — only when `db/**` or `supabase/**` paths are touched (use path-based required check or use `paths-ignore` + `if` guard)
 
 ### 5.3 Non-Negotiable Standards
 

--- a/docs/ENVIRONMENT_STRATEGY.md
+++ b/docs/ENVIRONMENT_STRATEGY.md
@@ -313,7 +313,7 @@ SUPABASE_STAGING_DB_PASSWORD=
 
 | Workflow            | Backend                           | Purpose                                | Cloud mutation risk                    |
 | ------------------- | --------------------------------- | -------------------------------------- | -------------------------------------- |
-| `qa.yml`            | Ephemeral PostgreSQL 17 container | Schema + pipeline + 421 QA + 17 sanity | **None** — container only              |
+| `qa.yml`            | Ephemeral PostgreSQL 17 container | Schema + pipeline + 777 QA + 17 sanity | **None** — container only              |
 | `ci.yml`            | Production keys (anon-level only) | Lint, build, Playwright E2E            | **Read-only** — anon key cannot mutate |
 | `build.yml`         | N/A (build only) + SonarCloud     | Build, unit tests, coverage            | **None**                               |
 | `sync-cloud-db.yml` | Staging then Production           | Auto-apply migrations on merge to main | **Schema only** — `supabase db push`   |
@@ -342,7 +342,7 @@ SUPABASE_STAGING_DB_PASSWORD=
 
 ```
 1. ☐ Develop migration locally (supabase db reset to test)
-2. ☐ Run RUN_QA.ps1 locally — all 421+ checks pass
+2. ☐ Run RUN_QA.ps1 locally — all 777+ checks pass
 3. ☐ Push to branch → CI green (qa.yml + ci.yml + build.yml)
 4. ☐ Merge to main → sync-cloud-db.yml applies to staging (if enabled), then production
 5. ☐ Run RUN_SANITY.ps1 -Env staging — all checks pass
@@ -353,7 +353,7 @@ SUPABASE_STAGING_DB_PASSWORD=
 
 ```
 1. ☐ Develop migration locally (supabase db reset to test)
-2. ☐ Run RUN_QA.ps1 locally — all 421+ checks pass
+2. ☐ Run RUN_QA.ps1 locally — all 777+ checks pass
 3. ☐ Push to branch → CI green (qa.yml + ci.yml + build.yml)
 4. ☐ Merge to main
 5. ☐ Apply to staging: supabase link --project-ref <staging-ref> && supabase db push

--- a/docs/FRONTEND_API_MAP.md
+++ b/docs/FRONTEND_API_MAP.md
@@ -8,7 +8,7 @@
 > Anonymous (unauthenticated) access is blocked for all endpoints except shared views.
 >
 > **Canonical registry:** See [api-registry.yaml](api-registry.yaml) for the structured,
-> machine-readable registry of all 107 functions with parameters, return types,
+> machine-readable registry that currently lists public-schema functions with parameters, return types,
 > auth requirements, domain classification, and P95 targets.
 >
 > **Naming conventions:** See [API_CONVENTIONS.md](API_CONVENTIONS.md) for the RPC naming

--- a/docs/INCIDENT_RESPONSE.md
+++ b/docs/INCIDENT_RESPONSE.md
@@ -380,7 +380,7 @@ When opening an incident issue, apply these labels:
 | **Supabase Dashboard**| Database health monitoring — triggers SEV-1 for connection failures      |
 | **GitHub Actions**    | CI/CD health — triggers SEV-3 for pipeline failures                     |
 | **Vercel**            | Frontend deployment status — triggers SEV-2 for build/deploy failures   |
-| **`.\RUN_QA.ps1`**    | Data integrity verification — 429 checks across 30 suites              |
+| **`.\RUN_QA.ps1`**    | Data integrity verification — 777 checks across 49 suites              |
 | **`.\RUN_SANITY.ps1`**| Quick health check — 17 row-count and schema assertions                 |
 
 ---

--- a/docs/RESEARCH_WORKFLOW.md
+++ b/docs/RESEARCH_WORKFLOW.md
@@ -483,7 +483,7 @@ Scoring version: v3.2
 3. **Generate SQL** — remove `--dry-run` to create the 4-step pipeline in `db/pipelines/<category>/`
 4. **Run pipeline** — `.\RUN_LOCAL.ps1 -Category <folder>`
 5. **Enrich** — `python enrich_ingredients.py` (ingredients + allergens)
-6. **Validate** — `.\RUN_QA.ps1` (421 checks across 30 suites must pass)
+6. **Validate** — `.\RUN_QA.ps1` (777 checks across 49 suites must pass)
 
 ### Generated Pipeline Files
 

--- a/docs/UX_UI_DESIGN.md
+++ b/docs/UX_UI_DESIGN.md
@@ -2,7 +2,7 @@
 
 > **Status:** Production-ready specification — architecture, data contracts, and UX rules locked.
 > **Last updated:** 2026-02-13 (docs sync: scanner/preferences/country/diet-allergen features now implemented)
-> **Implementation stage:** Spec-complete. No front-end code yet. All API endpoints exist and pass QA (421/421 checks + 29/29 negative tests). This document is the single source of truth for any future front-end implementation.
+> **Implementation stage:** Spec-complete. No front-end code yet. All API endpoints exist and pass QA (777/777 checks + 20/20 negative tests). This document is the single source of truth for any future front-end implementation.
 
 ---
 

--- a/docs/UX_UI_DESIGN.md
+++ b/docs/UX_UI_DESIGN.md
@@ -2,7 +2,7 @@
 
 > **Status:** Production-ready specification — architecture, data contracts, and UX rules locked.
 > **Last updated:** 2026-02-13 (docs sync: scanner/preferences/country/diet-allergen features now implemented)
-> **Implementation stage:** Spec-complete. No front-end code yet. All API endpoints exist and pass QA (777/777 checks + 20/20 negative tests). This document is the single source of truth for any future front-end implementation.
+> **Implementation stage:** Spec-complete. No front-end code yet. All API endpoints exist and pass the current documented QA and negative-validation suites. This document is the single source of truth for any future front-end implementation.
 
 ---
 

--- a/docs/VIEWING_AND_TESTING.md
+++ b/docs/VIEWING_AND_TESTING.md
@@ -101,7 +101,7 @@ Run all pipelines + QA suites automatically:
 ---
 
 ### 4. **Standalone QA Runner** (Recommended)
-Runs all 30 test suites with color-coded output:
+Runs the full current QA suite set with color-coded output:
 
 ```powershell
 .\RUN_QA.ps1
@@ -109,19 +109,19 @@ Runs all 30 test suites with color-coded output:
 
 **Expected output**:
 ```
-ALL TESTS PASSED (777/777 checks across 49 suites)
+✓ ALL TESTS PASSED (777/777 checks)
 ```
 
 ---
 
-### 5. **Negative Validation Tests** (29 constraint tests)
+### 5. **Negative Validation Tests** (destructive-intent validation)
 Verifies the database correctly rejects invalid data:
 
 ```powershell
 .\RUN_NEGATIVE_TESTS.ps1
 ```
 
-**Expected output**: `29/29 CAUGHT, 0 MISSED`
+**Expected output**: final success line like `✓ ALL ... checks correctly detected violations` with `0` missed checks.
 
 ---
 

--- a/docs/VIEWING_AND_TESTING.md
+++ b/docs/VIEWING_AND_TESTING.md
@@ -90,7 +90,7 @@ Run all pipelines + QA suites automatically:
 ================================================
   Running QA Checks
 ================================================
-  All QA checks passed (421/421 — zero violation rows).
+  All QA checks passed (777/777 — zero violation rows).
 
   Database inventory:
   active_products | deprecated | nutrition | categories
@@ -109,7 +109,7 @@ Runs all 30 test suites with color-coded output:
 
 **Expected output**:
 ```
-ALL TESTS PASSED (421/421 checks across 30 suites)
+ALL TESTS PASSED (777/777 checks across 49 suites)
 ```
 
 ---


### PR DESCRIPTION
## Summary
- reconciles stale QA/check-count references
- updates API registry function-count wording
- clarifies pipeline folder terminology
- updates Next.js security note wording
- adds changelog entry for docs cleanup

## Issue
Closes #1147

## Scope
- documentation only

## Verification
- stale-reference searches run for:
  - `421`
  - `107 functions`
  - `Will be resolved on Next.js`
  - `43 pipeline folders`
  - `30 suites` (current QA-suite context)
- fallback search command run in PowerShell (`Select-String`) because `rg` is unavailable in this environment
- docs hygiene command run:
  - `pwsh -File scripts/repo_verify.ps1` (6 passed, 0 failed)
  - `.\.venv\Scripts\python.exe scripts/check_doc_counts.py --strict` (0 mismatches)