### PR TITLE
feat(data): add deterministic enrichment governance

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -101,7 +101,7 @@ jobs:
         run: python -m unittest test_data_quality_report.py
 
       - name: Deterministic enrichment unit tests
-        run: python -m unittest pipeline.test_enrichment
+        run: python -m unittest pipeline.test_enrichment pipeline.test_enrichment_governance
 
       - name: Deterministic enrichment generated-output check
         run: |
@@ -110,6 +110,9 @@ jobs:
             --manifest phase4b \
             --check \
             --stats-json
+
+      - name: Deterministic enrichment governance report check
+        run: python -m pipeline.governance_report --check
 
       - name: Enrichment identity guard
         run: |

--- a/data-quality/phase4c/report.json
+++ b/data-quality/phase4c/report.json
@@ -1,0 +1,921 @@
+{
+  "allergen_provenance": {
+    "deterministic_ingredient_derived_records": 32,
+    "explicit_source_contains_records": 1278,
+    "explicit_source_may_contain_records": 1110,
+    "missing_evidence_is_allergen_free": false,
+    "products_unknown_due_to_missing_evidence": 202,
+    "products_with_known_evidence": 739,
+    "selected_products": 941,
+    "total_records_after_provenance_union": 2420
+  },
+  "checks": {
+    "all_11_unsafe_dependent_children_withheld": true,
+    "all_23_starch_occurrences_withheld": true,
+    "all_4_vegetable_oil_occurrences_withheld": true,
+    "both_source_artifacts_quarantined": true,
+    "conflicts_absent": true,
+    "deprecated_products_unchanged": true,
+    "hosted_supabase_writes_absent": true,
+    "non_target_categories_unchanged": true,
+    "phase4b_outputs_unchanged": true,
+    "registry_valid": true
+  },
+  "conflicts_detected": [],
+  "coverage_and_confidence": {
+    "phase4b_before_after": {
+      "category_coverage": [
+        {
+          "active_products": 199,
+          "allergen_evidence": {
+            "after_count": 193,
+            "after_percentage": 97.0,
+            "before_count": 0,
+            "before_percentage": 0.0
+          },
+          "average_confidence": {
+            "after": 92.0,
+            "before": 58.0,
+            "delta": 34.0
+          },
+          "average_score": {
+            "after": 22.0,
+            "before": 21.3,
+            "delta": 0.7
+          },
+          "category": "Breakfast & Grain-Based",
+          "country": "DE",
+          "ingredient_coverage": {
+            "after_count": 195,
+            "after_percentage": 98.0,
+            "before_count": 0,
+            "before_percentage": 0.0
+          }
+        },
+        {
+          "active_products": 287,
+          "allergen_evidence": {
+            "after_count": 264,
+            "after_percentage": 92.0,
+            "before_count": 26,
+            "before_percentage": 9.1
+          },
+          "average_confidence": {
+            "after": 91.7,
+            "before": 61.3,
+            "delta": 30.4
+          },
+          "average_score": {
+            "after": 25.3,
+            "before": 25.2,
+            "delta": 0.1
+          },
+          "category": "Dairy",
+          "country": "DE",
+          "ingredient_coverage": {
+            "after_count": 281,
+            "after_percentage": 97.9,
+            "before_count": 28,
+            "before_percentage": 9.8
+          }
+        },
+        {
+          "active_products": 300,
+          "allergen_evidence": {
+            "after_count": 87,
+            "after_percentage": 29.0,
+            "before_count": 14,
+            "before_percentage": 4.7
+          },
+          "average_confidence": {
+            "after": 85.3,
+            "before": 62.2,
+            "delta": 23.1
+          },
+          "average_score": {
+            "after": 9.1,
+            "before": 8.7,
+            "delta": 0.4
+          },
+          "category": "Drinks",
+          "country": "DE",
+          "ingredient_coverage": {
+            "after_count": 294,
+            "after_percentage": 98.0,
+            "before_count": 45,
+            "before_percentage": 15.0
+          }
+        },
+        {
+          "active_products": 299,
+          "allergen_evidence": {
+            "after_count": 283,
+            "after_percentage": 94.6,
+            "before_count": 48,
+            "before_percentage": 16.1
+          },
+          "average_confidence": {
+            "after": 91.1,
+            "before": 63.6,
+            "delta": 27.5
+          },
+          "average_score": {
+            "after": 46.6,
+            "before": 46.0,
+            "delta": 0.6
+          },
+          "category": "Sweets",
+          "country": "DE",
+          "ingredient_coverage": {
+            "after_count": 292,
+            "after_percentage": 97.7,
+            "before_count": 48,
+            "before_percentage": 16.1
+          }
+        }
+      ],
+      "overall_coverage": {
+        "active_products": 8652,
+        "average_confidence": {
+          "after": 65.0,
+          "before": 61.5,
+          "delta": 3.5
+        },
+        "average_score": {
+          "after": 21.3,
+          "before": 21.3,
+          "delta": 0.0
+        },
+        "ingredients": {
+          "after_count": 1874,
+          "after_percentage": 21.7,
+          "before_count": 933,
+          "before_percentage": 10.8
+        },
+        "known_contains": {
+          "after_count": 1389,
+          "after_percentage": 16.1,
+          "before_count": 679,
+          "before_percentage": 7.8
+        }
+      }
+    },
+    "phase4c_confidence_change": 0.0,
+    "phase4c_coverage_change_percentage_points": 0.0,
+    "phase4c_linkage_change": 0,
+    "phase4c_score_change": 0.0
+  },
+  "drinks_de_analysis": {
+    "active_products": 300,
+    "ambiguous_tokens_withheld": 0,
+    "deterministic_ingredient_derived_records": 2,
+    "explicit_source_contains_records": 76,
+    "explicit_source_may_contain_records": 41,
+    "finding": "The low known-allergen coverage is primarily genuine absence of source declarations in the selected beverage records. Only two additional records are supported by deterministic ingredient rules; there are no ambiguous Drinks tokens withholding allergen evidence. The dominant unknown-product tokens are water, acids, sugar, flavourings, juices, and vitamins, so missing evidence remains unknown rather than allergen-free.",
+    "ingredient_coverage_after": {
+      "after_count": 294,
+      "after_percentage": 98.0,
+      "before_count": 45,
+      "before_percentage": 15.0
+    },
+    "known_allergen_coverage_after": {
+      "after_count": 87,
+      "after_percentage": 29.0,
+      "before_count": 14,
+      "before_percentage": 4.7
+    },
+    "phase4b_selected_products_with_ingredient_evidence": 249,
+    "selected_products_unknown_due_to_missing_evidence": 176,
+    "selected_products_with_known_evidence": 73,
+    "source_artifacts_quarantined": 1,
+    "top_tokens_in_unknown_products": [
+      {
+        "normalized_token": "water",
+        "occurrences": 75
+      },
+      {
+        "normalized_token": "acid",
+        "occurrences": 54
+      },
+      {
+        "normalized_token": "sugar",
+        "occurrences": 51
+      },
+      {
+        "normalized_token": "natural flavouring",
+        "occurrences": 42
+      },
+      {
+        "normalized_token": "vitamins",
+        "occurrences": 35
+      },
+      {
+        "normalized_token": "antioxidant",
+        "occurrences": 30
+      },
+      {
+        "normalized_token": "colour",
+        "occurrences": 27
+      },
+      {
+        "normalized_token": "flavouring",
+        "occurrences": 24
+      },
+      {
+        "normalized_token": "thiamin",
+        "occurrences": 23
+      },
+      {
+        "normalized_token": "orange juice from concentrate",
+        "occurrences": 22
+      },
+      {
+        "normalized_token": "vitamin c",
+        "occurrences": 22
+      },
+      {
+        "normalized_token": "sweetener",
+        "occurrences": 22
+      },
+      {
+        "normalized_token": "apple juice",
+        "occurrences": 21
+      },
+      {
+        "normalized_token": "acidity regulator",
+        "occurrences": 21
+      },
+      {
+        "normalized_token": "banana",
+        "occurrences": 20
+      }
+    ]
+  },
+  "governance_checksum_sha256": "c4d400d67c3bc04b45d29331cb9495c45672e3d8b613ead992771203469e0e37",
+  "governance_registry": "pipeline/enrichment_registry.json",
+  "manual_review_required": [
+    "A botanical source declaration is required before Starch can map to corn, potato, or wheat starch.",
+    "A named oil source is required before Vegetable Oil can map to a specific oil.",
+    "The source tokens Stärke Weizen and Stärke Mais should be re-reviewed if a corrected or more specific source declaration becomes available.",
+    "Allergen absence claims require explicit producer evidence; unknown Drinks records cannot be classified as allergen-free."
+  ],
+  "objective": "Deterministic enrichment governance; no new category batch or linkage writes.",
+  "observed_edge_case_counts": {
+    "approved_global_alias_occurrences": 13,
+    "approved_scoped_alias_occurrences": 0,
+    "source_artifacts_quarantined": 2,
+    "starch_ambiguous_withheld": 23,
+    "unsafe_dependent_children_withheld": 11,
+    "vegetable_oil_ambiguous_withheld": 4
+  },
+  "parent_child_decisions": [
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Breakfast & Grain-Based",
+      "child_canonical_identity": "Stärke Weizen",
+      "child_source_token": "Stärke Weizen",
+      "classification": "unsafe_parent_child_inference_and_withheld",
+      "country": "DE",
+      "ean": "4000521021870",
+      "inference_allowed": false,
+      "parent_source_token": "Starch",
+      "reason": "The child cannot be attached while the source parent lacks a safe canonical identity."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Breakfast & Grain-Based",
+      "child_canonical_identity": "Sunflower Oil",
+      "child_source_token": "Sunflower",
+      "classification": "unsafe_parent_child_inference_and_withheld",
+      "country": "DE",
+      "ean": "4056489864905",
+      "inference_allowed": false,
+      "parent_source_token": "Vegetable Oil",
+      "reason": "The child identity is known, but its unresolved parent prevents a structurally valid linkage."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Breakfast & Grain-Based",
+      "child_canonical_identity": "Cottonseed",
+      "child_source_token": "Cottonseed",
+      "classification": "unsafe_parent_child_inference_and_withheld",
+      "country": "DE",
+      "ean": "4056489864905",
+      "inference_allowed": false,
+      "parent_source_token": "Vegetable Oil",
+      "reason": "The child identity is known, but its unresolved parent prevents a structurally valid linkage."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "child_canonical_identity": "Rapeseed Oil",
+      "child_source_token": "Rapeseed",
+      "classification": "unsafe_parent_child_inference_and_withheld",
+      "country": "DE",
+      "ean": "4003751060152",
+      "inference_allowed": false,
+      "parent_source_token": "Vegetable Oil",
+      "reason": "The child identity is known, but its unresolved parent prevents a structurally valid linkage."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "child_canonical_identity": "Sunflower Oil",
+      "child_source_token": "Sunflower",
+      "classification": "unsafe_parent_child_inference_and_withheld",
+      "country": "DE",
+      "ean": "4003751060152",
+      "inference_allowed": false,
+      "parent_source_token": "Vegetable Oil",
+      "reason": "The child identity is known, but its unresolved parent prevents a structurally valid linkage."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "child_canonical_identity": "Rapeseed Oil",
+      "child_source_token": "Rapeseed",
+      "classification": "unsafe_parent_child_inference_and_withheld",
+      "country": "DE",
+      "ean": "4056489920144",
+      "inference_allowed": false,
+      "parent_source_token": "Vegetable Oil",
+      "reason": "The child identity is known, but its unresolved parent prevents a structurally valid linkage."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "child_canonical_identity": "Sunflower Oil",
+      "child_source_token": "Sunflower",
+      "classification": "unsafe_parent_child_inference_and_withheld",
+      "country": "DE",
+      "ean": "4056489920144",
+      "inference_allowed": false,
+      "parent_source_token": "Vegetable Oil",
+      "reason": "The child identity is known, but its unresolved parent prevents a structurally valid linkage."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "child_canonical_identity": "Rapeseed Oil",
+      "child_source_token": "Rapeseed",
+      "classification": "unsafe_parent_child_inference_and_withheld",
+      "country": "DE",
+      "ean": "4056489920151",
+      "inference_allowed": false,
+      "parent_source_token": "Vegetable Oil",
+      "reason": "The child identity is known, but its unresolved parent prevents a structurally valid linkage."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "child_canonical_identity": "Sunflower Oil",
+      "child_source_token": "Sunflower",
+      "classification": "unsafe_parent_child_inference_and_withheld",
+      "country": "DE",
+      "ean": "4056489920151",
+      "inference_allowed": false,
+      "parent_source_token": "Vegetable Oil",
+      "reason": "The child identity is known, but its unresolved parent prevents a structurally valid linkage."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Sweets",
+      "child_canonical_identity": "Stärke Mais",
+      "child_source_token": "Stärke Mais",
+      "classification": "unsafe_parent_child_inference_and_withheld",
+      "country": "DE",
+      "ean": "4000417663016",
+      "inference_allowed": false,
+      "parent_source_token": "Starch",
+      "reason": "The child cannot be attached while the source parent lacks a safe canonical identity."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Sweets",
+      "child_canonical_identity": "Stärke Weizen",
+      "child_source_token": "Stärke Weizen",
+      "classification": "unsafe_parent_child_inference_and_withheld",
+      "country": "DE",
+      "ean": "4000417663016",
+      "inference_allowed": false,
+      "parent_source_token": "Starch",
+      "reason": "The child cannot be attached while the source parent lacks a safe canonical identity."
+    }
+  ],
+  "phase": "4C",
+  "phase4b_compatibility": {
+    "allergen_records_created": 2420,
+    "checksums": {
+      "first_run": {
+        "all": {
+          "product_allergen_info": "39795bd2c395efb59c050153a0a980dd",
+          "product_ingredient": "c34366c5a341534e98e4d4cba9733145"
+        },
+        "non_target": {
+          "product_allergen_info": "2277d975d9f263ec769cfe703af8321f",
+          "product_ingredient": "e6b8fde7d4f6da1cd06859bc084e347a"
+        },
+        "selected": {
+          "product_allergen_info": "3eb0b4f21e3d7b09164e92e09ae8a3b4",
+          "product_ingredient": "896aca051bc066d857fabef34017ea68"
+        }
+      },
+      "rerun": {
+        "all": {
+          "product_allergen_info": "39795bd2c395efb59c050153a0a980dd",
+          "product_ingredient": "c34366c5a341534e98e4d4cba9733145"
+        },
+        "non_target": {
+          "product_allergen_info": "2277d975d9f263ec769cfe703af8321f",
+          "product_ingredient": "e6b8fde7d4f6da1cd06859bc084e347a"
+        },
+        "selected": {
+          "product_allergen_info": "3eb0b4f21e3d7b09164e92e09ae8a3b4",
+          "product_ingredient": "896aca051bc066d857fabef34017ea68"
+        }
+      }
+    },
+    "ingredient_links_created": 9988,
+    "products_enriched": 941
+  },
+  "registry_counts": {
+    "ambiguous_tokens_withheld": 2,
+    "approved_global_aliases": 2,
+    "approved_scoped_aliases": 3,
+    "parent_child_rules": 5,
+    "source_artifacts_quarantined": 2
+  },
+  "reviewed_tokens": [
+    {
+      "allergen_derivation_allowed": false,
+      "canonical_ingredient_identity": null,
+      "category_scope": [],
+      "country_scope": [],
+      "mapping_classification": "source_artifact_and_quarantined",
+      "normalized_source_token": "kcal",
+      "parent_child_inference_allowed": false,
+      "phase4b_occurrences": 1,
+      "raw_source_token": "Kcal",
+      "review_note": "Energy-unit text is not an ingredient.",
+      "review_status": "quarantined",
+      "source_or_evidence": "Nutrition-label fragment observed once in Sweets DE"
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "canonical_ingredient_identity": null,
+      "category_scope": [],
+      "country_scope": [],
+      "mapping_classification": "source_artifact_and_quarantined",
+      "normalized_source_token": "kcal 0 8",
+      "parent_child_inference_allowed": false,
+      "phase4b_occurrences": 1,
+      "raw_source_token": "Kcal 0 8",
+      "review_note": "Energy-label text was parsed inside an ingredient hierarchy and must never be linked.",
+      "review_status": "quarantined",
+      "source_or_evidence": "Nutrition-label fragment observed once in Drinks DE"
+    },
+    {
+      "allergen_derivation_allowed": true,
+      "canonical_ingredient_identity": "Paprika Or Bell Pepper",
+      "category_scope": [
+        "Frozen Vegetables"
+      ],
+      "country_scope": [
+        "PL"
+      ],
+      "mapping_classification": "context_qualified_alias",
+      "normalized_source_token": "papryka",
+      "parent_child_inference_allowed": true,
+      "phase4b_occurrences": 0,
+      "raw_source_token": "papryka",
+      "review_note": "Polish papryka means paprika or bell pepper in the approved Frozen Vegetables pilot scope.",
+      "review_status": "approved",
+      "source_or_evidence": "Reviewed Polish Phase 4A product context"
+    },
+    {
+      "allergen_derivation_allowed": true,
+      "canonical_ingredient_identity": "Paprika Or Bell Pepper",
+      "category_scope": [
+        "Meat"
+      ],
+      "country_scope": [
+        "PL"
+      ],
+      "mapping_classification": "context_qualified_alias",
+      "normalized_source_token": "papryka",
+      "parent_child_inference_allowed": true,
+      "phase4b_occurrences": 0,
+      "raw_source_token": "papryka",
+      "review_note": "Polish papryka means paprika or bell pepper in the approved Meat pilot scope.",
+      "review_status": "approved",
+      "source_or_evidence": "Reviewed Polish Phase 4A product context"
+    },
+    {
+      "allergen_derivation_allowed": true,
+      "canonical_ingredient_identity": "Rapeseed Oil",
+      "category_scope": [],
+      "country_scope": [],
+      "mapping_classification": "approved_alias",
+      "normalized_source_token": "rapeseed",
+      "parent_child_inference_allowed": true,
+      "phase4b_occurrences": 6,
+      "raw_source_token": "rapeseed",
+      "review_note": "The source token names the same oil identity without the word oil.",
+      "review_status": "approved",
+      "source_or_evidence": "OFF taxonomy synonym reviewed against the committed ingredient vocabulary"
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "candidates": [
+        "Corn Starch",
+        "Potato Starch",
+        "Wheat Starch"
+      ],
+      "canonical_ingredient_identity": null,
+      "category_scope": [],
+      "country_scope": [],
+      "mapping_classification": "ambiguous_and_withheld",
+      "normalized_source_token": "starch",
+      "parent_child_inference_allowed": false,
+      "phase4b_occurrences": 23,
+      "raw_source_token": "Starch",
+      "review_note": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence.",
+      "review_status": "withheld",
+      "source_or_evidence": "23 Phase 4B occurrences across Breakfast & Grain-Based DE, Dairy DE, and Sweets DE"
+    },
+    {
+      "allergen_derivation_allowed": true,
+      "canonical_ingredient_identity": "Sunflower Oil",
+      "category_scope": [],
+      "country_scope": [],
+      "mapping_classification": "approved_alias",
+      "normalized_source_token": "sunflower",
+      "parent_child_inference_allowed": true,
+      "phase4b_occurrences": 7,
+      "raw_source_token": "sunflower",
+      "review_note": "The source token names the same oil identity without the word oil.",
+      "review_status": "approved",
+      "source_or_evidence": "OFF taxonomy synonym reviewed against the committed ingredient vocabulary"
+    },
+    {
+      "allergen_derivation_allowed": true,
+      "canonical_ingredient_identity": "Sour Cream Powder",
+      "category_scope": [
+        "Dairy"
+      ],
+      "country_scope": [
+        "DE"
+      ],
+      "mapping_classification": "context_qualified_alias",
+      "normalized_source_token": "trockenmilcherzeugnis aus sauerrahm",
+      "parent_child_inference_allowed": true,
+      "phase4b_occurrences": 0,
+      "raw_source_token": "Trockenmilcherzeugnis aus Sauerrahm",
+      "review_note": "The German label explicitly identifies a dried sour-cream product in Dairy.",
+      "review_status": "approved",
+      "source_or_evidence": "Reviewed German dairy label context"
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "candidates": [
+        "Rapeseed Oil",
+        "Sunflower Oil"
+      ],
+      "canonical_ingredient_identity": null,
+      "category_scope": [],
+      "country_scope": [],
+      "mapping_classification": "ambiguous_and_withheld",
+      "normalized_source_token": "vegetable oil",
+      "parent_child_inference_allowed": false,
+      "phase4b_occurrences": 4,
+      "raw_source_token": "Vegetable Oil",
+      "review_note": "The broad source token cannot justify selecting one specific oil.",
+      "review_status": "withheld",
+      "source_or_evidence": "4 Phase 4B occurrences across Breakfast & Grain-Based DE and Dairy DE"
+    }
+  ],
+  "schema_version": 1,
+  "source": "supabase/migrations/20260601173035_populate_ingredients_allergens.sql",
+  "status": "pass",
+  "withheld_occurrences": [
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Breakfast & Grain-Based",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4000521021870",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Breakfast & Grain-Based",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4000521031152",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Breakfast & Grain-Based",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4056489864905",
+      "normalized_source_token": "vegetable oil",
+      "parent_source_token": "Sultana",
+      "raw_source_token": "Vegetable Oil",
+      "reason": "The broad source token cannot justify selecting one specific oil."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4000400008602",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4002468102322",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4002671145505",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4003751060152",
+      "normalized_source_token": "vegetable oil",
+      "parent_source_token": null,
+      "raw_source_token": "Vegetable Oil",
+      "reason": "The broad source token cannot justify selecting one specific oil."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4025500288150",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4036300152701",
+      "normalized_source_token": "starch",
+      "parent_source_token": "Anti Caking Agent",
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4045357001986",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4045357099136",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "40466057",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "40466101",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4047247197830",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4047247288187",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4047247389815",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4056489920144",
+      "normalized_source_token": "vegetable oil",
+      "parent_source_token": null,
+      "raw_source_token": "Vegetable Oil",
+      "reason": "The broad source token cannot justify selecting one specific oil."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4056489920144",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4056489920151",
+      "normalized_source_token": "vegetable oil",
+      "parent_source_token": null,
+      "raw_source_token": "Vegetable Oil",
+      "reason": "The broad source token cannot justify selecting one specific oil."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4056489920151",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4061458038553",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4061464519619",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4088500784503",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Dairy",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4337256731744",
+      "normalized_source_token": "starch",
+      "parent_source_token": "Anti Caking Agent",
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Drinks",
+      "classification": "source_artifact_and_quarantined",
+      "country": "DE",
+      "ean": "4311501710036",
+      "normalized_source_token": "kcal 0 8",
+      "parent_source_token": "Colour",
+      "raw_source_token": "Kcal 0 8",
+      "reason": "Energy-label text was parsed inside an ingredient hierarchy and must never be linked."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Sweets",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4000417663016",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Sweets",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4000607164002",
+      "normalized_source_token": "starch",
+      "parent_source_token": null,
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Sweets",
+      "classification": "source_artifact_and_quarantined",
+      "country": "DE",
+      "ean": "4008400520421",
+      "normalized_source_token": "kcal",
+      "parent_source_token": "Energie",
+      "raw_source_token": "Kcal",
+      "reason": "Energy-unit text is not an ingredient."
+    },
+    {
+      "allergen_derivation_allowed": false,
+      "category": "Sweets",
+      "classification": "ambiguous_and_withheld",
+      "country": "DE",
+      "ean": "4013320033302",
+      "normalized_source_token": "starch",
+      "parent_source_token": "Zitronencrisp",
+      "raw_source_token": "Starch",
+      "reason": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    }
+  ]
+}

