### PR TITLE
fix(ci): skip staging gate for Dependabot

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -47,6 +47,10 @@ env:
 
 jobs:
   quality_gate:
+    # Dependabot cannot read the Supabase runtime and staging secrets needed
+    # to start the audited app. Its PRs remain covered by PR Gate (build,
+    # lint, unit, and Playwright) plus the separate Lighthouse workflow.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## What changed

Skip the staging-dependent Quality Gate job when a workflow is authored by Dependabot.

## Why

Dependabot-triggered workflows cannot read the Supabase runtime and staging secrets required to start the audited application. The job therefore timed out before reaching the credential guard added in #1214.

Dependabot PRs remain covered by PR Gate (build, lint, unit tests, and Playwright), the standalone Lighthouse workflow, dependency audit, license compliance, and CodeQL. Normal pull requests, scheduled runs, and manual runs continue to execute Quality Gate.

## Validation

- `actionlint -ignore SC2129 .github/workflows/quality-gate.yml`
- `git diff --check`
