### PR TITLE
feat(qa): add deterministic data quality report and CI gate

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -15,6 +15,9 @@ on:
       - "enrich_ingredients.py"
       - "check_enrichment_identity.py"
       - "check_pipeline_structure.py"
+      - "data_quality_report.py"
+      - "test_data_quality_report.py"
+      - "data-quality/**"
       - "fetch_off_category.py"
       - ".github/workflows/qa.yml"
   pull_request:
@@ -27,6 +30,9 @@ on:
       - "enrich_ingredients.py"
       - "check_enrichment_identity.py"
       - "check_pipeline_structure.py"
+      - "data_quality_report.py"
+      - "test_data_quality_report.py"
+      - "data-quality/**"
       - "fetch_off_category.py"
       - "RUN_QA.ps1"
       - "RUN_LOCAL.ps1"
@@ -91,6 +97,9 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r requirements.txt
 
+      - name: Data-quality report unit tests
+        run: python -m unittest test_data_quality_report.py
+
       - name: Enrichment identity guard
         run: |
           set -euo pipefail
@@ -119,21 +128,19 @@ jobs:
           echo '-- CI: skipped (orphan cleanup deferred to ci_post_enrichment.sql)' \
             > supabase/migrations/20260316000700_cleanup_orphan_ingredient_refs.sql
 
