### PR TITLE
fix(ci): skip Dependabot RPC contract gate

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -54,8 +54,9 @@ jobs:
     name: RPC Contract Validation
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Skip forks — they never have staging secrets
-    if: github.event.pull_request.head.repo.fork != true
+    # Skip forks and Dependabot — GitHub does not expose staging secrets to either.
+    # Dependabot changes remain covered by the secret-free PR validation suite.
+    if: github.event.pull_request.head.repo.fork != true && github.actor != 'dependabot[bot]'
 
     defaults:
       run:


### PR DESCRIPTION
## What changed

- skip the live RPC contract job for Dependabot-authored pull requests
- retain the contract gate for normal pull requests, pushes to main, scheduled runs, and manual runs

## Why

GitHub withholds repository staging secrets from Dependabot. The job therefore failed before running any contract tests, even for unrelated GitHub Actions dependency updates. Dependabot PRs remain covered by the secret-free PR gate, unit and browser tests, dependency audits, CodeQL, and deployment checks.

## Validation

- workflow syntax checked with actionlint
- diff whitespace validation passed
- full protected checks will run on this pull request