### PR TITLE
fix(ci): unblock Dependabot validation

### DIFF
--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -108,7 +108,10 @@ jobs:
           npx license-checker --production --excludePrivatePackages --json > /tmp/licenses.json 2>/dev/null || true
 
           # Forbidden license identifiers (grep-safe, pipe-separated)
-          FORBIDDEN_RE="GPL-2\.0|GPL-3\.0|AGPL|SSPL|EUPL|OSL-3\.0|CPAL|CPL-1\.0|Sleepycat|Watcom"
+          # Match GPL as a complete SPDX identifier so weak-copyleft LGPL
+          # expressions are not misclassified merely because they contain
+          # the substring "GPL". LGPL is intentionally not in FORBIDDEN.
+          FORBIDDEN_RE="(^|[^A-Za-z])GPL-(2\.0|3\.0)|AGPL|SSPL|EUPL|OSL-3\.0|CPAL|CPL-1\.0|Sleepycat|Watcom"
 
           # Known-safe overrides: packages manually audited as safe despite
           # ambiguous license metadata. Add "package@version" entries here.

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -106,8 +106,26 @@ jobs:
       - name: Wait for app ready
         run: npx wait-on http://localhost:3000 --timeout 60000
 
+      # Dependabot-triggered workflows cannot read ordinary Actions secrets.
+      # Keep build/test coverage active, but skip staging-only fixture audits
+      # when those credentials are unavailable instead of reporting a false
+      # application failure.
+      - name: Check staging credentials
+        id: staging
+        env:
+          STAGING_URL: ${{ secrets.SUPABASE_URL_STAGING }}
+          STAGING_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY_STAGING }}
+        run: |
+          if [ -n "$STAGING_URL" ] && [ -n "$STAGING_SERVICE_KEY" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Staging credentials unavailable; skipping fixture-dependent quality audits."
+          fi
+
       # ── Seed QA fixture data ──────────────────────────────────────────────
       - name: Seed QA fixture data
+        if: steps.staging.outputs.available == 'true'
         id: seed
         working-directory: frontend
         run: |
@@ -156,6 +174,7 @@ jobs:
 
       # ── Mobile Audit ─────────────────────────────────────────────────────
       - name: Run Mobile Audit
+        if: steps.staging.outputs.available == 'true'
         working-directory: frontend
         run: npx playwright test --project=quality-mobile --reporter=html,list
         env:
@@ -172,6 +191,7 @@ jobs:
       # error instead of the real seed failure, so it mirrors the Mobile Audit
       # step and only runs when prior steps succeed.
       - name: Run Desktop Audit
+        if: steps.staging.outputs.available == 'true'
         working-directory: frontend
         run: npx playwright test --project=quality-desktop --reporter=html,list
         env:
@@ -187,7 +207,7 @@ jobs:
       # In CI a missing staging secret fails this step (exit 1) rather than
       # leaving fixtures behind silently.
       - name: Teardown QA fixture data
-        if: always()
+        if: always() && steps.seed.outputs.seeded == 'true'
         working-directory: frontend
         run: node tests/quality/seed-fixtures.mjs --teardown
         env:


### PR DESCRIPTION
## What changed

- Match GPL as a complete SPDX identifier so LGPL metadata is not falsely classified as GPL.
- Detect unavailable staging credentials before fixture-dependent quality audits.
- Skip only staging fixture audits when Dependabot cannot access ordinary Actions secrets, while preserving build and test coverage.
- Teardown fixtures only when seeding actually completed.

## Why

Dependabot PRs were blocked by two shared CI false positives: the license matcher found `GPL` inside `LGPL`, and the quality gate hard-failed when Dependabot-triggered workflows could not read staging secrets.

Lighthouse thresholds are unchanged.

## Validation

- `actionlint -ignore SC2129` on both edited workflows
- `git diff --check`
- Regex cases verified for LGPL (allowed), GPL and AGPL (blocked)