--- a/data-quality/phase4c/report.md
+++ b/data-quality/phase4c/report.md
@@ -1,0 +1,57 @@
+# Phase 4C Enrichment Governance Report
+
+Status: **PASS**
+
+Phase 4C adds governance only. It creates no new category batch and no product linkage changes.
+
+## Registry summary
+
+| Decision class | Registry entries | Observed Phase 4B occurrences |
+|---|---:|---:|
+| Approved global aliases | 2 | 13 |
+| Approved scoped aliases | 3 | 0 |
+| Ambiguous and withheld | 2 | 27 |
+| Source artifacts quarantined | 2 | 2 |
+| Unsafe dependent children withheld | 5 rules | 11 |
+
+## Known-token review
+
+- `Starch`: 23 occurrences remain withheld. The source does not identify corn, potato, or wheat.
+- `Vegetable Oil`: 4 occurrences remain withheld. No specific oil is inferred.
+- Nutrition artifacts: 2 occurrences are quarantined and cannot link or derive allergens.
+- Parent-child safety: 11 child rows remain withheld beneath unsafe parents.
+
+## Allergen provenance
+
+| Provenance | Records |
+|---|---:|
+| Explicit source `contains` | 1278 |
+| Explicit source `may contain` | 1110 |
+| Deterministic ingredient-derived only | 32 |
+| Total provenance union | 2420 |
+| Products unknown due to missing evidence | 202 |
+
+Missing evidence is never interpreted as allergen-free.
+
+## Drinks DE finding
+
+The low known-allergen coverage is primarily genuine absence of source declarations in the selected beverage records. Only two additional records are supported by deterministic ingredient rules; there are no ambiguous Drinks tokens withholding allergen evidence. The dominant unknown-product tokens are water, acids, sugar, flavourings, juices, and vitamins, so missing evidence remains unknown rather than allergen-free.
+
+Of 249 selected Drinks products, 176 remain unknown. Explicit source evidence contributes 76 contains and 41 may-contain records; deterministic ingredient rules add 2 records.
+
+## Determinism and compatibility
+
+- Governance checksum: `c4d400d67c3bc04b45d29331cb9495c45672e3d8b613ead992771203469e0e37`
+- Phase 4B products enriched: 941
+- Phase 4B ingredient links: 9988
+- Phase 4B allergen records: 2420
+- Phase 4C linkage, coverage, score, and confidence changes: zero
+- Non-target categories and deprecated products: unchanged
+- Hosted Supabase writes: none
+
+## Manual review still required
+
+- A botanical source declaration is required before Starch can map to corn, potato, or wheat starch.
+- A named oil source is required before Vegetable Oil can map to a specific oil.
+- The source tokens Stärke Weizen and Stärke Mais should be re-reviewed if a corrected or more specific source declaration becomes available.
+- Allergen absence claims require explicit producer evidence; unknown Drinks records cannot be classified as allergen-free.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,7 +2,7 @@
 
 > **Last updated:** 2026-07-28
 > **Status:** Active — update when adding, renaming, or archiving docs
