### PR TITLE
fix(pipeline): enforce trusted SQL output paths

### DIFF
--- a/pipeline/sql_generator.py
+++ b/pipeline/sql_generator.py
@@ -79,7 +79,8 @@ def _write_pipeline_file(relative_path: str | Path, content: str) -> Path:
     """Validate and write one UTF-8 SQL file below ``PIPELINES_ROOT``."""
     path = _validated_pipeline_output_path(relative_path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content, encoding="utf-8")
+    # S8707's residual flow follows SQL content, not this validated path.
+    path.write_text(content, encoding="utf-8")  # NOSONAR
     return path
 
 

--- a/pipeline/sql_generator.py
+++ b/pipeline/sql_generator.py
@@ -24,27 +24,62 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 PIPELINES_ROOT = PROJECT_ROOT / "db" / "pipelines"
 
 
+class PipelineOutputPathError(ValueError):
+    """Raised when a generated SQL path escapes the trusted pipeline root."""
+
+
 def _resolve_pipeline_output_dir(output_dir: str | Path) -> Path:
     """Resolve an output directory and require it to stay under db/pipelines."""
     root = PIPELINES_ROOT.resolve()
-    path = Path(output_dir).resolve()
+    try:
+        path = Path(output_dir).resolve()
+    except (OSError, RuntimeError) as exc:
+        raise PipelineOutputPathError(
+            f"Invalid pipeline output directory: {output_dir!s}"
+        ) from exc
     try:
         path.relative_to(root)
     except ValueError as exc:
