### PR TITLE
fix: constrain SQL pipeline output

### DIFF
--- a/pipeline/sql_generator.py
+++ b/pipeline/sql_generator.py
@@ -20,6 +20,22 @@ from pathlib import Path
 # Helpers
 # ---------------------------------------------------------------------------
 
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PIPELINES_ROOT = PROJECT_ROOT / "db" / "pipelines"
+
+
+def _resolve_pipeline_output_dir(output_dir: str | Path) -> Path:
+    """Resolve an output directory and require it to stay under db/pipelines."""
+    root = PIPELINES_ROOT.resolve()
+    path = Path(output_dir).resolve()
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(
+            "Refusing to write outside db/pipelines: " + str(output_dir)
+        ) from exc
+    return path
+
 
 def _safe_child_path(directory: Path, filename: str) -> Path:
     """Return a file path that is guaranteed to remain inside *directory*."""
@@ -791,7 +807,7 @@ def generate_pipeline(
     list[Path]
         Paths of the generated files.
     """
-    out = Path(output_dir).resolve()
+    out = _resolve_pipeline_output_dir(output_dir)
     out.mkdir(parents=True, exist_ok=True)
 
     # Use the directory name as the file slug so that files inside

--- a/pipeline/test_batch_sql.py
+++ b/pipeline/test_batch_sql.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+import pipeline.sql_generator as sql_generator
 from pipeline.sql_generator import _chunk, generate_pipeline
 
 # ---------------------------------------------------------------------------
@@ -55,8 +56,9 @@ def _make_products(n: int) -> list[dict]:
 
 
 @pytest.fixture()
-def tmp_output(tmp_path: Path) -> Path:
+def tmp_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Return a fresh output directory for a fake category."""
+    monkeypatch.setattr(sql_generator, "PIPELINES_ROOT", tmp_path)
     out = tmp_path / "test-cat"
     out.mkdir()
     return out

--- a/pipeline/test_csv_importer.py
+++ b/pipeline/test_csv_importer.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+import pipeline.sql_generator as sql_generator
 from pipeline.csv_importer import (
     MAX_ROWS,
     VALID_CATEGORIES,
@@ -20,6 +21,12 @@ from pipeline.csv_importer import (
     CSVImporter,
     CSVImportError,
 )
+
+
+@pytest.fixture(autouse=True)
+def pipeline_output_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep generated test SQL isolated from the repository pipeline directory."""
+    monkeypatch.setattr(sql_generator, "PIPELINES_ROOT", tmp_path)
 
 
 def _write_csv(tmp_path: Path, content: str) -> Path:

--- a/pipeline/test_path_safety.py
+++ b/pipeline/test_path_safety.py
@@ -10,7 +10,10 @@ from pipeline.image_importer import (
     _safe_child_path as image_path,
     _safe_pipeline_subdirectory,
 )
-from pipeline.sql_generator import _safe_child_path as sql_path
+from pipeline.sql_generator import (
+    _resolve_pipeline_output_dir as sql_output_dir,
+    _safe_child_path as sql_path,
+)
 
 
 def test_sql_generator_output_stays_inside_directory(tmp_path: Path) -> None:
@@ -22,6 +25,11 @@ def test_sql_generator_output_stays_inside_directory(tmp_path: Path) -> None:
 def test_sql_generator_rejects_path_traversal(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="outside pipeline directory"):
         sql_path(tmp_path, "../outside.sql")
+
+
+def test_sql_generator_rejects_output_outside_pipeline_root() -> None:
+    with pytest.raises(ValueError, match="outside db/pipelines"):
+        sql_output_dir("../outside")
 
 
 def test_image_importer_rejects_output_outside_pipeline_root() -> None:


### PR DESCRIPTION
## Summary
- restrict SQL pipeline generation to `db/pipelines`
- reject output directories outside the repository pipeline root before creating files
- preserve isolated test outputs by redirecting the test-only pipeline root

## Why
SonarCloud identified that a caller-controlled output directory could allow generated SQL files to be written outside the intended pipeline location.

## Validation
- `python -m pytest pipeline/test_path_safety.py pipeline/test_batch_sql.py pipeline/test_csv_importer.py -q`
- 57 passed