### PR TITLE
fix(deps): resolve production nanoid audit finding

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11675,9 +11675,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,6 +62,7 @@
   },
   "overrides": {
     "minimatch": ">=10.2.4",
+    "nanoid": "3.3.17",
     "basic-ftp": "5.3.1",
     "uuid": "11.1.1",
     "@eslint/eslintrc": {


### PR DESCRIPTION
## Purpose

Resolve the high-severity `nanoid < 3.3.17` production dependency advisory that blocks the Phase 5 combined-parent PR.

## Change

Adds a root npm override for `nanoid@3.3.17` and updates only its resolved lockfile entry. Next.js and PostCSS versions are unchanged.

## Verification

- `npx npm@10.9.4 ci --ignore-scripts`
- `npx npm@10.9.4 audit --omit=dev --audit-level=high` — passes; the existing PostCSS advisory remains moderate
- Type-check, lint, and focused workflow/a11y tests

## Scope

No application, visual, database, hosted-service, or CI-policy behavior changes.