### PR TITLE
fix: correct allergen evidence semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ supabase db reset                        # Full rebuild (migrations + seed)
 .\RUN_SEED.ps1                           # Seed reference data only
 
 # ── Testing ──
-.\RUN_QA.ps1                             # 776 QA checks across 49 suites
+.\RUN_QA.ps1                             # 776 blocking QA checks across 50 suites
 .\RUN_NEGATIVE_TESTS.ps1                 # 20 constraint violation tests
 .\RUN_SANITY.ps1 -Env local              # Row-count + schema assertions
 python validate_eans.py                  # EAN checksum validation
@@ -187,7 +187,7 @@ echo "SELECT * FROM v_master LIMIT 5;" | docker exec -i supabase_db_tryvit psql 
 ```
 ┌─────────────────┐     ┌──────────────────┐     ┌─────────────────────────┐
 │  Open Food Facts │────▶│  Python Pipeline │────▶│  PostgreSQL (Supabase)  │
-│  API v2          │     │  sql_generator   │     │  232 migrations         │
+│  API v2          │     │  sql_generator   │     │  233 migrations         │
 │  (category tags, │     │  validator       │     │  58 pipeline folders    │
 │   countries=PL,DE│     │  off_client      │     │  products + nutrition   │
 └─────────────────┘     └──────────────────┘     │  + ingredients + scores │
@@ -319,7 +319,7 @@ tryvit/
 │   └── views/                       # Reference view definitions
 │
 ├── supabase/
-│   ├── migrations/                  # 232 append-only schema migrations
+│   ├── migrations/                  # 233 append-only schema migrations
 │   ├── seed/                        # Reference data seeds
 │   ├── tests/                       # pgTAP integration tests
 │   └── functions/                   # Edge Functions (API gateway, push notifications, CAPTCHA)
@@ -362,7 +362,7 @@ tryvit/
 
 ## 🧪 Testing
 
-Every change is validated against **776 automated checks** across 49 QA suites plus 20 negative validation tests. No data enters the database without verification.
+Every change is validated against **784 automated checks** across 50 QA suites (776 blocking) plus 20 negative validation tests. No data enters the database without verification.
 
 <table>
   <tr>

--- a/RUN_QA.ps1
+++ b/RUN_QA.ps1
@@ -52,6 +52,7 @@
        46. QA__rls_audit.sql (7 RLS audit checks — blocking)
        47. QA__function_security_audit.sql (6 function security audit checks — blocking)
        48. QA__recipe_integrity.sql (6 recipe data integrity checks — blocking)
+       50. QA__allergen_evidence_semantics.sql (7 allergen evidence semantics checks — blocking)
 
     Returns exit code 0 if all tests pass, 1 if any violations found.
     Test Suites 3, 33, 41, 42, 43, and 44 are informational and do not affect the exit code.
@@ -182,7 +183,8 @@ $suiteCatalog = @(
     @{ Num = 46; Name = "RLS Audit"; Short = "RLSAudit"; Id = "rls_audit"; Checks = 7; Blocking = $true; Kind = "sql"; File = "QA__rls_audit.sql" },
     @{ Num = 47; Name = "Function Security Audit"; Short = "FuncSecAudit"; Id = "function_security_audit"; Checks = 6; Blocking = $true; Kind = "sql"; File = "QA__function_security_audit.sql" },
     @{ Num = 48; Name = "Recipe Integrity"; Short = "RecipeInteg"; Id = "recipe_integrity"; Checks = 6; Blocking = $true; Kind = "sql"; File = "QA__recipe_integrity.sql" },
-    @{ Num = 49; Name = "Scoring Band Distribution"; Short = "ScoringDist"; Id = "scoring_distribution"; Checks = 12; Blocking = $false; Kind = "sql"; File = "QA__scoring_distribution.sql" }
+    @{ Num = 49; Name = "Scoring Band Distribution"; Short = "ScoringDist"; Id = "scoring_distribution"; Checks = 12; Blocking = $false; Kind = "sql"; File = "QA__scoring_distribution.sql" },
+    @{ Num = 50; Name = "Allergen Evidence Semantics"; Short = "AllergenEvidence"; Id = "allergen_evidence_semantics"; Checks = 7; Blocking = $true; Kind = "sql"; File = "QA__allergen_evidence_semantics.sql" }
 )
 
 $suiteByNum = @{}

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -9,7 +9,7 @@
 > **Servings:** removed as separate table — all nutrition data is per-100g on nutrition_facts
 > **Ingredient analytics:** 5,340 unique ingredients (all clean ASCII English), 2,691 allergen declarations, 2,702 trace declarations
 > **Ingredient concerns:** EFSA-based 4-tier additive classification (0=none, 1=low, 2=moderate, 3=high)
-> **QA:** 777 checks across 49 suites + 20 negative validation tests — all passing
+> **QA:** 784 checks across 50 suites (776 blocking) + 20 negative validation tests — all passing
 
 ---
 
@@ -189,7 +189,7 @@ tryvit/
 │   │   ├── api-gateway/             # Write-path gateway (rate limiting, validation) (#478)
 │   │   └── send-push-notification/  # Push notification handler
 │   ├── dr-drill/                    # Disaster recovery drill artifacts
-│   └── migrations/                  # 232 append-only schema migrations
+│   └── migrations/                  # 233 append-only schema migrations
 │       ├── 20260207000100_create_schema.sql
 │       ├── 20260207000200_baseline.sql
 │       ├── 20260207000300_add_chip_metadata.sql
@@ -304,7 +304,7 @@ tryvit/
 │       ├── 006-append-only-migrations.md
 │       └── 007-english-canonical-ingredients.md
 ├── RUN_LOCAL.ps1                    # Pipeline runner (idempotent)
-├── RUN_QA.ps1                       # QA test runner (777 checks across 49 suites)
+├── RUN_QA.ps1                       # QA test runner (784 checks across 50 suites; 776 blocking)
 ├── RUN_NEGATIVE_TESTS.ps1           # Negative test runner (20 injection tests)
 ├── RUN_SANITY.ps1                   # Sanity checks (16) — row counts, schema assertions
 ├── RUN_REMOTE.ps1                   # Remote deployment (requires confirmation)
@@ -699,7 +699,7 @@ a mix of `'baked'`, `'fried'`, and `'none'`.
 
 ## 7. Migrations
 
-**Location:** `supabase/migrations/` — managed by Supabase CLI. Currently **232 migrations**.
+**Location:** `supabase/migrations/` — managed by Supabase CLI. Currently **233 migrations**.
 
 **Rules:**
 
@@ -771,7 +771,7 @@ A change is **not done** unless relevant tests were added/updated, every suite i
 | Component tests     | **Testing Library React** + Vitest                | `frontend/src/components/**/*.test.tsx`      | same as above                        |
 | E2E smoke           | **Playwright 1.58** (Chromium)                    | `frontend/e2e/smoke.spec.ts`                 | `cd frontend && npx playwright test` |
 | E2E auth            | Playwright (requires `SUPABASE_SERVICE_ROLE_KEY`) | `frontend/e2e/authenticated.spec.ts`         | same (CI auto-detects key)           |
-| DB QA (777 checks)  | Raw SQL (zero rows = pass)                        | `db/qa/QA__*.sql` (49 suites)                | `.\RUN_QA.ps1`                       |
+| DB QA (784 checks; 776 blocking) | Raw SQL (zero rows = pass)          | `db/qa/QA__*.sql` (50 suites)                | `.\RUN_QA.ps1`                       |
 | Negative validation | SQL injection/constraint tests                    | `db/qa/TEST__negative_checks.sql`            | `.\RUN_NEGATIVE_TESTS.ps1`           |
 | DB sanity           | Row-count + schema assertions                     | via `RUN_SANITY.ps1`                         | `.\RUN_SANITY.ps1 -Env local`        |
 | Pipeline structure  | Python validator                                  | `check_pipeline_structure.py`                | `python check_pipeline_structure.py` |
@@ -912,7 +912,7 @@ E2E tests are the **only** exception — they run against a live dev server but 
   - **`pr-title-lint.yml`**: PR title conventional-commit validation (all PRs)
   - **`main-gate.yml`**: Typecheck → Lint → Build → Unit tests with coverage → Playwright smoke E2E → SonarCloud scan + BLOCKING Quality Gate → Sentry sourcemap upload
   - **`nightly.yml`**: Full Playwright (all projects incl. visual regression) + Data Integrity Audit (parallel)
-  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (777 checks) → Sanity (17 checks) → Confidence threshold
+  - **`qa.yml`**: Pipeline structure guard → Schema migrations → Schema drift detection → Pipelines → QA (784 checks; 776 blocking) → Sanity (17 checks) → Confidence threshold
   - **`deploy.yml`**: Manual trigger → Schema diff → Approval gate (production) → Pre-deploy backup → `supabase db push` → Post-deploy sanity
   - **`sync-cloud-db.yml`**: Auto-sync migrations to production on merge to `main`
 - **Required (merge-blocking) checks:** `Unit Tests`, `Playwright Smoke`, `Typecheck & Lint`, `Build`. These four must pass before a PR can merge.
@@ -949,7 +949,7 @@ If adding/changing DB schema or SQL functions:
 - For rollback procedures, see `DEPLOYMENT.md` → **Rollback Procedures** (5 scenarios + emergency checklist).
 - Add a QA check that verifies the migration outcome (row counts, constraint behavior).
 - Ensure idempotency (`IF NOT EXISTS`, `ON CONFLICT`, `DO UPDATE SET`).
-- Run `.\RUN_QA.ps1` to verify all 777 checks pass + `.\RUN_NEGATIVE_TESTS.ps1` for 20 injection tests.
+- Run `.\RUN_QA.ps1` to verify all 784 checks pass (776 blocking) + `.\RUN_NEGATIVE_TESTS.ps1` for 20 injection tests.
 
 ### 8.14 Snapshots Are Not Enough
 
@@ -1044,7 +1044,7 @@ At the end of every PR-like change, include a **Verification** section:
 | Scoring Band Distribution | `QA__scoring_distribution.sql`      |     12 | No        |
 | **Negative Validation**   | `TEST__negative_checks.sql`         |     20 | Yes       |
 
-**Run:** `.\RUN_QA.ps1` — expects **777/777 checks passing** (+ EAN validation).
+**Run:** `.\RUN_QA.ps1` — expects **784/784 checks passing** (776 blocking, + EAN validation).
 **Run:** `.\RUN_NEGATIVE_TESTS.ps1` — expects **20/20 caught**.
 
 ### 8.19 Key Regression Tests (Scoring Suite)
@@ -2043,7 +2043,7 @@ Else → fallback Z (always safe, always returns a value)
 ## Verification Checklist (Definition of Done)
 
 - [ ] `python check_pipeline_structure.py` — 0 errors
-- [ ] `.\RUN_QA.ps1` — all 777 checks pass
+- [ ] `.\RUN_QA.ps1` — all 784 checks pass (776 blocking)
 - [ ] `.\RUN_NEGATIVE_TESTS.ps1` — 20/20 caught
 - [ ] `supabase test db` — all pgTAP pass
 - [ ] `cd frontend && npx tsc --noEmit` — 0 errors
@@ -2537,7 +2537,7 @@ After implementation, update ALL of these that apply (per §18.1):
 
 ```powershell
 supabase test db                  → XX/XX pgTAP tests pass
-.\RUN_QA.ps1                      → 777/777 checks pass (0 failures)
+.\RUN_QA.ps1                      → 784/784 checks pass (776 blocking, 0 failures)
 .\RUN_NEGATIVE_TESTS.ps1          → 20/20 caught
 npx tsc --noEmit                  → 0 errors
 npx vitest run                    → XXX/XXX tests pass

--- a/db/ci_post_enrichment.sql
+++ b/db/ci_post_enrichment.sql
@@ -33,8 +33,8 @@ WHERE name_en ~ '^\d+$'
 -- inferred here.  Logic mirrors QA__allergen_integrity checks 9-14.
 
 -- Milk (excludes cocoa butter, coconut milk, lactic acid, etc.)
-INSERT INTO product_allergen_info (product_id, tag, type)
-SELECT DISTINCT pi.product_id, 'milk', 'contains'
+INSERT INTO product_allergen_info (product_id, tag, type, evidence_basis)
+SELECT DISTINCT pi.product_id, 'milk', 'contains', 'ingredient_derived'
 FROM product_ingredient pi
 JOIN ingredient_ref ir ON ir.ingredient_id = pi.ingredient_id
 JOIN products p ON p.product_id = pi.product_id AND p.is_deprecated IS NOT TRUE