-        raise ValueError(
+        raise PipelineOutputPathError(
             "Refusing to write outside db/pipelines: " + str(output_dir)
         ) from exc
     return path
 
 
-def _safe_child_path(directory: Path, filename: str) -> Path:
-    """Return a file path that is guaranteed to remain inside *directory*."""
-    root = directory.resolve()
-    path = (root / filename).resolve()
+def _validated_pipeline_output_path(relative_path: str | Path) -> Path:
+    """Resolve a relative generated-file path under the trusted pipeline root."""
+    requested = Path(relative_path)
+    if requested.is_absolute():
+        raise PipelineOutputPathError(
+            f"Pipeline output path must be relative: {relative_path!s}"
+        )
+    if requested == Path("."):
+        raise PipelineOutputPathError("Pipeline output path must name a file")
+
+    trusted_root = PIPELINES_ROOT.resolve()
     try:
-        path.relative_to(root)
+        candidate = (trusted_root / requested).resolve()
+    except (OSError, RuntimeError) as exc:
+        raise PipelineOutputPathError(
+            f"Invalid pipeline output path: {relative_path!s}"
+        ) from exc
+
+    try:
+        candidate.relative_to(trusted_root)
     except ValueError as exc:
-        raise ValueError(f"Refusing to write outside pipeline directory: {filename}") from exc
+        raise PipelineOutputPathError(
+            f"Refusing to write outside db/pipelines: {relative_path!s}"
+        ) from exc
+    if candidate == trusted_root:
+        raise PipelineOutputPathError("Pipeline output path must name a file")
+    return candidate
+
+
+def _write_pipeline_file(relative_path: str | Path, content: str) -> Path:
+    """Validate and write one UTF-8 SQL file below ``PIPELINES_ROOT``."""
+    path = _validated_pipeline_output_path(relative_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
     return path
 
 
@@ -808,7 +843,7 @@ def generate_pipeline(
         Paths of the generated files.
     """
     out = _resolve_pipeline_output_dir(output_dir)
-    out.mkdir(parents=True, exist_ok=True)
+    relative_out = out.relative_to(PIPELINES_ROOT.resolve())
 
     # Use the directory name as the file slug so that files inside
     # ``dairy-de/`` are named ``PIPELINE__dairy-de__*`` (matches
@@ -839,15 +874,13 @@ def generate_pipeline(
             batch_start = offset + 1
             batch_end = offset + len(chunk)
             offset += len(chunk)
-            path = _safe_child_path(
-                out, f"PIPELINE__{slug}__01_batch_{batch_num:03d}_insert_products.sql"
-            )
-            path.write_text(
+            path = _write_pipeline_file(
+                relative_out
+                / f"PIPELINE__{slug}__01_batch_{batch_num:03d}_insert_products.sql",
                 _gen_01_batch(
                     category, chunk, products, today, country,
                     batch_num, total_batches, batch_start, batch_end,
                 ),
-                encoding="utf-8",
             )
             files.append(path)
 
@@ -857,15 +890,13 @@ def generate_pipeline(
             batch_start = offset + 1
             batch_end = offset + len(chunk)
             offset += len(chunk)
-            path = _safe_child_path(
-                out, f"PIPELINE__{slug}__03_batch_{batch_num:03d}_add_nutrition.sql"
-            )
-            path.write_text(
+            path = _write_pipeline_file(
+                relative_out
+                / f"PIPELINE__{slug}__03_batch_{batch_num:03d}_add_nutrition.sql",
                 _gen_03_batch(
                     category, chunk, country,
                     batch_num, total_batches, batch_start, batch_end,
                 ),
-                encoding="utf-8",
             )
             files.append(path)
     else:
@@ -876,33 +907,45 @@ def generate_pipeline(
             old.unlink()
 
         # 01 — single insert products
-        path01 = _safe_child_path(out, f"PIPELINE__{slug}__01_insert_products.sql")
-        path01.write_text(_gen_01_insert_products(category, products, today, country), encoding="utf-8")
+        path01 = _write_pipeline_file(
+            relative_out / f"PIPELINE__{slug}__01_insert_products.sql",
+            _gen_01_insert_products(category, products, today, country),
+        )
         files.append(path01)
 
         # 03 — single add nutrition
-        path03 = _safe_child_path(out, f"PIPELINE__{slug}__03_add_nutrition.sql")
-        path03.write_text(_gen_03_add_nutrition(category, products, country), encoding="utf-8")
+        path03 = _write_pipeline_file(
+            relative_out / f"PIPELINE__{slug}__03_add_nutrition.sql",
+            _gen_03_add_nutrition(category, products, country),
+        )
         files.append(path03)
 
     # 04 — scoring (always single file)
-    path04 = _safe_child_path(out, f"PIPELINE__{slug}__04_scoring.sql")
-    path04.write_text(_gen_04_scoring(category, products, today, country), encoding="utf-8")
+    path04 = _write_pipeline_file(
+        relative_out / f"PIPELINE__{slug}__04_scoring.sql",
+        _gen_04_scoring(category, products, today, country),
+    )
     files.append(path04)
 
     # 05 — source provenance (always single file)
-    path05 = _safe_child_path(out, f"PIPELINE__{slug}__05_source_provenance.sql")
-    path05.write_text(_gen_05_source_provenance(category, products, today, country), encoding="utf-8")
+    path05 = _write_pipeline_file(
+        relative_out / f"PIPELINE__{slug}__05_source_provenance.sql",
+        _gen_05_source_provenance(category, products, today, country),
+    )
     files.append(path05)
 
     # 06 — add images (always single file)
-    path06 = _safe_child_path(out, f"PIPELINE__{slug}__06_add_images.sql")
-    path06.write_text(_gen_06_add_images(category, products, today, country), encoding="utf-8")
+    path06 = _write_pipeline_file(
+        relative_out / f"PIPELINE__{slug}__06_add_images.sql",
+        _gen_06_add_images(category, products, today, country),
+    )
     files.append(path06)
 
     # 07 — store availability (always single file)
-    path07 = _safe_child_path(out, f"PIPELINE__{slug}__07_store_availability.sql")
-    path07.write_text(_gen_07_store_availability(category, products, today, country), encoding="utf-8")
+    path07 = _write_pipeline_file(
+        relative_out / f"PIPELINE__{slug}__07_store_availability.sql",
+        _gen_07_store_availability(category, products, today, country),
+    )
     files.append(path07)
 
     return files

--- a/pipeline/test_path_safety.py
+++ b/pipeline/test_path_safety.py
@@ -1,9 +1,13 @@
 """Path-containment tests for pipeline file generation."""
 
+from __future__ import annotations
+
+import datetime
 from pathlib import Path
 
 import pytest
 
+import pipeline.sql_generator as sql_generator
 from pipeline.image_importer import (
     PIPELINES_ROOT,
     _resolve_pipeline_output_dir,
@@ -11,25 +15,148 @@ from pipeline.image_importer import (
     _safe_pipeline_subdirectory,
 )
 from pipeline.sql_generator import (
+    PipelineOutputPathError,
+    _gen_01_insert_products,
+    _gen_03_add_nutrition,
+    _gen_04_scoring,
+    _gen_05_source_provenance,
+    _gen_06_add_images,
+    _gen_07_store_availability,
     _resolve_pipeline_output_dir as sql_output_dir,
-    _safe_child_path as sql_path,
+    _validated_pipeline_output_path,
+    _write_pipeline_file,
+    generate_pipeline,
 )
 
 
-def test_sql_generator_output_stays_inside_directory(tmp_path: Path) -> None:
-    path = sql_path(tmp_path, "PIPELINE__chips__01_insert_products.sql")
+@pytest.fixture()
+def trusted_sql_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(sql_generator, "PIPELINES_ROOT", tmp_path)
+    return tmp_path
 
-    assert path.parent == tmp_path.resolve()
+
+def test_sql_generator_accepts_relative_output_path(trusted_sql_root: Path) -> None:
+    path = _validated_pipeline_output_path("PIPELINE__chips__01_insert_products.sql")
+
+    assert path == trusted_sql_root / "PIPELINE__chips__01_insert_products.sql"
 
 
-def test_sql_generator_rejects_path_traversal(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="outside pipeline directory"):
-        sql_path(tmp_path, "../outside.sql")
+def test_sql_generator_accepts_nested_output_path(trusted_sql_root: Path) -> None:
+    path = _validated_pipeline_output_path(
+        Path("nested") / "category" / "PIPELINE__chips__04_scoring.sql"
+    )
+
+    assert path == (
+        trusted_sql_root
+        / "nested"
+        / "category"
+        / "PIPELINE__chips__04_scoring.sql"
+    )
+
+
+def test_sql_generator_rejects_path_traversal(trusted_sql_root: Path) -> None:
+    with pytest.raises(PipelineOutputPathError, match="outside db/pipelines"):
+        _validated_pipeline_output_path(Path("..") / "outside.sql")
+
+
+def test_sql_generator_rejects_absolute_path(trusted_sql_root: Path) -> None:
+    with pytest.raises(PipelineOutputPathError, match="must be relative"):
+        _validated_pipeline_output_path(trusted_sql_root / "absolute.sql")
+
+
+def test_sql_generator_rejects_normalized_escape(trusted_sql_root: Path) -> None:
+    with pytest.raises(PipelineOutputPathError, match="outside db/pipelines"):
+        _validated_pipeline_output_path(
+            Path("nested") / ".." / ".." / "outside.sql"
+        )
+
+
+def test_sql_generator_rejects_empty_file_path(trusted_sql_root: Path) -> None:
+    with pytest.raises(PipelineOutputPathError, match="must name a file"):
+        _validated_pipeline_output_path(Path())
+
+
+def test_sql_generator_creates_parent_only_after_validation(
+    trusted_sql_root: Path,
+) -> None:
+    relative_path = Path("nested") / "category" / "generated.sql"
+
+    path = _write_pipeline_file(relative_path, "select 1;\n")
+
+    assert path == trusted_sql_root / relative_path
+    assert path.parent.is_dir()
+    assert path.read_text(encoding="utf-8") == "select 1;\n"
 
 
 def test_sql_generator_rejects_output_outside_pipeline_root() -> None:
-    with pytest.raises(ValueError, match="outside db/pipelines"):
+    with pytest.raises(PipelineOutputPathError, match="outside db/pipelines"):
         sql_output_dir("../outside")
+
+
+@pytest.mark.parametrize(
+    ("category", "slug", "country"),
+    [("Dairy", "dairy", "PL"), ("Bread", "bread-de", "DE")],
+)
+def test_generated_paths_and_contents_remain_unchanged(
+    trusted_sql_root: Path,
+    category: str,
+    slug: str,
+    country: str,
+) -> None:
+    products: list[dict] = []
+    output_dir = trusted_sql_root / slug
+    today = datetime.date.today().isoformat()
+
+    files = generate_pipeline(category, products, str(output_dir), country=country)
+
+    expected = {
+        f"PIPELINE__{slug}__01_insert_products.sql": _gen_01_insert_products(
+            category, products, today, country
+        ),
+        f"PIPELINE__{slug}__03_add_nutrition.sql": _gen_03_add_nutrition(
+            category, products, country
+        ),
+        f"PIPELINE__{slug}__04_scoring.sql": _gen_04_scoring(
+            category, products, today, country
+        ),
+        f"PIPELINE__{slug}__05_source_provenance.sql": _gen_05_source_provenance(
+            category, products, today, country
+        ),
+        f"PIPELINE__{slug}__06_add_images.sql": _gen_06_add_images(
+            category, products, today, country
+        ),
+        f"PIPELINE__{slug}__07_store_availability.sql": _gen_07_store_availability(
+            category, products, today, country
+        ),
+    }
+    assert [path.name for path in files] == list(expected)
+    for path in files:
+        assert path == output_dir / path.name
+        assert path.read_text(encoding="utf-8") == expected[path.name]
+
+
+def test_all_flagged_writes_use_validated_writer(
+    trusted_sql_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded_paths: list[Path] = []
+    real_writer = sql_generator._write_pipeline_file
+
+    def recording_writer(relative_path: str | Path, content: str) -> Path:
+        recorded_paths.append(Path(relative_path))
+        return real_writer(relative_path, content)
+
+    monkeypatch.setattr(sql_generator, "_write_pipeline_file", recording_writer)
+    generate_pipeline("Dairy", [], str(trusted_sql_root / "dairy"))
+
+    recorded_names = {path.name for path in recorded_paths}
+    assert {
+        "PIPELINE__dairy__03_add_nutrition.sql",
+        "PIPELINE__dairy__04_scoring.sql",
+        "PIPELINE__dairy__05_source_provenance.sql",
+        "PIPELINE__dairy__06_add_images.sql",
+        "PIPELINE__dairy__07_store_availability.sql",
+    } <= recorded_names
 
 
 def test_image_importer_rejects_output_outside_pipeline_root() -> None:


### PR DESCRIPTION
## Summary

- anchor generated SQL output paths to the fixed db/pipelines root
- reject absolute, traversing, normalized-escape, and empty relative file paths with a specific exception
- validate every generated path before creating parent directories or writing UTF-8 content
- route the five SonarCloud-flagged writes through the centralized validated writer

## Root cause and invariant

The earlier helper proved containment only relative to the caller-provided output directory. Because that directory originated at the CLI boundary, the fixed trusted boundary was not explicit at the write sinks and SonarCloud reported five pythonsecurity:S8707 vulnerabilities.

The new invariant is: every generated SQL file path must be relative to the resolved repository db/pipelines root, and its fully resolved candidate must remain inside that root before any directory creation or write occurs.

## Behavior

Normal generation is unchanged: filenames, category directories, file ordering, SQL contents, and UTF-8 encoding remain the same. Invalid absolute and escaping paths now raise PipelineOutputPathError.

## Verification

- Focused path and batch tests: 40 passed
- Complete Python suite: 232 passed
- Ruff 0.15.20: passed
- Enrichment identity guard: passed
- Pipeline structure guard: 58 categories passed
- Repository hygiene verification: 6 passed
- Python type checking: not configured in this repository

## Remote acceptance

This PR remains draft until SonarCloud confirms the five S8707 findings are absent and all relevant pull-request checks pass. No Supabase, deployment, SQL semantics, dependency, or data-dashboard changes are included.
## SonarCloud residual analysis

The first remote branch scan reduced the five original S8707 findings to one finding at the centralized Path.write_text sink. Sonar's flow traced the generated SQL content argument—not the validated path—and the scanner logged that simulation cost was too high for that sink. Because path containment is enforced before parent creation and covered by traversal/absolute-path tests, this is a demonstrated analyzer false positive. A single-line NOSONAR suppression is therefore applied only to that validated sink, as permitted by the task; no rule, file, or project-wide exclusion was added.
## Final remote result

- Main Gate branch dispatch on bad25789: passed
- SonarCloud pythonsecurity:S8707 open issues for pipeline/sql_generator.py: 0
- SonarCloud vulnerabilities: 0
- Quality Gate: passed; new security rating A (1)
- All PR checks: passed; Supabase preview and non-production smoke checks intentionally skipped

The workflow-dispatch scan is associated by SonarCloud with its main analysis rather than a separately named branch, even though it analyzed the unmerged PR commit. The PR remains draft and unmerged; Main Gate must run again after the eventual merge to record the resulting real main SHA.