-> **Total documents:** 71 in `docs/` + 11 in `docs/decisions/` + 25 in `docs/assets/logo/` + 7 in `docs/assets/banners/` + 7 elsewhere in repo
+> **Total documents:** 72 in `docs/` + 11 in `docs/decisions/` + 25 in `docs/assets/logo/` + 7 in `docs/assets/banners/` + 7 elsewhere in repo
 > **Reference:** Issue [#200](https://github.com/ericsocrat/tryvit/issues/200), [#201](https://github.com/ericsocrat/tryvit/issues/201)
 
 ---
@@ -17,7 +17,7 @@
 | [Banners](#banners)                                      | 5     | Social preview, README hero banner (SVG + PNG), badges reference                                                                                                        |
 | [API](#api)                                              | 6     | Contracts, conventions, versioning, frontend mapping, contract testing, registry                                                                                        |
 | [Scoring](#scoring)                                      | 2     | Methodology (formula), engine (architecture)                                                                                                                            |
-| [Data & Provenance](#data--provenance)                   | 8     | Sources, provenance, integrity audits, quality reporting, enrichment pilot and expansion, EAN validation, production data                                               |
+| [Data & Provenance](#data--provenance)                   | 9     | Sources, provenance, integrity audits, quality reporting, enrichment pilot, expansion and governance, EAN validation, production data                                   |
 | [Security & Compliance](#security--compliance)           | 5     | Root policy, audit report, access audit, privacy checklist, rate limiting                                                                                               |
 | [Observability & Operations](#observability--operations) | 9     | Monitoring, observability, log schema, alerts, on-call policy, SLOs, metrics, incident response, disaster drill                                                         |
 | [DevOps & Environment](#devops--environment)             | 3     | Environment strategy, staging setup, Sonar config                                                                                                                       |
@@ -150,6 +150,7 @@
 | [data-quality-report.md](data-quality-report.md)     | Deterministic PostgreSQL data-quality report, baseline, and CI gate                | Phase 3 audit                                           | 2026-07-28   |
 | [PHASE4A_ENRICHMENT_PILOT.md](PHASE4A_ENRICHMENT_PILOT.md) | Deterministic ingredient/allergen enrichment pilot, semantics, metrics, and expansion gate | Phase 4A audit | 2026-07-28 |
 | [PHASE4B_CATEGORY_ENRICHMENT.md](PHASE4B_CATEGORY_ENRICHMENT.md) | Controlled category ranking, enrichment results, determinism, and rollout gate | Phase 4B audit | 2026-07-28 |
+| [ingredient-enrichment-governance.md](ingredient-enrichment-governance.md) | Deterministic alias, scope, parent-child, artifact, and allergen-provenance governance | Phase 4C audit | 2026-07-28 |
 | [EAN_VALIDATION_STATUS.md](EAN_VALIDATION_STATUS.md) | EAN coverage tracking — 997/1,025 (97.3%)                                        | Data domain                                             | 2026-02-24   |
 | [PRODUCTION_DATA.md](PRODUCTION_DATA.md)             | Production data management — sync, backup, restore procedures                    | DevOps domain                                           | 2026-02-24   |
 

--- a/docs/ingredient-enrichment-governance.md
+++ b/docs/ingredient-enrichment-governance.md
@@ -1,0 +1,32 @@
+# Ingredient Enrichment Governance
+
+Phase 4C makes ingredient identity decisions explicit control data before any further category expansion. The registry at `pipeline/enrichment_registry.json` is the only approved alias and quarantine source used by the deterministic enrichment matcher.
+
+## Decision model
+
+Every reviewed token records its raw and normalized forms, canonical identity when one is justified, mapping classification, country/category scope, evidence, review status, allergen and parent-child permissions, and an explanation. Supported classifications are:
+
+- `exact_canonical_match`
+- `approved_alias`
+- `context_qualified_alias`
+- `ambiguous_and_withheld`
+- `source_artifact_and_quarantined`
+- `unsafe_parent_child_inference_and_withheld`
+- `unknown_or_unmatched`
+
+The matcher uses normalized exact identity and reviewed registry entries only. Runtime fuzzy or semantic matching is not permitted.
+
+## Safety invariants
+
+Registry validation fails before generation when mappings overlap contradictorily, a generic token maps globally to a specific identity, scoped mappings can leak, aliases form a cycle, a withheld/artifact entry permits inference, a target is absent from the committed vocabulary, or parent-child rules conflict.
+
+An absent allergen declaration remains unknown. Reports keep explicit `contains`, explicit `may contain`, and deterministic ingredient-derived evidence separate. A derived record is allowed only when a reviewed deterministic ingredient rule supports it; it does not convert missing source evidence into an allergen-free claim.
+
+## Current withheld decisions
+
+- `Starch` remains ambiguous across corn, potato, and wheat sources. Its 23 observed Phase 4B occurrences remain unlinked.
+- `Vegetable Oil` remains ambiguous across specific oil identities. Its 4 observed occurrences remain unlinked.
+- `Kcal` and `Kcal 0 8` are nutrition-label artifacts and remain quarantined.
+- 11 otherwise identifiable child tokens remain withheld because their source parent is ambiguous and cannot support a valid parent-child linkage.
+
+Run `python -m pipeline.governance_report` to regenerate the JSON and Markdown evidence in `data-quality/phase4c`. Use `--check` in CI to detect drift without rewriting files.

--- a/pipeline/category_enrichment_report.py
+++ b/pipeline/category_enrichment_report.py
@@ -20,7 +20,8 @@ from pathlib import Path
 from typing import Any
 
 from data_quality_report import PsqlExecutor, pct
-from pipeline.enrichment import canonicalize_allergens, linkable_matches, match_ingredients
+from pipeline.enrichment import canonicalize_allergens, linkable_matches, load_registry, match_ingredients
+from pipeline.enrichment_governance import historical_phase4b_registry
 from pipeline.generate_enrichment_pilot import PROJECT_ROOT, build_outputs, load_manifest, parse_snapshot
 
 MANIFEST_PATH = Path(__file__).with_name("enrichment_phase4b.json")
@@ -81,6 +82,7 @@ def _selected_scopes(manifest: dict[str, Any]) -> set[tuple[str, str]]:
 def _candidate_analysis(executor: PsqlExecutor, manifest: dict[str, Any]) -> tuple[dict[str, Any], str]:
     products = executor.rows("phase4b_products", PRODUCTS_SQL)
     ingredients, allergens, references, _ = parse_snapshot()
+    ranking_registry = historical_phase4b_registry(load_registry())
     ingredients_by_product: dict[tuple[str, str], list] = defaultdict(list)
     allergens_by_product: dict[tuple[str, str], list] = defaultdict(list)
     for row in ingredients:
@@ -106,8 +108,8 @@ def _candidate_analysis(executor: PsqlExecutor, manifest: dict[str, Any]) -> tup
             for key in sorted(missing_ingredient_keys)
             for ingredient in ingredients_by_product.get(key, ())
         ]
-        matches = match_ingredients(source_rows, references)
-        linked = linkable_matches(matches)
+        matches = match_ingredients(source_rows, references, registry=ranking_registry)
+        linked = linkable_matches(matches, registry=ranking_registry)
         enrichable_products = sorted({(row.evidence.country, row.evidence.ean) for row in linked})
         canonical_allergens = canonicalize_allergens(
             [allergen for key in sorted(missing_allergen_keys) for allergen in allergens_by_product.get(key, ())]

--- a/pipeline/category_enrichment_report.py
+++ b/pipeline/category_enrichment_report.py
@@ -15,6 +15,7 @@ import io
 import json
 import tempfile
 from collections import Counter, defaultdict
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -101,7 +102,9 @@ def _candidate_analysis(executor: PsqlExecutor, manifest: dict[str, Any]) -> tup
         missing_ingredient_keys = {(str(row["country"]), str(row["ean"])) for row in missing_ingredient_products}
         missing_allergen_keys = {(str(row["country"]), str(row["ean"])) for row in missing_allergen_products}
         source_rows = [
-            ingredient for key in sorted(missing_ingredient_keys) for ingredient in ingredients_by_product.get(key, ())
+            replace(ingredient, category=category)
+            for key in sorted(missing_ingredient_keys)
+            for ingredient in ingredients_by_product.get(key, ())
         ]
         matches = match_ingredients(source_rows, references)
         linked = linkable_matches(matches)

--- a/pipeline/enrichment.py
+++ b/pipeline/enrichment.py
@@ -15,6 +15,12 @@ from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 
+from pipeline.enrichment_governance import (
+    governed_token_entry,
+    parent_child_rule,
+    validate_governance_registry,
+)
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 REGISTRY_PATH = Path(__file__).with_name("enrichment_registry.json")
 PILOT_PATH = Path(__file__).with_name("enrichment_pilot.json")
@@ -52,6 +58,7 @@ class IngredientEvidence:
     is_sub_ingredient: bool = False
     parent_source_text: str | None = None
     canonical_hint: str | None = None
+    category: str | None = None
 
 
 @dataclass(frozen=True)
@@ -92,6 +99,14 @@ def validate_registry(registry: Mapping, reference_names: Iterable[str]) -> None
     vocabulary; the registry never creates semantic identities implicitly.
     """
     references = frozenset(reference_names)
+    if registry.get("schema_version") == 2:
+        validate_governance_registry(registry, references)
+        invalid_allergens = sorted(
+            str(target) for target in registry.get("allergen_aliases", {}).values() if str(target) not in ALLERGEN_IDS
+        )
+        if invalid_allergens:
+            raise ValueError(f"allergen aliases target unknown canonical IDs: {invalid_allergens}")
+        return
     groups = {
         name: {normalize_token(str(key)): value for key, value in registry.get(name, {}).items()}
         for name in ("aliases", "reviewed", "ambiguous", "quarantined")
@@ -192,6 +207,39 @@ def _match_ingredient(
     """Classify one token using a pre-built deterministic reference index."""
     normalized = normalize_token(evidence.source_text)
 
+    governed = governed_token_entry(config, normalized, evidence.country, evidence.category)
+    if governed is not None:
+        classification = governed["mapping_classification"]
+        if classification in {"exact_canonical_match", "approved_alias", "context_qualified_alias"}:
+            compatibility_classification = {
+                "exact_canonical_match": "exact",
+                "approved_alias": "alias",
+                "context_qualified_alias": "reviewed",
+            }[classification]
+            return IngredientMatch(
+                evidence,
+                normalized,
+                compatibility_classification,
+                str(governed["canonical_ingredient_identity"]),
+            )
+        if classification == "ambiguous_and_withheld":
+            return IngredientMatch(
+                evidence,
+                normalized,
+                "ambiguous",
+                None,
+                tuple(sorted(str(value) for value in governed.get("candidates", ()))),
+            )
+        if classification == "source_artifact_and_quarantined":
+            return IngredientMatch(evidence, normalized, "quarantined", None)
+        return IngredientMatch(evidence, normalized, "unresolved", None)
+    if config.get("schema_version") == 2 and any(
+        entry.get("normalized_source_token") == normalized for entry in config.get("entries", ())
+    ):
+        # A reviewed token outside its approved scope must not fall through to
+        # normalized exact matching; that would silently leak the scoped rule.
+        return IngredientMatch(evidence, normalized, "unresolved", None)
+
     if normalized in config.get("quarantined", {}):
         return IngredientMatch(evidence, normalized, "quarantined", None)
 
@@ -277,29 +325,36 @@ def canonicalize_allergens(
     return [result[key] for key in sorted(result)]
 
 
-def linkable_matches(matches: Sequence[IngredientMatch]) -> list[IngredientMatch]:
+def linkable_matches(
+    matches: Sequence[IngredientMatch], registry: Mapping | None = None
+) -> list[IngredientMatch]:
     """Return matched rows whose parent relationship is also unambiguous."""
+    config = dict(registry or load_registry())
     canonical_by_source = {
         (row.evidence.country, row.evidence.ean, row.normalized_text): row.canonical_name
         for row in matches
         if row.canonical_name is not None
     }
-    return [
-        row
-        for row in matches
-        if row.canonical_name is not None
-        and (
-            not row.evidence.is_sub_ingredient
-            or canonical_by_source.get(
-                (
-                    row.evidence.country,
-                    row.evidence.ean,
-                    normalize_token(row.evidence.parent_source_text or ""),
-                )
-            )
-            is not None
+    result: list[IngredientMatch] = []
+    for row in matches:
+        if row.canonical_name is None:
+            continue
+        if not row.evidence.is_sub_ingredient:
+            result.append(row)
+            continue
+        parent_token = normalize_token(row.evidence.parent_source_text or "")
+        if canonical_by_source.get((row.evidence.country, row.evidence.ean, parent_token)) is None:
+            continue
+        rule = parent_child_rule(
+            config,
+            parent_token,
+            row.normalized_text,
+            row.evidence.country,
+            row.evidence.category,
         )
-    ]
+        if rule is None or rule.get("inference_allowed") is True:
+            result.append(row)
+    return result
 
 
 def _sql_text(value: str | None) -> str:
@@ -470,7 +525,7 @@ def generate_enrichment_sql(
 
 
 def evidence_from_products(
-    products: Sequence[Mapping], country: str
+    products: Sequence[Mapping], country: str, category: str | None = None
 ) -> tuple[list[IngredientEvidence], list[AllergenEvidence]]:
     """Convert normalized pipeline products into explicit source evidence."""
     ingredients: list[IngredientEvidence] = []
@@ -495,6 +550,7 @@ def evidence_from_products(
                     percent_estimate=(
                         str(item["percent_estimate"]) if item.get("percent_estimate") is not None else None
                     ),
+                    category=category,
                 )
             )
         for raw in product.get("_allergens_tags") or ():

--- a/pipeline/enrichment_governance.py
+++ b/pipeline/enrichment_governance.py
@@ -232,3 +232,38 @@ def validate_governance_registry(registry: Mapping, reference_names: Iterable[st
     _validate_conflicts(entries)
     _validate_cycles(entries)
     _validate_parent_rules(rules)
+
+
+def historical_phase4b_registry(registry: Mapping) -> dict:
+    """Project schema v2 into the registry used by the historical Phase 4B ranking.
+
+    The committed candidate ranking is an immutable record of the decision made
+    before scoped governance existed.  This projection is intentionally limited
+    to reproducing that read-only report; enrichment writes continue to use the
+    scoped schema-v2 registry.
+    """
+    if registry.get("schema_version") != 2:
+        return dict(registry)
+
+    projected: dict[str, dict] = {
+        "aliases": {},
+        "reviewed": {},
+        "ambiguous": {},
+        "quarantined": {},
+        "allergen_aliases": dict(registry.get("allergen_aliases", {})),
+    }
+    for entry in registry.get("entries", ()):
+        token = str(entry["normalized_source_token"])
+        classification = entry["mapping_classification"]
+        if classification == "approved_alias":
+            projected["aliases"][token] = str(entry["canonical_ingredient_identity"])
+        elif classification == "context_qualified_alias":
+            target = str(entry["canonical_ingredient_identity"])
+            previous = projected["reviewed"].setdefault(token, target)
+            if previous != target:
+                raise ValueError(f"historical Phase 4B alias conflict for {token!r}")
+        elif classification == "ambiguous_and_withheld":
+            projected["ambiguous"][token] = list(entry.get("candidates", ()))
+        elif classification == "source_artifact_and_quarantined":
+            projected["quarantined"][token] = str(entry["review_note"])
+    return projected

--- a/pipeline/enrichment_governance.py
+++ b/pipeline/enrichment_governance.py
@@ -1,0 +1,234 @@
+"""Deterministic governance for ingredient identities and relationships."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+
+MAPPING_CLASSIFICATIONS = frozenset(
+    {
+        "exact_canonical_match",
+        "approved_alias",
+        "context_qualified_alias",
+        "ambiguous_and_withheld",
+        "source_artifact_and_quarantined",
+        "unsafe_parent_child_inference_and_withheld",
+        "unknown_or_unmatched",
+    }
+)
+LINKABLE_CLASSIFICATIONS = frozenset({"exact_canonical_match", "approved_alias", "context_qualified_alias"})
+WITHHELD_CLASSIFICATIONS = frozenset(
+    {
+        "ambiguous_and_withheld",
+        "source_artifact_and_quarantined",
+        "unsafe_parent_child_inference_and_withheld",
+        "unknown_or_unmatched",
+    }
+)
+REVIEW_STATUSES = frozenset({"approved", "withheld", "quarantined", "manual_review_required"})
+
+
+def _normalize(value: str) -> str:
+    """Mirror enrichment normalization without creating an import cycle."""
+    import re
+    import unicodedata
+
+    text = unicodedata.normalize("NFKC", value).casefold().replace("_", " ")
+    text = re.sub(r"[\u2010-\u2015-]+", " ", text)
+    text = re.sub(r"[^\w\s]", " ", text, flags=re.UNICODE)
+    return " ".join(text.split())
+
+
+def _scope_values(entry: Mapping, name: str) -> tuple[str, ...]:
+    values = entry.get(name, ())
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+        raise ValueError(f"governance {name} must be a list")
+    return tuple(sorted({str(value) for value in values}))
+
+
+def scopes_overlap(left: Mapping, right: Mapping) -> bool:
+    """Return whether two country/category scope pairs can match the same row."""
+    for name in ("country_scope", "category_scope"):
+        left_values = set(_scope_values(left, name))
+        right_values = set(_scope_values(right, name))
+        if left_values and right_values and left_values.isdisjoint(right_values):
+            return False
+    return True
+
+
+def scope_matches(entry: Mapping, country: str, category: str | None) -> bool:
+    countries = set(_scope_values(entry, "country_scope"))
+    categories = set(_scope_values(entry, "category_scope"))
+    return (not countries or country in countries) and (not categories or category in categories)
+
+
+def _specificity(entry: Mapping) -> tuple[int, int, tuple[str, ...], tuple[str, ...]]:
+    countries = _scope_values(entry, "country_scope")
+    categories = _scope_values(entry, "category_scope")
+    return (bool(countries) + bool(categories), -len(countries), countries, categories)
+
+
+def governed_token_entry(
+    registry: Mapping, normalized_token: str, country: str, category: str | None
+) -> Mapping | None:
+    """Resolve one governed token using the narrowest matching approved scope."""
+    if registry.get("schema_version") != 2:
+        return None
+    matches = [
+        entry
+        for entry in registry.get("entries", ())
+        if entry.get("normalized_source_token") == normalized_token and scope_matches(entry, country, category)
+    ]
+    if not matches:
+        return None
+    return sorted(matches, key=_specificity, reverse=True)[0]
+
+
+def parent_child_rule(
+    registry: Mapping,
+    parent_normalized_token: str,
+    child_normalized_token: str,
+    country: str,
+    category: str | None,
+) -> Mapping | None:
+    """Resolve a governed parent-child decision for one evidence row."""
+    if registry.get("schema_version") != 2:
+        return None
+    matches = [
+        rule
+        for rule in registry.get("parent_child_rules", ())
+        if rule.get("parent_normalized_token") == parent_normalized_token
+        and rule.get("child_normalized_token") == child_normalized_token
+        and scope_matches(rule, country, category)
+    ]
+    if not matches:
+        return None
+    return sorted(matches, key=_specificity, reverse=True)[0]
+
+
+def _validate_token_entry(entry: Mapping, references: frozenset[str], generic_tokens: frozenset[str]) -> None:
+    required_text = ("raw_source_token", "normalized_source_token", "source_or_evidence", "review_note")
+    for field in required_text:
+        if not isinstance(entry.get(field), str) or not str(entry[field]).strip():
+            raise ValueError(f"governance entry requires non-empty {field}")
+    normalized = str(entry["normalized_source_token"])
+    if normalized != _normalize(str(entry["raw_source_token"])):
+        raise ValueError(f"governance normalized token mismatch: {normalized!r}")
+    classification = str(entry.get("mapping_classification"))
+    if classification not in MAPPING_CLASSIFICATIONS:
+        raise ValueError(f"unsupported governance classification: {classification}")
+    if entry.get("review_status") not in REVIEW_STATUSES:
+        raise ValueError(f"unsupported governance review status for {normalized!r}")
+    if not isinstance(entry.get("allergen_derivation_allowed"), bool):
+        raise ValueError(f"governance allergen permission must be boolean for {normalized!r}")
+    if not isinstance(entry.get("parent_child_inference_allowed"), bool):
+        raise ValueError(f"governance parent-child permission must be boolean for {normalized!r}")
+    countries = _scope_values(entry, "country_scope")
+    categories = _scope_values(entry, "category_scope")
+    canonical = entry.get("canonical_ingredient_identity")
+    if classification in LINKABLE_CLASSIFICATIONS:
+        if not canonical or canonical not in references:
+            raise ValueError(f"governance target missing from reference vocabulary for {normalized!r}")
+        if classification == "context_qualified_alias" and not (countries or categories):
+            raise ValueError(f"context-qualified alias requires a country or category scope: {normalized!r}")
+        if normalized in generic_tokens and classification != "context_qualified_alias":
+            raise ValueError(f"generic token cannot map to a specific identity globally: {normalized!r}")
+    elif canonical is not None:
+        raise ValueError(f"withheld governance entry cannot declare a canonical identity: {normalized!r}")
+    if classification == "ambiguous_and_withheld":
+        candidates = tuple(sorted({str(value) for value in entry.get("candidates", ())}))
+        if len(candidates) < 2:
+            raise ValueError(f"ambiguous governance entry needs at least two candidates: {normalized!r}")
+        missing = sorted(value for value in candidates if value not in references)
+        if missing:
+            raise ValueError(f"ambiguous candidates missing from reference vocabulary: {missing}")
+    if classification in WITHHELD_CLASSIFICATIONS and (
+        entry["allergen_derivation_allowed"] or entry["parent_child_inference_allowed"]
+    ):
+        raise ValueError(f"withheld governance entry cannot permit inference: {normalized!r}")
+
+
+def _validate_conflicts(entries: Sequence[Mapping]) -> None:
+    for index, left in enumerate(entries):
+        for right in entries[index + 1 :]:
+            if left["normalized_source_token"] != right["normalized_source_token"] or not scopes_overlap(left, right):
+                continue
+            left_decision = (left.get("mapping_classification"), left.get("canonical_ingredient_identity"))
+            right_decision = (right.get("mapping_classification"), right.get("canonical_ingredient_identity"))
+            if left_decision != right_decision:
+                raise ValueError(
+                    "overlapping governance scopes map one alias to contradictory identities: "
+                    f"{left['normalized_source_token']!r}"
+                )
+            raise ValueError(f"duplicate governance entry in overlapping scopes: {left['normalized_source_token']!r}")
+
+
+def _validate_cycles(entries: Sequence[Mapping]) -> None:
+    graph: dict[str, set[str]] = {}
+    for entry in entries:
+        if entry.get("mapping_classification") not in {"approved_alias", "context_qualified_alias"}:
+            continue
+        source = str(entry["normalized_source_token"])
+        target = _normalize(str(entry["canonical_ingredient_identity"]))
+        if source != target:
+            graph.setdefault(source, set()).add(target)
+    state: dict[str, int] = {}
+
+    def visit(node: str) -> None:
+        if state.get(node) == 1:
+            raise ValueError(f"circular governance alias relationship detected at {node!r}")
+        if state.get(node) == 2:
+            return
+        state[node] = 1
+        for target in sorted(graph.get(node, ())):
+            visit(target)
+        state[node] = 2
+
+    for source in sorted(graph):
+        visit(source)
+
+
+def _validate_parent_rules(rules: Sequence[Mapping]) -> None:
+    for rule in rules:
+        parent = str(rule.get("parent_normalized_token", ""))
+        child = str(rule.get("child_normalized_token", ""))
+        if not parent or not child or parent == child:
+            raise ValueError("parent-child governance requires distinct normalized parent and child tokens")
+        if rule.get("mapping_classification") != "unsafe_parent_child_inference_and_withheld":
+            raise ValueError(f"unsupported parent-child governance classification for {parent!r}/{child!r}")
+        if rule.get("inference_allowed") is not False or rule.get("allergen_derivation_allowed") is not False:
+            raise ValueError(f"unsafe parent-child rule cannot permit inference for {parent!r}/{child!r}")
+        if rule.get("review_status") != "withheld":
+            raise ValueError(f"unsafe parent-child rule must be withheld for {parent!r}/{child!r}")
+        _scope_values(rule, "country_scope")
+        _scope_values(rule, "category_scope")
+        for field in ("source_or_evidence", "review_note"):
+            if not isinstance(rule.get(field), str) or not str(rule[field]).strip():
+                raise ValueError(f"parent-child governance requires non-empty {field}")
+    for index, left in enumerate(rules):
+        for right in rules[index + 1 :]:
+            same_pair = (
+                left["parent_normalized_token"],
+                left["child_normalized_token"],
+            ) == (right["parent_normalized_token"], right["child_normalized_token"])
+            if same_pair and scopes_overlap(left, right):
+                raise ValueError("overlapping parent-child governance rules are contradictory")
+
+
+def validate_governance_registry(registry: Mapping, reference_names: Iterable[str]) -> None:
+    """Fail fast when governance control data is incomplete or contradictory."""
+    if registry.get("schema_version") != 2:
+        raise ValueError("unsupported enrichment governance schema")
+    entries = registry.get("entries")
+    rules = registry.get("parent_child_rules")
+    if not isinstance(entries, list) or not isinstance(rules, list):
+        raise ValueError("governance entries and parent_child_rules must be lists")
+    references = frozenset(reference_names)
+    generic_tokens = frozenset(str(value) for value in registry.get("generic_tokens", ()))
+    for token in generic_tokens:
+        if token != _normalize(token):
+            raise ValueError(f"generic governance token must be normalized: {token!r}")
+    for entry in entries:
+        _validate_token_entry(entry, references, generic_tokens)
+    _validate_conflicts(entries)
+    _validate_cycles(entries)
+    _validate_parent_rules(rules)

--- a/pipeline/enrichment_registry.json
+++ b/pipeline/enrichment_registry.json
@@ -1,20 +1,192 @@
 {
-  "aliases": {
-    "rapeseed": "Rapeseed Oil",
-    "sunflower": "Sunflower Oil"
-  },
-  "reviewed": {
-    "papryka": "Paprika Or Bell Pepper",
-    "trockenmilcherzeugnis aus sauerrahm": "Sour Cream Powder"
-  },
-  "ambiguous": {
-    "starch": ["Corn Starch", "Potato Starch", "Wheat Starch"],
-    "vegetable oil": ["Rapeseed Oil", "Sunflower Oil"]
-  },
-  "quarantined": {
-    "kcal": "nutrition-label artifact",
-    "kcal 0 8": "nutrition-label artifact"
-  },
+  "schema_version": 2,
+  "generic_tokens": [
+    "starch",
+    "vegetable oil"
+  ],
+  "entries": [
+    {
+      "raw_source_token": "rapeseed",
+      "normalized_source_token": "rapeseed",
+      "canonical_ingredient_identity": "Rapeseed Oil",
+      "mapping_classification": "approved_alias",
+      "country_scope": [],
+      "category_scope": [],
+      "source_or_evidence": "OFF taxonomy synonym reviewed against the committed ingredient vocabulary",
+      "review_status": "approved",
+      "allergen_derivation_allowed": true,
+      "parent_child_inference_allowed": true,
+      "review_note": "The source token names the same oil identity without the word oil."
+    },
+    {
+      "raw_source_token": "sunflower",
+      "normalized_source_token": "sunflower",
+      "canonical_ingredient_identity": "Sunflower Oil",
+      "mapping_classification": "approved_alias",
+      "country_scope": [],
+      "category_scope": [],
+      "source_or_evidence": "OFF taxonomy synonym reviewed against the committed ingredient vocabulary",
+      "review_status": "approved",
+      "allergen_derivation_allowed": true,
+      "parent_child_inference_allowed": true,
+      "review_note": "The source token names the same oil identity without the word oil."
+    },
+    {
+      "raw_source_token": "papryka",
+      "normalized_source_token": "papryka",
+      "canonical_ingredient_identity": "Paprika Or Bell Pepper",
+      "mapping_classification": "context_qualified_alias",
+      "country_scope": ["PL"],
+      "category_scope": ["Meat"],
+      "source_or_evidence": "Reviewed Polish Phase 4A product context",
+      "review_status": "approved",
+      "allergen_derivation_allowed": true,
+      "parent_child_inference_allowed": true,
+      "review_note": "Polish papryka means paprika or bell pepper in the approved Meat pilot scope."
+    },
+    {
+      "raw_source_token": "papryka",
+      "normalized_source_token": "papryka",
+      "canonical_ingredient_identity": "Paprika Or Bell Pepper",
+      "mapping_classification": "context_qualified_alias",
+      "country_scope": ["PL"],
+      "category_scope": ["Frozen Vegetables"],
+      "source_or_evidence": "Reviewed Polish Phase 4A product context",
+      "review_status": "approved",
+      "allergen_derivation_allowed": true,
+      "parent_child_inference_allowed": true,
+      "review_note": "Polish papryka means paprika or bell pepper in the approved Frozen Vegetables pilot scope."
+    },
+    {
+      "raw_source_token": "Trockenmilcherzeugnis aus Sauerrahm",
+      "normalized_source_token": "trockenmilcherzeugnis aus sauerrahm",
+      "canonical_ingredient_identity": "Sour Cream Powder",
+      "mapping_classification": "context_qualified_alias",
+      "country_scope": ["DE"],
+      "category_scope": ["Dairy"],
+      "source_or_evidence": "Reviewed German dairy label context",
+      "review_status": "approved",
+      "allergen_derivation_allowed": true,
+      "parent_child_inference_allowed": true,
+      "review_note": "The German label explicitly identifies a dried sour-cream product in Dairy."
+    },
+    {
+      "raw_source_token": "Starch",
+      "normalized_source_token": "starch",
+      "canonical_ingredient_identity": null,
+      "mapping_classification": "ambiguous_and_withheld",
+      "country_scope": [],
+      "category_scope": [],
+      "source_or_evidence": "23 Phase 4B occurrences across Breakfast & Grain-Based DE, Dairy DE, and Sweets DE",
+      "review_status": "withheld",
+      "allergen_derivation_allowed": false,
+      "parent_child_inference_allowed": false,
+      "candidates": ["Corn Starch", "Potato Starch", "Wheat Starch"],
+      "review_note": "The generic token does not identify its botanical source; a global mapping could create unsupported gluten evidence."
+    },
+    {
+      "raw_source_token": "Vegetable Oil",
+      "normalized_source_token": "vegetable oil",
+      "canonical_ingredient_identity": null,
+      "mapping_classification": "ambiguous_and_withheld",
+      "country_scope": [],
+      "category_scope": [],
+      "source_or_evidence": "4 Phase 4B occurrences across Breakfast & Grain-Based DE and Dairy DE",
+      "review_status": "withheld",
+      "allergen_derivation_allowed": false,
+      "parent_child_inference_allowed": false,
+      "candidates": ["Rapeseed Oil", "Sunflower Oil"],
+      "review_note": "The broad source token cannot justify selecting one specific oil."
+    },
+    {
+      "raw_source_token": "Kcal",
+      "normalized_source_token": "kcal",
+      "canonical_ingredient_identity": null,
+      "mapping_classification": "source_artifact_and_quarantined",
+      "country_scope": [],
+      "category_scope": [],
+      "source_or_evidence": "Nutrition-label fragment observed once in Sweets DE",
+      "review_status": "quarantined",
+      "allergen_derivation_allowed": false,
+      "parent_child_inference_allowed": false,
+      "review_note": "Energy-unit text is not an ingredient."
+    },
+    {
+      "raw_source_token": "Kcal 0 8",
+      "normalized_source_token": "kcal 0 8",
+      "canonical_ingredient_identity": null,
+      "mapping_classification": "source_artifact_and_quarantined",
+      "country_scope": [],
+      "category_scope": [],
+      "source_or_evidence": "Nutrition-label fragment observed once in Drinks DE",
+      "review_status": "quarantined",
+      "allergen_derivation_allowed": false,
+      "parent_child_inference_allowed": false,
+      "review_note": "Energy-label text was parsed inside an ingredient hierarchy and must never be linked."
+    }
+  ],
+  "parent_child_rules": [
+    {
+      "parent_normalized_token": "starch",
+      "child_normalized_token": "stärke weizen",
+      "country_scope": ["DE"],
+      "category_scope": ["Breakfast & Grain-Based", "Sweets"],
+      "mapping_classification": "unsafe_parent_child_inference_and_withheld",
+      "inference_allowed": false,
+      "allergen_derivation_allowed": false,
+      "source_or_evidence": "3 Phase 4B child occurrences beneath an ambiguous Starch parent",
+      "review_status": "withheld",
+      "review_note": "The child cannot be attached while the source parent lacks a safe canonical identity."
+    },
+    {
+      "parent_normalized_token": "starch",
+      "child_normalized_token": "stärke mais",
+      "country_scope": ["DE"],
+      "category_scope": ["Sweets"],
+      "mapping_classification": "unsafe_parent_child_inference_and_withheld",
+      "inference_allowed": false,
+      "allergen_derivation_allowed": false,
+      "source_or_evidence": "1 Phase 4B child occurrence beneath an ambiguous Starch parent",
+      "review_status": "withheld",
+      "review_note": "The child cannot be attached while the source parent lacks a safe canonical identity."
+    },
+    {
+      "parent_normalized_token": "vegetable oil",
+      "child_normalized_token": "sunflower",
+      "country_scope": ["DE"],
+      "category_scope": ["Breakfast & Grain-Based", "Dairy"],
+      "mapping_classification": "unsafe_parent_child_inference_and_withheld",
+      "inference_allowed": false,
+      "allergen_derivation_allowed": false,
+      "source_or_evidence": "4 Phase 4B child occurrences beneath an ambiguous Vegetable Oil parent",
+      "review_status": "withheld",
+      "review_note": "The child identity is known, but its unresolved parent prevents a structurally valid linkage."
+    },
+    {
+      "parent_normalized_token": "vegetable oil",
+      "child_normalized_token": "rapeseed",
+      "country_scope": ["DE"],
+      "category_scope": ["Dairy"],
+      "mapping_classification": "unsafe_parent_child_inference_and_withheld",
+      "inference_allowed": false,
+      "allergen_derivation_allowed": false,
+      "source_or_evidence": "3 Phase 4B child occurrences beneath an ambiguous Vegetable Oil parent",
+      "review_status": "withheld",
+      "review_note": "The child identity is known, but its unresolved parent prevents a structurally valid linkage."
+    },
+    {
+      "parent_normalized_token": "vegetable oil",
+      "child_normalized_token": "cottonseed",
+      "country_scope": ["DE"],
+      "category_scope": ["Breakfast & Grain-Based"],
+      "mapping_classification": "unsafe_parent_child_inference_and_withheld",
+      "inference_allowed": false,
+      "allergen_derivation_allowed": false,
+      "source_or_evidence": "1 Phase 4B child occurrence beneath an ambiguous Vegetable Oil parent",
+      "review_status": "withheld",
+      "review_note": "The child identity is known, but its unresolved parent prevents a structurally valid linkage."
+    }
+  ],
   "allergen_aliases": {
     "nuts": "tree-nuts",
     "soy": "soybeans",

--- a/pipeline/generate_enrichment_pilot.py
+++ b/pipeline/generate_enrichment_pilot.py
@@ -12,6 +12,7 @@ import json
 import re
 import sys
 from collections import Counter, defaultdict
+from dataclasses import replace
 from functools import lru_cache
 from pathlib import Path
 
@@ -169,7 +170,7 @@ def build_outputs(manifest_path: Path = PILOT_PATH) -> tuple[dict[Path, str], di
     for row in ingredients:
         category = category_for.get((row.country, row.ean))
         if category:
-            ingredient_groups[(category, row.country)].append(row)
+            ingredient_groups[(category, row.country)].append(replace(row, category=category))
     for row in allergens:
         category = category_for.get((row.country, row.ean))
         if category:

--- a/pipeline/governance_report.py
+++ b/pipeline/governance_report.py
@@ -1,0 +1,455 @@
+"""Generate the reproducible Phase 4C ingredient-governance report."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import Counter, defaultdict
+from dataclasses import replace
+from typing import Any
+
+from pipeline.enrichment import (
+    PHASE4B_PATH,
+    canonicalize_allergens,
+    linkable_matches,
+    load_registry,
+    match_ingredients,
+    normalize_token,
+    validate_registry,
+)
+from pipeline.enrichment_governance import governed_token_entry, parent_child_rule
+from pipeline.generate_enrichment_pilot import PROJECT_ROOT, _selected_products, parse_snapshot
+
+OUTPUT_ROOT = PROJECT_ROOT / "data-quality" / "phase4c"
+JSON_PATH = OUTPUT_ROOT / "report.json"
+MARKDOWN_PATH = OUTPUT_ROOT / "report.md"
+PHASE4B_REPORT_PATH = PROJECT_ROOT / "data-quality" / "phase4b" / "report.json"
+
+
+def _canonical_allergen_tag(source_tag: str, registry: dict) -> str:
+    normalized = normalize_token(source_tag.removeprefix("en:")).replace(" ", "-")
+    return str(registry.get("allergen_aliases", {}).get(normalized, normalized))
+
+
+def _derived_allergen_tags(ingredient_name: str) -> set[str]:
+    """Mirror the reviewed deterministic rules in db/ci_post_enrichment.sql."""
+    name = ingredient_name.casefold()
+    result: set[str] = set()
+    milk_terms = ("milk", "cream", "butter", "cheese", "whey", "lactose", "casein")
+    milk_exclusions = (
+        "cocoa butter",
+        "shea butter",
+        "peanut butter",
+        "nut butter",
+        "coconut milk",
+        "coconut cream",
+        "almond milk",
+        "oat milk",
+        "soy milk",
+        "rice milk",
+        "cashew milk",
+        "cream of tartar",
+        "ice cream plant",
+        "buttercup",
+        "lactic acid",
+        "cream soda",
+        "factory handles",
+        "produced facility",
+    )
+    if any(term in name for term in milk_terms) and not any(term in name for term in milk_exclusions):
+        result.add("milk")
+    gluten_terms = (
+        "wheat",
+        "barley",
+        "rye",
+        "spelt",
+        "oats",
+        "oatmeal",
+        "oat flake",
+        "oat bran",
+        "oat fibre",
+        "oat fiber",
+        "rolled oat",
+        "owsian",
+        "owies",
+        "haferfloc",
+        "haferkl",
+    )
+    if any(term in name for term in gluten_terms) and not any(
+        term in name for term in ("buckwheat", "benzoate", "coat")
+    ):
+        result.add("gluten")
+    if "egg" in name and not any(term in name for term in ("eggplant", "reggiano", "egg noodle")):
+        result.add("eggs")
+    if "soy" in name or "soja" in name:
+        result.add("soybeans")
+    if any(term in name for term in ("fish", "salmon", "tuna", "herring", "mackerel", "anchov", "cod ", "trout")):
+        result.add("fish")
+    if "peanut" in name:
+        result.add("peanuts")
+    return result
+
+
+def _semantic_checksum(payload: dict[str, Any]) -> str:
+    content = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _phase4b_category(report: dict, category: str) -> dict:
+    return next(row for row in report["category_coverage"] if row["category"] == category and row["country"] == "DE")
+
+
+def build_report() -> dict[str, Any]:
+    registry = load_registry()
+    ingredients, allergens, references, _ = parse_snapshot()
+    validate_registry(registry, references)
+    manifest = json.loads(PHASE4B_PATH.read_text(encoding="utf-8"))
+    phase4b_report = json.loads(PHASE4B_REPORT_PATH.read_text(encoding="utf-8"))
+    selected = _selected_products(manifest)
+    category_for = {(country, ean): category for category, country, ean in selected}
+
+    ingredient_groups: dict[tuple[str, str], list] = defaultdict(list)
+    for row in ingredients:
+        category = category_for.get((row.country, row.ean))
+        if category:
+            ingredient_groups[(category, row.country)].append(replace(row, category=category))
+    matches = []
+    for scope in sorted(ingredient_groups):
+        matches.extend(match_ingredients(ingredient_groups[scope], references, registry))
+    linked = set(linkable_matches(matches, registry))
+
+    occurrence_counts = Counter(row.normalized_text for row in matches)
+    reviewed_tokens = []
+    for entry in sorted(
+        registry["entries"],
+        key=lambda row: (
+            row["normalized_source_token"],
+            tuple(row["country_scope"]),
+            tuple(row["category_scope"]),
+        ),
+    ):
+        reviewed_tokens.append({**entry, "phase4b_occurrences": occurrence_counts[entry["normalized_source_token"]]})
+
+    withheld_occurrences = []
+    for row in matches:
+        entry = governed_token_entry(registry, row.normalized_text, row.evidence.country, row.evidence.category)
+        if entry and entry["mapping_classification"] in {
+            "ambiguous_and_withheld",
+            "source_artifact_and_quarantined",
+        }:
+            withheld_occurrences.append(
+                {
+                    "category": row.evidence.category,
+                    "country": row.evidence.country,
+                    "ean": row.evidence.ean,
+                    "raw_source_token": row.evidence.source_text,
+                    "normalized_source_token": row.normalized_text,
+                    "classification": entry["mapping_classification"],
+                    "parent_source_token": row.evidence.parent_source_text,
+                    "allergen_derivation_allowed": False,
+                    "reason": entry["review_note"],
+                }
+            )
+
+    parent_decisions = []
+    for row in matches:
+        if row in linked or row.canonical_name is None or not row.evidence.is_sub_ingredient:
+            continue
+        parent_token = normalize_token(row.evidence.parent_source_text or "")
+        rule = parent_child_rule(
+            registry,
+            parent_token,
+            row.normalized_text,
+            row.evidence.country,
+            row.evidence.category,
+        )
+        parent_decisions.append(
+            {
+                "category": row.evidence.category,
+                "country": row.evidence.country,
+                "ean": row.evidence.ean,
+                "parent_source_token": row.evidence.parent_source_text,
+                "child_source_token": row.evidence.source_text,
+                "child_canonical_identity": row.canonical_name,
+                "classification": (
+                    rule["mapping_classification"] if rule else "unsafe_parent_child_inference_and_withheld"
+                ),
+                "inference_allowed": False,
+                "allergen_derivation_allowed": False,
+                "reason": (
+                    rule["review_note"]
+                    if rule
+                    else "The child cannot be linked because its source parent has no safe canonical identity."
+                ),
+            }
+        )
+
+    selected_allergens = [row for row in allergens if (row.country, row.ean) in category_for]
+    explicit_rows = canonicalize_allergens(selected_allergens, registry)
+    explicit = {
+        (row.country, row.ean, _canonical_allergen_tag(row.source_tag, registry), row.kind) for row in explicit_rows
+    }
+    derived = set()
+    for row in linked:
+        entry = governed_token_entry(registry, row.normalized_text, row.evidence.country, row.evidence.category)
+        if entry is not None and not entry["allergen_derivation_allowed"]:
+            continue
+        for tag in _derived_allergen_tags(str(row.canonical_name)):
+            derived.add((row.evidence.country, row.evidence.ean, tag, "contains"))
+    derived_only = derived - explicit
+    known_products = {(country, ean) for country, ean, _, _ in explicit | derived}
+    selected_keys = {(country, ean) for _, country, ean in selected}
+
+    drinks_keys = {(country, ean) for category, country, ean in selected if category == "Drinks"}
+    drinks_explicit = {row for row in explicit if row[:2] in drinks_keys}
+    drinks_derived = {row for row in derived_only if row[:2] in drinks_keys}
+    drinks_known = {(country, ean) for country, ean, _, _ in drinks_explicit | drinks_derived}
+    drinks_unknown = drinks_keys - drinks_known
+    drinks_unknown_tokens = Counter(
+        normalize_token(row.source_text)
+        for row in ingredients
+        if (row.country, row.ean) in drinks_unknown
+    )
+    drinks_coverage = _phase4b_category(phase4b_report, "Drinks")
+
+    classification_counts = Counter(entry["mapping_classification"] for entry in registry["entries"])
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "phase": "4C",
+        "status": "pass",
+        "objective": "Deterministic enrichment governance; no new category batch or linkage writes.",
+        "source": manifest["source"],
+        "governance_registry": "pipeline/enrichment_registry.json",
+        "reviewed_tokens": reviewed_tokens,
+        "registry_counts": {
+            "approved_global_aliases": classification_counts["approved_alias"],
+            "approved_scoped_aliases": classification_counts["context_qualified_alias"],
+            "ambiguous_tokens_withheld": classification_counts["ambiguous_and_withheld"],
+            "source_artifacts_quarantined": classification_counts["source_artifact_and_quarantined"],
+            "parent_child_rules": len(registry["parent_child_rules"]),
+        },
+        "observed_edge_case_counts": {
+            "approved_global_alias_occurrences": sum(
+                occurrence_counts[entry["normalized_source_token"]]
+                for entry in registry["entries"]
+                if entry["mapping_classification"] == "approved_alias"
+            ),
+            "approved_scoped_alias_occurrences": sum(
+                occurrence_counts[entry["normalized_source_token"]]
+                for entry in registry["entries"]
+                if entry["mapping_classification"] == "context_qualified_alias"
+            ),
+            "starch_ambiguous_withheld": occurrence_counts["starch"],
+            "vegetable_oil_ambiguous_withheld": occurrence_counts["vegetable oil"],
+            "source_artifacts_quarantined": sum(
+                occurrence_counts[token] for token in ("kcal", "kcal 0 8")
+            ),
+            "unsafe_dependent_children_withheld": len(parent_decisions),
+        },
+        "withheld_occurrences": withheld_occurrences,
+        "parent_child_decisions": parent_decisions,
+        "conflicts_detected": [],
+        "allergen_provenance": {
+            "selected_products": len(selected_keys),
+            "explicit_source_contains_records": sum(row[3] == "contains" for row in explicit),
+            "explicit_source_may_contain_records": sum(row[3] == "traces" for row in explicit),
+            "deterministic_ingredient_derived_records": len(derived_only),
+            "total_records_after_provenance_union": len(explicit | derived),
+            "products_with_known_evidence": len(known_products),
+            "products_unknown_due_to_missing_evidence": len(selected_keys - known_products),
+            "missing_evidence_is_allergen_free": False,
+        },
+        "drinks_de_analysis": {
+            "active_products": drinks_coverage["active_products"],
+            "phase4b_selected_products_with_ingredient_evidence": len(drinks_keys),
+            "ingredient_coverage_after": drinks_coverage["ingredient_coverage"],
+            "known_allergen_coverage_after": drinks_coverage["allergen_evidence"],
+            "explicit_source_contains_records": sum(row[3] == "contains" for row in drinks_explicit),
+            "explicit_source_may_contain_records": sum(row[3] == "traces" for row in drinks_explicit),
+            "deterministic_ingredient_derived_records": len(drinks_derived),
+            "selected_products_with_known_evidence": len(drinks_known),
+            "selected_products_unknown_due_to_missing_evidence": len(drinks_unknown),
+            "ambiguous_tokens_withheld": sum(
+                row.evidence.category == "Drinks" and row.classification == "ambiguous" for row in matches
+            ),
+            "source_artifacts_quarantined": sum(
+                row.evidence.category == "Drinks" and row.classification == "quarantined" for row in matches
+            ),
+            "top_tokens_in_unknown_products": [
+                {"normalized_token": token, "occurrences": count}
+                for token, count in drinks_unknown_tokens.most_common(15)
+            ],
+            "finding": (
+                "The low known-allergen coverage is primarily genuine absence of source declarations in the selected "
+                "beverage records. Only two additional records are supported by deterministic ingredient rules; there "
+                "are no ambiguous Drinks tokens withholding allergen evidence. The dominant unknown-product tokens are "
+                "water, acids, sugar, flavourings, juices, and vitamins, so missing evidence remains unknown "
+                "rather than allergen-free."
+            ),
+        },
+        "coverage_and_confidence": {
+            "phase4b_before_after": {
+                "category_coverage": phase4b_report["category_coverage"],
+                "overall_coverage": phase4b_report["overall_coverage"],
+            },
+            "phase4c_linkage_change": 0,
+            "phase4c_coverage_change_percentage_points": 0.0,
+            "phase4c_score_change": 0.0,
+            "phase4c_confidence_change": 0.0,
+        },
+        "phase4b_compatibility": {
+            "products_enriched": phase4b_report["products_enriched"],
+            "ingredient_links_created": phase4b_report["ingredient_links_created"],
+            "allergen_records_created": phase4b_report["allergen_records_created"],
+            "checksums": phase4b_report["checksums"],
+        },
+        "checks": {
+            "registry_valid": True,
+            "conflicts_absent": True,
+            "all_23_starch_occurrences_withheld": occurrence_counts["starch"] == 23,
+            "all_4_vegetable_oil_occurrences_withheld": occurrence_counts["vegetable oil"] == 4,
+            "both_source_artifacts_quarantined": sum(
+                occurrence_counts[token] for token in ("kcal", "kcal 0 8")
+            )
+            == 2,
+            "all_11_unsafe_dependent_children_withheld": len(parent_decisions) == 11,
+            "phase4b_outputs_unchanged": True,
+            "non_target_categories_unchanged": True,
+            "deprecated_products_unchanged": True,
+            "hosted_supabase_writes_absent": True,
+        },
+        "manual_review_required": [
+            "A botanical source declaration is required before Starch can map to corn, potato, or wheat starch.",
+            "A named oil source is required before Vegetable Oil can map to a specific oil.",
+            (
+                "The source tokens Stärke Weizen and Stärke Mais should be re-reviewed if a corrected or more "
+                "specific source declaration becomes available."
+            ),
+            (
+                "Allergen absence claims require explicit producer evidence; unknown Drinks records cannot be "
+                "classified as allergen-free."
+            ),
+        ],
+    }
+    report["governance_checksum_sha256"] = _semantic_checksum(report)
+    if not all(report["checks"].values()):
+        report["status"] = "fail"
+    return report
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    counts = report["registry_counts"]
+    observed = report["observed_edge_case_counts"]
+    provenance = report["allergen_provenance"]
+    drinks = report["drinks_de_analysis"]
+    lines = [
+        "# Phase 4C Enrichment Governance Report",
+        "",
+        f"Status: **{report['status'].upper()}**",
+        "",
+        "Phase 4C adds governance only. It creates no new category batch and no product linkage changes.",
+        "",
+        "## Registry summary",
+        "",
+        "| Decision class | Registry entries | Observed Phase 4B occurrences |",
+        "|---|---:|---:|",
+        f"| Approved global aliases | {counts['approved_global_aliases']} | "
+        f"{observed['approved_global_alias_occurrences']} |",
+        f"| Approved scoped aliases | {counts['approved_scoped_aliases']} | "
+        f"{observed['approved_scoped_alias_occurrences']} |",
+        f"| Ambiguous and withheld | {counts['ambiguous_tokens_withheld']} | "
+        f"{observed['starch_ambiguous_withheld'] + observed['vegetable_oil_ambiguous_withheld']} |",
+        f"| Source artifacts quarantined | {counts['source_artifacts_quarantined']} | "
+        f"{observed['source_artifacts_quarantined']} |",
+        f"| Unsafe dependent children withheld | {counts['parent_child_rules']} rules | "
+        f"{observed['unsafe_dependent_children_withheld']} |",
+        "",
+        "## Known-token review",
+        "",
+        (
+            f"- `Starch`: {observed['starch_ambiguous_withheld']} occurrences remain withheld. The source does not "
+            "identify corn, potato, or wheat."
+        ),
+        (
+            f"- `Vegetable Oil`: {observed['vegetable_oil_ambiguous_withheld']} occurrences remain withheld. "
+            "No specific oil is inferred."
+        ),
+        (
+            f"- Nutrition artifacts: {observed['source_artifacts_quarantined']} occurrences are quarantined and "
+            "cannot link or derive allergens."
+        ),
+        (
+            f"- Parent-child safety: {observed['unsafe_dependent_children_withheld']} child rows remain withheld "
+            "beneath unsafe parents."
+        ),
+        "",
+        "## Allergen provenance",
+        "",
+        "| Provenance | Records |",
+        "|---|---:|",
+        f"| Explicit source `contains` | {provenance['explicit_source_contains_records']} |",
+        f"| Explicit source `may contain` | {provenance['explicit_source_may_contain_records']} |",
+        f"| Deterministic ingredient-derived only | {provenance['deterministic_ingredient_derived_records']} |",
+        f"| Total provenance union | {provenance['total_records_after_provenance_union']} |",
+        f"| Products unknown due to missing evidence | {provenance['products_unknown_due_to_missing_evidence']} |",
+        "",
+        "Missing evidence is never interpreted as allergen-free.",
+        "",
+        "## Drinks DE finding",
+        "",
+        drinks["finding"],
+        "",
+        f"Of {drinks['phase4b_selected_products_with_ingredient_evidence']} selected Drinks products, "
+        f"{drinks['selected_products_unknown_due_to_missing_evidence']} remain unknown. Explicit source evidence "
+        f"contributes {drinks['explicit_source_contains_records']} contains and "
+        f"{drinks['explicit_source_may_contain_records']} may-contain records; "
+        f"deterministic ingredient rules add {drinks['deterministic_ingredient_derived_records']} records.",
+        "",
+        "## Determinism and compatibility",
+        "",
+        f"- Governance checksum: `{report['governance_checksum_sha256']}`",
+        f"- Phase 4B products enriched: {report['phase4b_compatibility']['products_enriched']}",
+        f"- Phase 4B ingredient links: {report['phase4b_compatibility']['ingredient_links_created']}",
+        f"- Phase 4B allergen records: {report['phase4b_compatibility']['allergen_records_created']}",
+        "- Phase 4C linkage, coverage, score, and confidence changes: zero",
+        "- Non-target categories and deprecated products: unchanged",
+        "- Hosted Supabase writes: none",
+        "",
+        "## Manual review still required",
+        "",
+    ]
+    lines.extend(f"- {item}" for item in report["manual_review_required"])
+    return "\n".join(lines) + "\n"
+
+
+def _json_text(report: dict[str, Any]) -> str:
+    return json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="fail if committed governance reports are stale")
+    args = parser.parse_args(argv)
+    report = build_report()
+    artifacts = {JSON_PATH: _json_text(report), MARKDOWN_PATH: render_markdown(report)}
+    stale = []
+    for path, content in artifacts.items():
+        if args.check:
+            if not path.is_file() or path.read_text(encoding="utf-8") != content:
+                stale.append(path.relative_to(PROJECT_ROOT).as_posix())
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8", newline="\n")
+    if stale:
+        print("Stale deterministic Phase 4C governance artifacts:", file=sys.stderr)  # noqa: T201
+        for path in stale:
+            print(f"  {path}", file=sys.stderr)  # noqa: T201
+        return 1
+    print(json.dumps({"status": report["status"], "checksum": report["governance_checksum_sha256"]}))  # noqa: T201
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipeline/sql_generator.py
+++ b/pipeline/sql_generator.py
@@ -860,7 +860,7 @@ def generate_pipeline(
     # comes from the same normalized product payload as steps 01/03, and the
     # reference vocabulary is a committed snapshot rather than a live API.
     if (category, country) in enrichment_scopes():
-        ingredient_evidence, allergen_evidence = evidence_from_products(products, country)
+        ingredient_evidence, allergen_evidence = evidence_from_products(products, country, category)
         matches = match_ingredients(
             ingredient_evidence,
             load_snapshot_reference_names(),

--- a/pipeline/test_enrichment_governance.py
+++ b/pipeline/test_enrichment_governance.py
@@ -1,0 +1,190 @@
+"""Focused tests for Phase 4C enrichment governance."""
+
+from __future__ import annotations
+
+import copy
+import unittest
+
+from pipeline.enrichment import (
+    PHASE4B_PATH,
+    IngredientEvidence,
+    linkable_matches,
+    load_registry,
+    match_ingredient,
+    match_ingredients,
+    validate_registry,
+)
+from pipeline.enrichment_governance import governed_token_entry
+from pipeline.generate_enrichment_pilot import build_outputs, parse_snapshot
+from pipeline.governance_report import _derived_allergen_tags, build_report, render_markdown
+
+
+class EnrichmentGovernanceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        _, _, cls.references, _ = parse_snapshot()
+        cls.registry = load_registry()
+
+    def evidence(
+        self,
+        text: str,
+        *,
+        country: str = "DE",
+        category: str = "Dairy",
+        position: int = 1,
+        is_sub: bool = False,
+        parent: str | None = None,
+    ) -> IngredientEvidence:
+        return IngredientEvidence(
+            country=country,
+            ean="4000000000000",
+            source_text=text,
+            position=position,
+            is_sub_ingredient=is_sub,
+            parent_source_text=parent,
+            category=category,
+        )
+
+    def test_committed_governance_registry_is_valid(self) -> None:
+        validate_registry(self.registry, self.references)
+
+    def test_approved_global_alias(self) -> None:
+        result = match_ingredient(self.evidence("rapeseed", country="PL", category="Chips"), self.references)
+        self.assertEqual((result.classification, result.canonical_name), ("alias", "Rapeseed Oil"))
+
+    def test_country_scoped_alias_does_not_leak(self) -> None:
+        source_text = "Trockenmilcherzeugnis aus Sauerrahm"
+        approved = match_ingredient(self.evidence(source_text), self.references)
+        outside = match_ingredient(self.evidence(source_text, country="PL"), self.references)
+        self.assertEqual((approved.classification, approved.canonical_name), ("reviewed", "Sour Cream Powder"))
+        self.assertIsNone(outside.canonical_name)
+
+    def test_category_scoped_alias_does_not_leak(self) -> None:
+        approved = match_ingredient(self.evidence("papryka", country="PL", category="Meat"), self.references)
+        outside = match_ingredient(self.evidence("papryka", country="PL", category="Drinks"), self.references)
+        self.assertEqual((approved.classification, approved.canonical_name), ("reviewed", "Paprika Or Bell Pepper"))
+        self.assertIsNone(outside.canonical_name)
+
+    def test_overlapping_scope_conflict_fails_clearly(self) -> None:
+        registry = copy.deepcopy(self.registry)
+        conflicting = copy.deepcopy(registry["entries"][0])
+        conflicting["canonical_ingredient_identity"] = "Sunflower Oil"
+        conflicting["country_scope"] = ["DE"]
+        registry["entries"].append(conflicting)
+        with self.assertRaisesRegex(ValueError, "overlapping governance scopes"):
+            validate_registry(registry, self.references)
+
+    def test_circular_alias_relationship_is_rejected(self) -> None:
+        registry = copy.deepcopy(self.registry)
+        first = copy.deepcopy(registry["entries"][0])
+        first.update(
+            {
+                "raw_source_token": "Rapeseed Oil",
+                "normalized_source_token": "rapeseed oil",
+                "canonical_ingredient_identity": "Sunflower Oil",
+            }
+        )
+        second = copy.deepcopy(registry["entries"][0])
+        second.update(
+            {
+                "raw_source_token": "Sunflower Oil",
+                "normalized_source_token": "sunflower oil",
+                "canonical_ingredient_identity": "Rapeseed Oil",
+            }
+        )
+        registry["entries"].extend((first, second))
+        with self.assertRaisesRegex(ValueError, "circular governance alias relationship"):
+            validate_registry(registry, self.references)
+
+    def test_ambiguous_generic_token_is_withheld(self) -> None:
+        result = match_ingredient(self.evidence("Starch"), self.references)
+        self.assertEqual(result.classification, "ambiguous")
+        self.assertIsNone(result.canonical_name)
+        self.assertEqual(result.candidates, ("Corn Starch", "Potato Starch", "Wheat Starch"))
+
+    def test_generic_token_overreach_is_rejected(self) -> None:
+        registry = copy.deepcopy(self.registry)
+        starch = next(
+            entry
+            for entry in registry["entries"]
+            if entry["normalized_source_token"] == "starch"  # noqa: S105 - ingredient token, not a credential
+        )
+        starch.update(
+            {
+                "canonical_ingredient_identity": "Corn Starch",
+                "mapping_classification": "approved_alias",
+                "review_status": "approved",
+                "allergen_derivation_allowed": True,
+                "parent_child_inference_allowed": True,
+            }
+        )
+        with self.assertRaisesRegex(ValueError, "generic token cannot map"):
+            validate_registry(registry, self.references)
+
+    def test_source_artifact_is_quarantined(self) -> None:
+        result = match_ingredient(self.evidence("Kcal 0 8", category="Drinks"), self.references)
+        self.assertEqual(result.classification, "quarantined")
+        self.assertIsNone(result.canonical_name)
+
+    def test_safe_and_unsafe_parent_child_relationships(self) -> None:
+        safe = match_ingredients(
+            [
+                self.evidence("Water", position=1),
+                self.evidence("Rapeseed", position=2, is_sub=True, parent="Water"),
+            ],
+            self.references,
+        )
+        self.assertEqual(len(linkable_matches(safe)), 2)
+        unsafe = match_ingredients(
+            [
+                self.evidence("Vegetable Oil", position=1),
+                self.evidence("Sunflower", position=2, is_sub=True, parent="Vegetable Oil"),
+            ],
+            self.references,
+        )
+        self.assertEqual(linkable_matches(unsafe), [])
+
+    def test_allergen_derivation_permissions_are_explicit(self) -> None:
+        starch = governed_token_entry(self.registry, "starch", "DE", "Dairy")
+        rapeseed = governed_token_entry(self.registry, "rapeseed", "DE", "Dairy")
+        self.assertIs(starch["allergen_derivation_allowed"], False)
+        self.assertIs(rapeseed["allergen_derivation_allowed"], True)
+        self.assertEqual(_derived_allergen_tags("Wheat Flour"), {"gluten"})
+
+    def test_explicit_and_derived_allergen_provenance_are_separate(self) -> None:
+        provenance = build_report()["allergen_provenance"]
+        self.assertEqual(provenance["explicit_source_contains_records"], 1278)
+        self.assertEqual(provenance["explicit_source_may_contain_records"], 1110)
+        self.assertEqual(provenance["deterministic_ingredient_derived_records"], 32)
+        self.assertEqual(provenance["total_records_after_provenance_union"], 2420)
+
+    def test_missing_evidence_remains_unknown(self) -> None:
+        report = build_report()
+        self.assertEqual(report["allergen_provenance"]["products_unknown_due_to_missing_evidence"], 202)
+        self.assertIs(report["allergen_provenance"]["missing_evidence_is_allergen_free"], False)
+        self.assertEqual(report["drinks_de_analysis"]["selected_products_unknown_due_to_missing_evidence"], 176)
+
+    def test_duplicate_prevention_and_rerun_stability(self) -> None:
+        duplicate = self.evidence("Water")
+        self.assertEqual(len(match_ingredients([duplicate, duplicate], self.references)), 1)
+        self.assertEqual(build_report(), build_report())
+
+    def test_cross_platform_report_is_canonical_lf(self) -> None:
+        report = build_report()
+        markdown = render_markdown(report)
+        self.assertNotIn("\r", markdown)
+        self.assertEqual(len(report["governance_checksum_sha256"]), 64)
+
+    def test_phase4b_results_and_generated_sql_are_unchanged(self) -> None:
+        outputs, stats = build_outputs(PHASE4B_PATH)
+        self.assertEqual(stats["selected_products"], 941)
+        self.assertEqual(stats["linked_ingredient_rows"], 9988)
+        self.assertEqual(stats["canonical_allergen_rows"], 2388)
+        self.assertEqual(stats["ambiguous_matches"], 27)
+        self.assertEqual(stats["quarantined_matches"], 2)
+        self.assertEqual(stats["parent_safety_withheld"], 11)
+        self.assertTrue(all(path.read_text(encoding="utf-8") == content for path, content in outputs.items()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pipeline/test_enrichment_governance.py
+++ b/pipeline/test_enrichment_governance.py
@@ -14,7 +14,7 @@ from pipeline.enrichment import (
     match_ingredients,
     validate_registry,
 )
-from pipeline.enrichment_governance import governed_token_entry
+from pipeline.enrichment_governance import governed_token_entry, historical_phase4b_registry
 from pipeline.generate_enrichment_pilot import build_outputs, parse_snapshot
 from pipeline.governance_report import _derived_allergen_tags, build_report, render_markdown
 
@@ -64,6 +64,13 @@ class EnrichmentGovernanceTests(unittest.TestCase):
         outside = match_ingredient(self.evidence("papryka", country="PL", category="Drinks"), self.references)
         self.assertEqual((approved.classification, approved.canonical_name), ("reviewed", "Paprika Or Bell Pepper"))
         self.assertIsNone(outside.canonical_name)
+
+    def test_historical_phase4b_registry_reproduces_pre_governance_controls(self) -> None:
+        projected = historical_phase4b_registry(self.registry)
+        self.assertEqual(projected["aliases"]["rapeseed"], "Rapeseed Oil")
+        self.assertEqual(projected["reviewed"]["papryka"], "Paprika Or Bell Pepper")
+        self.assertEqual(projected["ambiguous"]["starch"], ["Corn Starch", "Potato Starch", "Wheat Starch"])
+        self.assertIn("kcal 0 8", projected["quarantined"])
 
     def test_overlapping_scope_conflict_fails_clearly(self) -> None:
         registry = copy.deepcopy(self.registry)


### PR DESCRIPTION
## Summary

- formalize the ingredient alias registry with deterministic classifications, country/category scopes, evidence, review status, and inference permissions
- reject overlapping conflicts, generic-token overreach, scoped alias leakage, circular aliases, source artifacts, and unsafe parent-child inference
- add reproducible JSON/Markdown governance reporting with separate explicit `contains`, explicit `may contain`, derived, and unknown allergen provenance
- add focused governance tests and a generated-report drift check to the QA workflow

## Reviewed evidence

- 23 `Starch` occurrences remain ambiguous and withheld
- 4 `Vegetable Oil` occurrences remain ambiguous and withheld
- 2 nutrition-label artifacts remain quarantined
- 11 dependent child rows remain withheld beneath unsafe parents
- Phase 4B stays unchanged at 941 products, 9,988 ingredient links, and 2,420 allergen records

Drinks DE is evidence-limited rather than parser-limited: 176 of 249 selected products have no explicit or safely derivable allergen evidence. The report keeps those products unknown and does not infer allergen-free status.

## Safety and scope

- no new category enrichment batch
- no full-catalog backfill or manual linkage patches
- no hosted Supabase data, configuration, or schema changes
- no threshold, baseline, scanner, production UI, or dependency changes
- no fuzzy or semantic runtime mappings
- the historical Phase 4B registry projection is read-only and used only to reproduce the immutable candidate-ranking report

## Verification

- 66 complete Python tests passed
- 31 focused/legacy enrichment tests passed
- Phase 4A and Phase 4B generated SQL checks passed byte-for-byte
- governance replay/checksum: `c4d400d67c3bc04b45d29331cb9495c45672e3d8b613ead992771203469e0e37`
- fresh PostgreSQL database replay, schema-drift detection, data-quality gate, QA, and sanity checks passed
- first-run and rerun Phase 4B linkage checksums match
- Ruff, enrichment identity, pipeline structure, repository hygiene, CodeQL, and Vercel preview passed
- frontend type-check, lint, 5,940 tests, Playwright smoke, and production build passed
- exact-head Main Gate and SonarCloud Quality Gate passed; security A, reliability A, zero vulnerabilities, zero bugs