-          for f in $(ls supabase/migrations/*.sql | sort); do
+          while IFS= read -r -d '' f; do
             echo "Applying: $f"
             psql -v ON_ERROR_STOP=1 -f "$f"
-          done
+          done < <(find supabase/migrations -maxdepth 1 -type f -name '*.sql' -print0 | sort -z)
 
       - name: Run pipelines
         run: |
           set -euo pipefail
-          for category in db/pipelines/*/; do
-            cat_name=$(basename "$category")
-            for f in $(ls "$category"PIPELINE__*.sql 2>/dev/null | sort); do
-              echo "  RUN  $f"
-              psql -v ON_ERROR_STOP=1 -f "$f"
-            done
-          done
+          while IFS= read -r -d '' f; do
+            echo "  RUN  $f"
+            psql -v ON_ERROR_STOP=1 -f "$f"
+          done < <(find db/pipelines -mindepth 2 -maxdepth 2 \
+            -type f -name 'PIPELINE__*.sql' -print0 | sort -z)
 
       - name: Replay enrichment data
         run: |
@@ -203,6 +210,45 @@ jobs:
           echo "Applying CI post-pipeline fixup..."
           psql -v ON_ERROR_STOP=1 -f db/ci_post_pipeline.sql
           echo "Post-pipeline fixup complete."
+
+      - name: Generate data-quality report
+        id: data_quality
+        run: |
+          set +e
+          python data_quality_report.py \
+            --config data-quality/thresholds.json \
+            --baseline data-quality/baselines/ci-v1.json \
+            --dataset-id deterministic-ci-qa-v1 \
+            --environment ci \
+            --json-out data-quality-report.json \
+            --markdown-out data-quality-report.md
+          exit_code=$?
+          set -e
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          if [ "$exit_code" -ne 0 ]; then
+            echo "::warning::Data-quality gate exited with code $exit_code"
+          fi
+
+      - name: Upload data-quality report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: data-quality-report
+          path: |
+            data-quality-report.json
+            data-quality-report.md
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Add data-quality summary
+        if: always()
+        shell: pwsh
+        run: |
+          if (Test-Path 'data-quality-report.md') {
+            Get-Content 'data-quality-report.md' | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          } else {
+            "## TryVit data-quality report`n`n[FAIL] Report was not generated." | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          }
 
       - name: Scoring diagnostic
         if: always()
@@ -301,28 +347,6 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
-      - name: Confidence coverage threshold
-        run: |
-          # Fail if more than 5% of products have low confidence
-          # Note: CI threshold is 5% (not 1%) because data-enrichment migrations
-          # use hardcoded product_ids and don't populate ingredient/allergen data,
-          # artificially deflating confidence scores.
-          low_count=$(psql --tuples-only -c "
-            SELECT COUNT(*) FROM v_product_confidence WHERE confidence_band = 'low';
-          " 2>&1 | tr -d ' ')
-          total=$(psql --tuples-only -c "
-            SELECT COUNT(*) FROM products WHERE is_deprecated IS NOT TRUE;
-          " 2>&1 | tr -d ' ')
-          # Integer math: threshold = total * 5 / 100 (5% floor division)
-          threshold=$((total * 5 / 100))
-          echo "Low confidence: $low_count / $total (threshold: $threshold)"
-          if [ "$low_count" -gt "$threshold" ]; then
-            echo "✗ FAILED — More than 5% of products have low confidence ($low_count / $total)"
-            exit 1
-          else
-            echo "✓ PASS — Low confidence within threshold"
-          fi
-
       - name: Generate QA summary
         if: always()
         shell: pwsh
@@ -354,20 +378,38 @@ jobs:
           [void]$sb.AppendLine("*Schema version: $($qa.version) · Timestamp: $($qa.timestamp)*")
           $sb.ToString() | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
 
-      - name: Fail if QA failed
+      - name: Fail if QA or data quality failed
         if: always()
         shell: pwsh
         run: |
-          if (-not (Test-Path 'qa.json')) { exit 1 }
+          $failed = $false
+          if (-not (Test-Path 'qa.json')) {
+            Write-Host "::error::qa.json was not generated"
+            $failed = $true
+          }
+          if (-not (Test-Path 'data-quality-report.json')) {
+            Write-Host "::error::data-quality-report.json was not generated"
+            $failed = $true
+          }
+          if ($failed) { exit 1 }
           $qa = Get-Content 'qa.json' -Raw | ConvertFrom-Json
           if ($qa.overall -eq 'fail') {
             Write-Host "::error::QA FAILED — $($qa.summary.failed) check(s) failed"
-            exit 1
+            $failed = $true
           }
           if ($qa.overall -eq 'warn') {
             Write-Host "::warning::QA passed with warnings ($($qa.summary.warnings) flagged items)"
             # Only fail on warn if explicitly requested
             $failOnWarn = '${{ inputs.fail_on_warn }}' -eq 'true'
-            if ($failOnWarn) { exit 2 }
+            if ($failOnWarn) { $failed = $true }
           }
+          $dataQuality = Get-Content 'data-quality-report.json' -Raw | ConvertFrom-Json
+          if ($dataQuality.status -eq 'fail' -or $dataQuality.failures.Count -gt 0) {
+            Write-Host "::error::Data-quality gate FAILED — $($dataQuality.failures.Count) failure(s)"
+            $failed = $true
+          } elseif ($dataQuality.status -eq 'warn') {
+            Write-Host "::warning::Data-quality gate passed with $($dataQuality.warnings.Count) warning(s)"
+          }
+          if ($failed) { exit 1 }
           Write-Host "QA passed: $($qa.summary.passed)/$($qa.summary.total_checks) checks"
+          Write-Host "Data quality passed: $($dataQuality.active_product_count) active products"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,15 @@ Adheres to [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+- Document the deterministic PostgreSQL data-quality report, metric semantics,
+  threshold policy, and intentional baseline-update workflow.
 - Reconcile stale documentation references across project docs: update outdated QA/check-count references to current documented values, switch API registry references in `API_CONVENTIONS.md` and `FRONTEND_API_MAP.md` to count-neutral wording, clarify pipeline folder terminology in `copilot-instructions.md`, and mark the stale Next.js upgrade note in `SECURITY.md` as resolved (#1147)
+
+### CI
+
+- Add a versioned data-quality report and regression gate to deterministic DB
+  QA, with JSON/Markdown artifacts and one source of truth for confidence
+  thresholds.
 
 ### Fixed
 

--- a/check_pipeline_structure.py
+++ b/check_pipeline_structure.py
@@ -8,6 +8,7 @@ Checks:
   - Step 01 uses ON CONFLICT (country, brand, product_name)
   - Step 03 uses ON CONFLICT (product_id)
   - Step 04 calls score_category()
+  - Every product deprecation records a reason
   - No hardcoded product_id integer literals in INSERT/UPDATE
   - No references to non-portable constructs
 
@@ -63,6 +64,11 @@ STEP_04_SCORE_CALL = re.compile(
 # Batch file step pattern: 01_batch_001_insert_products → base step "01_insert_products"
 _BATCH_STEP_RE = re.compile(r"^(\d{2})_batch_\d{3}_(.+)$")
 
+_PRODUCT_DEPRECATION = re.compile(
+    r"update\s+products\s+set\s+(?:(?!;).)*is_deprecated\s*=\s*true(?:(?!;).)*;",
+    re.IGNORECASE | re.DOTALL,
+)
+
 
 def _check_required_files(category: str, folder: Path) -> list[str]:
     """Check that all required step files exist for a category."""
@@ -102,32 +108,29 @@ def _check_hardcoded_pids(category: str, fname: str, content: str) -> list[str]:
                 continue
             if _is_subquery_context(content, match.start(), match.end()):
                 continue
-            violations.append(
-                f"[{category}/{fname}] Possible hardcoded product_id: {match.group().strip()}"
-            )
+            violations.append(f"[{category}/{fname}] Possible hardcoded product_id: {match.group().strip()}")
     return violations
 
 
-def _check_step_structure(
-    category: str, fname: str, step: str, content: str
-) -> list[str]:
+def _check_step_structure(category: str, fname: str, step: str, content: str) -> list[str]:
     """Validate step-specific SQL patterns."""
     violations: list[str] = []
 
     if step == "01_insert_products" and not STEP_01_CONFLICT.search(content):
-        violations.append(
-            f"[{category}/{fname}] Missing ON CONFLICT (country, brand, product_name)"
-        )
+        violations.append(f"[{category}/{fname}] Missing ON CONFLICT (country, brand, product_name)")
+
+    if step == "01_insert_products":
+        for statement in _PRODUCT_DEPRECATION.findall(content):
+            if "deprecated_reason" not in statement.lower():
+                violations.append(f"[{category}/{fname}] Product deprecation is missing deprecated_reason")
 
     elif step == "03_add_nutrition":
         has_upsert = STEP_03_CONFLICT.search(content)
-        has_delete_insert = re.search(
-            r"delete\s+from\s+nutrition_facts", content, re.IGNORECASE
-        ) and re.search(r"insert\s+into\s+nutrition_facts", content, re.IGNORECASE)
+        has_delete_insert = re.search(r"delete\s+from\s+nutrition_facts", content, re.IGNORECASE) and re.search(
+            r"insert\s+into\s+nutrition_facts", content, re.IGNORECASE
+        )
         if not has_upsert and not has_delete_insert:
-            violations.append(
-                f"[{category}/{fname}] Missing ON CONFLICT (product_id) or delete-then-insert pattern"
-            )
+            violations.append(f"[{category}/{fname}] Missing ON CONFLICT (product_id) or delete-then-insert pattern")
 
     elif step == "04_scoring" and not STEP_04_SCORE_CALL.search(content):
         violations.append(f"[{category}/{fname}] Missing CALL score_category()")

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -253,6 +253,7 @@ tryvit/
 │   ├── CONTRACT_TESTING.md          # API contract testing strategy & pgTAP patterns
 │   ├── COUNTRY_EXPANSION_GUIDE.md   # Multi-country protocol (PL active, DE full parity)
 │   ├── DATA_INTEGRITY_AUDITS.md     # Ongoing data integrity audit framework
+│   ├── data-quality-report.md        # Deterministic DB quality report, baseline, and CI gate
 │   ├── DATA_PROVENANCE.md           # Data provenance & freshness governance
 │   ├── DATA_SOURCES.md              # Source hierarchy & validation workflow
 │   ├── DISASTER_DRILL_REPORT.md     # Disaster recovery drill report & findings

--- a/data-quality/baselines/ci-v1.json
+++ b/data-quality/baselines/ci-v1.json
@@ -1,0 +1,24 @@
+{
+  "baseline_id": "deterministic-ci-v1",
+  "baseline_schema_version": 1,
+  "created_at": "2026-07-28T00:00:00+00:00",
+  "dataset_id": "deterministic-ci-qa-v1",
+  "report_schema_version": 1,
+  "values": {
+    "active_products": 8552,
+    "allergen_known_contains_pct": 8.1,
+    "average_confidence": 61.6,
+    "duplicate_country_ean_products": 0,
+    "ean_valid_pct": 99.9,
+    "ingredient_coverage_pct": 11.2,
+    "ingredient_orphan_links": 0,
+    "low_confidence_pct": 0.1,
+    "missing_confidence_rows": 0,
+    "missing_critical_identity": 0,
+    "nutrition_impossible_values": 0,
+    "nutrition_usable_core_pct": 100.0,
+    "scoring_collapsed_categories": 0,
+    "scoring_empty_categories": 0,
+    "scoring_invalid_scores": 0
+  }
+}

--- a/data-quality/report.schema.json
+++ b/data-quality/report.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tryvit.example/schemas/data-quality-report-v1.json",
+  "additionalProperties": false,
+  "properties": {
+    "active_product_count": {
+      "type": ["integer", "null"]
+    },
+    "baseline": {
+      "type": ["object", "null"]
+    },
+    "breakdowns": {
+      "properties": {
+        "category": { "type": "object" },
+        "country": { "type": "object" }
+      },
+      "required": ["country", "category"],
+      "type": "object"
+    },
+    "dataset_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "environment": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "failures": {
+      "items": { "type": "string" },
+      "type": "array"
+    },
+    "generated_at": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "metrics": {
+      "type": "object"
+    },
+    "regressions": {
+      "items": { "type": "object" },
+      "type": "array"
+    },
+    "report_schema_version": {
+      "const": 1
+    },
+    "status": {
+      "enum": ["pass", "warn", "fail"]
+    },
+    "thresholds": {
+      "type": "object"
+    },
+    "warnings": {
+      "items": { "type": "string" },
+      "type": "array"
+    }
+  },
+  "required": [
+    "report_schema_version",
+    "generated_at",
+    "environment",
+    "dataset_id",
+    "status",
+    "active_product_count",
+    "metrics",
+    "breakdowns",
+    "thresholds",
+    "baseline",
+    "regressions",
+    "warnings",
+    "failures"
+  ],
+  "title": "TryVit data-quality report",
+  "type": "object"
+}

--- a/data-quality/thresholds.json
+++ b/data-quality/thresholds.json
@@ -1,0 +1,143 @@
+{
+  "country_overrides": {},
+  "report_schema_version": 1,
+  "rules": [
+    {
+      "direction": "higher",
+      "hard_min": 1,
+      "id": "active_products",
+      "max_regression": 0,
+      "path": "metrics.dataset.active_products",
+      "regression_unit": "count",
+      "severity": "failure"
+    },
+    {
+      "direction": "higher",
+      "hard_min": 7.1,
+      "id": "allergen_known_contains_pct",
+      "max_regression": 1.0,
+      "path": "metrics.allergens.known_contains.pct",
+      "regression_unit": "percentage_points",
+      "severity": "failure"
+    },
+    {
+      "direction": "higher",
+      "hard_min": 60.6,
+      "id": "average_confidence",
+      "max_regression": 1.0,
+      "path": "metrics.confidence.average_total",
+      "regression_unit": "points",
+      "severity": "failure"
+    },
+    {
+      "direction": "lower",
+      "id": "scoring_empty_categories",
+      "max_regression": 0,
+      "path": "metrics.scoring.empty_category_count",
+      "regression_unit": "count",
+      "severity": "warning"
+    },
+    {
+      "direction": "lower",
+      "hard_max": 0,
+      "id": "duplicate_country_ean_products",
+      "max_regression": 0,
+      "path": "metrics.ean.duplicate_country_aware_products",
+      "regression_unit": "count",
+      "severity": "failure"
+    },
+    {
+      "direction": "higher",
+      "hard_min": 98.9,
+      "id": "ean_valid_pct",
+      "max_regression": 1.0,
+      "path": "metrics.ean.valid.pct",
+      "regression_unit": "percentage_points",
+      "severity": "failure"
+    },
+    {
+      "direction": "higher",
+      "hard_min": 10.2,
+      "id": "ingredient_coverage_pct",
+      "max_regression": 1.0,
+      "path": "metrics.ingredients.with_links.pct",
+      "regression_unit": "percentage_points",
+      "severity": "failure"
+    },
+    {
+      "direction": "lower",
+      "hard_max": 0,
+      "id": "ingredient_orphan_links",
+      "max_regression": 0,
+      "path": "metrics.ingredients.orphan_links.missing_reference",
+      "regression_unit": "count",
+      "severity": "failure"
+    },
+    {
+      "direction": "lower",
+      "hard_max": 5.0,
+      "id": "low_confidence_pct",
+      "max_regression": 0.5,
+      "path": "metrics.confidence.bands.low.pct",
+      "regression_unit": "percentage_points",
+      "severity": "failure"
+    },
+    {
+      "direction": "lower",
+      "hard_max": 0,
+      "id": "missing_confidence_rows",
+      "max_regression": 0,
+      "path": "metrics.confidence.missing_from_view.count",
+      "regression_unit": "count",
+      "severity": "failure"
+    },
+    {
+      "direction": "lower",
+      "hard_max": 0,
+      "id": "missing_critical_identity",
+      "max_regression": 0,
+      "path": "metrics.critical_fields.missing_any.count",
+      "regression_unit": "count",
+      "severity": "failure"
+    },
+    {
+      "direction": "higher",
+      "hard_min": 99.0,
+      "id": "nutrition_usable_core_pct",
+      "max_regression": 1.0,
+      "path": "metrics.nutrition.usable_core.pct",
+      "regression_unit": "percentage_points",
+      "severity": "failure"
+    },
+    {
+      "direction": "lower",
+      "hard_max": 0,
+      "id": "nutrition_impossible_values",
+      "max_regression": 0,
+      "path": "metrics.nutrition.impossible_values.count",
+      "regression_unit": "count",
+      "severity": "failure"
+    },
+    {
+      "direction": "lower",
+      "id": "scoring_collapsed_categories",
+      "max_regression": 1,
+      "path": "metrics.scoring.collapsed_category_count",
+      "regression_unit": "count",
+      "severity": "warning"
+    },
+    {
+      "direction": "lower",
+      "hard_max": 0,
+      "id": "scoring_invalid_scores",
+      "max_regression": 0,
+      "path": "metrics.scoring.invalid_scores.count",
+      "regression_unit": "count",
+      "severity": "failure"
+    }
+  ],
+  "schema_version": 1,
+  "scoring": {
+    "collapsed_category_min_products": 5
+  }
+}

--- a/data_quality_report.py
+++ b/data_quality_report.py
@@ -1,0 +1,1014 @@
+#!/usr/bin/env python3
+"""Generate TryVit's canonical PostgreSQL data-quality report and CI gate.
+
+The report is intentionally read-only. It measures the same deterministic
+PostgreSQL fixture used by ``.github/workflows/qa.yml`` and never connects to
+the hosted Supabase project unless an operator deliberately supplies those
+PostgreSQL connection variables.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from statistics import median
+from typing import Any, Protocol
+
+REPORT_SCHEMA_VERSION = 1
+BASELINE_SCHEMA_VERSION = 1
+SAMPLE_LIMIT = 10
+REQUIRED_OBJECTS = {
+    "ingredient_ref": "table",
+    "is_valid_ean": "function",
+    "mv_scoring_distribution": "materialized_view",
+    "nutrition_facts": "table",
+    "product_allergen_info": "table",
+    "product_ingredient": "table",
+    "products": "table",
+    "v_data_coverage_summary": "materialized_view",
+    "v_product_confidence": "materialized_view",
+}
+CORE_NUTRITION_FIELDS = (
+    "calories",
+    "total_fat_g",
+    "saturated_fat_g",
+    "carbs_g",
+    "sugars_g",
+    "protein_g",
+    "salt_g",
+)
+CONFIDENCE_COMPONENTS = (
+    "nutrition_pts",
+    "ingredient_pts",
+    "source_pts",
+    "ean_pts",
+    "allergen_pts",
+)
+SAFE_IDENTIFIER = re.compile(r"^[A-Za-z0-9_.:-]{1,100}$")
+
+
+OBJECTS_SQL = r"""
+WITH required(name, kind) AS (
+  VALUES
+    ('products', 'table'),
+    ('product_ingredient', 'table'),
+    ('ingredient_ref', 'table'),
+    ('product_allergen_info', 'table'),
+    ('nutrition_facts', 'table'),
+    ('v_data_coverage_summary', 'materialized_view'),
+    ('v_product_confidence', 'materialized_view'),
+    ('mv_scoring_distribution', 'materialized_view'),
+    ('is_valid_ean', 'function')
+)
+SELECT r.name, r.kind,
+       CASE
+         WHEN r.kind = 'function' THEN EXISTS (
+           SELECT 1
+           FROM pg_proc p
+           JOIN pg_namespace n ON n.oid = p.pronamespace
+           WHERE n.nspname = 'public' AND p.proname = r.name
+         )
+         WHEN r.kind = 'materialized_view' THEN EXISTS (
+           SELECT 1
+           FROM pg_class c
+           JOIN pg_namespace n ON n.oid = c.relnamespace
+           WHERE n.nspname = 'public' AND c.relname = r.name AND c.relkind = 'm'
+         )
+         ELSE EXISTS (
+           SELECT 1
+           FROM pg_class c
+           JOIN pg_namespace n ON n.oid = c.relnamespace
+           WHERE n.nspname = 'public' AND c.relname = r.name AND c.relkind IN ('r', 'p')
+         )
+       END AS exists
+FROM required r
+ORDER BY r.name
+"""
+
+DATASET_SQL = r"""
+SELECT
+  COUNT(*) FILTER (WHERE is_deprecated IS NOT TRUE)::integer AS active_products,
+  COUNT(*) FILTER (WHERE is_deprecated IS TRUE)::integer AS deprecated_products,
+  COUNT(*)::integer AS total_products,
+  COUNT(DISTINCT country) FILTER (WHERE is_deprecated IS NOT TRUE)::integer AS countries,
+  COUNT(DISTINCT category) FILTER (WHERE is_deprecated IS NOT TRUE)::integer AS categories
+FROM public.products
+"""
+
+EXPECTED_SEGMENTS_SQL = r"""
+SELECT 'country' AS scope, country_code AS segment,
+       (SELECT COUNT(*) FROM public.products p
+        WHERE p.is_deprecated IS NOT TRUE AND p.country = c.country_code)::integer AS active_products
+FROM public.country_ref c
+WHERE c.is_active
+UNION ALL
+SELECT 'category', category,
+       (SELECT COUNT(*) FROM public.products p
+        WHERE p.is_deprecated IS NOT TRUE AND p.category = c.category)::integer
+FROM public.category_ref c
+WHERE c.is_active
+ORDER BY 1, 2
+"""
+
+PRODUCT_FACTS_SQL = r"""
+SELECT
+  p.product_id,
+  p.country,
+  p.category,
+  p.product_name,
+  p.brand,
+  p.ean,
+  public.is_valid_ean(p.ean) AS ean_valid,
+  p.confidence AS persisted_confidence,
+  p.unhealthiness_score,
+  COALESCE(i.ingredient_count, 0)::integer AS ingredient_count,
+  COALESCE(a.contains_count, 0)::integer AS allergen_contains_count,
+  COALESCE(a.traces_count, 0)::integer AS allergen_traces_count,
+  nf.calories,
+  nf.total_fat_g,
+  nf.saturated_fat_g,
+  nf.trans_fat_g,
+  nf.carbs_g,
+  nf.sugars_g,
+  nf.fibre_g,
+  nf.protein_g,
+  nf.salt_g,
+  c.nutrition_pts,
+  c.ingredient_pts,
+  c.source_pts,
+  c.ean_pts,
+  c.allergen_pts,
+  c.total_confidence,
+  c.confidence_band
+FROM public.products p
+LEFT JOIN LATERAL (
+  SELECT COUNT(*) AS ingredient_count
+  FROM public.product_ingredient pi
+  WHERE pi.product_id = p.product_id
+) i ON true
+LEFT JOIN LATERAL (
+  SELECT COUNT(*) FILTER (WHERE pai.type = 'contains') AS contains_count,
+         COUNT(*) FILTER (WHERE pai.type = 'traces') AS traces_count
+  FROM public.product_allergen_info pai
+  WHERE pai.product_id = p.product_id
+) a ON true
+LEFT JOIN public.nutrition_facts nf ON nf.product_id = p.product_id
+LEFT JOIN public.v_product_confidence c ON c.product_id = p.product_id
+WHERE p.is_deprecated IS NOT TRUE
+ORDER BY p.product_id
+"""
+
+INGREDIENT_REFS_SQL = r"""
+SELECT
+  (SELECT COUNT(*) FROM public.ingredient_ref)::integer AS total_refs,
+  (SELECT COUNT(DISTINCT ingredient_id) FROM public.product_ingredient)::integer AS used_refs,
+  (SELECT COUNT(*) FROM public.ingredient_ref ir
+   WHERE NOT EXISTS (
+     SELECT 1 FROM public.product_ingredient pi
+     WHERE pi.ingredient_id = ir.ingredient_id
+   ))::integer AS unused_refs,
+  (SELECT COUNT(*) FROM public.product_ingredient pi
+   WHERE NOT EXISTS (
+     SELECT 1 FROM public.products p WHERE p.product_id = pi.product_id
+   ))::integer AS orphan_product_links,
+  (SELECT COUNT(*) FROM public.product_ingredient pi
+   WHERE NOT EXISTS (
+     SELECT 1 FROM public.ingredient_ref ir
+     WHERE ir.ingredient_id = pi.ingredient_id
+   ))::integer AS orphan_ref_links
+"""
+
+DUPLICATE_EANS_SQL = r"""
+SELECT country, ean, COUNT(*)::integer AS product_count,
+       ARRAY_AGG(product_id ORDER BY product_id) AS product_ids
+FROM public.products
+WHERE is_deprecated IS NOT TRUE AND ean IS NOT NULL AND btrim(ean) <> ''
+GROUP BY country, ean
+HAVING COUNT(*) > 1
+ORDER BY country, ean
+"""
+
+COVERAGE_VIEW_SQL = r"""
+SELECT country, category, total_products, with_ingredients, ingredient_pct,
+       with_allergens, allergen_pct, with_ean, ean_pct, avg_completeness_pct
+FROM public.v_data_coverage_summary
+ORDER BY country, category
+"""
+
+SCORING_VIEW_SQL = r"""
+SELECT country, category, band, product_count, pct_of_category,
+       avg_score, min_score, max_score, stddev_score
+FROM public.mv_scoring_distribution
+ORDER BY country, category,
+  CASE band
+    WHEN 'Green' THEN 1 WHEN 'Yellow' THEN 2 WHEN 'Orange' THEN 3
+    WHEN 'Red' THEN 4 WHEN 'Dark Red' THEN 5 ELSE 6
+  END
+"""
+
+
+class QueryExecutor(Protocol):
+    """Minimal interface used by the report builder and unit tests."""
+
+    def rows(self, name: str, sql: str) -> list[dict[str, Any]]:
+        """Return a query result as JSON-compatible row dictionaries."""
+
+
+@dataclass
+class PsqlExecutor:
+    """Read-only JSON query runner using the repository's existing psql convention."""
+
+    executable: str = "psql"
+
+    def rows(self, name: str, sql: str) -> list[dict[str, Any]]:
+        wrapped = f"SELECT COALESCE(jsonb_agg(row_to_json(q)), '[]'::jsonb) FROM ({sql.rstrip().rstrip(';')}) q;"
+        command = [
+            self.executable,
+            "-X",
+            "--no-psqlrc",
+            "--quiet",
+            "--tuples-only",
+            "--no-align",
+            "--set=ON_ERROR_STOP=1",
+            "--command",
+            wrapped,
+        ]
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env=os.environ.copy(),
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip().splitlines()
+            safe_detail = detail[-1] if detail else "psql returned no diagnostic"
+            raise RuntimeError(f"query {name!r} failed: {safe_detail}")
+        payload = result.stdout.strip()
+        if not payload:
+            raise RuntimeError(f"query {name!r} returned no JSON payload")
+        parsed = json.loads(payload)
+        if not isinstance(parsed, list):
+            raise RuntimeError(f"query {name!r} returned malformed JSON")
+        return parsed
+
+
+def pct(count: int, total: int) -> float | None:
+    """Return a one-decimal percentage, preserving not-applicable as null."""
+    if total == 0:
+        return None
+    return round(100.0 * count / total, 1)
+
+
+def count_metric(count: int, total: int) -> dict[str, int | float | None]:
+    return {"count": count, "pct": pct(count, total)}
+
+
+def safe_identifier(value: str, label: str) -> str:
+    if not SAFE_IDENTIFIER.fullmatch(value):
+        raise ValueError(f"{label} must contain only safe identifier characters")
+    return value
+
+
+def load_json_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"{label} not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label} is malformed JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must contain a JSON object: {path}")
+    return value
+
+
+def validate_config(config: dict[str, Any]) -> None:
+    if config.get("schema_version") != 1:
+        raise ValueError("threshold config schema_version must be 1")
+    if config.get("report_schema_version") != REPORT_SCHEMA_VERSION:
+        raise ValueError("threshold config targets an incompatible report schema")
+    if not isinstance(config.get("rules"), list) or not config["rules"]:
+        raise ValueError("threshold config rules must be a non-empty list")
+    seen: set[str] = set()
+    for rule in config["rules"]:
+        if not isinstance(rule, dict):
+            raise ValueError("every threshold rule must be an object")
+        required = {"id", "path", "direction", "severity"}
+        if not required.issubset(rule):
+            raise ValueError(f"threshold rule is missing fields: {required - set(rule)}")
+        if rule["id"] in seen:
+            raise ValueError(f"duplicate threshold rule id: {rule['id']}")
+        seen.add(rule["id"])
+        if rule["direction"] not in {"higher", "lower"}:
+            raise ValueError(f"invalid direction for rule {rule['id']}")
+        if rule["severity"] not in {"failure", "warning"}:
+            raise ValueError(f"invalid severity for rule {rule['id']}")
+        if rule.get("regression_unit") not in {"count", "percentage_points", "points"}:
+            raise ValueError(f"invalid regression_unit for rule {rule['id']}")
+        for key in ("hard_min", "hard_max", "max_regression"):
+            if key in rule and rule[key] is not None and not isinstance(rule[key], (int, float)):
+                raise ValueError(f"{key} must be numeric for rule {rule['id']}")
+    if not isinstance(config.get("country_overrides", {}), dict):
+        raise ValueError("country_overrides must be an object")
+
+
+def validate_baseline(baseline: dict[str, Any], dataset_id: str) -> None:
+    if baseline.get("baseline_schema_version") != BASELINE_SCHEMA_VERSION:
+        raise ValueError("baseline schema_version is missing or incompatible")
+    if baseline.get("report_schema_version") != REPORT_SCHEMA_VERSION:
+        raise ValueError("baseline targets an incompatible report schema")
+    if baseline.get("dataset_id") != dataset_id:
+        raise ValueError("baseline dataset_id does not match the current dataset")
+    if not isinstance(baseline.get("values"), dict):
+        raise ValueError("baseline values must be an object")
+    safe_identifier(str(baseline.get("baseline_id", "")), "baseline_id")
+
+
+def get_path(value: dict[str, Any], path: str) -> Any:
+    current: Any = value
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            raise KeyError(path)
+        current = current[part]
+    return current
+
+
+def nutrition_impossible(row: dict[str, Any]) -> bool:
+    values = {field: row.get(field) for field in CORE_NUTRITION_FIELDS}
+    numeric = [value for value in values.values() if value is not None]
+    if any(value < 0 for value in numeric):
+        return True
+    if any((values[field] or 0) > 100 for field in ("total_fat_g", "carbs_g", "protein_g")):
+        return True
+    if (values["salt_g"] or 0) > 40 or (values["calories"] or 0) > 900:
+        return True
+    if (
+        values["saturated_fat_g"] is not None
+        and values["total_fat_g"] is not None
+        and values["saturated_fat_g"] > values["total_fat_g"]
+    ):
+        return True
+    if values["sugars_g"] is not None and values["carbs_g"] is not None and values["sugars_g"] > values["carbs_g"]:
+        return True
+    return sum((values[field] or 0) for field in ("total_fat_g", "carbs_g", "protein_g")) > 105
+
+
+def segment_metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    total = len(rows)
+    with_ingredients = sum(row["ingredient_count"] > 0 for row in rows)
+    with_contains = sum(row["allergen_contains_count"] > 0 for row in rows)
+    with_any_allergen = sum(row["allergen_contains_count"] + row["allergen_traces_count"] > 0 for row in rows)
+    nutrition_present = {field: sum(row.get(field) is not None for row in rows) for field in CORE_NUTRITION_FIELDS}
+    core_counts = [sum(row.get(field) is not None for field in CORE_NUTRITION_FIELDS) for row in rows]
+    usable_core = sum(count == len(CORE_NUTRITION_FIELDS) for count in core_counts)
+    missing_all_core = sum(count == 0 for count in core_counts)
+    partial_core = total - usable_core - missing_all_core
+    with_ean = sum(bool(row.get("ean") and str(row["ean"]).strip()) for row in rows)
+    valid_ean = sum(row.get("ean_valid") is True for row in rows)
+    invalid_ean = with_ean - valid_ean
+    duplicate_ean = sum(bool(row.get("ean_duplicate_country")) for row in rows)
+    view_rows = [row for row in rows if row.get("total_confidence") is not None]
+    confidence_bands = Counter(row.get("confidence_band") for row in view_rows)
+    persisted_mismatch = sum(
+        row.get("persisted_confidence") is not None
+        and {"verified": "high", "estimated": "medium", "low": "low"}.get(row.get("persisted_confidence"))
+        != row.get("confidence_band")
+        for row in view_rows
+    )
+    identity_fields = ("product_name", "brand", "category", "country")
+    missing_identity = {
+        field: sum(not row.get(field) or not str(row[field]).strip() for row in rows) for field in identity_fields
+    }
+    missing_any_identity = sum(
+        any(not row.get(field) or not str(row[field]).strip() for field in identity_fields) for row in rows
+    )
+    confidence_values = [float(row["total_confidence"]) for row in view_rows]
+    component_averages = {
+        field: round(sum(float(row[field]) for row in view_rows) / len(view_rows), 1) if view_rows else None
+        for field in CONFIDENCE_COMPONENTS
+    }
+    return {
+        "products": total,
+        "ingredients": {
+            "with_links": count_metric(with_ingredients, total),
+            "without_links": count_metric(total - with_ingredients, total),
+        },
+        "allergens": {
+            "known_contains": count_metric(with_contains, total),
+            "positive_declaration_present": count_metric(with_any_allergen, total),
+            "unknown": count_metric(total - with_any_allergen, total),
+        },
+        "nutrition": {
+            "usable_core": count_metric(usable_core, total),
+            "missing_all_core": count_metric(missing_all_core, total),
+            "partial_core": count_metric(partial_core, total),
+            "per_field": {field: count_metric(nutrition_present[field], total) for field in CORE_NUTRITION_FIELDS},
+            "impossible_values": count_metric(sum(nutrition_impossible(row) for row in rows), total),
+        },
+        "ean": {
+            "with_ean": count_metric(with_ean, total),
+            "without_ean": count_metric(total - with_ean, total),
+            "valid": count_metric(valid_ean, total),
+            "invalid": count_metric(invalid_ean, total),
+            "duplicate_country_aware": count_metric(duplicate_ean, total),
+        },
+        "confidence": {
+            "bands": {
+                band: count_metric(confidence_bands.get(band, 0), len(view_rows)) for band in ("high", "medium", "low")
+            },
+            "average_total": round(sum(confidence_values) / len(confidence_values), 1) if confidence_values else None,
+            "median_total": round(median(confidence_values), 1) if confidence_values else None,
+            "component_averages": component_averages,
+            "persisted_band_mismatch": count_metric(persisted_mismatch, len(view_rows)),
+            "missing_from_view": count_metric(total - len(view_rows), total),
+        },
+        "critical_fields": {
+            "definition": list(identity_fields),
+            "missing_any": count_metric(missing_any_identity, total),
+            "missing_by_field": {field: count_metric(missing_identity[field], total) for field in identity_fields},
+        },
+    }
+
+
+def build_breakdowns(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {"global": segment_metrics(rows), "country": {}, "category": {}}
+    for scope, field in (("country", "country"), ("category", "category")):
+        grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for row in rows:
+            grouped[str(row.get(field) or "<missing>")].append(row)
+        result[scope] = {key: segment_metrics(grouped[key]) for key in sorted(grouped)}
+    return result
+
+
+def object_failure_report(
+    *, generated_at: str, environment: str, dataset_id: str, failures: list[str]
+) -> dict[str, Any]:
+    return {
+        "report_schema_version": REPORT_SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "environment": environment,
+        "dataset_id": dataset_id,
+        "status": "fail",
+        "active_product_count": None,
+        "metrics": {},
+        "breakdowns": {"country": {}, "category": {}},
+        "thresholds": {},
+        "baseline": None,
+        "regressions": [],
+        "warnings": [],
+        "failures": sorted(failures),
+    }
+
+
+def reconcile_coverage(rows: list[dict[str, Any]], coverage_rows: list[dict[str, Any]]) -> list[str]:
+    expected: dict[tuple[str, str], dict[str, int]] = {}
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[(str(row.get("country")), str(row.get("category")))].append(row)
+    for key, group in grouped.items():
+        expected[key] = {
+            "total_products": len(group),
+            "with_ingredients": sum(item["ingredient_count"] > 0 for item in group),
+            "with_allergens": sum(
+                item["allergen_contains_count"] + item["allergen_traces_count"] > 0 for item in group
+            ),
+            "with_ean": sum(bool(item.get("ean") and str(item["ean"]).strip()) for item in group),
+        }
+    actual = {
+        (str(row["country"]), str(row["category"])): {
+            field: int(row[field]) for field in ("total_products", "with_ingredients", "with_allergens", "with_ean")
+        }
+        for row in coverage_rows
+    }
+    failures: list[str] = []
+    if set(expected) != set(actual):
+        failures.append("v_data_coverage_summary segments do not match active products")
+    for key in sorted(set(expected) & set(actual)):
+        if expected[key] != actual[key]:
+            failures.append(f"v_data_coverage_summary is stale for {key[0]}/{key[1]}")
+    return failures
+
+
+def score_band(value: float | int | None) -> str | None:
+    if value is None:
+        return None
+    score = float(value)
+    if 1 <= score <= 20:
+        return "Green"
+    if score <= 40:
+        return "Yellow"
+    if score <= 60:
+        return "Orange"
+    if score <= 80:
+        return "Red"
+    if score <= 100:
+        return "Dark Red"
+    return None
+
+
+def reconcile_scoring(rows: list[dict[str, Any]], scoring_rows: list[dict[str, Any]]) -> list[str]:
+    expected: Counter[tuple[str, str, str | None]] = Counter()
+    for row in rows:
+        if row.get("unhealthiness_score") is not None:
+            expected[(str(row["country"]), str(row["category"]), score_band(row["unhealthiness_score"]))] += 1
+    actual = Counter(
+        {
+            (str(row["country"]), str(row["category"]), row.get("band")): int(row["product_count"])
+            for row in scoring_rows
+        }
+    )
+    if expected != actual:
+        return ["mv_scoring_distribution does not reconcile with active product scores"]
+    return []
+
+
+def aggregate_scoring_rows(scoring_rows: list[dict[str, Any]], field: str) -> dict[str, Any]:
+    grouped: dict[str, Counter[str]] = defaultdict(Counter)
+    for row in scoring_rows:
+        grouped[str(row[field])][str(row["band"])] += int(row["product_count"])
+    result: dict[str, Any] = {}
+    for key in sorted(grouped):
+        total = sum(grouped[key].values())
+        result[key] = {
+            band: count_metric(grouped[key].get(band, 0), total)
+            for band in ("Green", "Yellow", "Orange", "Red", "Dark Red")
+        }
+    return result
+
+
+def scoring_metrics(
+    rows: list[dict[str, Any]], scoring_rows: list[dict[str, Any]], minimum_sample: int
+) -> dict[str, Any]:
+    valid_products = [row for row in rows if row.get("unhealthiness_score") is not None]
+    invalid_products = [
+        row
+        for row in valid_products
+        if float(row["unhealthiness_score"]) < 1 or float(row["unhealthiness_score"]) > 100
+    ]
+    band_counts: Counter[str] = Counter()
+    category_bands: dict[str, set[str]] = defaultdict(set)
+    category_counts: Counter[str] = Counter()
+    for row in scoring_rows:
+        count = int(row["product_count"])
+        band_counts[str(row["band"])] += count
+        category_bands[str(row["category"])].add(str(row["band"]))
+        category_counts[str(row["category"])] += count
+    collapsed = sorted(
+        category
+        for category, bands in category_bands.items()
+        if len(bands) == 1 and category_counts[category] >= minimum_sample
+    )
+    product_categories = {str(row["category"]) for row in rows}
+    scoring_categories = {str(row["category"]) for row in scoring_rows}
+    empty_categories = sorted(product_categories - scoring_categories)
+    values = [float(row["unhealthiness_score"]) for row in valid_products]
+    return {
+        "source": "mv_scoring_distribution",
+        "bands": {
+            band: count_metric(band_counts.get(band, 0), len(valid_products))
+            for band in ("Green", "Yellow", "Orange", "Red", "Dark Red")
+        },
+        "null_scores": count_metric(len(rows) - len(valid_products), len(rows)),
+        "invalid_scores": count_metric(len(invalid_products), len(rows)),
+        "average_score": round(sum(values) / len(values), 1) if values else None,
+        "median_score": round(median(values), 1) if values else None,
+        "collapsed_categories": collapsed,
+        "collapsed_category_count": len(collapsed),
+        "empty_categories": empty_categories,
+        "empty_category_count": len(empty_categories),
+        "by_country": aggregate_scoring_rows(scoring_rows, "country"),
+        "by_category": aggregate_scoring_rows(scoring_rows, "category"),
+        "country_category": [
+            {
+                "country": row["country"],
+                "category": row["category"],
+                "band": row["band"],
+                "product_count": int(row["product_count"]),
+                "pct_of_category": row["pct_of_category"],
+                "avg_score": row["avg_score"],
+                "min_score": row["min_score"],
+                "max_score": row["max_score"],
+                "stddev_score": row["stddev_score"],
+            }
+            for row in scoring_rows
+        ],
+    }
+
+
+def apply_thresholds(report: dict[str, Any], config: dict[str, Any], baseline: dict[str, Any] | None) -> None:
+    failures: list[str] = report["failures"]
+    warnings: list[str] = report["warnings"]
+    regressions: list[dict[str, Any]] = report["regressions"]
+    baseline_values = baseline["values"] if baseline else {}
+    outcomes: list[dict[str, Any]] = []
+    for rule in sorted(config["rules"], key=lambda item: item["id"]):
+        rule_id = str(rule["id"])
+        try:
+            current = get_path(report, str(rule["path"]))
+        except KeyError:
+            failures.append(f"threshold metric unavailable: {rule_id}")
+            continue
+        if current is None or not isinstance(current, (int, float)):
+            failures.append(f"threshold metric is not numeric: {rule_id}")
+            continue
+        messages: list[str] = []
+        hard_min = rule.get("hard_min")
+        hard_max = rule.get("hard_max")
+        if hard_min is not None and current < hard_min:
+            messages.append(f"{rule_id}={current} is below hard minimum {hard_min}")
+        if hard_max is not None and current > hard_max:
+            messages.append(f"{rule_id}={current} exceeds hard maximum {hard_max}")
+        baseline_value = baseline_values.get(rule_id)
+        regression = None
+        if baseline is not None:
+            if not isinstance(baseline_value, (int, float)):
+                failures.append(f"baseline value missing or non-numeric: {rule_id}")
+                continue
+            delta = round(float(current) - float(baseline_value), 3)
+            adverse = -delta if rule["direction"] == "higher" else delta
+            allowed = float(rule.get("max_regression", 0))
+            regression = {
+                "rule_id": rule_id,
+                "path": rule["path"],
+                "baseline": baseline_value,
+                "current": current,
+                "delta": delta,
+                "direction": rule["direction"],
+                "allowed_regression": allowed,
+                "regressed": adverse > allowed,
+                "improved": delta > 0 if rule["direction"] == "higher" else delta < 0,
+            }
+            regressions.append(regression)
+            if regression["regressed"]:
+                messages.append(f"{rule_id} regressed from {baseline_value} to {current} (allowed {allowed})")
+        target = failures if rule["severity"] == "failure" else warnings
+        target.extend(messages)
+        outcomes.append(
+            {
+                "id": rule_id,
+                "path": rule["path"],
+                "severity": rule["severity"],
+                "regression_unit": rule["regression_unit"],
+                "current": current,
+                "hard_min": hard_min,
+                "hard_max": hard_max,
+                "passed": not messages,
+            }
+        )
+    report["thresholds"] = {
+        "config_schema_version": config["schema_version"],
+        "rules": outcomes,
+        "country_overrides": config.get("country_overrides", {}),
+    }
+
+
+def collect_report(
+    executor: QueryExecutor,
+    *,
+    config: dict[str, Any],
+    baseline: dict[str, Any] | None,
+    generated_at: str,
+    environment: str,
+    dataset_id: str,
+) -> dict[str, Any]:
+    objects = executor.rows("required_objects", OBJECTS_SQL)
+    found = {str(row["name"]): bool(row["exists"]) for row in objects}
+    missing = sorted(name for name in REQUIRED_OBJECTS if not found.get(name, False))
+    if missing:
+        return object_failure_report(
+            generated_at=generated_at,
+            environment=environment,
+            dataset_id=dataset_id,
+            failures=[f"required database object is missing: {name}" for name in missing],
+        )
+
+    dataset = executor.rows("dataset", DATASET_SQL)[0]
+    rows = executor.rows("product_facts", PRODUCT_FACTS_SQL)
+    refs = executor.rows("ingredient_refs", INGREDIENT_REFS_SQL)[0]
+    duplicate_eans = executor.rows("duplicate_eans", DUPLICATE_EANS_SQL)
+    coverage_rows = executor.rows("coverage_view", COVERAGE_VIEW_SQL)
+    scoring_rows = executor.rows("scoring_view", SCORING_VIEW_SQL)
+    expected_segments = executor.rows("expected_segments", EXPECTED_SEGMENTS_SQL)
+    active = int(dataset["active_products"])
+    duplicate_product_ids = {int(product_id) for duplicate in duplicate_eans for product_id in duplicate["product_ids"]}
+    for row in rows:
+        row["ean_duplicate_country"] = int(row["product_id"]) in duplicate_product_ids
+    breakdowns = build_breakdowns(rows)
+    failures = reconcile_coverage(rows, coverage_rows)
+    failures.extend(reconcile_scoring(rows, scoring_rows))
+    warnings: list[str] = []
+    if active == 0:
+        failures.append("dataset has zero active products")
+    if len(rows) != active:
+        failures.append("active product query does not reconcile with products table")
+    missing_confidence = breakdowns["global"]["confidence"]["missing_from_view"]["count"]
+    if missing_confidence:
+        failures.append(f"v_product_confidence is missing {missing_confidence} active products")
+
+    empty_segments = {
+        scope: sorted(
+            str(row["segment"]) for row in expected_segments if row["scope"] == scope and row["active_products"] == 0
+        )
+        for scope in ("country", "category")
+    }
+    if empty_segments["country"]:
+        warnings.append(f"{len(empty_segments['country'])} active country references have zero products")
+    if empty_segments["category"]:
+        warnings.append(f"{len(empty_segments['category'])} active category references have zero products")
+
+    ingredient_metrics = breakdowns["global"]["ingredients"] | {
+        "reference_usage": {
+            "total": int(refs["total_refs"]),
+            "used": int(refs["used_refs"]),
+            "unused": int(refs["unused_refs"]),
+        },
+        "orphan_links": {
+            "missing_product": int(refs["orphan_product_links"]),
+            "missing_reference": int(refs["orphan_ref_links"]),
+        },
+    }
+    allergen_metrics = breakdowns["global"]["allergens"] | {
+        "completed_assessment": {
+            "value": None,
+            "availability": "unavailable",
+            "reason": "schema stores positive declarations but no assessment-complete state",
+        },
+        "explicit_no_known_allergens": {
+            "value": None,
+            "availability": "unavailable",
+            "reason": "absence of rows means unknown, not an explicit negative assessment",
+        },
+        "semantic_limit": (
+            "product_allergen_info represents contains/traces declarations only; "
+            "it cannot prove a completed assessment or no-known-allergens result"
+        ),
+    }
+    duplicate_products = sum(int(row["product_count"]) for row in duplicate_eans)
+    ean_metrics = breakdowns["global"]["ean"] | {
+        "duplicate_country_aware_groups": len(duplicate_eans),
+        "duplicate_country_aware_products": duplicate_products,
+        "duplicate_samples": [
+            {
+                "country": row["country"],
+                "ean": row["ean"],
+                "product_ids": list(row["product_ids"])[:SAMPLE_LIMIT],
+            }
+            for row in duplicate_eans[:SAMPLE_LIMIT]
+        ],
+    }
+    critical_samples = sorted(
+        int(row["product_id"])
+        for row in rows
+        if any(
+            not row.get(field) or not str(row[field]).strip()
+            for field in ("product_name", "brand", "category", "country")
+        )
+    )[:SAMPLE_LIMIT]
+    low_samples = []
+    for row in sorted(rows, key=lambda item: int(item["product_id"])):
+        if row.get("confidence_band") != "low":
+            continue
+        reasons = [field.removesuffix("_pts") for field in CONFIDENCE_COMPONENTS if row.get(field) == 0]
+        low_samples.append(
+            {
+                "product_id": int(row["product_id"]),
+                "total_confidence": row["total_confidence"],
+                "zero_components": reasons,
+            }
+        )
+        if len(low_samples) == SAMPLE_LIMIT:
+            break
+
+    report: dict[str, Any] = {
+        "report_schema_version": REPORT_SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "environment": environment,
+        "dataset_id": dataset_id,
+        "status": "pass",
+        "active_product_count": active,
+        "metrics": {
+            "dataset": {
+                "active_products": active,
+                "deprecated_products": int(dataset["deprecated_products"]),
+                "total_products": int(dataset["total_products"]),
+                "countries_with_products": int(dataset["countries"]),
+                "categories_with_products": int(dataset["categories"]),
+                "expected_empty_segments": empty_segments,
+            },
+            "ingredients": ingredient_metrics,
+            "allergens": allergen_metrics,
+            "nutrition": breakdowns["global"]["nutrition"],
+            "ean": ean_metrics,
+            "confidence": breakdowns["global"]["confidence"] | {"low_samples": low_samples},
+            "critical_fields": breakdowns["global"]["critical_fields"] | {"sample_product_ids": critical_samples},
+            "scoring": scoring_metrics(
+                rows,
+                scoring_rows,
+                int(config.get("scoring", {}).get("collapsed_category_min_products", 5)),
+            ),
+            "view_reconciliation": {
+                "coverage_view_rows": len(coverage_rows),
+                "confidence_view_rows": active - missing_confidence,
+                "scoring_view_rows": len(scoring_rows),
+            },
+        },
+        "breakdowns": {
+            "country": breakdowns["country"],
+            "category": breakdowns["category"],
+        },
+        "thresholds": {},
+        "baseline": {
+            "baseline_id": baseline["baseline_id"],
+            "dataset_id": baseline["dataset_id"],
+        }
+        if baseline
+        else None,
+        "regressions": [],
+        "warnings": warnings,
+        "failures": failures,
+    }
+    apply_thresholds(report, config, baseline)
+    report["failures"] = sorted(set(report["failures"]))
+    report["warnings"] = sorted(set(report["warnings"]))
+    report["regressions"] = sorted(report["regressions"], key=lambda item: item["rule_id"])
+    if report["failures"]:
+        report["status"] = "fail"
+    elif report["warnings"]:
+        report["status"] = "warn"
+    return report
+
+
+def baseline_from_report(report: dict[str, Any], config: dict[str, Any], baseline_id: str) -> dict[str, Any]:
+    values = {
+        rule["id"]: get_path(report, rule["path"]) for rule in sorted(config["rules"], key=lambda item: item["id"])
+    }
+    return {
+        "baseline_schema_version": BASELINE_SCHEMA_VERSION,
+        "report_schema_version": REPORT_SCHEMA_VERSION,
+        "baseline_id": safe_identifier(baseline_id, "baseline_id"),
+        "dataset_id": report["dataset_id"],
+        "created_at": report["generated_at"],
+        "values": values,
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    status_icon = {"pass": "[PASS]", "warn": "[WARN]", "fail": "[FAIL]"}[report["status"]]
+    lines = [
+        "# TryVit data-quality report",
+        "",
+        f"{status_icon} **Status: {report['status'].upper()}**",
+        "",
+        f"- Report schema: `{report['report_schema_version']}`",
+        f"- Generated: `{report['generated_at']}`",
+        f"- Environment: `{report['environment']}`",
+        f"- Dataset: `{report['dataset_id']}`",
+        f"- Active products: `{report['active_product_count']}`",
+        "",
+    ]
+    if not report["metrics"]:
+        lines.extend(["## Failures", "", *[f"- {item}" for item in report["failures"]], ""])
+        return "\n".join(lines)
+    metrics = report["metrics"]
+    lines.extend(
+        [
+            "## Required coverage",
+            "",
+            "| Metric | Count | Percent |",
+            "|---|---:|---:|",
+        ]
+    )
+    coverage_rows = (
+        ("Ingredients linked", metrics["ingredients"]["with_links"]),
+        ("Known allergen contains", metrics["allergens"]["known_contains"]),
+        ("Nutrition usable core", metrics["nutrition"]["usable_core"]),
+        ("Valid EAN", metrics["ean"]["valid"]),
+        ("Low confidence", metrics["confidence"]["bands"]["low"]),
+        ("Missing critical identity", metrics["critical_fields"]["missing_any"]),
+    )
+    for label, value in coverage_rows:
+        percent = "N/A" if value["pct"] is None else f"{value['pct']:.1f}%"
+        lines.append(f"| {label} | {value['count']} | {percent} |")
+    lines.extend(
+        [
+            "",
+            "## Confidence",
+            "",
+            f"Average: `{metrics['confidence']['average_total']}`; "
+            f"Median: `{metrics['confidence']['median_total']}`; "
+            f"Missing view rows: `{metrics['confidence']['missing_from_view']['count']}`",
+            "",
+            "## Allergen semantics",
+            "",
+            metrics["allergens"]["semantic_limit"],
+            "",
+            "## Scoring",
+            "",
+            f"Average score: `{metrics['scoring']['average_score']}`; "
+            f"Median score: `{metrics['scoring']['median_score']}`; "
+            f"Collapsed categories: `{metrics['scoring']['collapsed_category_count']}`",
+            "",
+            "## Baseline comparison",
+            "",
+            "| Rule | Baseline | Current | Delta | Result |",
+            "|---|---:|---:|---:|---|",
+        ]
+    )
+    if report["regressions"]:
+        for item in report["regressions"]:
+            result = "regressed" if item["regressed"] else "improved" if item["improved"] else "stable"
+            lines.append(
+                f"| `{item['rule_id']}` | {item['baseline']} | {item['current']} | {item['delta']:+g} | {result} |"
+            )
+    else:
+        lines.append("| _No baseline supplied_ | N/A | N/A | N/A | N/A |")
+    for heading, values in (("Failures", report["failures"]), ("Warnings", report["warnings"])):
+        lines.extend(["", f"## {heading}", ""])
+        lines.extend([f"- {item}" for item in values] or ["- None"])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_outputs(report: dict[str, Any], json_path: Path, markdown_path: Path) -> None:
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=Path("data-quality/thresholds.json"))
+    parser.add_argument("--baseline", type=Path)
+    parser.add_argument("--json-out", type=Path, default=Path("data-quality-report.json"))
+    parser.add_argument("--markdown-out", type=Path, default=Path("data-quality-report.md"))
+    parser.add_argument("--environment", default="ci" if os.environ.get("CI") else "local")
+    parser.add_argument("--dataset-id", default="local-postgres")
+    parser.add_argument("--generated-at")
+    parser.add_argument("--update-baseline", type=Path)
+    parser.add_argument("--baseline-id")
+    return parser.parse_args(argv)
+
+
+def run(argv: list[str] | None = None, executor: QueryExecutor | None = None) -> int:
+    args = parse_args(argv)
+    generated_at = args.generated_at or datetime.now(UTC).replace(microsecond=0).isoformat()
+    report: dict[str, Any]
+    try:
+        environment = safe_identifier(args.environment, "environment")
+        dataset_id = safe_identifier(args.dataset_id, "dataset_id")
+        config = load_json_object(args.config, "threshold config")
+        validate_config(config)
+        baseline = None
+        if args.baseline:
+            baseline = load_json_object(args.baseline, "baseline")
+            validate_baseline(baseline, dataset_id)
+        if args.update_baseline and args.baseline:
+            raise ValueError("--update-baseline cannot be combined with --baseline")
+        report = collect_report(
+            executor or PsqlExecutor(),
+            config=config,
+            baseline=baseline,
+            generated_at=generated_at,
+            environment=environment,
+            dataset_id=dataset_id,
+        )
+        if args.update_baseline:
+            if report["failures"]:
+                raise ValueError("refusing to update a baseline from a failing report")
+            if not args.baseline_id:
+                raise ValueError("--baseline-id is required with --update-baseline")
+            baseline_payload = baseline_from_report(report, config, args.baseline_id)
+            args.update_baseline.parent.mkdir(parents=True, exist_ok=True)
+            args.update_baseline.write_text(
+                json.dumps(baseline_payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+    except (RuntimeError, ValueError, json.JSONDecodeError) as exc:
+        environment = getattr(args, "environment", "unknown")
+        dataset_id = getattr(args, "dataset_id", "unknown")
+        report = object_failure_report(
+            generated_at=generated_at,
+            environment=str(environment),
+            dataset_id=str(dataset_id),
+            failures=[str(exc)],
+        )
+    write_outputs(report, args.json_out, args.markdown_out)
+    sys.stdout.write(markdown_report(report))
+    return 1 if report["failures"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/db/pipelines/chips-pl/PIPELINE__chips-pl__01_insert_products.sql
+++ b/db/pipelines/chips-pl/PIPELINE__chips-pl__01_insert_products.sql
@@ -4,7 +4,9 @@
 
 -- 0a. DEPRECATE old products in this category & release their EANs
 update products
-set is_deprecated = true, ean = null
+set is_deprecated = true,
+    deprecated_reason = 'Replaced by pipeline refresh',
+    ean = null
 where country = 'PL'
   and category = 'Chips'
   and is_deprecated is not true;

--- a/db/pipelines/chips-pl/PIPELINE__chips__01_insert_products.sql
+++ b/db/pipelines/chips-pl/PIPELINE__chips__01_insert_products.sql
@@ -4,7 +4,9 @@
 
 -- 0a. DEPRECATE old products in this category & release their EANs
 update products
-set is_deprecated = true, ean = null
+set is_deprecated = true,
+    deprecated_reason = 'Replaced by pipeline refresh',
+    ean = null
 where country = 'PL'
   and category = 'Chips'
   and is_deprecated is not true;

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,8 +1,8 @@
 # Documentation Index
 
-> **Last updated:** 2026-05-31
+> **Last updated:** 2026-07-28
 > **Status:** Active — update when adding, renaming, or archiving docs
-> **Total documents:** 68 in `docs/` + 11 in `docs/decisions/` + 25 in `docs/assets/logo/` + 7 in `docs/assets/banners/` + 7 elsewhere in repo
+> **Total documents:** 69 in `docs/` + 11 in `docs/decisions/` + 25 in `docs/assets/logo/` + 7 in `docs/assets/banners/` + 7 elsewhere in repo
 > **Reference:** Issue [#200](https://github.com/ericsocrat/tryvit/issues/200), [#201](https://github.com/ericsocrat/tryvit/issues/201)
 
 ---
@@ -17,7 +17,7 @@
 | [Banners](#banners)                                      | 5     | Social preview, README hero banner (SVG + PNG), badges reference                                                                                                        |
 | [API](#api)                                              | 6     | Contracts, conventions, versioning, frontend mapping, contract testing, registry                                                                                        |
 | [Scoring](#scoring)                                      | 2     | Methodology (formula), engine (architecture)                                                                                                                            |
-| [Data & Provenance](#data--provenance)                   | 5     | Sources, provenance, integrity audits, EAN validation, production data                                                                                                  |
+| [Data & Provenance](#data--provenance)                   | 6     | Sources, provenance, integrity audits, quality reporting, EAN validation, production data                                                                               |
 | [Security & Compliance](#security--compliance)           | 5     | Root policy, audit report, access audit, privacy checklist, rate limiting                                                                                               |
 | [Observability & Operations](#observability--operations) | 9     | Monitoring, observability, log schema, alerts, on-call policy, SLOs, metrics, incident response, disaster drill                                                         |
 | [DevOps & Environment](#devops--environment)             | 3     | Environment strategy, staging setup, Sonar config                                                                                                                       |
@@ -147,6 +147,7 @@
 | [DATA_SOURCES.md](DATA_SOURCES.md)                   | Source hierarchy & validation workflow — OFF API, manual entry                   | [#193](https://github.com/ericsocrat/tryvit/issues/193) | 2026-02-12   |
 | [DATA_PROVENANCE.md](DATA_PROVENANCE.md)             | Data provenance & freshness governance — lineage tracking, staleness detection   | [#193](https://github.com/ericsocrat/tryvit/issues/193) | 2026-02-24   |
 | [DATA_INTEGRITY_AUDITS.md](DATA_INTEGRITY_AUDITS.md) | Ongoing data integrity audit framework — nightly checks, contradiction detection | [#184](https://github.com/ericsocrat/tryvit/issues/184) | 2026-05-25   |
+| [data-quality-report.md](data-quality-report.md)     | Deterministic PostgreSQL data-quality report, baseline, and CI gate                | Phase 3 audit                                           | 2026-07-28   |
 | [EAN_VALIDATION_STATUS.md](EAN_VALIDATION_STATUS.md) | EAN coverage tracking — 997/1,025 (97.3%)                                        | Data domain                                             | 2026-02-24   |
 | [PRODUCTION_DATA.md](PRODUCTION_DATA.md)             | Production data management — sync, backup, restore procedures                    | DevOps domain                                           | 2026-02-24   |
 

--- a/docs/data-quality-report.md
+++ b/docs/data-quality-report.md
@@ -1,0 +1,82 @@
+# Data-quality report and CI gate
+
+> **Last updated:** 2026-07-28
+> **Status:** Active
+> **Owner issue:** Phase 3 repository audit
+
+`data_quality_report.py` is the canonical evidence-producing data gate for the
+deterministic PostgreSQL fixture used by `.github/workflows/qa.yml`. It is
+separate from `run_data_audit.py`, whose existing purpose is a credentialed,
+nightly Supabase integrity audit.
+
+## Grain and semantics
+
+The report uses one active product as its base grain. Global, country, and
+category results are all aggregated from the same ordered product facts, so
+their product counts reconcile. It reuses `v_product_confidence` and
+`mv_scoring_distribution`; it checks `v_data_coverage_summary` against source
+rows and fails if that view is missing or stale.
+
+Core nutrition means the seven non-null fields required by the product-detail
+API contract: calories, total fat, saturated fat, carbohydrate, sugars,
+protein, and salt. Fibre and trans fat are nullable in that contract.
+Impossible nutrition values follow the existing QA rules: negatives, core
+macronutrients over 100 g, salt over 40 g, calories over 900 kcal, saturated
+fat above total fat, sugars above carbohydrates, or total fat + carbohydrate +
+protein over 105 g per 100 g.
+
+The allergen schema stores positive `contains` and `traces` declarations only.
+It has no assessment-complete flag and no explicit “no known allergens” state.
+The report therefore labels those two metrics unavailable and treats a product
+with no declaration as unknown. It never converts absence into a safety claim.
+
+Critical identity fields are `product_name`, `brand`, `category`, and
+`country`: the product-detail API requires strings for all four. EAN is
+reported separately because the same contract explicitly permits a null EAN.
+
+## Thresholds and baseline
+
+`data-quality/thresholds.json` is version controlled. Percentage rules express
+regression tolerance in percentage points; count rules express absolute row
+changes. Hard structural failures—zero active products, query errors, malformed
+configuration/baselines, missing database objects, stale coverage/confidence
+views, scoring-view mismatch, and unavailable configured metrics—cannot be
+configured away.
+
+The committed baseline comes only from the deterministic CI fixture. The first
+fixture contained 8,552 active products, with 11.2% ingredient links, 8.1%
+known-allergen declarations, 100.0% usable core nutrition, 99.9% valid EANs,
+0.1% low-confidence products, and average confidence 61.6. Coverage floors are
+one percentage point below those observed values; the 5% low-confidence ceiling
+preserves the previous QA workflow policy. These are regression guardrails, not
+claims that the enrichment level is sufficient for the product.
+
+CI reads
+it and never updates it. An intentional baseline update is explicit:
+
+```powershell
+python data_quality_report.py `
+  --config data-quality/thresholds.json `
+  --dataset-id deterministic-ci-qa-v1 `
+  --environment ci `
+  --generated-at 2026-07-28T00:00:00+00:00 `
+  --update-baseline data-quality/baselines/ci-v1.json `
+  --baseline-id deterministic-ci-v1 `
+  --json-out data-quality-report.json `
+  --markdown-out data-quality-report.md
+```
+
+Review the baseline diff like any other source change. Do not update it merely
+to make CI pass. The initial hard targets are set from the deterministic
+fixture and its existing QA constraints; no hosted Supabase or staging data is
+used.
+
+## Exit behavior
+
+- Exit `0`: pass, including explicit warning-only findings.
+- Exit `1`: hard threshold, baseline regression, structural/query, or
+  configuration failure.
+
+JSON is the versioned machine contract, with its top-level schema in
+`data-quality/report.schema.json`. Markdown is rendered from the same report
+object and is intended for artifacts and the GitHub Actions summary.

--- a/test_data_quality_report.py
+++ b/test_data_quality_report.py
@@ -1,0 +1,510 @@
+"""Contract and failure-mode tests for the canonical data-quality report."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from copy import deepcopy
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+import check_pipeline_structure as pipeline_structure
+import data_quality_report as dqr
+
+
+def quiet_run(*args: Any, **kwargs: Any) -> int:
+    with redirect_stdout(StringIO()):
+        return dqr.run(*args, **kwargs)
+
+
+class FakeExecutor:
+    def __init__(self, values: dict[str, list[dict[str, Any]]]) -> None:
+        self.values = values
+
+    def rows(self, name: str, sql: str) -> list[dict[str, Any]]:
+        del sql
+        value = self.values[name]
+        if isinstance(value, Exception):
+            raise value
+        return deepcopy(value)
+
+
+def config(*, severity: str = "failure", max_regression: float = 1.0) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "report_schema_version": 1,
+        "scoring": {"collapsed_category_min_products": 5},
+        "country_overrides": {},
+        "rules": [
+            {
+                "id": "active_products",
+                "path": "metrics.dataset.active_products",
+                "regression_unit": "count",
+                "direction": "higher",
+                "severity": "failure",
+                "hard_min": 1,
+                "max_regression": 0,
+            },
+            {
+                "id": "ingredient_coverage_pct",
+                "path": "metrics.ingredients.with_links.pct",
+                "regression_unit": "percentage_points",
+                "direction": "higher",
+                "severity": severity,
+                "hard_min": 50,
+                "max_regression": max_regression,
+            },
+        ],
+    }
+
+
+def baseline(ingredient_pct: float = 66.7) -> dict[str, Any]:
+    return {
+        "baseline_schema_version": 1,
+        "report_schema_version": 1,
+        "baseline_id": "ci-v1",
+        "dataset_id": "deterministic-ci-qa-v1",
+        "created_at": "2026-07-28T00:00:00+00:00",
+        "values": {
+            "active_products": 3,
+            "ingredient_coverage_pct": ingredient_pct,
+        },
+    }
+
+
+def row(
+    product_id: int,
+    *,
+    country: str,
+    category: str,
+    ingredients: int,
+    allergens: int,
+    ean: str | None,
+    ean_valid: bool | None,
+    band: str,
+    total: int,
+    persisted: str,
+    score: int,
+) -> dict[str, Any]:
+    nutrition = {
+        "calories": 100,
+        "total_fat_g": 2,
+        "saturated_fat_g": 1,
+        "trans_fat_g": None,
+        "carbs_g": 10,
+        "sugars_g": 5,
+        "fibre_g": None,
+        "protein_g": 3,
+        "salt_g": 0.2,
+    }
+    return {
+        "product_id": product_id,
+        "country": country,
+        "category": category,
+        "product_name": f"Product {product_id}",
+        "brand": "TryVit",
+        "ean": ean,
+        "ean_valid": ean_valid,
+        "persisted_confidence": persisted,
+        "unhealthiness_score": score,
+        "ingredient_count": ingredients,
+        "allergen_contains_count": allergens,
+        "allergen_traces_count": 0,
+        **nutrition,
+        "nutrition_pts": 30,
+        "ingredient_pts": 25 if ingredients else 0,
+        "source_pts": 18,
+        "ean_pts": 10 if ean else 0,
+        "allergen_pts": 10 if allergens else 0,
+        "total_confidence": total,
+        "confidence_band": band,
+    }
+
+
+def valid_values() -> dict[str, list[dict[str, Any]]]:
+    rows = [
+        row(
+            1,
+            country="PL",
+            category="A",
+            ingredients=2,
+            allergens=1,
+            ean="5901234123457",
+            ean_valid=True,
+            band="high",
+            total=93,
+            persisted="verified",
+            score=10,
+        ),
+        row(
+            2,
+            country="PL",
+            category="A",
+            ingredients=1,
+            allergens=0,
+            ean="96385074",
+            ean_valid=True,
+            band="medium",
+            total=63,
+            persisted="estimated",
+            score=30,
+        ),
+        row(
+            3,
+            country="DE",
+            category="B",
+            ingredients=0,
+            allergens=0,
+            ean=None,
+            ean_valid=None,
+            band="low",
+            total=48,
+            persisted="low",
+            score=70,
+        ),
+    ]
+    return {
+        "required_objects": [
+            {"name": name, "kind": kind, "exists": True} for name, kind in sorted(dqr.REQUIRED_OBJECTS.items())
+        ],
+        "dataset": [
+            {
+                "active_products": 3,
+                "deprecated_products": 1,
+                "total_products": 4,
+                "countries": 2,
+                "categories": 2,
+            }
+        ],
+        "product_facts": rows,
+        "ingredient_refs": [
+            {
+                "total_refs": 2,
+                "used_refs": 2,
+                "unused_refs": 0,
+                "orphan_product_links": 0,
+                "orphan_ref_links": 0,
+            }
+        ],
+        "duplicate_eans": [],
+        "coverage_view": [
+            {
+                "country": "DE",
+                "category": "B",
+                "total_products": 1,
+                "with_ingredients": 0,
+                "ingredient_pct": 0,
+                "with_allergens": 0,
+                "allergen_pct": 0,
+                "with_ean": 0,
+                "ean_pct": 0,
+                "avg_completeness_pct": 50,
+            },
+            {
+                "country": "PL",
+                "category": "A",
+                "total_products": 2,
+                "with_ingredients": 2,
+                "ingredient_pct": 100,
+                "with_allergens": 1,
+                "allergen_pct": 50,
+                "with_ean": 2,
+                "ean_pct": 100,
+                "avg_completeness_pct": 90,
+            },
+        ],
+        "scoring_view": [
+            {
+                "country": "DE",
+                "category": "B",
+                "band": "Red",
+                "product_count": 1,
+                "pct_of_category": 100,
+                "avg_score": 70,
+                "min_score": 70,
+                "max_score": 70,
+                "stddev_score": 0,
+            },
+            {
+                "country": "PL",
+                "category": "A",
+                "band": "Green",
+                "product_count": 1,
+                "pct_of_category": 50,
+                "avg_score": 10,
+                "min_score": 10,
+                "max_score": 10,
+                "stddev_score": 0,
+            },
+            {
+                "country": "PL",
+                "category": "A",
+                "band": "Yellow",
+                "product_count": 1,
+                "pct_of_category": 50,
+                "avg_score": 30,
+                "min_score": 30,
+                "max_score": 30,
+                "stddev_score": 0,
+            },
+        ],
+        "expected_segments": [
+            {"scope": "category", "segment": "A", "active_products": 2},
+            {"scope": "category", "segment": "B", "active_products": 1},
+            {"scope": "country", "segment": "DE", "active_products": 1},
+            {"scope": "country", "segment": "PL", "active_products": 2},
+        ],
+    }
+
+
+def report_for(
+    values: dict[str, list[dict[str, Any]]] | None = None,
+    *,
+    threshold_config: dict[str, Any] | None = None,
+    baseline_value: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return dqr.collect_report(
+        FakeExecutor(values or valid_values()),
+        config=threshold_config or config(),
+        baseline=baseline_value,
+        generated_at="2026-07-28T00:00:00+00:00",
+        environment="ci",
+        dataset_id="deterministic-ci-qa-v1",
+    )
+
+
+class DataQualityReportTests(unittest.TestCase):
+    def test_valid_dataset_passes(self) -> None:
+        report = report_for()
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual(report["failures"], [])
+
+    def test_zero_products_is_always_a_hard_failure(self) -> None:
+        values = valid_values()
+        values["dataset"][0].update(
+            active_products=0, deprecated_products=0, total_products=0, countries=0, categories=0
+        )
+        values["product_facts"] = []
+        values["coverage_view"] = []
+        values["scoring_view"] = []
+        values["expected_segments"] = []
+        report = report_for(values)
+        self.assertEqual(report["status"], "fail")
+        self.assertIn("dataset has zero active products", report["failures"])
+
+    def test_ingredient_regression_beyond_tolerance_fails(self) -> None:
+        report = report_for(baseline_value=baseline(80.0))
+        self.assertEqual(report["status"], "fail")
+        self.assertTrue(any("ingredient_coverage_pct regressed" in item for item in report["failures"]))
+
+    def test_regression_within_tolerance_is_reported_but_passes(self) -> None:
+        report = report_for(baseline_value=baseline(67.0))
+        self.assertEqual(report["status"], "pass")
+        regression = next(item for item in report["regressions"] if item["rule_id"] == "ingredient_coverage_pct")
+        self.assertFalse(regression["regressed"])
+        self.assertEqual(regression["delta"], -0.3)
+
+    def test_warning_only_rule_does_not_fail(self) -> None:
+        report = report_for(
+            threshold_config=config(severity="warning"),
+            baseline_value=baseline(80.0),
+        )
+        self.assertEqual(report["status"], "warn")
+        self.assertEqual(report["failures"], [])
+        self.assertTrue(report["warnings"])
+
+    def test_malformed_threshold_config_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "schema_version"):
+            dqr.validate_config({"schema_version": 9})
+
+    def test_incompatible_baseline_is_rejected(self) -> None:
+        value = baseline()
+        value["report_schema_version"] = 99
+        with self.assertRaisesRegex(ValueError, "incompatible"):
+            dqr.validate_baseline(value, "deterministic-ci-qa-v1")
+
+    def test_missing_baseline_file_produces_failure_report(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(config()), encoding="utf-8")
+            exit_code = quiet_run(
+                [
+                    "--config",
+                    str(config_path),
+                    "--baseline",
+                    str(root / "missing.json"),
+                    "--json-out",
+                    str(root / "report.json"),
+                    "--markdown-out",
+                    str(root / "report.md"),
+                ],
+                executor=FakeExecutor(valid_values()),
+            )
+            self.assertEqual(exit_code, 1)
+            payload = json.loads((root / "report.json").read_text(encoding="utf-8"))
+            self.assertIn("baseline not found", payload["failures"][0])
+
+    def test_explicit_baseline_update_writes_versioned_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config_path = root / "config.json"
+            baseline_path = root / "baseline.json"
+            config_path.write_text(json.dumps(config()), encoding="utf-8")
+            exit_code = quiet_run(
+                [
+                    "--config",
+                    str(config_path),
+                    "--dataset-id",
+                    "deterministic-ci-qa-v1",
+                    "--generated-at",
+                    "2026-07-28T00:00:00+00:00",
+                    "--update-baseline",
+                    str(baseline_path),
+                    "--baseline-id",
+                    "ci-v1",
+                    "--json-out",
+                    str(root / "report.json"),
+                    "--markdown-out",
+                    str(root / "report.md"),
+                ],
+                executor=FakeExecutor(valid_values()),
+            )
+            self.assertEqual(exit_code, 0)
+            payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["report_schema_version"], 1)
+            self.assertEqual(payload["values"]["ingredient_coverage_pct"], 66.7)
+
+    def test_json_contract_contains_required_top_level_fields(self) -> None:
+        report = report_for()
+        expected = {
+            "report_schema_version",
+            "generated_at",
+            "environment",
+            "dataset_id",
+            "status",
+            "active_product_count",
+            "metrics",
+            "breakdowns",
+            "thresholds",
+            "baseline",
+            "regressions",
+            "warnings",
+            "failures",
+        }
+        self.assertEqual(set(report), expected)
+
+    def test_markdown_is_rendered_from_same_report_model(self) -> None:
+        report = report_for()
+        markdown = dqr.markdown_report(report)
+        self.assertIn(f"Active products: `{report['active_product_count']}`", markdown)
+        self.assertIn(f"Average: `{report['metrics']['confidence']['average_total']}`", markdown)
+
+    def test_breakdown_order_and_low_samples_are_deterministic(self) -> None:
+        values = valid_values()
+        values["product_facts"] = list(reversed(values["product_facts"]))
+        report = report_for(values)
+        self.assertEqual(list(report["breakdowns"]["country"]), ["DE", "PL"])
+        self.assertEqual(report["metrics"]["confidence"]["low_samples"][0]["product_id"], 3)
+
+    def test_report_never_copies_connection_secrets(self) -> None:
+        report = report_for()
+        serialized = json.dumps(report)
+        self.assertNotIn("PGPASSWORD", serialized)
+        self.assertNotIn("postgresql://", serialized)
+
+    def test_country_and_category_breakdowns_reconcile(self) -> None:
+        report = report_for()
+        global_total = report["active_product_count"]
+        for scope in ("country", "category"):
+            subtotal = sum(item["products"] for item in report["breakdowns"][scope].values())
+            self.assertEqual(subtotal, global_total)
+
+    def test_missing_required_object_cannot_false_pass(self) -> None:
+        values = valid_values()
+        values["required_objects"][0]["exists"] = False
+        report = report_for(values)
+        self.assertEqual(report["status"], "fail")
+        self.assertTrue(report["failures"])
+
+    def test_stale_coverage_view_cannot_false_pass(self) -> None:
+        values = valid_values()
+        values["coverage_view"][0]["total_products"] = 99
+        report = report_for(values)
+        self.assertEqual(report["status"], "fail")
+        self.assertTrue(any("stale" in item for item in report["failures"]))
+
+    def test_stale_scoring_view_cannot_false_pass(self) -> None:
+        values = valid_values()
+        values["scoring_view"][0]["product_count"] = 2
+        report = report_for(values)
+        self.assertEqual(report["status"], "fail")
+        self.assertTrue(any("mv_scoring_distribution" in item for item in report["failures"]))
+
+    def test_missing_confidence_rows_cannot_false_pass(self) -> None:
+        values = valid_values()
+        values["product_facts"][0]["total_confidence"] = None
+        values["product_facts"][0]["confidence_band"] = None
+        report = report_for(values)
+        self.assertEqual(report["status"], "fail")
+        self.assertTrue(any("v_product_confidence is missing" in item for item in report["failures"]))
+
+    def test_allergen_negative_assessment_is_explicitly_unavailable(self) -> None:
+        report = report_for()
+        metric = report["metrics"]["allergens"]["explicit_no_known_allergens"]
+        self.assertIsNone(metric["value"])
+        self.assertEqual(metric["availability"], "unavailable")
+
+    def test_query_failure_becomes_a_hard_failure(self) -> None:
+        values = valid_values()
+        values["required_objects"] = RuntimeError("database unavailable")  # type: ignore[assignment]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(config()), encoding="utf-8")
+            exit_code = quiet_run(
+                [
+                    "--config",
+                    str(config_path),
+                    "--json-out",
+                    str(root / "report.json"),
+                    "--markdown-out",
+                    str(root / "report.md"),
+                ],
+                executor=FakeExecutor(values),
+            )
+            self.assertEqual(exit_code, 1)
+            report = json.loads((root / "report.json").read_text(encoding="utf-8"))
+            self.assertIn("database unavailable", report["failures"])
+
+
+class PipelineDeprecationGuardTests(unittest.TestCase):
+    def test_missing_deprecation_reason_is_rejected(self) -> None:
+        sql = """
+        UPDATE products SET is_deprecated = true, ean = null
+        WHERE country = 'PL';
+        ON CONFLICT (country, brand, product_name) DO NOTHING;
+        """
+        violations = pipeline_structure._check_step_structure(
+            "example", "PIPELINE__example__01_insert_products.sql", "01_insert_products", sql
+        )
+        self.assertTrue(any("deprecated_reason" in item for item in violations))
+
+    def test_deprecation_with_reason_is_accepted(self) -> None:
+        sql = """
+        UPDATE products
+        SET is_deprecated = true, deprecated_reason = 'Replaced by refresh', ean = null
+        WHERE country = 'PL';
+        ON CONFLICT (country, brand, product_name) DO NOTHING;
+        """
+        violations = pipeline_structure._check_step_structure(
+            "example", "PIPELINE__example__01_insert_products.sql", "01_insert_products", sql
+        )
+        self.assertEqual(violations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements Phase 3 of the TryVit audit as one canonical, read-only PostgreSQL data-quality report and regression gate.

- adds `data_quality_report.py`, producing versioned JSON and Markdown from the deterministic QA database
- reports dataset viability, ingredients, allergen semantics, nutrition, EAN quality, confidence, critical fields, and scoring globally and by country/category
- reuses `v_product_confidence` and `mv_scoring_distribution`, and reconciles `v_data_coverage_summary` plus scoring rows against active products so stale/missing views cannot pass
- adds version-controlled thresholds, a JSON contract, and a committed deterministic-CI baseline
- uploads JSON/Markdown artifacts, appends the Markdown to the Actions summary, and defers failure until artifacts and summaries exist
- removes the standalone low-confidence SQL threshold so the report configuration is the single source of truth
- adds 22 focused failure-mode/contract tests
- fixes the PL chips refresh to record `deprecated_reason`, with a structural guard preventing recurrence

## Root cause

TryVit had strong schema and QA checks but no reproducible evidence artifact answering whether the loaded database contained sufficiently usable product data. Relevant signals were split across SQL diagnostics and a standalone confidence threshold. The existing `run_data_audit.py` is a credentialed hosted-Supabase integrity job, so it was not appropriate for deterministic PR gating.

Full local replay also exposed a separate CI blocker: both PL chips refresh files deprecated prior products without recording a reason. That violated existing sanity/data-consistency contracts. The fix is in the deterministic pipeline source, not a manual product edit.

## Metric semantics

- **Grain:** one active product; country/category totals reconcile to global totals
- **Ingredients:** products with/without links, orphan links, and reference usage
- **Allergens:** positive `contains`/declaration coverage and unknown products; completed assessment and explicit “no known allergens” remain explicitly unavailable because the schema cannot represent them
- **Nutrition:** seven API-required core fields, all/partial/missing coverage, per-field coverage, and existing plausibility rules
- **EAN:** presence, GS1-valid/invalid values, and country-aware duplicates
- **Confidence:** existing materialized-view bands, averages/median/components, persisted-band mismatch, missing rows, and bounded low-confidence reasons
- **Critical fields:** API-required product identity fields with bounded product IDs
- **Scoring:** existing distribution MV, null/invalid scores, descriptive statistics, collapsed/empty categories, and country/category distributions

## Deterministic CI baseline

| Metric | Value |
|---|---:|
| Active products | 8,552 |
| Ingredient link coverage | 11.2% |
| Known allergen contains coverage | 8.1% |
| Usable core nutrition | 100.0% |
| Valid EAN | 99.9% |
| Low confidence | 0.1% (7 products) |
| Average / median confidence | 61.6 / 58.0 |
| Missing critical identity | 0 |
| Duplicate country-aware EAN products | 0 |
| Invalid/impossible scoring or nutrition | 0 |

Initial coverage floors are derived from this fixture with a one-percentage-point allowance. The existing 5% low-confidence ceiling is preserved. These are regression guardrails, not a claim that 11.2% ingredient or 8.1% allergen coverage is product-ready.

## Validation

- `254 passed` — full Python pytest suite
- `769/769 passed` — full deterministic PostgreSQL QA
- `17/17 passed` — sanity checks
- baseline-backed report: pass, 0 failures, 0 warnings
- Ruff lint and format: pass
- enrichment identity and 58-folder pipeline structure guards: pass
- actionlint for `qa.yml`: pass
- repository verification and strict documentation count checks: pass

## Limitations and non-goals

- no hosted Supabase connection, staging credentials, or project reactivation
- baseline represents the deterministic CI fixture, not production or staging
- the current allergen schema cannot prove completed negative assessments
- no scanner, country expansion, UI, scoring-formula, or scheduler work
- CI never updates the baseline automatically; intentional updates require the documented explicit command and a reviewed diff

This PR is intentionally draft and should not be merged until remote QA, Main/PR Gate, CodeQL, and SonarCloud finish on the branch.