@@ -55,8 +55,8 @@ AND NOT EXISTS (
 ON CONFLICT (product_id, tag, type) DO NOTHING;
 
 -- Gluten (excludes buckwheat, benzoate, coat)
-INSERT INTO product_allergen_info (product_id, tag, type)
-SELECT DISTINCT pi.product_id, 'gluten', 'contains'
+INSERT INTO product_allergen_info (product_id, tag, type, evidence_basis)
+SELECT DISTINCT pi.product_id, 'gluten', 'contains', 'ingredient_derived'
 FROM product_ingredient pi
 JOIN ingredient_ref ir ON ir.ingredient_id = pi.ingredient_id
 JOIN products p ON p.product_id = pi.product_id AND p.is_deprecated IS NOT TRUE
@@ -77,8 +77,8 @@ AND NOT EXISTS (
 ON CONFLICT (product_id, tag, type) DO NOTHING;
 
 -- Eggs (excludes eggplant, reggiano, egg noodle)
-INSERT INTO product_allergen_info (product_id, tag, type)
-SELECT DISTINCT pi.product_id, 'eggs', 'contains'
+INSERT INTO product_allergen_info (product_id, tag, type, evidence_basis)
+SELECT DISTINCT pi.product_id, 'eggs', 'contains', 'ingredient_derived'
 FROM product_ingredient pi
 JOIN ingredient_ref ir ON ir.ingredient_id = pi.ingredient_id
 JOIN products p ON p.product_id = pi.product_id AND p.is_deprecated IS NOT TRUE
@@ -91,8 +91,8 @@ AND NOT EXISTS (
 ON CONFLICT (product_id, tag, type) DO NOTHING;
 
 -- Soybeans
-INSERT INTO product_allergen_info (product_id, tag, type)
-SELECT DISTINCT pi.product_id, 'soybeans', 'contains'
+INSERT INTO product_allergen_info (product_id, tag, type, evidence_basis)
+SELECT DISTINCT pi.product_id, 'soybeans', 'contains', 'ingredient_derived'
 FROM product_ingredient pi
 JOIN ingredient_ref ir ON ir.ingredient_id = pi.ingredient_id
 JOIN products p ON p.product_id = pi.product_id AND p.is_deprecated IS NOT TRUE
@@ -104,8 +104,8 @@ AND NOT EXISTS (
 ON CONFLICT (product_id, tag, type) DO NOTHING;
 
 -- Fish
-INSERT INTO product_allergen_info (product_id, tag, type)
-SELECT DISTINCT pi.product_id, 'fish', 'contains'
+INSERT INTO product_allergen_info (product_id, tag, type, evidence_basis)
+SELECT DISTINCT pi.product_id, 'fish', 'contains', 'ingredient_derived'
 FROM product_ingredient pi
 JOIN ingredient_ref ir ON ir.ingredient_id = pi.ingredient_id
 JOIN products p ON p.product_id = pi.product_id AND p.is_deprecated IS NOT TRUE
@@ -119,8 +119,8 @@ AND NOT EXISTS (
 ON CONFLICT (product_id, tag, type) DO NOTHING;
 
 -- Peanuts
-INSERT INTO product_allergen_info (product_id, tag, type)
-SELECT DISTINCT pi.product_id, 'peanuts', 'contains'
+INSERT INTO product_allergen_info (product_id, tag, type, evidence_basis)
+SELECT DISTINCT pi.product_id, 'peanuts', 'contains', 'ingredient_derived'
 FROM product_ingredient pi
 JOIN ingredient_ref ir ON ir.ingredient_id = pi.ingredient_id
 JOIN products p ON p.product_id = pi.product_id AND p.is_deprecated IS NOT TRUE

--- a/db/ci_post_phase4d.sql
+++ b/db/ci_post_phase4d.sql
@@ -174,8 +174,8 @@ derived AS (
   FROM target_links
   WHERE ingredient_name LIKE '%peanut%'
 )
-INSERT INTO product_allergen_info (product_id, tag, type)
-SELECT product_id, tag, 'contains'
+INSERT INTO product_allergen_info (product_id, tag, type, evidence_basis)
+SELECT product_id, tag, 'contains', 'ingredient_derived'
 FROM derived
 ON CONFLICT (product_id, tag, type) DO NOTHING;
 

--- a/db/ci_post_phase4e.sql
+++ b/db/ci_post_phase4e.sql
@@ -174,8 +174,8 @@ derived AS (
   FROM target_links
   WHERE ingredient_name LIKE '%peanut%'
 )
-INSERT INTO product_allergen_info (product_id, tag, type)
-SELECT product_id, tag, 'contains'
+INSERT INTO product_allergen_info (product_id, tag, type, evidence_basis)
+SELECT product_id, tag, 'contains', 'ingredient_derived'
 FROM derived
 ON CONFLICT (product_id, tag, type) DO NOTHING;
 

--- a/db/ci_post_pipeline.sql
+++ b/db/ci_post_pipeline.sql
@@ -206,8 +206,10 @@ WHERE  product_id IN (
 -- the allergen declarations here, after products exist, so allergen-related
 -- QA checks have data to validate against.
 
-INSERT INTO product_allergen_info (product_id, tag, type)
-SELECT p.product_id, v.tag, v.type
+INSERT INTO product_allergen_info (
+  product_id, tag, type, source_tag, evidence_basis
+)
+SELECT p.product_id, v.tag, v.type, v.tag, 'explicit_source'
 FROM (VALUES
   -- Chips (contain milk / gluten from flavoring ingredients)
   ('PL', '5900073020118', 'gluten', 'contains'),

--- a/db/qa/QA__allergen_evidence_semantics.sql
+++ b/db/qa/QA__allergen_evidence_semantics.sql
@@ -1,0 +1,113 @@
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- QA Suite: Phase 5 allergen evidence semantics
+-- Positive rows have explicit provenance; missing rows remain unknown.
+-- 7 checks.
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+-- 1. Every positive evidence row has a supported non-null basis.
+SELECT '1. allergen evidence basis is valid' AS check_name,
+       COUNT(*) AS violations
+FROM product_allergen_info
+WHERE evidence_basis IS NULL
+   OR evidence_basis NOT IN (
+       'explicit_source',
+       'ingredient_derived',
+       'legacy_unclassified'
+   );
+
+-- 2. Explicit source evidence must retain source traceability.
+SELECT '2. explicit allergen evidence retains source tag' AS check_name,
+       COUNT(*) AS violations
+FROM product_allergen_info
+WHERE evidence_basis = 'explicit_source'
+  AND source_tag IS NULL;
+
+-- 3. Deterministic ingredient rules may establish contains evidence only.
+SELECT '3. ingredient-derived evidence is contains-only' AS check_name,
+       COUNT(*) AS violations
+FROM product_allergen_info
+WHERE evidence_basis = 'ingredient_derived'
+  AND type <> 'contains';
+
+-- 4. A representative product with no positive rows reports unknown.
+WITH sample AS (
+    SELECT p.product_id
+    FROM products p
+    WHERE p.is_deprecated IS NOT TRUE
+      AND NOT EXISTS (
+          SELECT 1
+          FROM product_allergen_info ai
+          WHERE ai.product_id = p.product_id
+      )
+    ORDER BY p.product_id
+    LIMIT 1
+)
+SELECT '4. no evidence reports unknown in product profile' AS check_name,
+       COUNT(*) AS violations
+FROM sample
+WHERE api_get_product_profile(sample.product_id)
+          ->'allergens'->>'evidence_status' <> 'unknown';
+
+-- 5. Product profiles never synthesize assessed absence in this contract.
+WITH samples AS (
+    SELECT p.product_id
+    FROM products p
+    WHERE p.is_deprecated IS NOT TRUE
+    ORDER BY p.product_id
+    LIMIT 25
+)
+SELECT '5. product profiles do not synthesize assessed absence' AS check_name,
+       COUNT(*) AS violations
+FROM samples
+WHERE api_get_product_profile(samples.product_id)
+          ->'allergens'->>'absence_assessment' <> 'not_assessed'
+   OR jsonb_array_length(
+          api_get_product_profile(samples.product_id)
+              ->'allergens'->'assessed_absent'
+      ) <> 0;
+
+-- 6. The batch API returns explicit unknown payloads for requested products.
+WITH sample AS (
+    SELECT p.product_id
+    FROM products p
+    WHERE p.is_deprecated IS NOT TRUE
+      AND NOT EXISTS (
+          SELECT 1
+          FROM product_allergen_info ai
+          WHERE ai.product_id = p.product_id
+      )
+    ORDER BY p.product_id
+    LIMIT 1
+), response AS (
+    SELECT sample.product_id,
+           api_get_product_allergens(ARRAY[sample.product_id]) AS payload
+    FROM sample
+)
+SELECT '6. batch allergen API names missing evidence unknown' AS check_name,
+       COUNT(*) AS violations
+FROM response
+WHERE payload->(product_id::text)->>'evidence_status' <> 'unknown'
+   OR jsonb_array_length(payload->(product_id::text)->'evidence') <> 0;
+
+-- 7. The retained wire key is documented as exclusion, not absence proof.
+SELECT '7. legacy search key has truthful semantic contract' AS check_name,
+       CASE
+           WHEN COALESCE(
+               obj_description(
+                   'public.api_search_products(text,jsonb,integer,integer,boolean)'
+                       ::regprocedure,
+                   'pg_proc'
+               ),
+               ''
+           ) ILIKE '%exclude products with matching contains evidence%'
+            AND COALESCE(
+               obj_description(
+                   'public.api_search_products(text,jsonb,integer,integer,boolean)'
+                       ::regprocedure,
+                   'pg_proc'
+               ),
+               ''
+           ) ILIKE '%does not prove allergen absence%'
+           THEN 0
+           ELSE 1
+       END AS violations;

--- a/docs/BRAND_GUIDELINES.md
+++ b/docs/BRAND_GUIDELINES.md
@@ -186,7 +186,10 @@ These colors are defined by EU regulation and **must not be modified**.
 | ------- | -------------------------- | --------- | --------- |
 | Present | `--color-allergen-present` | `#ef4444` | `#f87171` |
 | Traces  | `--color-allergen-traces`  | `#f59e0b` | `#fbbf24` |
-| Free    | `--color-allergen-free`    | `#22c55e` | `#4ade80` |
+| Assessed absent¹ | `--color-allergen-free` | `#22c55e` | `#4ade80` |
+
+¹ Reserved for authoritative assessed-absence evidence. Missing evidence must
+use the neutral unknown treatment, never this success color.
 
 ### 3.8 Semantic Feedback
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,8 +1,8 @@
 # Documentation Index
 
-> **Last updated:** 2026-07-28
+> **Last updated:** 2026-07-30
 > **Status:** Active — update when adding, renaming, or archiving docs
-> **Total documents:** 72 in `docs/` + 11 in `docs/decisions/` + 25 in `docs/assets/logo/` + 7 in `docs/assets/banners/` + 7 elsewhere in repo
+> **Total documents:** 73 in `docs/` + 11 in `docs/decisions/` + 25 in `docs/assets/logo/` + 7 in `docs/assets/banners/` + 7 elsewhere in repo
 > **Reference:** Issue [#200](https://github.com/ericsocrat/tryvit/issues/200), [#201](https://github.com/ericsocrat/tryvit/issues/201)
 
 ---
@@ -17,7 +17,7 @@
 | [Banners](#banners)                                      | 5     | Social preview, README hero banner (SVG + PNG), badges reference                                                                                                        |
 | [API](#api)                                              | 6     | Contracts, conventions, versioning, frontend mapping, contract testing, registry                                                                                        |
 | [Scoring](#scoring)                                      | 2     | Methodology (formula), engine (architecture)                                                                                                                            |
-| [Data & Provenance](#data--provenance)                   | 9     | Sources, provenance, integrity audits, quality reporting, enrichment pilot, expansion and governance, EAN validation, production data                                   |
+| [Data & Provenance](#data--provenance)                   | 10    | Sources, provenance, integrity audits, quality reporting, enrichment, allergen evidence semantics, EAN validation, production data                                      |
 | [Security & Compliance](#security--compliance)           | 5     | Root policy, audit report, access audit, privacy checklist, rate limiting                                                                                               |
 | [Observability & Operations](#observability--operations) | 9     | Monitoring, observability, log schema, alerts, on-call policy, SLOs, metrics, incident response, disaster drill                                                         |
 | [DevOps & Environment](#devops--environment)             | 3     | Environment strategy, staging setup, Sonar config                                                                                                                       |
@@ -151,6 +151,7 @@
 | [PHASE4A_ENRICHMENT_PILOT.md](PHASE4A_ENRICHMENT_PILOT.md) | Deterministic ingredient/allergen enrichment pilot, semantics, metrics, and expansion gate | Phase 4A audit | 2026-07-28 |
 | [PHASE4B_CATEGORY_ENRICHMENT.md](PHASE4B_CATEGORY_ENRICHMENT.md) | Controlled category ranking, enrichment results, determinism, and rollout gate | Phase 4B audit | 2026-07-28 |
 | [ingredient-enrichment-governance.md](ingredient-enrichment-governance.md) | Deterministic alias, scope, parent-child, artifact, and allergen-provenance governance | Phase 4C audit | 2026-07-28 |
+| [PHASE5_PREFLIGHT_ALLERGEN_EVIDENCE.md](PHASE5_PREFLIGHT_ALLERGEN_EVIDENCE.md) | Positive allergen-evidence provenance, unknown-state semantics, truthful search behavior, and verification boundary | Phase 5 preflight A | 2026-07-30 |
 | [EAN_VALIDATION_STATUS.md](EAN_VALIDATION_STATUS.md) | EAN coverage tracking — 997/1,025 (97.3%)                                        | Data domain                                             | 2026-02-24   |
 | [PRODUCTION_DATA.md](PRODUCTION_DATA.md)             | Production data management — sync, backup, restore procedures                    | DevOps domain                                           | 2026-02-24   |
 

--- a/docs/PHASE5_PREFLIGHT_ALLERGEN_EVIDENCE.md
+++ b/docs/PHASE5_PREFLIGHT_ALLERGEN_EVIDENCE.md
@@ -1,0 +1,107 @@
+# Phase 5 preflight A: allergen evidence semantics
+
+## Purpose
+
+TryVit stores positive allergen evidence. A missing row does not say that an
+allergen was assessed and found absent. This preflight makes that distinction
+explicit before the Phase 5 experience redesign.
+
+## Previous contract and defect
+
+`product_allergen_info` stored `contains` and `traces` rows but did not identify
+whether a positive row came from a source declaration or a deterministic
+ingredient rule. The product profile reduced the rows to comma-separated lists.
+The product matrix then treated every unmentioned EU-14 allergen as `free`, and
+the no-row state as a green all-clear.
+
+The search payload also used the legacy key `allergen_free`. Its actual SQL only
+excluded products with a matching `contains` row. Products with a matching
+`traces` row, and products with no allergen evidence at all, remained eligible.
+The UI nevertheless called the filter “Allergen-Free.” Saved searches persisted
+the same misleading wording.
+
+## Evidence contract
+
+`product_allergen_info` remains a positive-evidence table. Its new
+`evidence_basis` column has three values:
+
+| Value | Meaning |
+| --- | --- |
+| `explicit_source` | Positive `contains` or `may contain` evidence supplied by a source declaration. |
+| `ingredient_derived` | Positive evidence produced by an approved deterministic ingredient-to-allergen rule. |
+| `legacy_unclassified` | Historical positive evidence whose provenance cannot be reconstructed safely. |
+
+Historical rows are deliberately backfilled as `legacy_unclassified`. An older
+normalization step copied tag text into `source_tag`, so the mere presence of
+`source_tag` is not proof of a source declaration. Current reproducible source
+pipelines and derivation steps set the stronger basis explicitly.
+
+There is no assessed-absence row type in this phase. The API exposes
+`absence_assessment: "not_assessed"` and an empty `assessed_absent` array.
+Authoritative negative evidence can be added later only with a real source and
+separate review. Empty arrays, zero counts, null fields, and unmentioned EU-14
+allergens all mean evidence is unknown or unavailable.
+
+## API contract
+
+`api_get_product_profile` preserves its existing allergen fields and adds:
+
+- `evidence`: tag, positive evidence type, basis, and source tag;
+- `evidence_status`: `positive_evidence_available` or `unknown`;
+- `absence_assessment`: currently always `not_assessed`;
+- `assessed_absent`: currently always empty.
+
+`api_get_product_allergens` preserves `contains` and `traces` arrays and adds the
+same evidence metadata. It returns an explicit unknown payload for requested
+products without positive rows instead of silently omitting them.
+
+The legacy `allergen_free` search key remains on the wire for saved-search and
+RPC compatibility. Its documented and user-visible meaning is now: **exclude
+products declared or deterministically evidenced to contain the selected
+allergen**. It does not exclude `may contain` or unknown products, and it does
+not certify any returned product as free from the allergen.
+
+`api_get_filter_options` allergen counts likewise mean products with positive
+`contains` evidence, not products assessed free from an allergen.
+
+## Presentation contract
+
+The product matrix presents every EU-14 allergen in one of these states:
+
+1. explicit contains evidence;
+2. deterministic ingredient-derived evidence;
+3. may-contain evidence;
+4. evidence unavailable;
+5. assessed absent, reserved for a future authoritative contract.
+
+Unmentioned allergens use a neutral unknown treatment. The no-evidence summary
+is neutral and never green. Derived evidence remains a positive warning but is
+visibly distinguishable from explicit source evidence. English, Polish, and
+German use equivalent claims.
+
+Search filters, active chips, and saved-search summaries use “exclude contains
+evidence” language. Product exports use “evidence unavailable” instead of
+“none” when the data contains no allergen tags.
+
+## Compatibility and security
+
+The profile extension is additive. Existing `contains`, `traces`, and count
+fields remain available. Legacy CSV-only frontend payloads remain positive
+evidence but render with provenance unavailable. No caller may infer assessed
+absence from missing new fields.
+
+The evidence-aware RPCs remain `SECURITY DEFINER`, use a fixed `search_path`,
+revoke default public execution, and grant only the established API roles. The
+renamed internal profile implementation is not directly executable by API roles
+and deliberately does not use the public `api_` naming contract.
+
+## Verification boundary
+
+Tests cover explicit, may-contain, derived, mixed, unknown, and future assessed
+absence states; truthful search behavior; saved-filter copy in EN/PL/DE; API
+compatibility; idempotent database writes; and neutral no-evidence rendering.
+The full local database replay must preserve Phase 4 governance, reports,
+thresholds, baselines, and linkage checksums.
+
+This contract requires no hosted Supabase access and makes no remote deployment,
+scanner, dependency, or Phase 5 visual-redesign change.

--- a/docs/PRODUCTION_DATA.md
+++ b/docs/PRODUCTION_DATA.md
@@ -45,7 +45,7 @@
 
 ### 1.2 Migration Inventory
 
-**Location:** `supabase/migrations/` — **232 migration files**, append-only.
+**Location:** `supabase/migrations/` — **233 migration files**, append-only.
 
 **Naming convention:** `YYYYMMDDHHMMSS_description.sql` (Supabase CLI timestamps). Files are applied in lexicographic sort order.
 
@@ -329,7 +329,7 @@ There is no standalone `init_db_structure.py` script. Database initialization fo
 
 ```
 supabase db reset
-  → Applies all 232 migrations in order (supabase/migrations/*.sql)
+  → Applies all 233 migrations in order (supabase/migrations/*.sql)
   → Runs seed.sql (empty — no-op)
   → Schema is ready
 
@@ -465,7 +465,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
 
 - **EAN coverage:** 997/1,025 (97.3%)
 - **Scoring version:** v3.2 — 9-factor weighted formula
-- **QA checks:** 777 checks across 49 suites — all passing
+- **QA checks:** 784 checks across 50 suites (776 blocking) — all passing
 - **Negative tests:** 20 injection tests — all caught
 - **Confidence threshold (CI):** ≤5% low-confidence products allowed
 - **CHECK constraints:** 24 domain constraints enforced at DB level
@@ -511,7 +511,7 @@ Backup = supabase/migrations/*.sql + db/pipelines/*.sql
 ```
 
 Since the database can be fully reconstructed from:
-1. 232 migration files (schema + functions + views)
+1. 233 migration files (schema + functions + views)
 2. 25 × 4 pipeline SQL files (all product data)
 3. `ci_post_pipeline.sql` (data fixups)
 

--- a/docs/SCORING_METHODOLOGY.md
+++ b/docs/SCORING_METHODOLOGY.md
@@ -490,14 +490,14 @@ SELECT ROUND((
     (CASE WHEN p.nutri_score_label != 'UNKNOWN' THEN 1 ELSE 0 END) +           -- 11. Nutri-Score (A-E or NOT-APPLICABLE)
     (CASE WHEN p.nova_classification IS NOT NULL THEN 1 ELSE 0 END) +           -- 12. NOVA
     (CASE WHEN EXISTS (...product_ingredient...) THEN 1 ELSE 0 END) +           -- 13. Ingredients
-    (CASE WHEN EXISTS (...allergen OR ingredient...) THEN 1 ELSE 0 END) +       -- 14. Allergen assessment
+    (CASE WHEN EXISTS (...allergen OR ingredient...) THEN 1 ELSE 0 END) +       -- 14. Allergen-evaluation inputs
     (CASE WHEN p.source_type IS NOT NULL THEN 1 ELSE 0 END)                     -- 15. Source provenance
 )::numeric / 15.0 * 100)
 ```
 
 **Key design decisions:**
 - **Equal weights** — Each checkpoint is worth ~6.67%. This avoids over-weighting nutrition fields (which are almost always complete) at the expense of ingredient/allergen coverage.
-- **Allergen assessment** (checkpoint 14) counts as passed if the product has allergen data OR ingredient data (since ingredient data implies allergen assessment was possible, even if the product is allergen-free).
+- **Allergen-evaluation inputs** (checkpoint 14) counts as passed if the product has positive allergen evidence or ingredient data that can support governed evaluation. It is a data-availability checkpoint only: it does not certify that every allergen was assessed, and it never proves an unmentioned allergen absent.
 - **NOT-APPLICABLE Nutri-Score** counts as "complete" — it's a valid assessment, not missing data.
 - **Dynamic computation** — `score_category()` calls `compute_data_completeness()` automatically; the static `p_data_completeness` parameter is retained for backward compatibility but ignored.
 

--- a/docs/assets/design-tokens.json
+++ b/docs/assets/design-tokens.json
@@ -296,7 +296,7 @@
     },
     "free": {
       "value": "#22c55e",
-      "label": "Free from allergen"
+      "label": "Authoritatively assessed absent"
     }
   },
   "border": {

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -282,7 +282,8 @@
     "asc": "↑ Aufsteigend",
     "desc": "↓ Absteigend",
     "category": "Kategorie",
-    "allergenFree": "Allergenfrei",
+    "excludeAllergenEvidence": "Produkte mit Enthalten-Hinweisen ausschließen",
+    "excludeAllergenEvidenceHint": "Produkte mit passenden Enthalten-Hinweisen werden ausgeschlossen. Fehlende Angaben gelten nicht als allergenfrei.",
     "novaGroup": "NOVA-Gruppe",
     "nova1": "1 — Unverarbeitet",
     "nova2": "2 — Verarbeitete Zutaten",
@@ -512,7 +513,8 @@
     },
     "allergens": "Allergene",
     "mayContain": "Kann Spuren enthalten von:",
-    "noKnownAllergens": "Keine bekannten Allergene aufgeführt",
+    "noKnownAllergens": "Allergenhinweise nicht verfügbar",
+    "allergenEvidenceUnavailable": "Allergenhinweise nicht verfügbar — fehlende Angaben bedeuten nicht, dass das Produkt allergenfrei ist",
     "dataQuality": "Datenqualität",
     "productPhotos": "Produktfotos",
     "confidence": "Vertrauensstufe: {value}",
@@ -592,7 +594,6 @@
     "ecoScoreComingSoon": "Eco-Score-Daten demnächst verfügbar. Wir arbeiten an der Integration von Umweltdaten für Produkte.",
     "trafficLightSummary": "Nährstoff-Ampelzusammenfassung",
     "keyNutrients": "Hauptnährstoffe",
-    "noKnownAllergens": "Keine bekannten Allergene",
     "quickSummary": "Schnellübersicht",
     "showFullAnalysis": "Vollständige Analyse anzeigen",
     "showSummary": "Zusammenfassung anzeigen",
@@ -628,18 +629,30 @@
     "contains": "Enthält",
     "traces": "Kann Spuren enthalten von"
   },
+  "allergenBadge": {
+    "present": "Enthält {name}",
+    "traces": "Kann Spuren von {name} enthalten",
+    "derived": "Zutaten weisen auf {name} hin",
+    "unknown": "Hinweise zu {name} sind nicht verfügbar",
+    "assessedAbsent": "Eine maßgebliche Quelle bestätigt die Abwesenheit von {name}"
+  },
   "allergenMatrix": {
     "title": "Allergen-Statusübersicht",
     "contains": "Enthält",
     "traces": "Kann Spuren enthalten",
-    "free": "Frei von",
-    "disclaimer": "Allergeninformationen stammen von Produktetiketten und können sich ändern. Überprüfen Sie immer die Verpackung vor dem Verzehr, insbesondere bei schweren Allergien."
+    "derived": "Aus Zutaten abgeleitet",
+    "derivedShort": "abgeleitet",
+    "unknown": "Hinweise nicht verfügbar",
+    "assessedAbsent": "Abwesenheit bestätigt",
+    "explicitSource": "Expliziter Quellenhinweis",
+    "provenanceUnavailable": "Positiver Hinweis; Quellenherkunft nicht verfügbar",
+    "disclaimer": "Allergenhinweise können von Produktetiketten oder deterministischen Zutatenbeziehungen stammen und unvollständig sein. Fehlende Hinweise beweisen niemals die Abwesenheit. Prüfen Sie vor dem Verzehr immer die Verpackung, insbesondere bei schweren Allergien."
   },
   "allergenPreset": {
-    "glutenFree": "Glutenfrei",
-    "dairyFree": "Laktosefrei",
-    "nutFree": "Nussfrei",
-    "vegan": "Vegan"
+    "glutenFree": "Glutenhinweise ausschließen",
+    "dairyFree": "Milchhinweise ausschließen",
+    "nutFree": "Nuss- und Erdnusshinweise ausschließen",
+    "vegan": "Häufige Allergenhinweise tierischen Ursprungs"
   },
   "categories": {
     "title": "Kategorien",
@@ -819,7 +832,7 @@
     "cannotUndo": "Diese Aktion kann nicht rückgängig gemacht werden.",
     "categories": "{count} {count|Kategorie|Kategorien}",
     "nutriFilter": "Nutri: {values}",
-    "allergenFreeFilter": "Frei von: {values}",
+    "excludeAllergenEvidenceFilter": "Produkte mit Enthalten-Hinweisen ausschließen: {values}",
     "maxScoreFilter": "Bewertung ≤ {score}",
     "sortFilter": "Sortierung: {sortBy}"
   },
@@ -1211,7 +1224,7 @@
   "chips": {
     "nutri": "Nutri {value}",
     "nova_group": "NOVA {value}",
-    "allergenFree": "{label}-frei",
+    "excludeAllergenEvidence": "Produkte mit Enthalten-Hinweisen zu {label} ausschließen",
     "scoreMin": "TryVit Score ≥ {value}",
     "sortLabel": "Sortierung: {label}",
     "removeFilter": "Filter {label} entfernen"
@@ -1225,7 +1238,7 @@
     "extreme": "Extrem",
     "contains": "Enthält",
     "mayContainTraces": "Kann Spuren enthalten von",
-    "freeFrom": "Frei von",
+    "freeFrom": "Als nicht vorhanden bewertet",
     "unprocessed": "Unverarbeitet",
     "processedIngredients": "Verarbeitete Zutaten",
     "processed": "Verarbeitet",
@@ -1313,7 +1326,9 @@
     "allergen": {
       "present": "Enthält {name} — Dieses Produkt listet {name} als Zutat auf.",
       "traces": "Kann Spuren von {name} enthalten — Kreuzkontamination während der Herstellung möglich.",
-      "free": "Frei von {name} — Kein {name} in diesem Produkt nachgewiesen."
+      "derived": "Zutaten weisen auf {name} hin — Prüfen Sie vor dem Verzehr das Produktetikett.",
+      "unknown": "Hinweise zu {name} sind nicht verfügbar — Das bedeutet nicht, dass das Allergen abwesend ist.",
+      "assessedAbsent": "Eine maßgebliche Quelle bestätigt die Abwesenheit von {name} — Prüfen Sie immer das aktuelle Verpackungsetikett."
     },
     "nutrient": {
       "low": "{nutrient}: {value}{unit} pro 100 g — Niedriger Wert (FSA grün). Innerhalb der empfohlenen Grenzen.",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -282,7 +282,8 @@
     "asc": "↑ Asc",
     "desc": "↓ Desc",
     "category": "Category",
-    "allergenFree": "Allergen-Free",
+    "excludeAllergenEvidence": "Exclude products with contains evidence",
+    "excludeAllergenEvidenceHint": "Products with matching contains evidence are excluded. Missing evidence is not treated as allergen-free.",
     "novaGroup": "NOVA Group",
     "nova1": "1 — Unprocessed",
     "nova2": "2 — Processed ingredients",
@@ -512,7 +513,8 @@
     },
     "allergens": "Allergens",
     "mayContain": "May contain:",
-    "noKnownAllergens": "No known allergens listed",
+    "noKnownAllergens": "Allergen evidence unavailable",
+    "allergenEvidenceUnavailable": "Allergen evidence unavailable — missing information does not mean allergen-free",
     "dataQuality": "Data Quality",
     "productPhotos": "Product Photos",
     "confidence": "Confidence: {value}",
@@ -586,7 +588,6 @@
     "ecoScoreComingSoon": "Eco-Score data coming soon. We're working on integrating environmental impact data for products.",
     "trafficLightSummary": "Nutrient traffic light summary",
     "keyNutrients": "Key Nutrients",
-    "noKnownAllergens": "No known allergens",
     "quickSummary": "Quick Summary",
     "showFullAnalysis": "Show full analysis",
     "showSummary": "Show summary",
@@ -628,18 +629,30 @@
     "contains": "Contains",
     "traces": "May contain (traces)"
   },
+  "allergenBadge": {
+    "present": "Contains {name}",
+    "traces": "May contain traces of {name}",
+    "derived": "Ingredient evidence indicates {name}",
+    "unknown": "Evidence for {name} is unavailable",
+    "assessedAbsent": "Authoritative evidence assesses {name} as absent"
+  },
   "allergenMatrix": {
     "title": "Allergen status matrix",
     "contains": "Contains",
     "traces": "May contain traces",
-    "free": "Free from",
-    "disclaimer": "Allergen information is sourced from product labels and may change. Always check packaging before consumption, especially if you have severe allergies."
+    "derived": "Derived from ingredients",
+    "derivedShort": "derived",
+    "unknown": "Evidence unavailable",
+    "assessedAbsent": "Assessed absent",
+    "explicitSource": "Explicit source evidence",
+    "provenanceUnavailable": "Positive evidence; source provenance unavailable",
+    "disclaimer": "Allergen evidence may come from product labels or deterministic ingredient relationships and may be incomplete. Missing evidence never proves absence. Always check packaging before consumption, especially if you have severe allergies."
   },
   "allergenPreset": {
-    "glutenFree": "Gluten-free",
-    "dairyFree": "Dairy-free",
-    "nutFree": "Nut-free",
-    "vegan": "Vegan"
+    "glutenFree": "Avoid gluten evidence",
+    "dairyFree": "Avoid milk evidence",
+    "nutFree": "Avoid tree-nut and peanut evidence",
+    "vegan": "Common animal-source allergen evidence"
   },
   "categories": {
     "title": "Categories",
@@ -819,7 +832,7 @@
     "cannotUndo": "This action cannot be undone.",
     "categories": "{count} {count|category|categories}",
     "nutriFilter": "Nutri: {values}",
-    "allergenFreeFilter": "Free: {values}",
+    "excludeAllergenEvidenceFilter": "Exclude products with contains evidence: {values}",
     "maxScoreFilter": "Score ≤ {score}",
     "sortFilter": "Sort: {sortBy}"
   },
@@ -1211,7 +1224,7 @@
   "chips": {
     "nutri": "Nutri {value}",
     "nova_group": "NOVA {value}",
-    "allergenFree": "{label}-free",
+    "excludeAllergenEvidence": "Exclude products with {label} contains evidence",
     "scoreMin": "TryVit Score ≥ {value}",
     "sortLabel": "Sort: {label}",
     "removeFilter": "Remove {label} filter"
@@ -1225,7 +1238,7 @@
     "extreme": "Extreme",
     "contains": "Contains",
     "mayContainTraces": "May contain traces of",
-    "freeFrom": "Free from",
+    "freeFrom": "Assessed absent",
     "unprocessed": "Unprocessed",
     "processedIngredients": "Processed ingredients",
     "processed": "Processed",
@@ -1313,7 +1326,9 @@
     "allergen": {
       "present": "Contains {name} — This product lists {name} as an ingredient.",
       "traces": "May contain traces of {name} — Cross-contamination possible during manufacturing.",
-      "free": "Free from {name} — No {name} detected in this product."
+      "derived": "Ingredient evidence indicates {name} — Verify the product label before consumption.",
+      "unknown": "Evidence for {name} is unavailable — This does not mean the allergen is absent.",
+      "assessedAbsent": "An authoritative source assesses {name} as absent — Always verify the current package label."
     },
     "nutrient": {
       "low": "{nutrient}: {value}{unit} per 100g — Low level (FSA green). Within recommended limits.",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -282,7 +282,8 @@
     "asc": "↑ Rosnąco",
     "desc": "↓ Malejąco",
     "category": "Kategoria",
-    "allergenFree": "Bez alergenów",
+    "excludeAllergenEvidence": "Wyklucz produkty z potwierdzoną obecnością alergenów",
+    "excludeAllergenEvidenceHint": "Produkty z dowodami obecności wybranych alergenów są wykluczane. Brak danych nie oznacza produktu bez alergenów.",
     "novaGroup": "Grupa NOVA",
     "nova1": "1 — Nieprzetworzone",
     "nova2": "2 — Przetworzone składniki",
@@ -512,7 +513,8 @@
     },
     "allergens": "Alergeny",
     "mayContain": "Może zawierać:",
-    "noKnownAllergens": "Brak znanych alergenów",
+    "noKnownAllergens": "Dane o alergenach są niedostępne",
+    "allergenEvidenceUnavailable": "Dane o alergenach są niedostępne — brak informacji nie oznacza produktu bez alergenów",
     "dataQuality": "Jakość danych",
     "productPhotos": "Zdjęcia produktu",
     "confidence": "Pewność: {value}",
@@ -586,7 +588,6 @@
     "ecoScoreComingSoon": "Dane Eco-Score wkrótce dostępne. Pracujemy nad integracją danych o wpływie produktów na środowisko.",
     "trafficLightSummary": "Podsumowanie sygnalizacji świetlnej składników odżywczych",
     "keyNutrients": "Kluczowe składniki odżywcze",
-    "noKnownAllergens": "Brak znanych alergenów",
     "quickSummary": "Szybkie podsumowanie",
     "showFullAnalysis": "Pokaż pełną analizę",
     "showSummary": "Pokaż podsumowanie",
@@ -628,18 +629,30 @@
     "contains": "Zawiera",
     "traces": "Może zawierać (śladowe ilości)"
   },
+  "allergenBadge": {
+    "present": "Zawiera {name}",
+    "traces": "Może zawierać śladowe ilości {name}",
+    "derived": "Składniki wskazują na obecność {name}",
+    "unknown": "Brak danych o {name}",
+    "assessedAbsent": "Wiarygodne źródło potwierdza brak {name}"
+  },
   "allergenMatrix": {
     "title": "Matryca statusu alergenów",
     "contains": "Zawiera",
     "traces": "Może zawierać ślady",
-    "free": "Nie zawiera",
-    "disclaimer": "Informacje o alergenach pochodzą z etykiet produktów i mogą ulec zmianie. Przed spożyciem zawsze sprawdzaj opakowanie, szczególnie jeśli masz poważne alergie."
+    "derived": "Wywnioskowane ze składników",
+    "derivedShort": "ze składników",
+    "unknown": "Brak danych",
+    "assessedAbsent": "Potwierdzony brak",
+    "explicitSource": "Jawna informacja źródłowa",
+    "provenanceUnavailable": "Dowód obecności; pochodzenie danych niedostępne",
+    "disclaimer": "Dane o alergenach mogą pochodzić z etykiet lub deterministycznych powiązań ze składnikami i mogą być niepełne. Brak danych nigdy nie potwierdza braku alergenu. Przed spożyciem zawsze sprawdzaj opakowanie, szczególnie jeśli masz poważne alergie."
   },
   "allergenPreset": {
-    "glutenFree": "Bez glutenu",
-    "dairyFree": "Bez nabiału",
-    "nutFree": "Bez orzechów",
-    "vegan": "Wegańskie"
+    "glutenFree": "Unikaj danych wskazujących na gluten",
+    "dairyFree": "Unikaj danych wskazujących na mleko",
+    "nutFree": "Unikaj danych wskazujących na orzechy i orzeszki ziemne",
+    "vegan": "Typowe dane o alergenach pochodzenia zwierzęcego"
   },
   "categories": {
     "title": "Kategorie",
@@ -819,7 +832,7 @@
     "cannotUndo": "Tej operacji nie można cofnąć.",
     "categories": "{count} {count|kategoria|kategorie|kategorii}",
     "nutriFilter": "Nutri: {values}",
-    "allergenFreeFilter": "Bez: {values}",
+    "excludeAllergenEvidenceFilter": "Wyklucz produkty z potwierdzoną obecnością: {values}",
     "maxScoreFilter": "Wynik ≤ {score}",
     "sortFilter": "Sortuj: {sortBy}"
   },
@@ -1211,7 +1224,7 @@
   "chips": {
     "nutri": "Nutri {value}",
     "nova_group": "NOVA {value}",
-    "allergenFree": "Bez {label}",
+    "excludeAllergenEvidence": "Wyklucz produkty z potwierdzoną obecnością: {label}",
     "scoreMin": "Wynik TryVit ≥ {value}",
     "sortLabel": "Sortuj: {label}",
     "removeFilter": "Usuń filtr {label}"
@@ -1225,7 +1238,7 @@
     "extreme": "Ekstremalny",
     "contains": "Zawiera",
     "mayContainTraces": "Może zawierać śladowe ilości",
-    "freeFrom": "Bez",
+    "freeFrom": "Potwierdzony brak",
     "unprocessed": "Nieprzetworzone",
     "processedIngredients": "Przetworzone składniki",
     "processed": "Przetworzone",
@@ -1313,7 +1326,9 @@
     "allergen": {
       "present": "Zawiera {name} — Ten produkt wymienia {name} jako składnik.",
       "traces": "Może zawierać śladowe ilości {name} — Możliwe zanieczyszczenie krzyżowe podczas produkcji.",
-      "free": "Bez {name} — Nie wykryto {name} w tym produkcie."
+      "derived": "Składniki wskazują na obecność {name} — Przed spożyciem sprawdź etykietę produktu.",
+      "unknown": "Brak danych o {name} — Nie oznacza to, że alergen jest nieobecny.",
+      "assessedAbsent": "Wiarygodne źródło potwierdza brak {name} — Zawsze sprawdzaj aktualną etykietę opakowania."
     },
     "nutrient": {
       "low": "{nutrient}: {value}{unit} na 100g — Niski poziom (FSA zielony). W zalecanych granicach.",

--- a/frontend/src/app/app/product/[id]/page.test.tsx
+++ b/frontend/src/app/app/product/[id]/page.test.tsx
@@ -564,7 +564,9 @@ describe("ProductDetailPage", () => {
     render(<ProductDetailPage />, { wrapper: createWrapper() });
 
     await waitFor(() => {
-      expect(screen.getByText("May contain traces")).toBeInTheDocument();
+      expect(
+        screen.getAllByText("May contain traces").length,
+      ).toBeGreaterThanOrEqual(1);
     });
     expect(screen.getByText("Soy")).toBeInTheDocument();
   });
@@ -1187,7 +1189,9 @@ describe("ProductDetailPage", () => {
         screen.getAllByText("Test Chips Original").length,
       ).toBeGreaterThanOrEqual(1);
     });
-    expect(screen.getByText(/No known allergens/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Allergen evidence unavailable/),
+    ).toBeInTheDocument();
   });
 
   it("handles null nutri_score with question mark", async () => {
@@ -1312,7 +1316,9 @@ describe("ProductDetailPage", () => {
     render(<ProductDetailPage />, { wrapper: createWrapper() });
 
     await waitFor(() => {
-      expect(screen.getByText("Contains")).toBeInTheDocument();
+      expect(screen.getAllByText("Contains").length).toBeGreaterThanOrEqual(
+        1,
+      );
     });
 
     // AllergenMatrix renders contains allergens with red styling in a <table>
@@ -1328,7 +1334,9 @@ describe("ProductDetailPage", () => {
     render(<ProductDetailPage />, { wrapper: createWrapper() });
 
     await waitFor(() => {
-      expect(screen.getByText("May contain traces")).toBeInTheDocument();
+      expect(
+        screen.getAllByText("May contain traces").length,
+      ).toBeGreaterThanOrEqual(1);
     });
 
     // AllergenMatrix renders traces allergens with amber styling in a <table>

--- a/frontend/src/app/app/search/saved/page.test.tsx
+++ b/frontend/src/app/app/search/saved/page.test.tsx
@@ -199,7 +199,9 @@ describe("SavedSearchesPage", () => {
       expect(screen.getByText("1 category")).toBeInTheDocument();
     });
     expect(screen.getByText("Nutri: A, B")).toBeInTheDocument();
-    expect(screen.getByText(/Free:.*Gluten/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Exclude products with contains evidence:.*Gluten/),
+    ).toBeInTheDocument();
     expect(screen.getByText("Score ≤ 40")).toBeInTheDocument();
     expect(screen.getByText("Sort: unhealthiness")).toBeInTheDocument();
   });

--- a/frontend/src/app/app/search/saved/page.tsx
+++ b/frontend/src/app/app/search/saved/page.tsx
@@ -198,7 +198,9 @@ function FilterSummaryChips({ filters }: Readonly<{ filters: SearchFilters }>) {
       return info ? t(info.labelKey) : tag.replace(/^en:/, "");
     });
     chips.push(
-      t("savedSearches.allergenFreeFilter", { values: labels.join(", ") }),
+      t("savedSearches.excludeAllergenEvidenceFilter", {
+        values: labels.join(", "),
+      }),
     );
   }
   if (filters.max_unhealthiness !== undefined) {

--- a/frontend/src/app/app/settings/nutrition/page.test.tsx
+++ b/frontend/src/app/app/settings/nutrition/page.test.tsx
@@ -270,22 +270,26 @@ describe("NutritionSettingsPage", () => {
       expect(screen.getByTestId("allergen-presets")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Gluten-free")).toBeInTheDocument();
-    expect(screen.getByText("Dairy-free")).toBeInTheDocument();
-    expect(screen.getByText("Nut-free")).toBeInTheDocument();
+    expect(screen.getByText("Avoid gluten evidence")).toBeInTheDocument();
+    expect(screen.getByText("Avoid milk evidence")).toBeInTheDocument();
+    expect(
+      screen.getByText("Avoid tree-nut and peanut evidence"),
+    ).toBeInTheDocument();
     const presetContainer = screen.getByTestId("allergen-presets");
-    expect(presetContainer).toHaveTextContent("Vegan");
+    expect(presetContainer).toHaveTextContent(
+      "Common animal-source allergen evidence",
+    );
   });
 
-  it("clicking Gluten-free preset selects the gluten allergen", async () => {
+  it("clicking the gluten-evidence preset selects gluten", async () => {
     render(<NutritionSettingsPage />, { wrapper: createWrapper() });
     const user = userEvent.setup();
 
     await waitFor(() => {
-      expect(screen.getByText("Gluten-free")).toBeInTheDocument();
+      expect(screen.getByText("Avoid gluten evidence")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText("Gluten-free"));
+    await user.click(screen.getByText("Avoid gluten evidence"));
 
     // Gluten tag should now be selected — save button should appear (dirty)
     expect(
@@ -293,15 +297,19 @@ describe("NutritionSettingsPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("clicking Nut-free preset selects both Tree Nuts and Peanuts", async () => {
+  it("clicking the nut-evidence preset selects Tree Nuts and Peanuts", async () => {
     render(<NutritionSettingsPage />, { wrapper: createWrapper() });
     const user = userEvent.setup();
 
     await waitFor(() => {
-      expect(screen.getByText("Nut-free")).toBeInTheDocument();
+      expect(
+        screen.getByText("Avoid tree-nut and peanut evidence"),
+      ).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText("Nut-free"));
+    await user.click(
+      screen.getByText("Avoid tree-nut and peanut evidence"),
+    );
 
     // Should show strictness toggles since allergens are now selected
     await waitFor(() => {
@@ -314,12 +322,12 @@ describe("NutritionSettingsPage", () => {
     const user = userEvent.setup();
 
     await waitFor(() => {
-      expect(screen.getByText("Dairy-free")).toBeInTheDocument();
+      expect(screen.getByText("Avoid milk evidence")).toBeInTheDocument();
     });
 
     // Select then deselect
-    await user.click(screen.getByText("Dairy-free"));
-    await user.click(screen.getByText("Dairy-free"));
+    await user.click(screen.getByText("Avoid milk evidence"));
+    await user.click(screen.getByText("Avoid milk evidence"));
 
     // No strictness toggles since allergens are now empty again
     expect(

--- a/frontend/src/app/dev/components/page.tsx
+++ b/frontend/src/app/dev/components/page.tsx
@@ -408,7 +408,9 @@ export default function DevComponentsPage() {
         <Row label="Status">
           <AllergenBadge status="present" allergenName="Gluten" />
           <AllergenBadge status="traces" allergenName="Milk" />
-          <AllergenBadge status="free" allergenName="Nuts" />
+          <AllergenBadge status="derived" allergenName="Eggs" />
+          <AllergenBadge status="unknown" allergenName="Soy" />
+          <AllergenBadge status="assessed-absent" allergenName="Nuts" />
         </Row>
       </Section>
     </div>

--- a/frontend/src/components/common/AllergenBadge.test.tsx
+++ b/frontend/src/components/common/AllergenBadge.test.tsx
@@ -1,73 +1,68 @@
-import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: { name?: string }) =>
+      `${key}${params?.name ? ` ${params.name}` : ""}`,
+  }),
+}));
+
 import { AllergenBadge } from "./AllergenBadge";
 
 describe("AllergenBadge", () => {
-  it("renders allergen name", () => {
-    render(<AllergenBadge status="present" allergenName="Gluten" />);
-    expect(screen.getByText("Gluten")).toBeTruthy();
-  });
-
-  it("applies present status styling", () => {
+  it("renders explicit presence with warning styling", () => {
     render(<AllergenBadge status="present" allergenName="Milk" />);
-    const badge = screen.getByLabelText("Contains Milk");
+    const badge = screen.getByLabelText("allergenBadge.present Milk");
     expect(badge.className).toContain("text-allergen-present");
-    expect(badge.className).toContain("bg-allergen-present/10");
   });
 
-  it("applies traces status styling", () => {
+  it("renders may-contain evidence", () => {
     render(<AllergenBadge status="traces" allergenName="Nuts" />);
-    const badge = screen.getByLabelText("May contain traces of Nuts");
-    expect(badge.className).toContain("text-allergen-traces");
+    expect(
+      screen.getByLabelText("allergenBadge.traces Nuts"),
+    ).toBeInTheDocument();
   });
 
-  it("applies free status styling", () => {
-    render(<AllergenBadge status="free" allergenName="Soy" />);
-    const badge = screen.getByLabelText("Free from Soy");
+  it("renders deterministic derived evidence distinctly", () => {
+    render(<AllergenBadge status="derived" allergenName="Gluten" />);
+    expect(
+      screen.getByLabelText("allergenBadge.derived Gluten"),
+    ).toHaveClass("text-warning-text");
+  });
+
+  it("renders missing evidence as neutral unknown, never green", () => {
+    render(<AllergenBadge status="unknown" allergenName="Soy" />);
+    const badge = screen.getByLabelText("allergenBadge.unknown Soy");
+    expect(badge).toHaveClass("text-foreground-muted", "bg-surface-muted");
+    expect(badge.className).not.toContain("allergen-free");
+  });
+
+  it("reserves green treatment for authoritative assessed absence", () => {
+    render(<AllergenBadge status="assessed-absent" allergenName="Sesame" />);
+    const badge = screen.getByLabelText(
+      "allergenBadge.assessedAbsent Sesame",
+    );
     expect(badge.className).toContain("text-allergen-free");
   });
 
-  it("shows correct icon for present", () => {
-    const { container } = render(
-      <AllergenBadge status="present" allergenName="Eggs" />,
-    );
-    expect(container.querySelector("svg")).toBeTruthy();
-  });
-
-  it("shows correct icon for traces", () => {
-    const { container } = render(
-      <AllergenBadge status="traces" allergenName="Fish" />,
-    );
-    // Zap icon renders as SVG
-    expect(container.querySelectorAll("svg").length).toBeGreaterThanOrEqual(1);
-  });
-
-  it("shows correct icon for free", () => {
-    const { container } = render(
-      <AllergenBadge status="free" allergenName="Sesame" />,
-    );
-    // Check icon renders as SVG
-    expect(container.querySelectorAll("svg").length).toBeGreaterThanOrEqual(1);
-  });
-
   it("applies size classes", () => {
-    render(<AllergenBadge status="present" allergenName="Gluten" size="md" />);
-    const badge = screen.getByLabelText("Contains Gluten");
-    expect(badge.className).toContain("text-sm");
+    render(<AllergenBadge status="present" allergenName="Eggs" size="md" />);
+    expect(screen.getByLabelText("allergenBadge.present Eggs")).toHaveClass(
+      "text-sm",
+    );
   });
 
-  it("shows tooltip on hover when showTooltip is true", async () => {
+  it("shows an evidence-specific tooltip", async () => {
     const user = userEvent.setup();
     render(
       <TooltipPrimitive.Provider delayDuration={0}>
-        <AllergenBadge status="present" allergenName="Gluten" showTooltip />
+        <AllergenBadge status="derived" allergenName="Gluten" showTooltip />
       </TooltipPrimitive.Provider>,
     );
-
     await user.hover(screen.getByText("Gluten"));
-    const tooltip = await screen.findByRole("tooltip");
-    expect(tooltip.textContent).toContain("Gluten");
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Gluten");
   });
 });

--- a/frontend/src/components/common/AllergenBadge.tsx
+++ b/frontend/src/components/common/AllergenBadge.tsx
@@ -1,44 +1,39 @@
+"use client";
+
 /**
- * AllergenBadge — color-coded allergen warning badge.
+ * AllergenBadge — evidence-aware allergen status badge.
  *
- * Statuses:
- *   present → red (allergen confirmed present)
- *   traces  → yellow/amber (may contain traces)
- *   free    → green (allergen-free)
- *
- * Uses `--color-allergen-*` design tokens. Shows generic warning icon for
- * unknown allergens.
+ * `assessed-absent` is reserved for authoritative absence evidence. Callers
+ * must use `unknown` when evidence is missing.
  */
 
-import { AlertTriangle, Check, Zap } from "lucide-react";
+import { useTranslation } from "@/lib/i18n";
+import { AlertTriangle, Check, CircleHelp, Dna, Zap } from "lucide-react";
 import React, { type ReactElement } from "react";
 import { InfoTooltip } from "./InfoTooltip";
 
-// ─── Types ──────────────────────────────────────────────────────────────────
-
-export type AllergenStatus = "present" | "traces" | "free";
+export type AllergenStatus =
+  | "present"
+  | "traces"
+  | "derived"
+  | "unknown"
+  | "assessed-absent";
 export type AllergenBadgeSize = "sm" | "md";
 
 export interface AllergenBadgeProps {
-  /** Allergen presence status. */
   readonly status: AllergenStatus;
-  /** Human-readable allergen name. */
   readonly allergenName: string;
-  /** Size preset. @default "sm" */
   readonly size?: AllergenBadgeSize;
-  /** Show explanatory tooltip on hover. @default false */
   readonly showTooltip?: boolean;
-  /** Additional CSS classes. */
   readonly className?: string;
 }
-
-// ─── Status styling ─────────────────────────────────────────────────────────
 
 interface StatusConfig {
   icon: ReactElement;
   bg: string;
   text: string;
-  srLabel: string;
+  labelKey: string;
+  tooltipKey: string;
 }
 
 const STATUS_CONFIGS: Record<AllergenStatus, StatusConfig> = {
@@ -46,19 +41,36 @@ const STATUS_CONFIGS: Record<AllergenStatus, StatusConfig> = {
     icon: <AlertTriangle size={12} />,
     bg: "bg-allergen-present/10",
     text: "text-allergen-present",
-    srLabel: "Contains",
+    labelKey: "allergenBadge.present",
+    tooltipKey: "present",
   },
   traces: {
     icon: <Zap size={12} />,
     bg: "bg-allergen-traces/10",
     text: "text-allergen-traces",
-    srLabel: "May contain traces of",
+    labelKey: "allergenBadge.traces",
+    tooltipKey: "traces",
   },
-  free: {
+  derived: {
+    icon: <Dna size={12} />,
+    bg: "bg-warning-bg",
+    text: "text-warning-text",
+    labelKey: "allergenBadge.derived",
+    tooltipKey: "derived",
+  },
+  unknown: {
+    icon: <CircleHelp size={12} />,
+    bg: "bg-surface-muted",
+    text: "text-foreground-muted",
+    labelKey: "allergenBadge.unknown",
+    tooltipKey: "unknown",
+  },
+  "assessed-absent": {
     icon: <Check size={12} />,
     bg: "bg-allergen-free/10",
     text: "text-allergen-free",
-    srLabel: "Free from",
+    labelKey: "allergenBadge.assessedAbsent",
+    tooltipKey: "assessedAbsent",
   },
 };
 
@@ -67,8 +79,6 @@ const SIZE_CLASSES: Record<AllergenBadgeSize, string> = {
   md: "px-2.5 py-1 text-sm",
 };
 
-// ─── Component ──────────────────────────────────────────────────────────────
-
 export const AllergenBadge = React.memo(function AllergenBadge({
   status,
   allergenName,
@@ -76,6 +86,7 @@ export const AllergenBadge = React.memo(function AllergenBadge({
   showTooltip = false,
   className = "",
 }: Readonly<AllergenBadgeProps>) {
+  const { t } = useTranslation();
   const config = STATUS_CONFIGS[status];
 
   const badge = (
@@ -89,7 +100,7 @@ export const AllergenBadge = React.memo(function AllergenBadge({
       ]
         .filter(Boolean)
         .join(" ")}
-      aria-label={`${config.srLabel} ${allergenName}`}
+      aria-label={t(config.labelKey, { name: allergenName })}
     >
       <span aria-hidden="true">{config.icon}</span>
       {allergenName}
@@ -99,7 +110,7 @@ export const AllergenBadge = React.memo(function AllergenBadge({
   if (showTooltip) {
     return (
       <InfoTooltip
-        messageKey={`tooltip.allergen.${status}`}
+        messageKey={`tooltip.allergen.${config.tooltipKey}`}
         params={{ name: allergenName }}
       >
         {badge}

--- a/frontend/src/components/common/AllergenChips.test.tsx
+++ b/frontend/src/components/common/AllergenChips.test.tsx
@@ -86,18 +86,38 @@ describe("AllergenChips", () => {
 
   // ── Tooltip text ──────────────────────────────────────────────────────
 
-  it("shows 'Contains: ...' tooltip for contains type", () => {
+  it("uses the translated contains-evidence tooltip", () => {
     render(<AllergenChips warnings={[makeWarning({ type: "contains" })]} />);
 
     const chip = screen.getByTestId("allergen-chip");
-    expect(chip.getAttribute("title")).toBe("Contains: Milk");
+    expect(chip.getAttribute("title")).toBe(
+      "Contains Milk — This product lists Milk as an ingredient.",
+    );
   });
 
-  it("shows 'May contain traces: ...' tooltip for traces type", () => {
+  it("uses the translated may-contain tooltip", () => {
     render(<AllergenChips warnings={[makeWarning({ type: "traces" })]} />);
 
     const chip = screen.getByTestId("allergen-chip");
-    expect(chip.getAttribute("title")).toBe("May contain traces: Milk");
+    expect(chip.getAttribute("title")).toBe(
+      "May contain traces of Milk — Cross-contamination possible during manufacturing.",
+    );
+  });
+
+  it("labels ingredient-derived positive evidence distinctly", () => {
+    render(
+      <AllergenChips
+        warnings={[
+          makeWarning({ evidenceBasis: "ingredient_derived" }),
+        ]}
+      />,
+    );
+
+    const chip = screen.getByTestId("allergen-chip");
+    expect(chip.getAttribute("title")).toContain(
+      "Ingredient evidence indicates Milk",
+    );
+    expect(chip).toHaveTextContent(/derived/i);
   });
 
   // ── Max visible / overflow ────────────────────────────────────────────

--- a/frontend/src/components/common/AllergenChips.tsx
+++ b/frontend/src/components/common/AllergenChips.tsx
@@ -28,9 +28,11 @@ function AllergenChip({ warning }: AllergenChipProps) {
   const name = t(warning.labelKey);
   const style = CHIP_STYLES[warning.type];
   const tooltip =
-    warning.type === "contains"
-      ? `Contains: ${name}`
-      : `May contain traces: ${name}`;
+    warning.evidenceBasis === "ingredient_derived"
+      ? t("tooltip.allergen.derived", { name })
+      : warning.type === "contains"
+        ? t("tooltip.allergen.present", { name })
+        : t("tooltip.allergen.traces", { name });
 
   return (
     <span
@@ -40,6 +42,9 @@ function AllergenChip({ warning }: AllergenChipProps) {
     >
       <span aria-hidden="true">{warning.icon}</span>
       <span className="max-w-16 truncate">{name}</span>
+      {warning.evidenceBasis === "ingredient_derived" && (
+        <span className="sr-only">({t("allergenMatrix.derivedShort")})</span>
+      )}
     </span>
   );
 }

--- a/frontend/src/components/product/AllergenMatrix.test.tsx
+++ b/frontend/src/components/product/AllergenMatrix.test.tsx
@@ -2,169 +2,140 @@ import type { ProfileAllergens } from "@/lib/types";
 import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-// ── Mocks ────────────────────────────────────────────────────────────────────
-
 vi.mock("@/lib/i18n", () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
+  useTranslation: () => ({ t: (key: string) => key }),
 }));
 
 import { AllergenMatrix } from "./AllergenMatrix";
 
-// ── Fixtures ─────────────────────────────────────────────────────────────────
-
 function makeAllergens(
-  overrides?: Partial<ProfileAllergens>,
+  overrides: Partial<ProfileAllergens> = {},
 ): ProfileAllergens {
   return {
     contains: "gluten,milk",
     traces: "eggs,soybeans",
     contains_count: 2,
     traces_count: 2,
+    evidence: [
+      {
+        tag: "gluten",
+        evidence_type: "contains",
+        evidence_basis: "ingredient_derived",
+      },
+      {
+        tag: "milk",
+        evidence_type: "contains",
+        evidence_basis: "explicit_source",
+      },
+      {
+        tag: "eggs",
+        evidence_type: "may_contain",
+        evidence_basis: "explicit_source",
+      },
+      {
+        tag: "soybeans",
+        evidence_type: "may_contain",
+        evidence_basis: "legacy_unclassified",
+      },
+    ],
+    evidence_status: "positive_evidence_available",
+    absence_assessment: "not_assessed",
+    assessed_absent: [],
     ...overrides,
   };
 }
 
-// ── Tests ────────────────────────────────────────────────────────────────────
-
 describe("AllergenMatrix", () => {
-  it("renders no-allergens message when contains and traces are both 0", () => {
+  it("renders a neutral unavailable state and unknown EU-14 rows with no evidence", () => {
     render(
       <AllergenMatrix
-        allergens={{
+        allergens={makeAllergens({
           contains: "",
           traces: "",
           contains_count: 0,
           traces_count: 0,
-        }}
-      />,
-    );
-    expect(screen.getByText("product.noKnownAllergens")).toBeInTheDocument();
-    // Should NOT render the grid
-    expect(screen.queryByRole("table")).not.toBeInTheDocument();
-  });
-
-  it("renders the allergen grid when allergens are present", () => {
-    render(<AllergenMatrix allergens={makeAllergens()} />);
-    expect(screen.getByRole("table")).toBeInTheDocument();
-  });
-
-  it("groups allergens by status: contains first, then traces, then free", () => {
-    render(<AllergenMatrix allergens={makeAllergens()} />);
-    const rows = screen.getAllByRole("row");
-    const cells = rows.map(
-      (r) => within(r).getByRole("cell").textContent ?? "",
-    );
-
-    // Mock t() returns keys as-is, so match on i18n keys
-    const glutenIdx = cells.findIndex((c) => c.includes("allergens.gluten"));
-    const milkIdx = cells.findIndex((c) => c.includes("allergens.milk"));
-    const eggsIdx = cells.findIndex((c) => c.includes("allergens.eggs"));
-    const soyIdx = cells.findIndex((c) => c.includes("allergens.soybeans"));
-    // The first "free" EU allergen (e.g., Crustaceans or Peanuts)
-    const freeIdx = cells.findIndex((c) => c.includes("allergens.peanuts"));
-
-    // contains before traces
-    expect(glutenIdx).toBeLessThan(eggsIdx);
-    expect(milkIdx).toBeLessThan(eggsIdx);
-    // traces before free
-    expect(soyIdx).toBeLessThan(freeIdx);
-  });
-
-  it("normalises tags via lowercase/trim (legacy en: prefix fallback)", () => {
-    render(
-      <AllergenMatrix
-        allergens={makeAllergens({
-          contains: "gluten",
-          traces: "",
-          contains_count: 1,
-          traces_count: 0,
+          evidence: [],
+          evidence_status: "unknown",
         })}
       />,
     );
-    // Mock t() returns keys — check for the i18n key
-    const table = screen.getByRole("table");
-    const cells = within(table).getAllByRole("cell");
-    const textValues = cells.map((c) => c.textContent);
-    expect(textValues).toContain("allergens.gluten");
+    expect(
+      screen.getByText("product.allergenEvidenceUnavailable"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("row")).toHaveLength(14);
+    expect(screen.getAllByText("allergenMatrix.unknown")).toHaveLength(15);
   });
 
-  it("includes all 14 EU mandatory allergens even if not in data", () => {
+  it("does not render success styling when evidence is missing", () => {
     render(
       <AllergenMatrix
         allergens={makeAllergens({
-          contains: "gluten",
+          contains: "",
           traces: "",
-          contains_count: 1,
+          contains_count: 0,
           traces_count: 0,
-        })}
-      />,
-    );
-    const rows = screen.getAllByRole("row");
-    // At minimum, all 14 EU allergens should be present
-    expect(rows.length).toBeGreaterThanOrEqual(14);
-  });
-
-  it("formats allergen names using DISPLAY_NAMES map", () => {
-    render(
-      <AllergenMatrix
-        allergens={makeAllergens({
-          contains: "sesame",
-          traces: "sulphites",
-          contains_count: 1,
-          traces_count: 1,
+          evidence: [],
         })}
       />,
     );
     const table = screen.getByRole("table");
-    expect(within(table).getByText("allergens.sesame")).toBeInTheDocument();
-    expect(within(table).getByText("allergens.sulphites")).toBeInTheDocument();
+    expect(table.querySelector(".bg-success-bg")).toBeNull();
+    expect(table.querySelector(".text-success-text")).toBeNull();
   });
 
-  it("renders the legend with all three statuses", () => {
+  it("distinguishes explicit, derived, may-contain, and unknown states", () => {
     render(<AllergenMatrix allergens={makeAllergens()} />);
-    expect(screen.getByText("allergenMatrix.contains")).toBeInTheDocument();
-    expect(screen.getByText("allergenMatrix.traces")).toBeInTheDocument();
-    expect(screen.getByText("allergenMatrix.free")).toBeInTheDocument();
-  });
-
-  it("renders the disclaimer text", () => {
-    render(<AllergenMatrix allergens={makeAllergens()} />);
-    expect(screen.getByText("allergenMatrix.disclaimer")).toBeInTheDocument();
-  });
-
-  it("adds extra allergens not in the EU14 baseline", () => {
-    render(
-      <AllergenMatrix
-        allergens={makeAllergens({
-          contains: "gluten,buckwheat",
-          traces: "",
-          contains_count: 2,
-          traces_count: 0,
-        })}
-      />,
-    );
-    const table = screen.getByRole("table");
-    expect(within(table).getByText("allergens.buckwheat")).toBeInTheDocument();
-    // Total rows should be > 14 (14 EU + 1 extra)
     const rows = screen.getAllByRole("row");
-    expect(rows.length).toBe(15);
+    const rowFor = (name: string) =>
+      rows.find((row) => row.textContent?.includes(`allergens.${name}`));
+
+    expect(rowFor("milk")?.textContent).toContain("allergenMatrix.contains");
+    expect(rowFor("gluten")?.textContent).toContain("allergenMatrix.derived");
+    expect(rowFor("eggs")?.textContent).toContain("allergenMatrix.traces");
+    expect(rowFor("peanuts")?.textContent).toContain("allergenMatrix.unknown");
   });
 
-  it("handles empty comma-separated strings gracefully", () => {
+  it("marks positive legacy evidence with unavailable provenance", () => {
+    render(<AllergenMatrix allergens={makeAllergens()} />);
+    expect(
+      screen.getByText("allergenMatrix.provenanceUnavailable"),
+    ).toBeInTheDocument();
+  });
+
+  it("preserves the legacy CSV response shape without calling gaps free", () => {
     render(
       <AllergenMatrix
         allergens={{
-          contains: ",,",
-          traces: ",",
+          contains: "en:milk",
+          traces: "gluten",
           contains_count: 1,
           traces_count: 1,
         }}
       />,
     );
-    // Should render grid without errors — all 14 EU allergens as "free"
-    const rows = screen.getAllByRole("row");
-    expect(rows.length).toBe(14);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("allergens.milk")).toBeInTheDocument();
+    expect(within(table).getByText("allergens.gluten")).toBeInTheDocument();
+    expect(screen.queryByText("allergenMatrix.free")).not.toBeInTheDocument();
+  });
+
+  it("supports authoritative assessed absence without inferring it", () => {
+    render(
+      <AllergenMatrix
+        allergens={makeAllergens({
+          evidence: [],
+          contains: "",
+          traces: "",
+          contains_count: 0,
+          traces_count: 0,
+          absence_assessment: "assessed",
+          assessed_absent: ["milk"],
+        })}
+      />,
+    );
+    const milkRow = screen
+      .getAllByRole("row")
+      .find((row) => row.textContent?.includes("allergens.milk"));
+    expect(milkRow?.textContent).toContain("allergenMatrix.assessedAbsent");
   });
 });

--- a/frontend/src/components/product/AllergenMatrix.tsx
+++ b/frontend/src/components/product/AllergenMatrix.tsx
@@ -1,88 +1,16 @@
 "use client";
 
-// ─── AllergenMatrix ─────────────────────────────────────────────────────────
-// Structured allergen display: grouped by status (contains / traces / free),
-// EU FIC Regulation 1169/2011-aligned grid with color-coded badges.
-
+import {
+  buildAllergenDisplayRows,
+  getAllergenEvidence,
+  type AllergenDisplayStatus,
+} from "@/lib/allergen-evidence";
 import { useTranslation } from "@/lib/i18n";
 import type { ProfileAllergens } from "@/lib/types";
-import { AlertTriangle, Check, Minus } from "lucide-react";
-
-/**
- * EU FIC Regulation 1169/2011 mandates declaration of these 14 allergens.
- * Tags are now bare canonical IDs (e.g. "milk", "gluten").
- * Legacy data may still carry the "en:" prefix; normaliseTag() strips it as a fallback.
- */
-const EU_14_ALLERGENS = [
-  "gluten",
-  "crustaceans",
-  "eggs",
-  "fish",
-  "peanuts",
-  "soybeans",
-  "milk",
-  "tree-nuts",
-  "celery",
-  "mustard",
-  "sesame",
-  "sulphites",
-  "lupin",
-  "molluscs",
-] as const;
-
-
-
-/** Normalise an allergen tag: trim, lowercase, and strip legacy "en:" prefix if present. */
-function normaliseTag(tag: string): string {
-  return tag.trim().replace(/^en:/, "").toLowerCase();
-}
-
-type AllergenStatus = "contains" | "traces" | "free";
-
-interface AllergenRow {
-  name: string;
-  status: AllergenStatus;
-}
-
-function parseAllergens(allergens: ProfileAllergens): AllergenRow[] {
-  const containsSet = new Set(
-    allergens.contains.split(",").filter(Boolean).map(normaliseTag),
-  );
-  const tracesSet = new Set(
-    allergens.traces.split(",").filter(Boolean).map(normaliseTag),
-  );
-
-  // Collect all mentioned allergens + EU14 baseline
-  const allNames = new Set<string>([
-    ...EU_14_ALLERGENS,
-    ...containsSet,
-    ...tracesSet,
-  ]);
-
-  const rows: AllergenRow[] = [];
-  for (const name of allNames) {
-    if (containsSet.has(name)) {
-      rows.push({ name, status: "contains" });
-    } else if (tracesSet.has(name)) {
-      rows.push({ name, status: "traces" });
-    } else {
-      rows.push({ name, status: "free" });
-    }
-  }
-
-  // Sort: contains first, then traces, then free
-  const statusOrder: Record<AllergenStatus, number> = {
-    contains: 0,
-    traces: 1,
-    free: 2,
-  };
-  rows.sort((a, b) => statusOrder[a.status] - statusOrder[b.status]);
-
-  return rows;
-}
+import { AlertTriangle, Check, CircleHelp, Dna, Minus } from "lucide-react";
 
 const STATUS_CONFIG: Record<
-  AllergenStatus,
+  AllergenDisplayStatus,
   { bg: string; border: string; text: string; label: string }
 > = {
   contains: {
@@ -91,34 +19,46 @@ const STATUS_CONFIG: Record<
     text: "text-error-text",
     label: "allergenMatrix.contains",
   },
-  traces: {
+  derived: {
+    bg: "bg-warning-bg",
+    border: "border-warning-border",
+    text: "text-warning-text",
+    label: "allergenMatrix.derived",
+  },
+  may_contain: {
     bg: "bg-warning-bg",
     border: "border-warning-border",
     text: "text-warning-text",
     label: "allergenMatrix.traces",
   },
-  free: {
+  unknown: {
+    bg: "bg-surface-muted",
+    border: "border-border",
+    text: "text-foreground-muted",
+    label: "allergenMatrix.unknown",
+  },
+  assessed_absent: {
     bg: "bg-success-bg",
     border: "border-success-border",
     text: "text-success-text",
-    label: "allergenMatrix.free",
+    label: "allergenMatrix.assessedAbsent",
   },
 };
 
-function StatusIcon({ status }: Readonly<{ status: AllergenStatus }>) {
+function StatusIcon({ status }: Readonly<{ status: AllergenDisplayStatus }>) {
   switch (status) {
     case "contains":
-      return (
-        <AlertTriangle size={12} className="text-error-text" aria-hidden="true" />
-      );
-    case "traces":
-      return <Minus size={12} className="text-warning-text" aria-hidden="true" />;
-    case "free":
-      return <Check size={12} className="text-success-text" aria-hidden="true" />;
+      return <AlertTriangle size={13} aria-hidden="true" />;
+    case "derived":
+      return <Dna size={13} aria-hidden="true" />;
+    case "may_contain":
+      return <Minus size={13} aria-hidden="true" />;
+    case "unknown":
+      return <CircleHelp size={13} aria-hidden="true" />;
+    case "assessed_absent":
+      return <Check size={13} aria-hidden="true" />;
   }
 }
-
-
 
 interface AllergenMatrixProps {
   readonly allergens: ProfileAllergens;
@@ -126,36 +66,45 @@ interface AllergenMatrixProps {
 
 export function AllergenMatrix({ allergens }: AllergenMatrixProps) {
   const { t } = useTranslation();
-  const rows = parseAllergens(allergens);
-  const hasAny = allergens.contains_count > 0 || allergens.traces_count > 0;
-
-  if (!hasAny) {
-    return (
-      <p className="flex items-center gap-1 text-sm text-success-text">
-        <Check size={14} aria-hidden="true" /> {t("product.noKnownAllergens")}
-      </p>
-    );
-  }
+  const rows = buildAllergenDisplayRows(allergens);
+  const evidence = getAllergenEvidence(allergens);
+  const hasEvidence = evidence.length > 0;
 
   return (
     <div className="space-y-3">
-      {/* Compact grid */}
+      {!hasEvidence && (
+        <p className="flex items-center gap-1.5 text-sm text-foreground-muted">
+          <CircleHelp size={14} aria-hidden="true" />
+          {t("product.allergenEvidenceUnavailable")}
+        </p>
+      )}
+
       <table
         className="w-full border-separate border-spacing-1.5"
         aria-label={t("allergenMatrix.title")}
       >
         <tbody>
           {rows.map((row) => {
-            const cfg = STATUS_CONFIG[row.status];
+            const config = STATUS_CONFIG[row.status];
             return (
               <tr key={row.name}>
                 <td
-                  className={`flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 ${cfg.bg} ${cfg.border}`}
+                  className={`rounded-lg border px-2.5 py-1.5 ${config.bg} ${config.border}`}
                 >
-                  <StatusIcon status={row.status} />
-                  <span className={`text-xs font-medium ${cfg.text}`}>
-                    {t(`allergens.${row.name}`)}
+                  <span className={`flex items-center gap-1.5 ${config.text}`}>
+                    <StatusIcon status={row.status} />
+                    <span className="text-xs font-medium">
+                      {t(`allergens.${row.name}`)}
+                    </span>
+                    <span className="ml-auto text-xxs font-normal">
+                      {t(config.label)}
+                    </span>
                   </span>
+                  {row.evidenceBasis === "legacy_unclassified" && (
+                    <span className="mt-0.5 block pl-[19px] text-xxs text-foreground-muted">
+                      {t("allergenMatrix.provenanceUnavailable")}
+                    </span>
+                  )}
                 </td>
               </tr>
             );
@@ -163,27 +112,25 @@ export function AllergenMatrix({ allergens }: AllergenMatrixProps) {
         </tbody>
       </table>
 
-      {/* Legend */}
       <div className="flex flex-wrap gap-3 text-xs text-foreground-muted">
         <span className="flex items-center gap-1">
-          <AlertTriangle
-            size={10}
-            className="text-error"
-            aria-hidden="true"
-          />{" "}
+          <AlertTriangle size={10} className="text-error" aria-hidden="true" />
           {t("allergenMatrix.contains")}
         </span>
         <span className="flex items-center gap-1">
-          <Minus size={10} className="text-warning" aria-hidden="true" />{" "}
+          <Dna size={10} className="text-warning" aria-hidden="true" />
+          {t("allergenMatrix.derived")}
+        </span>
+        <span className="flex items-center gap-1">
+          <Minus size={10} className="text-warning" aria-hidden="true" />
           {t("allergenMatrix.traces")}
         </span>
         <span className="flex items-center gap-1">
-          <Check size={10} className="text-success" aria-hidden="true" />{" "}
-          {t("allergenMatrix.free")}
+          <CircleHelp size={10} aria-hidden="true" />
+          {t("allergenMatrix.unknown")}
         </span>
       </div>
 
-      {/* Disclaimer */}
       <p className="text-xs leading-relaxed text-foreground-muted">
         {t("allergenMatrix.disclaimer")}
       </p>

--- a/frontend/src/components/product/AllergenQuickBadges.test.tsx
+++ b/frontend/src/components/product/AllergenQuickBadges.test.tsx
@@ -20,6 +20,12 @@ function makeAllergens(
     traces: "eggs,soybeans",
     contains_count: 2,
     traces_count: 2,
+    evidence: [
+      { tag: "gluten", evidence_type: "contains", evidence_basis: "ingredient_derived" },
+      { tag: "milk", evidence_type: "contains", evidence_basis: "explicit_source" },
+      { tag: "eggs", evidence_type: "may_contain", evidence_basis: "explicit_source" },
+      { tag: "soybeans", evidence_type: "may_contain", evidence_basis: "legacy_unclassified" },
+    ],
     ...overrides,
   };
 }
@@ -51,7 +57,22 @@ describe("AllergenQuickBadges", () => {
   it("renders only contains when traces is empty", () => {
     render(
       <AllergenQuickBadges
-        allergens={makeAllergens({ traces: "", traces_count: 0 })}
+        allergens={makeAllergens({
+          traces: "",
+          traces_count: 0,
+          evidence: [
+            {
+              tag: "gluten",
+              evidence_type: "contains",
+              evidence_basis: "ingredient_derived",
+            },
+            {
+              tag: "milk",
+              evidence_type: "contains",
+              evidence_basis: "explicit_source",
+            },
+          ],
+        })}
       />,
     );
     expect(screen.getByText("gluten")).toBeInTheDocument();
@@ -64,7 +85,14 @@ describe("AllergenQuickBadges", () => {
   it("renders only traces when contains is empty", () => {
     render(
       <AllergenQuickBadges
-        allergens={makeAllergens({ contains: "", contains_count: 0 })}
+        allergens={makeAllergens({
+          contains: "",
+          contains_count: 0,
+          evidence: [
+            { tag: "eggs", evidence_type: "may_contain", evidence_basis: "explicit_source" },
+            { tag: "soybeans", evidence_type: "may_contain", evidence_basis: "legacy_unclassified" },
+          ],
+        })}
       />,
     );
     expect(screen.getByText("eggs")).toBeInTheDocument();
@@ -73,7 +101,7 @@ describe("AllergenQuickBadges", () => {
 
   // ── Empty state ──────────────────────────────────────────────────────────
 
-  it("renders no-allergens message when both are empty", () => {
+  it("renders neutral unavailable evidence when both are empty", () => {
     render(
       <AllergenQuickBadges
         allergens={{
@@ -81,11 +109,12 @@ describe("AllergenQuickBadges", () => {
           traces: "",
           contains_count: 0,
           traces_count: 0,
+          evidence: [],
         }}
       />,
     );
     expect(
-      screen.getByText("product.noKnownAllergens"),
+      screen.getByText("product.allergenEvidenceUnavailable"),
     ).toBeInTheDocument();
   });
 
@@ -97,6 +126,7 @@ describe("AllergenQuickBadges", () => {
           traces: "",
           contains_count: 0,
           traces_count: 0,
+          evidence: [],
         }}
       />,
     );

--- a/frontend/src/components/product/AllergenQuickBadges.tsx
+++ b/frontend/src/components/product/AllergenQuickBadges.tsx
@@ -1,29 +1,26 @@
 "use client";
 
+import { getAllergenEvidence } from "@/lib/allergen-evidence";
 import { useTranslation } from "@/lib/i18n";
 import type { ProfileAllergens } from "@/lib/types";
-import { AlertTriangle, ShieldCheck } from "lucide-react";
+import { AlertTriangle, CircleHelp, Dna } from "lucide-react";
 
 interface AllergenQuickBadgesProps {
   readonly allergens: ProfileAllergens;
 }
 
-function parseList(csv: string): string[] {
-  if (!csv) return [];
-  return csv.split(",").map((s) => s.trim()).filter(Boolean);
-}
-
 export function AllergenQuickBadges({ allergens }: AllergenQuickBadgesProps) {
   const { t } = useTranslation();
-  const contains = parseList(allergens.contains);
-  const traces = parseList(allergens.traces);
+  const evidence = getAllergenEvidence(allergens);
+  const contains = evidence.filter((item) => item.evidence_type === "contains");
+  const traces = evidence.filter((item) => item.evidence_type === "may_contain");
 
-  if (contains.length === 0 && traces.length === 0) {
+  if (evidence.length === 0) {
     return (
       <div className="card">
-        <div className="flex items-center gap-2 text-sm text-score-green-text">
-          <ShieldCheck className="h-4 w-4 shrink-0" aria-hidden />
-          <span>{t("product.noKnownAllergens")}</span>
+        <div className="flex items-center gap-2 text-sm text-foreground-muted">
+          <CircleHelp className="h-4 w-4 shrink-0" aria-hidden />
+          <span>{t("product.allergenEvidenceUnavailable")}</span>
         </div>
       </div>
     );
@@ -35,22 +32,38 @@ export function AllergenQuickBadges({ allergens }: AllergenQuickBadgesProps) {
         {t("allergenMatrix.title")}
       </p>
       <div className="flex flex-wrap gap-1.5">
-        {contains.map((a) => (
+        {contains.map((item) => {
+          const isDerived = item.evidence_basis === "ingredient_derived";
+          const Icon = isDerived ? Dna : AlertTriangle;
+          return (
+            <span
+              key={`c-${item.tag}`}
+              className="inline-flex items-center gap-1 rounded-full bg-error-bg px-2 py-0.5 text-xs font-medium text-error-text"
+              title={t(
+                isDerived
+                  ? "allergenMatrix.derived"
+                  : item.evidence_basis === "explicit_source"
+                    ? "allergenMatrix.explicitSource"
+                    : "allergenMatrix.provenanceUnavailable",
+              )}
+            >
+              <Icon className="h-3 w-3 flex-shrink-0" aria-hidden />
+              {item.tag}
+              {isDerived && (
+                <span className="font-normal">
+                  ({t("allergenMatrix.derivedShort")})
+                </span>
+              )}
+            </span>
+          );
+        })}
+        {traces.map((item) => (
           <span
-            key={`c-${a}`}
-            className="inline-flex items-center gap-1 rounded-full bg-error-bg px-2 py-0.5 text-xs font-medium text-error-text"
-          >
-            <AlertTriangle className="h-3 w-3 flex-shrink-0" aria-hidden />
-            {a}
-          </span>
-        ))}
-        {traces.map((a) => (
-          <span
-            key={`t-${a}`}
+            key={`t-${item.tag}`}
             className="rounded-full bg-warning-bg px-2 py-0.5 text-xs text-warning-text"
             title={t("allergenMatrix.traces")}
           >
-            {a}
+            {item.tag}
           </span>
         ))}
       </div>

--- a/frontend/src/components/search/ActiveFilterChips.test.tsx
+++ b/frontend/src/components/search/ActiveFilterChips.test.tsx
@@ -105,7 +105,7 @@ describe("ActiveFilterChips", () => {
     expect(screen.getByText("Nutri Unknown")).toBeTruthy();
   });
 
-  // ─── Allergen-free chips ────────────────────────────────────────────
+  // ─── Allergen evidence exclusion chips ─────────────────────────────
 
   // ─── NOVA group chips ───────────────────────────────────────────────
 
@@ -143,17 +143,18 @@ describe("ActiveFilterChips", () => {
     });
   });
 
-  // ─── Allergen-free chips ────────────────────────────────────────────
+  // ─── Allergen evidence exclusion chips ─────────────────────────────
 
-  it("renders allergen-free chips with label lookup", () => {
+  it("renders truthful allergen-evidence chips with label lookup", () => {
     render(
       <ActiveFilterChips
         filters={{ allergen_free: ["gluten"] }}
         onChange={onChange}
       />,
     );
-    // Should find the ALLERGEN_TAGS entry and render "{label}-free"
-    const chip = screen.getByText(/gluten-free/i);
+    const chip = screen.getByText(
+      /exclude products with gluten contains evidence/i,
+    );
     expect(chip).toBeTruthy();
   });
 
@@ -164,7 +165,9 @@ describe("ActiveFilterChips", () => {
         onChange={onChange}
       />,
     );
-    expect(screen.getByText("mystery-free")).toBeTruthy();
+    expect(
+      screen.getByText("Exclude products with mystery contains evidence"),
+    ).toBeTruthy();
   });
 
   // ─── Min TryVit Score chip ──────────────────────────────────────────

--- a/frontend/src/components/search/ActiveFilterChips.tsx
+++ b/frontend/src/components/search/ActiveFilterChips.tsx
@@ -67,13 +67,16 @@ export function ActiveFilterChips({
     });
   }
 
-  // Allergen-free chips
+  // Positive allergen-evidence exclusion chips. The legacy wire key is kept
+  // for API and saved-search compatibility; the user-facing claim is truthful.
   for (const tag of filters.allergen_free ?? []) {
     const info = ALLERGEN_TAGS.find((a) => a.tag === tag);
     // Tags are bare canonical IDs; strip legacy en: prefix as fallback
     const label = info
-      ? t("chips.allergenFree", { label: t(info.labelKey) })
-      : t("chips.allergenFree", { label: tag.replace(/^en:/, "") });
+      ? t("chips.excludeAllergenEvidence", { label: t(info.labelKey) })
+      : t("chips.excludeAllergenEvidence", {
+          label: tag.replace(/^en:/, ""),
+        });
     chips.push({
       key: `al-${tag}`,
       label,

--- a/frontend/src/components/search/FilterPanel.test.tsx
+++ b/frontend/src/components/search/FilterPanel.test.tsx
@@ -166,15 +166,22 @@ describe("FilterPanel", () => {
     expect(screen.queryAllByText(/^UNKNOWN$/)).toHaveLength(0);
   });
 
-  it("renders allergen-free filter checkboxes", async () => {
+  it("renders truthful allergen-evidence exclusion checkboxes", async () => {
     renderPanel();
     await waitFor(() => {
-      expect(screen.getAllByText("Gluten-free").length).toBeGreaterThanOrEqual(
-        1,
-      );
+      expect(
+        screen.getAllByText(
+          "Exclude products with Gluten contains evidence",
+        ).length,
+      ).toBeGreaterThanOrEqual(1);
     });
     expect(
-      screen.getAllByText("Milk-free").length,
+      screen.getAllByText("Exclude products with Milk contains evidence")
+        .length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      screen.getAllByText(/Missing evidence is not treated as allergen-free/)
+        .length,
     ).toBeGreaterThanOrEqual(1);
   });
 

--- a/frontend/src/components/search/FilterPanel.tsx
+++ b/frontend/src/components/search/FilterPanel.tsx
@@ -298,12 +298,15 @@ export function FilterPanel({
 
           <hr className="border-t border-border/40" />
 
-          {/* Allergen-Free */}
+          {/* Allergen evidence exclusion (legacy wire key: allergen_free) */}
           {data && (data.allergens?.length ?? 0) > 0 && (
             <div>
               <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-foreground-secondary">
-                {t("filters.allergenFree")}
+                {t("filters.excludeAllergenEvidence")}
               </h3>
+              <p className="mb-2 text-xs leading-relaxed text-foreground-muted">
+                {t("filters.excludeAllergenEvidenceHint")}
+              </p>
               <div className="space-y-1 max-h-40 overflow-y-auto">
                 {data.allergens.map((al) => {
                   const labelInfo = ALLERGEN_TAGS.find((a) => a.tag === al.tag);
@@ -325,7 +328,9 @@ export function FilterPanel({
                         }
                         className="h-5 w-5 rounded border-strong text-brand focus-visible:ring-brand"
                       />
-                      <span className="text-sm">{t("chips.allergenFree", { label })}</span>
+                      <span className="text-sm">
+                        {t("chips.excludeAllergenEvidence", { label })}
+                      </span>
                       <span className="ml-auto text-xs text-foreground-muted">
                         {al.count}
                       </span>

--- a/frontend/src/lib/allergen-evidence.test.ts
+++ b/frontend/src/lib/allergen-evidence.test.ts
@@ -1,0 +1,140 @@
+import type { ProfileAllergens } from "@/lib/types";
+import { describe, expect, it } from "vitest";
+import {
+  buildAllergenDisplayRows,
+  getAllergenEvidence,
+} from "./allergen-evidence";
+
+function profile(overrides: Partial<ProfileAllergens> = {}): ProfileAllergens {
+  return {
+    contains: "",
+    traces: "",
+    contains_count: 0,
+    traces_count: 0,
+    evidence: [],
+    evidence_status: "unknown",
+    absence_assessment: "not_assessed",
+    assessed_absent: [],
+    ...overrides,
+  };
+}
+
+describe("allergen evidence semantics", () => {
+  it("preserves explicit contains evidence", () => {
+    const rows = buildAllergenDisplayRows(
+      profile({
+        evidence: [
+          {
+            tag: "milk",
+            evidence_type: "contains",
+            evidence_basis: "explicit_source",
+          },
+        ],
+      }),
+    );
+    expect(rows.find((row) => row.name === "milk")).toMatchObject({
+      status: "contains",
+      evidenceBasis: "explicit_source",
+    });
+  });
+
+  it("preserves explicit may-contain evidence", () => {
+    const rows = buildAllergenDisplayRows(
+      profile({
+        evidence: [
+          {
+            tag: "eggs",
+            evidence_type: "may_contain",
+            evidence_basis: "explicit_source",
+          },
+        ],
+      }),
+    );
+    expect(rows.find((row) => row.name === "eggs")?.status).toBe(
+      "may_contain",
+    );
+  });
+
+  it("keeps deterministic ingredient-derived evidence distinguishable", () => {
+    const rows = buildAllergenDisplayRows(
+      profile({
+        evidence: [
+          {
+            tag: "gluten",
+            evidence_type: "contains",
+            evidence_basis: "ingredient_derived",
+          },
+        ],
+      }),
+    );
+    expect(rows.find((row) => row.name === "gluten")?.status).toBe("derived");
+  });
+
+  it("treats no evidence and every unmentioned EU-14 allergen as unknown", () => {
+    const rows = buildAllergenDisplayRows(profile());
+    expect(rows).toHaveLength(14);
+    expect(rows.every((row) => row.status === "unknown")).toBe(true);
+  });
+
+  it("handles mixed explicit and derived evidence without inferring absence", () => {
+    const rows = buildAllergenDisplayRows(
+      profile({
+        evidence: [
+          {
+            tag: "milk",
+            evidence_type: "contains",
+            evidence_basis: "explicit_source",
+          },
+          {
+            tag: "gluten",
+            evidence_type: "contains",
+            evidence_basis: "ingredient_derived",
+          },
+        ],
+      }),
+    );
+    expect(rows.find((row) => row.name === "milk")?.status).toBe("contains");
+    expect(rows.find((row) => row.name === "gluten")?.status).toBe("derived");
+    expect(rows.find((row) => row.name === "eggs")?.status).toBe("unknown");
+  });
+
+  it("only presents assessed absence when the contract says assessment occurred", () => {
+    const unassessed = buildAllergenDisplayRows(
+      profile({ assessed_absent: ["milk"] }),
+    );
+    expect(unassessed.find((row) => row.name === "milk")?.status).toBe(
+      "unknown",
+    );
+
+    const assessed = buildAllergenDisplayRows(
+      profile({
+        absence_assessment: "assessed",
+        assessed_absent: ["milk"],
+      }),
+    );
+    expect(assessed.find((row) => row.name === "milk")?.status).toBe(
+      "assessed_absent",
+    );
+  });
+
+  it("keeps older CSV-only responses positive but provenance-unclassified", () => {
+    const evidence = getAllergenEvidence({
+      contains: "en:milk",
+      traces: "gluten",
+      contains_count: 1,
+      traces_count: 1,
+    });
+    expect(evidence).toEqual([
+      {
+        tag: "milk",
+        evidence_type: "contains",
+        evidence_basis: "legacy_unclassified",
+      },
+      {
+        tag: "gluten",
+        evidence_type: "may_contain",
+        evidence_basis: "legacy_unclassified",
+      },
+    ]);
+  });
+});

--- a/frontend/src/lib/allergen-evidence.ts
+++ b/frontend/src/lib/allergen-evidence.ts
@@ -1,0 +1,151 @@
+import type {
+  AllergenEvidenceBasis,
+  ProfileAllergenEvidence,
+  ProfileAllergens,
+} from "@/lib/types";
+
+/** EU FIC Regulation 1169/2011 mandatory allergen groups. */
+export const EU_14_ALLERGENS = [
+  "gluten",
+  "crustaceans",
+  "eggs",
+  "fish",
+  "peanuts",
+  "soybeans",
+  "milk",
+  "tree-nuts",
+  "celery",
+  "mustard",
+  "sesame",
+  "sulphites",
+  "lupin",
+  "molluscs",
+] as const;
+
+export type AllergenDisplayStatus =
+  | "contains"
+  | "derived"
+  | "may_contain"
+  | "unknown"
+  | "assessed_absent";
+
+export interface AllergenDisplayRow {
+  name: string;
+  status: AllergenDisplayStatus;
+  evidenceBasis?: AllergenEvidenceBasis;
+}
+
+export function normaliseAllergenTag(tag: string): string {
+  return tag.trim().replace(/^en:/, "").toLowerCase();
+}
+
+function parseCsvEvidence(
+  csv: string,
+  evidenceType: ProfileAllergenEvidence["evidence_type"],
+): ProfileAllergenEvidence[] {
+  return csv
+    .split(",")
+    .map(normaliseAllergenTag)
+    .filter(Boolean)
+    .map((tag) => ({
+      tag,
+      evidence_type: evidenceType,
+      evidence_basis: "legacy_unclassified",
+    }));
+}
+
+/**
+ * Return positive evidence while preserving compatibility with an older API
+ * payload. Legacy CSV values remain positive but are never presented as
+ * explicit source declarations when provenance is unavailable.
+ */
+export function getAllergenEvidence(
+  allergens: ProfileAllergens,
+): ProfileAllergenEvidence[] {
+  if (allergens.evidence) {
+    return allergens.evidence.map((item) => ({
+      ...item,
+      tag: normaliseAllergenTag(item.tag),
+    }));
+  }
+
+  return [
+    ...parseCsvEvidence(allergens.contains, "contains"),
+    ...parseCsvEvidence(allergens.traces, "may_contain"),
+  ];
+}
+
+function containsPriority(evidence: ProfileAllergenEvidence): number {
+  if (evidence.evidence_basis === "explicit_source") return 0;
+  if (evidence.evidence_basis === "ingredient_derived") return 1;
+  return 2;
+}
+
+export function buildAllergenDisplayRows(
+  allergens: ProfileAllergens,
+): AllergenDisplayRow[] {
+  const evidence = getAllergenEvidence(allergens);
+  const evidenceByTag = new Map<string, ProfileAllergenEvidence[]>();
+
+  for (const item of evidence) {
+    const entries = evidenceByTag.get(item.tag) ?? [];
+    entries.push(item);
+    evidenceByTag.set(item.tag, entries);
+  }
+
+  const assessedAbsent = new Set(
+    allergens.absence_assessment === "assessed"
+      ? (allergens.assessed_absent ?? []).map(normaliseAllergenTag)
+      : [],
+  );
+  const allNames = new Set<string>([
+    ...EU_14_ALLERGENS,
+    ...evidenceByTag.keys(),
+    ...assessedAbsent,
+  ]);
+
+  const rows: AllergenDisplayRow[] = [];
+  for (const name of allNames) {
+    const entries = evidenceByTag.get(name) ?? [];
+    const contains = entries
+      .filter((item) => item.evidence_type === "contains")
+      .toSorted((a, b) => containsPriority(a) - containsPriority(b));
+    const mayContain = entries.find(
+      (item) => item.evidence_type === "may_contain",
+    );
+
+    if (contains.length > 0) {
+      const strongest = contains[0];
+      rows.push({
+        name,
+        status:
+          strongest.evidence_basis === "ingredient_derived"
+            ? "derived"
+            : "contains",
+        evidenceBasis: strongest.evidence_basis,
+      });
+    } else if (mayContain) {
+      rows.push({
+        name,
+        status: "may_contain",
+        evidenceBasis: mayContain.evidence_basis,
+      });
+    } else if (assessedAbsent.has(name)) {
+      rows.push({ name, status: "assessed_absent" });
+    } else {
+      rows.push({ name, status: "unknown" });
+    }
+  }
+
+  const statusOrder: Record<AllergenDisplayStatus, number> = {
+    contains: 0,
+    derived: 1,
+    may_contain: 2,
+    unknown: 3,
+    assessed_absent: 4,
+  };
+
+  return rows.toSorted(
+    (a, b) => statusOrder[a.status] - statusOrder[b.status] || a.name.localeCompare(b.name),
+  );
+}

--- a/frontend/src/lib/allergen-matching.test.ts
+++ b/frontend/src/lib/allergen-matching.test.ts
@@ -48,6 +48,38 @@ describe("matchProductAllergens", () => {
     });
   });
 
+  it("keeps deterministic ingredient-derived warnings distinguishable", () => {
+    const data: ProductAllergenData = {
+      contains: ["milk"],
+      traces: [],
+      evidence: [
+        {
+          tag: "milk",
+          evidence_type: "contains",
+          evidence_basis: "ingredient_derived",
+        },
+      ],
+    };
+
+    expect(matchProductAllergens(data, ["milk"], false)[0]).toMatchObject({
+      tag: "milk",
+      type: "contains",
+      evidenceBasis: "ingredient_derived",
+    });
+  });
+
+  it("does not turn an unknown evidence state into a warning or all-clear", () => {
+    const data: ProductAllergenData = {
+      contains: [],
+      traces: [],
+      evidence: [],
+      evidence_status: "unknown",
+      absence_assessment: "not_assessed",
+    };
+
+    expect(matchProductAllergens(data, ["milk"], true)).toEqual([]);
+  });
+
   it("matches multiple contains allergens", () => {
     const data: ProductAllergenData = {
       contains: ["milk", "gluten", "eggs"],

--- a/frontend/src/lib/allergen-matching.ts
+++ b/frontend/src/lib/allergen-matching.ts
@@ -3,6 +3,7 @@
 // All functions are pure (no hooks/side-effects) for easy testing.
 
 import { ALLERGEN_TAGS } from "@/lib/constants";
+import type { AllergenEvidenceBasis } from "@/lib/types";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -10,6 +11,13 @@ import { ALLERGEN_TAGS } from "@/lib/constants";
 export interface ProductAllergenData {
   readonly contains: string[];
   readonly traces: string[];
+  readonly evidence?: readonly {
+    readonly tag: string;
+    readonly evidence_type: "contains" | "may_contain";
+    readonly evidence_basis: AllergenEvidenceBasis;
+  }[];
+  readonly evidence_status?: "unknown" | "positive_evidence_available";
+  readonly absence_assessment?: "not_assessed" | "assessed";
 }
 
 /** Allergen data map keyed by product_id */
@@ -27,6 +35,8 @@ export interface AllergenWarning {
   readonly icon: string;
   /** Whether the product "contains" or has "traces" of this allergen */
   readonly type: "contains" | "traces";
+  /** Provenance when returned by the evidence-aware API. */
+  readonly evidenceBasis?: AllergenEvidenceBasis;
 }
 
 // ─── Allergen icon mapping ──────────────────────────────────────────────────
@@ -73,6 +83,13 @@ export function matchProductAllergens(
 
   const avoidSet = new Set(userAvoidAllergens);
   const warnings: AllergenWarning[] = [];
+  const evidenceBasis = (
+    tag: string,
+    evidenceType: "contains" | "may_contain",
+  ) =>
+    productAllergens.evidence?.find(
+      (item) => item.tag === tag && item.evidence_type === evidenceType,
+    )?.evidence_basis;
 
   // Check "contains" allergens
   for (const tag of productAllergens.contains) {
@@ -82,6 +99,7 @@ export function matchProductAllergens(
         labelKey: LABEL_KEY_MAP.get(tag) ?? `allergens.${tag}`,
         icon: ALLERGEN_ICONS[tag] ?? "⚠️",
         type: "contains",
+        evidenceBasis: evidenceBasis(tag, "contains"),
       });
     }
   }
@@ -96,6 +114,7 @@ export function matchProductAllergens(
           labelKey: LABEL_KEY_MAP.get(tag) ?? `allergens.${tag}`,
           icon: ALLERGEN_ICONS[tag] ?? "⚠️",
           type: "traces",
+          evidenceBasis: evidenceBasis(tag, "may_contain"),
         });
       }
     }

--- a/frontend/src/lib/export.test.ts
+++ b/frontend/src/lib/export.test.ts
@@ -112,7 +112,9 @@ describe("generateCSV", () => {
   it("handles products with missing optional fields", () => {
     const csv = generateCSV([MINIMAL_PRODUCT], { includeTimestamp: false });
     // Missing EAN, calories etc. should be empty
-    expect(csv).toContain("Simple Item,TestBrand,,Other,50,C,3,,,,,,,,,");
+    expect(csv).toContain(
+      "Simple Item,TestBrand,,Other,50,C,3,,,,,,,,Evidence unavailable,",
+    );
   });
 
   it("uses CRLF line endings", () => {
@@ -203,9 +205,9 @@ describe("generateText", () => {
     expect(text).toContain("Allergens: milk");
   });
 
-  it("shows 'none' when no allergens", () => {
+  it("shows evidence unavailable when no allergens are recorded", () => {
     const text = generateText([MINIMAL_PRODUCT], { includeTimestamp: false });
-    expect(text).toContain("Allergens: none");
+    expect(text).toContain("Allergens: evidence unavailable");
   });
 
   it("can skip the header block", () => {

--- a/frontend/src/lib/export.ts
+++ b/frontend/src/lib/export.ts
@@ -74,6 +74,9 @@ function escapeCSVField(value: string | number | undefined | null): string {
 }
 
 function productToCSVRow(p: ExportableProduct): string {
+  const allergenEvidence = p.allergen_tags?.length
+    ? p.allergen_tags.join("; ")
+    : "Evidence unavailable";
   const fields: (string | number | undefined)[] = [
     p.product_name,
     p.brand,
@@ -89,7 +92,7 @@ function productToCSVRow(p: ExportableProduct): string {
     p.salt_g,
     p.protein_g,
     p.fiber_g,
-    p.allergen_tags?.join("; "),
+    allergenEvidence,
     p.confidence_band,
   ];
   return fields.map(escapeCSVField).join(",");
@@ -160,7 +163,13 @@ export function generateComparisonCSV(products: ExportableProduct[]): string {
     ["Salt (g)", (p) => p.salt_g],
     ["Protein (g)", (p) => p.protein_g],
     ["Fiber (g)", (p) => p.fiber_g],
-    ["Allergens", (p) => p.allergen_tags?.join("; ")],
+    [
+      "Allergens",
+      (p) =>
+        p.allergen_tags?.length
+          ? p.allergen_tags.join("; ")
+          : "Evidence unavailable",
+    ],
     ["Confidence", (p) => p.confidence_band],
   ];
 
@@ -212,7 +221,9 @@ export function generateText(
     const salt = p.salt_g == null ? "–" : `${p.salt_g}g`;
     lines.push(`   Per 100g: ${cal} kcal · Fat ${fat} · Sugar ${sugar} · Salt ${salt}`);
 
-    const allergens = p.allergen_tags?.length ? p.allergen_tags.join(", ") : "none";
+    const allergens = p.allergen_tags?.length
+      ? p.allergen_tags.join(", ")
+      : "evidence unavailable";
     lines.push(`   Allergens: ${allergens}`, "");
   });
 

--- a/frontend/src/lib/i18n-dictionaries.test.ts
+++ b/frontend/src/lib/i18n-dictionaries.test.ts
@@ -192,7 +192,9 @@ describe("i18n message dictionaries", () => {
     // Allergen statuses
     "tooltip.allergen.present",
     "tooltip.allergen.traces",
-    "tooltip.allergen.free",
+    "tooltip.allergen.derived",
+    "tooltip.allergen.unknown",
+    "tooltip.allergen.assessedAbsent",
     // Nutrient traffic light
     "tooltip.nutrient.low",
     "tooltip.nutrient.medium",

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -60,6 +60,11 @@ export interface SearchFilters {
   category?: string[];
   nutri_score?: string[];
   nova_group?: string[];
+  /**
+   * Legacy wire key retained for saved-search and RPC compatibility.
+   * Semantics: exclude products with matching positive `contains` evidence.
+   * It does not mean that remaining products are allergen-free.
+   */
   allergen_free?: string[];
   max_unhealthiness?: number;
   country?: string;
@@ -692,6 +697,25 @@ export interface ProfileAllergens {
   traces: string;
   contains_count: number;
   traces_count: number;
+  /** Additive Phase 5 evidence contract; omitted by pre-Phase-5 responses. */
+  evidence?: ProfileAllergenEvidence[];
+  evidence_status?: "positive_evidence_available" | "unknown";
+  absence_assessment?: "not_assessed" | "assessed";
+  assessed_absent?: string[];
+}
+
+export type AllergenEvidenceType = "contains" | "may_contain";
+
+export type AllergenEvidenceBasis =
+  | "explicit_source"
+  | "ingredient_derived"
+  | "legacy_unclassified";
+
+export interface ProfileAllergenEvidence {
+  tag: string;
+  evidence_type: AllergenEvidenceType;
+  evidence_basis: AllergenEvidenceBasis;
+  source_tag?: string | null;
 }
 
 export interface ScoreBreakdownFactor {

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -440,7 +440,7 @@
     --color-allergen-traces: #f59e0b;
     /* May contain traces */
     --color-allergen-free: #22c55e;
-    /* Free from */
+    /* Reserved for authoritatively assessed absence */
 
     /* ── Semantic Feedback ── */
     --color-success: #22c55e;

--- a/supabase/migrations/20260730173135_phase5_allergen_evidence_semantics.sql
+++ b/supabase/migrations/20260730173135_phase5_allergen_evidence_semantics.sql
@@ -1,4 +1,6 @@
--- Phase 5 preflight A: truthful allergen evidence semantics.
+-- Migration: Phase 5 preflight A — truthful allergen evidence semantics.
+-- Rollback: Restore the verified pre-Phase-5 API/view definitions, then drop
+-- product_allergen_info evidence-basis constraints, trigger, function, and column.
 --
 -- product_allergen_info continues to store positive evidence only. Absence of
 -- a row is unknown, never an assessed absence. The additive evidence_basis

--- a/supabase/migrations/20260730173135_phase5_allergen_evidence_semantics.sql
+++ b/supabase/migrations/20260730173135_phase5_allergen_evidence_semantics.sql
@@ -1,0 +1,251 @@
+-- Phase 5 preflight A: truthful allergen evidence semantics.
+--
+-- product_allergen_info continues to store positive evidence only. Absence of
+-- a row is unknown, never an assessed absence. The additive evidence_basis
+-- column records whether positive evidence came from a source declaration,
+-- deterministic ingredient rules, or a historical row whose provenance
+-- cannot be reconstructed safely.
+
+BEGIN;
+
+ALTER TABLE public.product_allergen_info
+    ADD COLUMN IF NOT EXISTS evidence_basis text;
+
+UPDATE public.product_allergen_info
+SET evidence_basis = 'legacy_unclassified'
+WHERE evidence_basis IS NULL;
+
+ALTER TABLE public.product_allergen_info
+    ALTER COLUMN evidence_basis SET DEFAULT 'legacy_unclassified',
+    ALTER COLUMN evidence_basis SET NOT NULL;
+
+ALTER TABLE public.product_allergen_info
+    DROP CONSTRAINT IF EXISTS chk_product_allergen_evidence_basis;
+
+ALTER TABLE public.product_allergen_info
+    ADD CONSTRAINT chk_product_allergen_evidence_basis
+    CHECK (evidence_basis IN (
+        'explicit_source',
+        'ingredient_derived',
+        'legacy_unclassified'
+    ));
+
+ALTER TABLE public.product_allergen_info
+    DROP CONSTRAINT IF EXISTS chk_explicit_allergen_source_traceability;
+
+ALTER TABLE public.product_allergen_info
+    ADD CONSTRAINT chk_explicit_allergen_source_traceability
+    CHECK (
+        evidence_basis <> 'explicit_source'
+        OR source_tag IS NOT NULL
+    );
+
+COMMENT ON COLUMN public.product_allergen_info.evidence_basis IS
+'Provenance of positive allergen evidence. explicit_source = source contains/may-contain declaration; ingredient_derived = deterministic governed ingredient relationship; legacy_unclassified = positive evidence whose provenance cannot be reconstructed. Missing rows mean unknown, not absent.';
+
+CREATE OR REPLACE FUNCTION public.set_product_allergen_evidence_basis()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $function$
+BEGIN
+    -- Generated source-evidence pipelines preserve source_tag. Upgrade the
+    -- safe default when that traceability is present. Never infer assessed
+    -- absence here: this trigger only classifies positive evidence rows.
+    IF NEW.source_tag IS NOT NULL
+       AND NEW.evidence_basis = 'legacy_unclassified' THEN
+        NEW.evidence_basis := 'explicit_source';
+    END IF;
+    RETURN NEW;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.set_product_allergen_evidence_basis() FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS trg_product_allergen_evidence_basis
+    ON public.product_allergen_info;
+
+CREATE TRIGGER trg_product_allergen_evidence_basis
+    BEFORE INSERT OR UPDATE OF source_tag, evidence_basis
+    ON public.product_allergen_info
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_product_allergen_evidence_basis();
+
+-- Keep the established product-profile payload intact and add an explicit,
+-- additive evidence contract. The renamed implementation is private and can
+-- only be reached through the evidence-aware wrapper below.
+ALTER FUNCTION public.api_get_product_profile(bigint, text)
+    RENAME TO get_product_profile_v1_legacy_internal;
+
+REVOKE ALL ON FUNCTION public.get_product_profile_v1_legacy_internal(bigint, text)
+    FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.api_get_product_profile(
+    p_product_id bigint,
+    p_language text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+    v_profile jsonb;
+    v_evidence jsonb;
+    v_allergens jsonb;
+BEGIN
+    v_profile := public.get_product_profile_v1_legacy_internal(
+        p_product_id,
+        p_language
+    );
+
+    IF v_profile IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'tag', ai.tag,
+                'evidence_type', CASE ai.type
+                    WHEN 'traces' THEN 'may_contain'
+                    ELSE 'contains'
+                END,
+                'evidence_basis', ai.evidence_basis,
+                'source_tag', ai.source_tag
+            )
+            ORDER BY
+                CASE ai.type WHEN 'contains' THEN 0 ELSE 1 END,
+                ai.tag,
+                ai.evidence_basis
+        ),
+        '[]'::jsonb
+    )
+    INTO v_evidence
+    FROM public.product_allergen_info ai
+    WHERE ai.product_id = p_product_id;
+
+    v_allergens := COALESCE(v_profile->'allergens', '{}'::jsonb)
+        || jsonb_build_object(
+            'evidence', v_evidence,
+            'evidence_status', CASE
+                WHEN jsonb_array_length(v_evidence) = 0 THEN 'unknown'
+                ELSE 'positive_evidence_available'
+            END,
+            'absence_assessment', 'not_assessed',
+            'assessed_absent', '[]'::jsonb
+        );
+
+    RETURN jsonb_set(v_profile, '{allergens}', v_allergens, true);
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.api_get_product_profile(bigint, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.api_get_product_profile(bigint, text)
+    TO anon, authenticated, service_role;
+
+COMMENT ON FUNCTION public.api_get_product_profile(bigint, text) IS
+'Canonical product profile with additive allergen evidence provenance. Empty evidence and unmentioned allergens are unknown; assessed_absent remains empty unless a future authoritative source supports absence.';
+
+-- Product-card warnings retain the existing contains/traces arrays while
+-- exposing provenance for consumers that can distinguish derived evidence.
+CREATE OR REPLACE FUNCTION public.api_get_product_allergens(
+    p_product_ids bigint[]
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+BEGIN
+    RETURN (
+        SELECT COALESCE(
+            jsonb_object_agg(
+                grouped.product_id::text,
+                jsonb_build_object(
+                    'contains', grouped.contains_tags,
+                    'traces', grouped.traces_tags,
+                    'evidence', grouped.evidence,
+                    'evidence_status', CASE
+                        WHEN jsonb_array_length(grouped.evidence) = 0
+                            THEN 'unknown'
+                        ELSE 'positive_evidence_available'
+                    END,
+                    'absence_assessment', 'not_assessed'
+                )
+            ),
+            '{}'::jsonb
+        )
+        FROM (
+            SELECT
+                requested.product_id,
+                COALESCE(
+                    array_agg(ai.tag ORDER BY ai.tag)
+                        FILTER (
+                            WHERE ai.product_id IS NOT NULL
+                              AND ai.type = 'contains'
+                        ),
+                    ARRAY[]::text[]
+                ) AS contains_tags,
+                COALESCE(
+                    array_agg(ai.tag ORDER BY ai.tag)
+                        FILTER (
+                            WHERE ai.product_id IS NOT NULL
+                              AND ai.type = 'traces'
+                        ),
+                    ARRAY[]::text[]
+                ) AS traces_tags,
+                COALESCE(
+                    jsonb_agg(
+                        jsonb_build_object(
+                            'tag', ai.tag,
+                            'evidence_type', CASE ai.type
+                                WHEN 'traces' THEN 'may_contain'
+                                ELSE 'contains'
+                            END,
+                            'evidence_basis', ai.evidence_basis
+                        )
+                        ORDER BY
+                            CASE ai.type WHEN 'contains' THEN 0 ELSE 1 END,
+                            ai.tag,
+                            ai.evidence_basis
+                    ) FILTER (WHERE ai.product_id IS NOT NULL),
+                    '[]'::jsonb
+                ) AS evidence
+            FROM unnest(COALESCE(p_product_ids, ARRAY[]::bigint[]))
+                AS requested(product_id)
+            LEFT JOIN public.product_allergen_info ai
+                ON ai.product_id = requested.product_id
+            GROUP BY requested.product_id
+        ) grouped
+    );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.api_get_product_allergens(bigint[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.api_get_product_allergens(bigint[])
+    TO anon, authenticated, service_role;
+
+COMMENT ON FUNCTION public.api_get_product_allergens(bigint[]) IS
+'Batch positive-allergen evidence lookup. Every requested product is returned; products with no rows have empty arrays and evidence_status unknown, never allergen-free.';
+
+COMMENT ON FUNCTION public.api_search_products(text, jsonb, integer, integer, boolean) IS
+'Search endpoint. The legacy allergen_free JSON key is retained for compatibility but means exclude products with matching contains evidence. Products with only may-contain evidence or no evidence remain eligible; the key does not prove allergen absence.';
+
+COMMENT ON FUNCTION public.api_get_filter_options(text) IS
+'Filter options endpoint. Allergen counts are counts of products with positive contains evidence, not counts of allergen-free products.';
+
+COMMENT ON COLUMN public.v_master.allergen_count IS
+'Count of positive contains-evidence rows. Zero means no contains evidence is recorded; it does not prove absence.';
+COMMENT ON COLUMN public.v_master.allergen_tags IS
+'Comma-separated tags with positive contains evidence. NULL means unknown/unavailable, not allergen-free.';
+COMMENT ON COLUMN public.v_master.trace_count IS
+'Count of explicit may-contain/trace evidence rows.';
+COMMENT ON COLUMN public.v_master.trace_tags IS
+'Comma-separated tags with may-contain/trace evidence.';
+
+COMMENT ON FUNCTION public.compute_data_completeness(bigint) IS
+'Computes the established 15-checkpoint data-availability score. Its allergen checkpoint means positive evidence or ingredient inputs are available for governed evaluation; it does not certify assessed absence or complete allergen coverage.';
+
+COMMIT;

--- a/supabase/tests/allergen_evidence_semantics.test.sql
+++ b/supabase/tests/allergen_evidence_semantics.test.sql
@@ -1,0 +1,296 @@
+-- pgTAP: Phase 5 allergen evidence semantics
+-- Self-contained fixtures prove that missing positive evidence stays unknown.
+
+BEGIN;
+SELECT plan(20);
+
+INSERT INTO public.category_ref (
+    category, slug, display_name, sort_order, is_active
+)
+VALUES (
+    'pgtap-allergen-evidence',
+    'pgtap-allergen-evidence',
+    'pgTAP Allergen Evidence',
+    999,
+    true
+)
+ON CONFLICT (category) DO UPDATE
+SET slug = EXCLUDED.slug;
+
+INSERT INTO public.country_ref (country_code, country_name, is_active)
+VALUES ('XX', 'Test Country', true)
+ON CONFLICT (country_code) DO NOTHING;
+
+INSERT INTO public.products (
+    product_id, ean, product_name, brand, category, country,
+    unhealthiness_score, nutri_score_label, nova_classification
+)
+VALUES
+    (999971, '5901234999971', 'Phase5 Evidence Explicit', 'Test Brand',
+     'pgtap-allergen-evidence', 'XX', 40, 'B', '2'),
+    (999970, '5901234999970', 'Phase5 Evidence May Contain', 'Test Brand',
+     'pgtap-allergen-evidence', 'XX', 40, 'B', '2'),
+    (999969, '5901234999969', 'Phase5 Evidence Derived', 'Test Brand',
+     'pgtap-allergen-evidence', 'XX', 40, 'B', '2'),
+    (999968, '5901234999968', 'Phase5 Evidence Unknown', 'Test Brand',
+     'pgtap-allergen-evidence', 'XX', 40, 'B', '2')
+ON CONFLICT (product_id) DO NOTHING;
+
+INSERT INTO public.product_allergen_info (
+    product_id, tag, type, source_tag
+)
+VALUES (999971, 'milk', 'contains', 'en:milk');
+
+INSERT INTO public.product_allergen_info (
+    product_id, tag, type, evidence_basis
+)
+VALUES
+    (999971, 'gluten', 'contains', 'ingredient_derived'),
+    (999969, 'milk', 'contains', 'ingredient_derived');
+
+INSERT INTO public.product_allergen_info (
+    product_id, tag, type, source_tag
+)
+VALUES (999970, 'milk', 'traces', 'en:milk');
+
+SELECT has_column(
+    'public',
+    'product_allergen_info',
+    'evidence_basis',
+    'positive allergen evidence records have a provenance basis'
+);
+
+SELECT is(
+    (SELECT evidence_basis
+     FROM public.product_allergen_info
+     WHERE product_id = 999971 AND tag = 'milk'),
+    'explicit_source',
+    'source-tagged positive evidence is classified as explicit source'
+);
+
+SELECT is(
+    (SELECT evidence_basis
+     FROM public.product_allergen_info
+     WHERE product_id = 999969 AND tag = 'milk'),
+    'ingredient_derived',
+    'deterministic ingredient evidence remains distinguishable'
+);
+
+SELECT is(
+    jsonb_array_length(
+        public.api_get_product_profile(999971)->'allergens'->'evidence'
+    ),
+    2,
+    'profile returns mixed explicit and derived positive evidence'
+);
+
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(
+            public.api_get_product_profile(999971)
+                ->'allergens'->'evidence'
+        ) item
+        WHERE item->>'tag' = 'milk'
+          AND item->>'evidence_type' = 'contains'
+          AND item->>'evidence_basis' = 'explicit_source'
+    ),
+    'profile identifies explicit contains evidence'
+);
+
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(
+            public.api_get_product_profile(999971)
+                ->'allergens'->'evidence'
+        ) item
+        WHERE item->>'tag' = 'gluten'
+          AND item->>'evidence_basis' = 'ingredient_derived'
+    ),
+    'profile identifies deterministic derived evidence'
+);
+
+SELECT is(
+    public.api_get_product_profile(999971)
+        ->'allergens'->>'evidence_status',
+    'positive_evidence_available',
+    'profile reports positive evidence without claiming completeness'
+);
+
+SELECT is(
+    public.api_get_product_profile(999968)
+        ->'allergens'->>'evidence_status',
+    'unknown',
+    'product with no positive rows reports evidence unknown'
+);
+
+SELECT is(
+    public.api_get_product_profile(999968)
+        ->'allergens'->>'absence_assessment',
+    'not_assessed',
+    'no evidence does not become assessed absence'
+);
+
+SELECT is(
+    jsonb_array_length(
+        public.api_get_product_profile(999968)
+            ->'allergens'->'assessed_absent'
+    ),
+    0,
+    'profile never synthesizes absent allergens'
+);
+
+SELECT ok(
+    public.api_get_product_allergens(
+        ARRAY[999971, 999970, 999969, 999968]::bigint[]
+    ) ? '999968',
+    'batch API returns an explicit payload for an unknown product'
+);
+
+SELECT is(
+    jsonb_array_length(
+        public.api_get_product_allergens(ARRAY[999968]::bigint[])
+            ->'999968'->'evidence'
+    ),
+    0,
+    'batch API unknown payload has no invented evidence'
+);
+
+SELECT is(
+    public.api_get_product_allergens(ARRAY[999968]::bigint[])
+        ->'999968'->>'evidence_status',
+    'unknown',
+    'batch API names the no-row state unknown'
+);
+
+SELECT is(
+    (
+        SELECT COUNT(*)::integer
+        FROM jsonb_array_elements(
+            public.api_search_products(
+                'Phase5 Evidence',
+                '{"country":"XX","allergen_free":["milk"]}'::jsonb,
+                1,
+                20
+            )->'results'
+        ) result
+        WHERE (result->>'product_id')::bigint = 999971
+    ),
+    0,
+    'legacy filter key excludes matching explicit contains evidence'
+);
+
+SELECT is(
+    (
+        SELECT COUNT(*)::integer
+        FROM jsonb_array_elements(
+            public.api_search_products(
+                'Phase5 Evidence',
+                '{"country":"XX","allergen_free":["milk"]}'::jsonb,
+                1,
+                20
+            )->'results'
+        ) result
+        WHERE (result->>'product_id')::bigint = 999969
+    ),
+    0,
+    'legacy filter key excludes matching ingredient-derived contains evidence'
+);
+
+SELECT is(
+    (
+        SELECT COUNT(*)::integer
+        FROM jsonb_array_elements(
+            public.api_search_products(
+                'Phase5 Evidence',
+                '{"country":"XX","allergen_free":["milk"]}'::jsonb,
+                1,
+                20
+            )->'results'
+        ) result
+        WHERE (result->>'product_id')::bigint = 999970
+    ),
+    1,
+    'contains-evidence filter does not misrepresent may-contain as absent'
+);
+
+SELECT is(
+    (
+        SELECT COUNT(*)::integer
+        FROM jsonb_array_elements(
+            public.api_search_products(
+                'Phase5 Evidence',
+                '{"country":"XX","allergen_free":["milk"]}'::jsonb,
+                1,
+                20
+            )->'results'
+        ) result
+        WHERE (result->>'product_id')::bigint = 999968
+    ),
+    1,
+    'contains-evidence filter keeps unknown products without calling them free'
+);
+
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(
+            public.api_get_product_profile(999970)
+                ->'allergens'->'evidence'
+        ) item
+        WHERE item->>'tag' = 'milk'
+          AND item->>'evidence_type' = 'may_contain'
+          AND item->>'evidence_basis' = 'explicit_source'
+    ),
+    'profile preserves explicit may-contain evidence'
+);
+
+SELECT is(
+    jsonb_array_length(
+        public.api_get_product_profile(999971)
+            ->'allergens'->'assessed_absent'
+    ),
+    0,
+    'unmentioned EU-14 allergens are not emitted as assessed absent'
+);
+
+CREATE TEMP TABLE phase5_allergen_checksum_before AS
+SELECT md5(
+    string_agg(
+        concat_ws(':', product_id, tag, type, evidence_basis),
+        '|' ORDER BY product_id, tag, type
+    )
+) AS checksum
+FROM public.product_allergen_info
+WHERE product_id BETWEEN 999968 AND 999971;
+
+INSERT INTO public.product_allergen_info (
+    product_id, tag, type, source_tag, evidence_basis
+)
+VALUES
+    (999971, 'milk', 'contains', 'en:milk', 'explicit_source'),
+    (999971, 'gluten', 'contains', NULL, 'ingredient_derived'),
+    (999970, 'milk', 'traces', 'en:milk', 'explicit_source'),
+    (999969, 'milk', 'contains', NULL, 'ingredient_derived')
+ON CONFLICT (product_id, tag, type) DO UPDATE
+SET source_tag = EXCLUDED.source_tag,
+    evidence_basis = EXCLUDED.evidence_basis;
+
+SELECT is(
+    (
+        SELECT md5(
+            string_agg(
+                concat_ws(':', product_id, tag, type, evidence_basis),
+                '|' ORDER BY product_id, tag, type
+            )
+        )
+        FROM public.product_allergen_info
+        WHERE product_id BETWEEN 999968 AND 999971
+    ),
+    (SELECT checksum FROM phase5_allergen_checksum_before),
+    'reapplying the same evidence produces an identical checksum'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Purpose

Correct TryVit’s allergen evidence semantics before Phase 5 visual work. Missing or unmentioned allergen evidence is now unknown everywhere; it is never presented as absent or allergen-free.

## Behavior changes

- Adds an additive `evidence_basis` contract for positive allergen rows: `explicit_source`, `ingredient_derived`, and `legacy_unclassified`.
- Extends product-profile and batch-allergen RPC payloads with positive evidence provenance, explicit unknown status, and a reserved assessed-absence contract.
- Keeps historical rows conservative when provenance cannot be reconstructed.
- Replaces the green all-clear for missing rows with neutral evidence-unavailable states.
- Distinguishes explicit contains, explicit may-contain, and deterministic ingredient-derived evidence.
- Retains the legacy `allergen_free` wire key only for compatibility; visible copy now truthfully says that matching contains evidence is excluded, while may-contain and unknown products can remain.
- Updates saved-search, active-chip, export, EN/PL/DE, scoring-methodology, and design-token documentation semantics.
- Adds seven blocking repository QA assertions and a 20-case pgTAP contract.

## Verification

- Focused allergen/i18n frontend tests: 138 passed.
- Complete frontend suite: 5,944 passed, 19 skipped.
- TypeScript, ESLint, and production build: passed.
- Local browser journeys: 45 passed, 1 conditional test skipped, including product, search/filter, desktop/mobile/dark WCAG audits; zero blocking or warning violations. The Windows Node 24 runner emitted a libuv shutdown assertion after reporting passing totals, so GitHub’s Node 22 run is authoritative.
- Fresh local PostgreSQL replay: passed.
- Blocking database QA: 776/776 passed.
- Sanity: 17/17 passed.
- Focused pgTAP allergen evidence suite: 20/20 passed.
- Schema drift: no changes found after migration replay.
- Phase 4 governance, generated evidence, thresholds, baselines, and linkage checksum checks: unchanged/passed.

The repository-wide non-gating `supabase test db` aggregate still reports pre-existing unrelated plan/count failures in older business, localization, scanner, telemetry, and schema-contract suites. The new Phase 5 suite itself passes and the maintained QA workflow is green locally.

## Accessibility and performance

- Unknown states use neutral text/icon treatment instead of color-only green success.
- Evidence states have translated accessible labels and provenance distinctions.
- No new network request, dependency, animation, or runtime data pipeline was added.

## Screenshots

Not included: this preflight intentionally avoids redesign work. The narrowly scoped visual change is removal of misleading success styling, covered by component and Playwright accessibility tests.

## Security and hosted-service boundary

- No hosted Supabase database, schema, configuration, or admin API was modified.
- No migration was linked, pushed, or deployed remotely.
- During local browser harness setup, two unauthenticated login attempts were mistakenly routed to the existing hosted Auth endpoint and rejected with HTTP 400. No session was created and no hosted data was read or written. All subsequent replay, auth, browser, and database work used the local stack.
- No Vercel/production deployment or configuration action was taken.

## Deferred decision

`assessed_absent` remains reserved and unused. Enabling it later requires an authoritative source, provenance model, product/legal review, and dedicated tests; it must not be synthesized to restore green “free from” UI.