### PR TITLE
ci: handle Vercel SSO in smoke tests

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -97,7 +97,7 @@ jobs:
             echo "Health check attempt $attempt/$MAX_RETRIES..."
 
             # Capture body AND HTTP status separately (no -f flag)
-            http_code=$(curl -s -o /tmp/health_body.txt -w "%{http_code}" \
+            http_code=$(curl -s -D /tmp/health_headers.txt -o /tmp/health_body.txt -w "%{http_code}" \
               --max-time 20 "$TARGET_URL/api/health" 2>/dev/null) || true
             response=$(cat /tmp/health_body.txt 2>/dev/null || echo "")
 
@@ -130,8 +130,9 @@ jobs:
             fi
           fi
 
-          # ── Vercel Deployment Protection (401/403) ──
-          if [ "$http_code" = "401" ] || [ "$http_code" = "403" ]; then
+          # ── Vercel Deployment Protection (401/403 or SSO redirect) ──
+          if [ "$http_code" = "401" ] || [ "$http_code" = "403" ] || \
+             { [ "$http_code" = "302" ] && grep -qi '^location: https://vercel.com/sso-api' /tmp/health_headers.txt; }; then
             echo "| /api/health | ⏭️ HTTP $http_code — Vercel deployment protection (skipped) |" >> "$GITHUB_STEP_SUMMARY"
             echo "::notice::Health check skipped — Vercel deployment protection returned HTTP $http_code on deployment-specific URL"
             exit 0


### PR DESCRIPTION
## Summary

- capture health-check response headers in the post-deploy smoke test
- recognize Vercel Deployment Protection's SSO redirect (`302` to `vercel.com/sso-api`) alongside the existing `401`/`403` handling

## Root cause

Vercel protected the deployment URL with an SSO redirect. The smoke test then attempted to parse the plain redirect body as JSON and failed, even though the deployment was healthy.

## Validation

- `actionlint .github/workflows/smoke-test.yml` (only existing shell-style suggestions)
- verified the production URL returns the expected `302` SSO redirect and the workflow condition detects it